### PR TITLE
[TECH] Correction d'un bug venant du theme et centrer les stories

### DIFF
--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -1,8 +1,10 @@
-import { addParameters } from '@storybook/ember';
+import { addParameters, addDecorator } from '@storybook/ember';
 import storybookCustomTheme from './storybook-custom-theme';
+import centered from '@storybook/addon-centered/ember';
 
 addParameters({
   options: {
     theme: storybookCustomTheme,
   },
 });
+addDecorator(centered);

--- a/.storybook/storybook-custom-theme.js
+++ b/.storybook/storybook-custom-theme.js
@@ -4,7 +4,7 @@ export default create({
   base: 'light', // needed, this is not an optional parameter
 
   colorPrimary: '#388AFF',
-  colorSecondary: 'linear-gradient(135deg, #388AFF 0%, #985FFF 100%)',
+  colorSecondary: '#388AFF',
 
   // UI
   appBg: '#F4F5F7', // background of the global app

--- a/package-lock.json
+++ b/package-lock.json
@@ -1542,6 +1542,24 @@
       "integrity": "sha512-ONhaKPIufzzrlNbqtWFFd+jlnemX6lJAgq9ZeiZtS7I1PIf/la7CW4m83rTXRnVnsMbW2k56pGYu7AUFJD9Pow==",
       "dev": true
     },
+    "@storybook/addon-centered": {
+      "version": "5.3.19",
+      "resolved": "https://registry.npmjs.org/@storybook/addon-centered/-/addon-centered-5.3.19.tgz",
+      "integrity": "sha512-uOgGF0WGM8a15ap266zplG20F79DyPvGpqzYhLXvbrOlUn+13yit3kCZpL3V5to4iQKQjpVL5wj1RJI8ar+JZw==",
+      "requires": {
+        "@storybook/addons": "5.3.19",
+        "core-js": "^3.0.1",
+        "global": "^4.3.2",
+        "util-deprecate": "^1.0.2"
+      },
+      "dependencies": {
+        "core-js": {
+          "version": "3.6.5",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.6.5.tgz",
+          "integrity": "sha512-vZVEEwZoIsI+vPEuoF9Iqf5H7/M3eeQqWlQnYa8FSKKePuYTf5MWnxb5SDAzCa60b3JBRS5g9b+Dq7b1y/RCrA=="
+        }
+      }
+    },
     "@storybook/addon-notes": {
       "version": "5.3.19",
       "resolved": "https://registry.npmjs.org/@storybook/addon-notes/-/addon-notes-5.3.19.tgz",

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "test:ember-compatibility": "ember try:each"
   },
   "dependencies": {
+    "@storybook/addon-centered": "^5.3.19",
     "@storybook/addon-notes": "^5.3.19",
     "ember-cli-babel": "^7.18.0",
     "ember-cli-htmlbars": "^4.2.3",


### PR DESCRIPTION
## :unicorn: Description
Cette PR résoud un bug introduit avec https://github.com/1024pix/pix-ui/pull/7 .
Elle permet de plus de centrer le contenu de toutes les stories.

## :rainbow: Remarques
Afin de centrer les stories nous avons installé : [l'addon centered ](https://github.com/storybookjs/storybook/tree/master/addons/centered). [Autre lien utile au sujet de cet addon avec ember.](https://github.com/storybookjs/ember-cli-storybook/issues/18) 

Pour enlever l'action de l'addon sur une story en particulier, il suffit de rajouter dans les paramètres d'une story :  ```centered: { disable: true } ```.
Ce qui donne, par exemple, dans `pix-tooltip.stories.js` : 
```javascript
// ... 
tooltip.story = {
  parameters: {
    centered: { disable: true },
    notes: {
      markdown,
    },
  },
};
```

## :100: Pour tester
Créer un composant et sa story, constater que son contenu se centre automatiquement.
