### PR TITLE
[TECH] Ajout d'un script de déploiement de storybook sur GitHub Pages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3089,6 +3089,19 @@
         }
       }
     },
+    "@storybook/storybook-deployer": {
+      "version": "2.8.6",
+      "resolved": "https://registry.npmjs.org/@storybook/storybook-deployer/-/storybook-deployer-2.8.6.tgz",
+      "integrity": "sha512-Bpe7ZtsR5NUuohK3VsQa+nxEHtVxMZZo3DRlRUZW5IZOmzmvSID3i+jkizloG9xO7sw5zUvlD31YMHm7OtdrMA==",
+      "dev": true,
+      "requires": {
+        "git-url-parse": "^11.1.2",
+        "glob": "^7.1.3",
+        "parse-repo": "^1.0.4",
+        "shelljs": "^0.8.1",
+        "yargs": "^15.0.0"
+      }
+    },
     "@storybook/theming": {
       "version": "5.3.19",
       "resolved": "https://registry.npmjs.org/@storybook/theming/-/theming-5.3.19.tgz",
@@ -14473,6 +14486,25 @@
         }
       }
     },
+    "git-up": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/git-up/-/git-up-4.0.1.tgz",
+      "integrity": "sha512-LFTZZrBlrCrGCG07/dm1aCjjpL1z9L3+5aEeI9SBhAqSc+kiA9Or1bgZhQFNppJX6h/f5McrvJt1mQXTFm6Qrw==",
+      "dev": true,
+      "requires": {
+        "is-ssh": "^1.3.0",
+        "parse-url": "^5.0.0"
+      }
+    },
+    "git-url-parse": {
+      "version": "11.1.2",
+      "resolved": "https://registry.npmjs.org/git-url-parse/-/git-url-parse-11.1.2.tgz",
+      "integrity": "sha512-gZeLVGY8QVKMIkckncX+iCq2/L8PlwncvDFKiWkBn9EtCfYDbliRTTp6qzyQ1VMdITUfq7293zDzfpjdiGASSQ==",
+      "dev": true,
+      "requires": {
+        "git-up": "^4.0.0"
+      }
+    },
     "git-write-pkt-line": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/git-write-pkt-line/-/git-write-pkt-line-0.1.0.tgz",
@@ -15813,6 +15845,15 @@
       "resolved": "https://registry.npmjs.org/is-set/-/is-set-2.0.1.tgz",
       "integrity": "sha512-eJEzOtVyenDs1TMzSQ3kU3K+E0GUS9sno+F0OBT97xsgcJsF9nXMBtkT9/kut5JEpM7oL7X/0qxR17K3mcwIAA==",
       "dev": true
+    },
+    "is-ssh": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/is-ssh/-/is-ssh-1.3.1.tgz",
+      "integrity": "sha512-0eRIASHZt1E68/ixClI8bp2YK2wmBPVWEismTs6M+M099jKgrzl/3E976zIbImSIob48N2/XGe9y7ZiYdImSlg==",
+      "dev": true,
+      "requires": {
+        "protocols": "^1.1.0"
+      }
     },
     "is-stream": {
       "version": "2.0.0",
@@ -18147,6 +18188,42 @@
       "integrity": "sha1-bVuTSkVpk7I9N/QKOC1vFmao5cY=",
       "dev": true
     },
+    "parse-path": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/parse-path/-/parse-path-4.0.1.tgz",
+      "integrity": "sha512-d7yhga0Oc+PwNXDvQ0Jv1BuWkLVPXcAoQ/WREgd6vNNoKYaW52KI+RdOFjI63wjkmps9yUE8VS4veP+AgpQ/hA==",
+      "dev": true,
+      "requires": {
+        "is-ssh": "^1.3.0",
+        "protocols": "^1.4.0"
+      }
+    },
+    "parse-repo": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/parse-repo/-/parse-repo-1.0.4.tgz",
+      "integrity": "sha1-dLkdLLhnXRG5mXagBl9s4X+hvMg=",
+      "dev": true
+    },
+    "parse-url": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/parse-url/-/parse-url-5.0.1.tgz",
+      "integrity": "sha512-flNUPP27r3vJpROi0/R3/2efgKkyXqnXwyP1KQ2U0SfFRgdizOdWfvrrvJg1LuOoxs7GQhmxJlq23IpQ/BkByg==",
+      "dev": true,
+      "requires": {
+        "is-ssh": "^1.3.0",
+        "normalize-url": "^3.3.0",
+        "parse-path": "^4.0.0",
+        "protocols": "^1.4.0"
+      },
+      "dependencies": {
+        "normalize-url": {
+          "version": "3.3.0",
+          "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-3.3.0.tgz",
+          "integrity": "sha512-U+JJi7duF1o+u2pynbp2zXDW2/PADgC30f0GsHZtRh+HOcXHnw137TrNlyxxRvWW5fjKd3bcLHPxofWuCjaeZg==",
+          "dev": true
+        }
+      }
+    },
     "parse5": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/parse5/-/parse5-5.1.0.tgz",
@@ -18731,6 +18808,12 @@
       "requires": {
         "xtend": "^4.0.0"
       }
+    },
+    "protocols": {
+      "version": "1.4.7",
+      "resolved": "https://registry.npmjs.org/protocols/-/protocols-1.4.7.tgz",
+      "integrity": "sha512-Fx65lf9/YDn3hUX08XUc0J8rSux36rEsyiv21ZGUC1mOyeM3lTRpZLcrm8aAolzS4itwVfm7TAPyxC2E5zd6xg==",
+      "dev": true
     },
     "proxy-addr": {
       "version": "2.0.6",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
   "scripts": {
     "build": "ember build --environment=production",
     "build-storybook": "ember build && build-storybook -s dist",
+    "deploy-storybook": "storybook-to-ghpages",
     "lint:hbs": "ember-template-lint .",
     "lint:js": "eslint .",
     "start": "ember serve",
@@ -47,6 +48,7 @@
     "@storybook/addons": "^5.3.19",
     "@storybook/ember": "^6.0.0-alpha.27",
     "@storybook/ember-cli-storybook": "^0.2.1",
+    "@storybook/storybook-deployer": "^2.8.6",
     "@storybook/theming": "^5.3.19",
     "babel-eslint": "^10.1.0",
     "broccoli-asset-rev": "^3.0.0",


### PR DESCRIPTION
## :unicorn: Description
Comme suggeré dans la [doc de storybook pour le déploiement](https://storybook.js.org/docs/basics/exporting-storybook/) j'ai installé [storybook-deployer](https://github.com/storybookjs/storybook-deployer).

Ce dernier permet de déployer automatiquement une version statique de storybook sur la branche `gh-pages`. 
Pour ce faire il suffit de taper : `npm run deploy-storybook` à partir de la branche qu'on souhaite voir se déployer sur `https://1024pix.github.io/pix-ui/`.

🔴  : ATTENTION `npm run deploy-storybook` add et push tout seul à votre place sur la branche `gh-pages`.
🟠  : ATTENTION il n'existe qu'une seule branche `gh-pages` , donc qu'un seul déploiement de storybook en ligne. Ce genre de déploiement devra donc s'effectuer pour les Mises En Production de pix-ui et non pas sur chacune des PR. Cela ne permet pas de faire des RA.
