### PR TITLE
[TECH] Correction de l'ordre des titres du Changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,10 @@
+# Pix-UI Changelog
 
-## v0.1.0 (03/06/2020)
 ## v0.1.1 (03/06/2020)
 
 - [#12](https://github.com/1024pix/pix-ui/pull/12) [BUGFIX] Ajustements sur le script de déploiement.
 
+## v0.1.0 (03/06/2020)
 
 - [#2](https://github.com/1024pix/pix-ui/pull/2) [FEATURE] Création d'un composant Tooltip
 - [#1](https://github.com/1024pix/pix-ui/pull/1) [FEATURE] Ajout de style commun avec sass

--- a/scripts/get-pull-requests-to-release-in-prod.js
+++ b/scripts/get-pull-requests-to-release-in-prod.js
@@ -3,20 +3,26 @@ const axios = require('axios');
 const moment = require('moment');
 const _ = require('lodash');
 const fs = require('fs');
+
 const CHANGELOG_FILE = 'CHANGELOG.md';
 const CHANGELOG_HEADER_LINES = 2;
+
 function buildRequestObject() {
   return 'https://api.github.com/repos/1024pix/pix-ui/pulls?state=closed&sort=updated&direction=desc';
 }
+
 function getTheLastCommitOnMaster() {
   return 'https://api.github.com/repos/1024pix/pix-ui/commits/master';
 }
+
 function getTheCommitDate(RawDataCommit) {
   return RawDataCommit.commit.committer.date;
 }
+
 function displayPullRequest(pr) {
   return `- [#${pr.number}](${pr.html_url}) ${pr.title}`;
 }
+
 function orderPr(listPR) {
   const typeOrder = ['FEATURE', 'QUICK WIN', 'BUGFIX', 'TECH'];
   return _.sortBy(listPR, (pr) => {
@@ -25,16 +31,20 @@ function orderPr(listPR) {
     return typeIndex < 0 ? Number.MAX_VALUE : typeIndex;
   });
 }
+
 function filterPullRequest(pullrequests, dateOfLastMEP) {
   return pullrequests.filter((PR) => PR.merged_at > dateOfLastMEP);
 }
+
 function getHeadOfChangelog(tagVersion) {
   const date = ' (' + moment().format('DD/MM/YYYY') + ')';
   return '## v' + tagVersion + date + '\n';
 }
+
 function main() {
   const tagVersion = process.argv[2];
   let dateOfLastMEP;
+
   axios(getTheLastCommitOnMaster())
     .then(({ data: lastCommit }) => {
       dateOfLastMEP = getTheCommitDate(lastCommit);
@@ -42,14 +52,18 @@ function main() {
     })
     .then(({ data: pullRequests }) => {
       const newChangeLogLines = [];
+
       newChangeLogLines.push(getHeadOfChangelog(tagVersion));
       const pullRequestsSinceLastMEP = filterPullRequest(pullRequests, dateOfLastMEP);
+
       const orderedPR = orderPr(pullRequestsSinceLastMEP);
       newChangeLogLines.push(...orderedPR.map(displayPullRequest));
       newChangeLogLines.push('');
+
       const currentChangeLog = fs.readFileSync(CHANGELOG_FILE, 'utf-8').split('\n');
+
       currentChangeLog.splice(CHANGELOG_HEADER_LINES, 0, ...newChangeLogLines);
-      console.log(`Writing to ${CHANGELOG_FILE}`);
+
       fs.writeFileSync(CHANGELOG_FILE, currentChangeLog.join('\n'));
     })
     .catch((e)=>{
@@ -57,7 +71,9 @@ function main() {
       process.exit(1);
     });
 }
+
 /*=================== tests =============================*/
+
 if (process.env.NODE_ENV !== 'test') {
   main();
 } else {

--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -108,7 +108,7 @@ ensure_new_version_is_either_minor_or_patch_or_major
 echo "== Package release =="
 checkout_dev
 fetch_and_rebase
-update_pix_ui_module_version "/tmp/pixui"
+update_pix_ui_module_version
 complete_change_log
 create_a_release_commit
 push_commit_to_remote_dev


### PR DESCRIPTION
## :unicorn: Description
Le changelog est split en un tableau avec "3 types d'éléments" : "titre", "saut de ligne", "contenu (PR ajoutées)".

L'index où on ajoutait le nouveau contenu du changelog vallait par défaut 2. 

Pour les autres app le changelog avait un titre + saut de ligne, d'où cet ajout **après les 2 premiers éléments** du changelog.

Dans le changelog de pix-ui nous n'avions pas rajouté de titre. 

2 solutions : 
- ajouter un titre
- ou mettre par défaut l'ajout des nouveaux éléments à l'index 0

J'ai choisis la première solution car elle + iso aux autres app.
