### PR TITLE
[FEATURE] Ajout du composant PixTag

### DIFF
--- a/addon/components/pix-tag.hbs
+++ b/addon/components/pix-tag.hbs
@@ -1,0 +1,3 @@
+<div class="pix-tag {{concat "pix-tag--" @color}}" ...attributes>
+  {{yield}}
+</div>

--- a/addon/stories/pix-tag.stories.js
+++ b/addon/stories/pix-tag.stories.js
@@ -1,0 +1,72 @@
+import { hbs } from 'ember-cli-htmlbars';
+
+export default { title: 'Chips' };
+
+const canvasContent = hbs`
+<h3>Classic colors</h3>
+
+<PixTag>
+  This is a blue tag
+</PixTag>
+
+<PixTag @color='purple'>
+  This is a purple tag
+</PixTag>
+
+<PixTag @color='green'>
+  This is a green tag
+</PixTag>
+
+<br><br>
+<h3>Light colors</h3>
+
+<PixTag @color='blue-light'>
+  This is a blue tag
+</PixTag>
+
+<PixTag @color='purple-light'>
+  This is a purple tag
+</PixTag>
+
+<PixTag @color='green-light'>
+  This is a green tag
+</PixTag>
+`;
+
+const markdown = `
+# Tag
+
+Un \`Tag\` est un type de \`Chips\` qui permet de mettre en avant une information ou bien de la catégoriser.
+
+> Il est possible de surcharger le style d'un \`<PixTag>\` via l'attribut \`class\` ainsi que de passer n'importe quel attribut sur sa \`div\` wrapper (par exemple, un \`aria-label\`)
+
+## Usage
+
+~~~javascript
+<PixTag @color='Couleur du tag' aria-label="mon tag">
+  // ici ajouter le contenu du tag
+</PixTag>
+~~~
+
+## Props
+
+| Nom           | Type          | Valeurs possibles     | Par défaut | Optionnel |
+| ------------- |:-------------:|:---------------------:|:----------:|----------:|
+| color         | string        | blue, blue-light, purple, purple-light, green, green-light   | blue       | oui       |
+`
+;
+
+export const tag = () => {
+  return {
+    template: canvasContent,
+  }
+};
+
+tag.story = {
+  parameters: {
+    notes: {
+      markdown,
+    },
+  },
+};
+

--- a/addon/styles/_pix-tag.scss
+++ b/addon/styles/_pix-tag.scss
@@ -1,0 +1,42 @@
+.pix-tag {
+  display: inline-block;
+  box-sizing: border-box;
+  text-align: center;
+  vertical-align: baseline;
+  white-space: nowrap;
+  line-height: 1.25rem;
+  padding: 0 8px;
+  
+  font-family: $font-roboto;
+  font-size: 0.8125rem;
+  font-weight: $font-normal;
+
+  border: 1px solid transparent;
+  border-radius: 0.75rem;
+
+  color: $white;
+  background-color: $blue;
+
+  &--blue-light {
+    color: darken($blue, 10%);
+    background-color: lighten($blue, 30%);
+  }
+
+  &--green {
+    background-color: $dark-green-certif;
+  }
+
+  &--green-light {
+    color: darken($dark-green-certif, 10%);
+    background-color: lighten($dark-green-certif, 60%);
+  }
+
+  &--purple {
+    background-color: $purple;
+  }
+
+  &--purple-light {
+    color: darken($purple, 10%);
+    background-color: lighten($purple, 30%);
+  }
+}

--- a/addon/styles/addon.scss
+++ b/addon/styles/addon.scss
@@ -1,6 +1,7 @@
 @import 'colors';
 @import 'fonts';
 @import 'pix-tooltip';
+@import 'pix-tag';
 
 html {
   font-size: 16px;

--- a/app/components/pix-tag.js
+++ b/app/components/pix-tag.js
@@ -1,0 +1,1 @@
+export { default } from 'pix-ui/components/pix-tag';

--- a/tests/integration/components/pix-tag-test.js
+++ b/tests/integration/components/pix-tag-test.js
@@ -1,0 +1,28 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+
+module('Integration | Component | pix-tag', function(hooks) {
+  setupRenderingTest(hooks);
+
+  test('it renders the given content', async function(assert) {
+    await render(hbs`<PixTag>tag text</PixTag>`);
+
+    assert.equal(this.element.textContent.trim(), 'tag text');
+  });
+
+  test('it renders with the given color class', async function(assert) {
+    await render(hbs`<PixTag @color="purple" />`);
+
+    const pixTagElement = this.element.querySelector('.pix-tag');
+    assert.equal(pixTagElement.classList.toString(), 'pix-tag pix-tag--purple');
+  });
+
+  test('it renders with attributes override', async function(assert) {
+    await render(hbs`<PixTag @color="blue" aria-label="world" />`);
+
+    const pixTagElement = this.element.querySelector('.pix-tag');
+    assert.equal(pixTagElement.getAttribute('aria-label'), 'world');
+  });
+});


### PR DESCRIPTION
## :unicorn: Description du composant

Un Tag est un type de componsant Chips qui permet de mettre en avant une information ou bien de la catégoriser.

> Il est possible de surcharger le style d'un \`<PixTag>\` via l'attribut \`class\` ainsi que de passer n'importe quel attribut sur sa \`div\` wrapper (par exemple, un \`aria-label\`)

Exemple d'utilisation dans Pix-Orga:
![image](https://user-images.githubusercontent.com/516360/84274276-f62a4780-ab2f-11ea-9093-f5e433dd63b7.png)

## :rainbow: Remarques
Le Tag est un sous composant de la catégorie Chips (voir design-system)
https://app.abstract.com/projects/ff1da878-3f3a-4299-9c47-fad5841962f7/branches/master/commits/b6449eab7c983990a561c4eb2dbfd07f8ccec23d/files/DD03E7C8-8D2E-487B-A863-74B75273DC80/layers/BF78658E-35AF-4765-A78A-588A3311B92F?mode=build&selected=root-BF78658E-35AF-4765-A78A-588A3311B92F

Pour le moment, ce composant a été déclinée uniquement en 3 couleurs (dont 2 utilisées actuellement dans pix-orga)

## :100: Pour tester
> _Lien vers Zeroheight (modèle) et Storybook (rendu final)._

Validé avec @QuentinChapelain-ui sur la base du design system en cours

