### PR TITLE
[FEATURE] Ajout d'un PixBackgroundBlue & PixBlocShadow

### DIFF
--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -1,10 +1,8 @@
-import { addParameters, addDecorator } from '@storybook/ember';
+import { addParameters } from '@storybook/ember';
 import storybookCustomTheme from './storybook-custom-theme';
-import centered from '@storybook/addon-centered/ember';
 
 addParameters({
   options: {
     theme: storybookCustomTheme,
   },
 });
-addDecorator(centered);

--- a/addon/components/pix-background-header.hbs
+++ b/addon/components/pix-background-header.hbs
@@ -1,0 +1,7 @@
+<div class="pix-background-header" ...attributes>
+
+  <div class="pix-background-header__background"></div>
+
+  {{yield}}
+
+</div>

--- a/addon/components/pix-background-header.js
+++ b/addon/components/pix-background-header.js
@@ -1,0 +1,5 @@
+import Component from '@glimmer/component';
+
+export default class PixBackgroundHeaderComponent extends Component {
+  text = 'pix-background-header';
+}

--- a/addon/components/pix-block.hbs
+++ b/addon/components/pix-block.hbs
@@ -1,0 +1,5 @@
+<div class="pix-block {{concat "pix-block--shadow-" this.getShadowWeight}}" ...attributes>
+
+  {{yield}}
+
+</div>

--- a/addon/components/pix-block.js
+++ b/addon/components/pix-block.js
@@ -1,0 +1,11 @@
+import Component from '@glimmer/component';
+
+export default class PixBlockComponent extends Component {
+  text = 'pix-block';
+
+  get getShadowWeight() {
+    const shadowParam = this.args.shadow;
+    const correctsWeight = ['light', 'heavy'];
+    return correctsWeight.includes(shadowParam) ? shadowParam : 'light';
+  }
+}

--- a/addon/stories/pix-background-header.stories.js
+++ b/addon/stories/pix-background-header.stories.js
@@ -1,0 +1,66 @@
+import { hbs } from 'ember-cli-htmlbars';
+
+export default { title: 'BackroundHeader' };
+
+const canvasContent = hbs`
+<PixBackgroundHeader @background-color='pink'>
+
+  <PixBlock>Un panel avec du text</PixBlock>
+
+  <PixBlock> 
+    Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis a interdum mauris. Morbi ac diam varius, maximus massa id, venenatis lectus. Fusce interdum tincidunt mattis. Nullam porta sollicitudin lorem, sodales cursus arcu finibus in. Nam pretium congue diam sollicitudin faucibus. Aliquam nec augue massa. Pellentesque eleifend nec arcu eu tincidunt. Pellentesque at quam dignissim, lacinia sem et, pharetra magna. Etiam venenatis felis augue, id sollicitudin sapien interdum at. Cras bibendum fermentum eros, rutrum varius turpis venenatis vitae. Suspendisse aliquet iaculis sem in blandit. Mauris vitae erat lobortis est volutpat bibendum non molestie purus.
+    Orci varius natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Sed consequat porttitor metus a imperdiet. Duis quis enim fermentum, sodales massa sit amet, blandit elit. Aliquam felis purus, dictum sed pretium vel, aliquam sit amet felis. Nunc convallis pellentesque convallis. Suspendisse potenti. Aenean iaculis, nunc placerat aliquam posuere, tellus enim facilisis metus, non egestas sapien arcu et leo.
+  </PixBlock>
+
+</PixBackgroundHeader>
+`;
+
+const markdown = `
+# BackroundHeader
+
+Un \`BackroundHeader\` est une bannière donnant un fond de couleur bleu en haut d'une page.
+Les enfants de la bannière se mettrons en colonne.
+
+> Pour le moment ce composant n'est pas paramétrable car nous n'avons pas d'autres types de bannières.
+
+> Le \`BackroundHeader\` se couple bien avec un ou plusieurs \`PixBlock\`.
+
+## Usage
+
+~~~javascript
+<PixBackgroundHeader>
+  // ici le contenu que vous souhaitez
+</PixBackgroundHeader>
+~~~
+
+Souvent utilisé avec la PixBlock :
+
+~~~javascript
+<PixBackgroundHeader>
+  <PixBlock>
+    // ce que je veux dans mon premier panel
+  </PixBlock>
+
+  // un deuxième panel ou autre chose...
+</PixBackgroundHeader>
+~~~
+
+## Props
+
+Aucune props pour le moment.
+`
+;
+
+export const backgroundHeader = () => {
+  return {
+    template: canvasContent,
+  }
+};
+
+backgroundHeader.story = {
+  parameters: {
+    notes: {
+      markdown,
+    },
+  }
+};

--- a/addon/stories/pix-block.stories.js
+++ b/addon/stories/pix-block.stories.js
@@ -1,0 +1,61 @@
+import { hbs } from 'ember-cli-htmlbars';
+
+export default { title: 'Block' };
+
+const canvasContent = hbs`
+<div style='background-color: #F4F5F7; padding: 30px;'>
+
+  <PixBlock @shadow='heavy'>
+    <div> Un bloc avec une ombre forte </div>
+  </PixBlock>
+
+  <PixBlock @shadow='light'> 
+    <div> Un bloc avec une ombre faible </div>
+  </PixBlock>
+
+</div>
+`;
+
+const markdown = `
+# Block
+
+Un \`Block\` est un bloc de fond blanc dont les bords sont arrondis et ayant une ombre projetée.
+
+> Les marges intérieures du bloc sont de 14px (haut et bas) et 24px (droite et gauche), sauf pour la version mobile où c'est 16px (partout).
+
+> Un \`Block\` prendra toute la largeur de son parent, dans la limite maximale de 980px.
+
+> Donnez donc un parent de la taille que vous souhaitez, votre bloc prendra la même taille.
+
+## Usage
+
+~~~javascript
+<PixBlock @shadow='heavy'>
+  // ici le contenu que vous souhaitez
+</PixBlock>
+~~~
+
+Il est souvent utilisé dans le PixBackgroundHeader.
+
+## Props
+
+| Nom           | Type          |  Valeurs possibles  | Par défaut | Optionnel |
+| ------------- |:-------------:|:-------------------:|:----------:|----------:|
+| shadow        | string        | ["light", "heavy"]  |  "light"   | oui       |
+
+`
+;
+
+export const block = () => {
+  return {
+    template: canvasContent,
+  }
+};
+
+block.story = {
+  parameters: {
+    notes: {
+      markdown,
+    },
+  }
+};

--- a/addon/stories/pix-message.stories.js
+++ b/addon/stories/pix-message.stories.js
@@ -1,4 +1,5 @@
 import { hbs } from 'ember-cli-htmlbars';
+import centered from '@storybook/addon-centered/ember';
 
 export default { title: 'Message' };
 
@@ -59,4 +60,5 @@ message.story = {
       markdown,
     },
   },
+  decorators: [centered],
 };

--- a/addon/stories/pix-tag.stories.js
+++ b/addon/stories/pix-tag.stories.js
@@ -1,4 +1,5 @@
 import { hbs } from 'ember-cli-htmlbars';
+import centered from '@storybook/addon-centered/ember';
 
 export default { title: 'Chips' };
 
@@ -68,5 +69,6 @@ tag.story = {
       markdown,
     },
   },
+  decorators: [centered],
 };
 

--- a/addon/stories/pix-tooltip.stories.js
+++ b/addon/stories/pix-tooltip.stories.js
@@ -1,4 +1,5 @@
 import { hbs } from 'ember-cli-htmlbars';
+import centered from '@storybook/addon-centered/ember';
 
 export default { title: 'Tooltip' };
 
@@ -83,4 +84,5 @@ tooltip.story = {
       markdown,
     },
   },
+  decorators: [centered],
 };

--- a/addon/styles/_breakpoints.scss
+++ b/addon/styles/_breakpoints.scss
@@ -1,0 +1,17 @@
+$breakpoints: (
+  'mobile': (max-width: 767px),
+  'tablet': (min-width: 768px),
+  'desktop': (min-width: 980px),
+  'large-screen': (min-width: 1261px),
+) !default;
+
+@mixin device-is($breakpoint) {
+  @if map-has-key($breakpoints, $breakpoint) {
+    @media #{inspect(map-get($breakpoints, $breakpoint))} {
+      @content;
+    }
+  } @else {
+    @warn "Unfortunately, no value could be retrieved from `#{$breakpoint}`. "
+        + "Available breakpoints are: #{map-keys($breakpoints)}.";
+  }
+}

--- a/addon/styles/_colors.scss
+++ b/addon/styles/_colors.scss
@@ -45,6 +45,7 @@ $grey-70: #344563;
 $grey-80: #253858;
 $grey-90: #172B4D;
 $grey-100: #091E42;
+$grey-150: #0C163A;
 $grey-200: #07142E;
 // gradients domain
 $information-gradient: linear-gradient(180deg, #F24645 0%, #F1A141 100%);

--- a/addon/styles/_pix-background-header.scss
+++ b/addon/styles/_pix-background-header.scss
@@ -1,0 +1,18 @@
+.pix-background-header {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: 0 24px;
+
+  &__background {
+    position: absolute;
+    top: 0; left: 0;
+    z-index: -1;
+    width: 100%;
+    min-height: 270px;
+    background: $pix-gradient;
+    box-shadow: 0 2px 8px 0 rgba(0, 0, 0, 0.1);
+    color: $white;
+  }
+}

--- a/addon/styles/_pix-block.scss
+++ b/addon/styles/_pix-block.scss
@@ -1,0 +1,30 @@
+.pix-block {
+  position: relative;
+  box-sizing: border-box;
+  width: 100%;
+  max-width: 980px;
+  padding: 14px 24px;
+  margin-bottom: 32px;
+  background-color: $white;
+  border-radius: 5px;
+  
+  &--shadow-light {
+    box-shadow: 0 10px 20px 0 rgba($blue, .06);
+  }
+  &--shadow-heavy {
+    box-shadow: 0 50px 54px -40px rgba($grey-200, .4),
+                0 7px 14px 0 rgba($grey-150, .1);
+  }
+}
+
+.pix-background-header {
+  &__background + .pix-block {
+    margin-top: 68px;
+  }
+}
+
+@include device-is('mobile') {
+  .pix-block {
+    padding: 16px;
+  }
+}

--- a/addon/styles/addon.scss
+++ b/addon/styles/addon.scss
@@ -1,3 +1,4 @@
+@import 'breakpoints';
 @import 'colors';
 @import 'fonts';
 @import 'pix-tooltip';

--- a/addon/styles/addon.scss
+++ b/addon/styles/addon.scss
@@ -2,6 +2,7 @@
 @import 'colors';
 @import 'fonts';
 @import 'pix-background-header';
+@import 'pix-block';
 @import 'pix-tooltip';
 @import 'pix-tag';
 @import 'pix-message';

--- a/addon/styles/addon.scss
+++ b/addon/styles/addon.scss
@@ -1,6 +1,7 @@
 @import 'breakpoints';
 @import 'colors';
 @import 'fonts';
+@import 'pix-background-header';
 @import 'pix-tooltip';
 @import 'pix-tag';
 @import 'pix-message';

--- a/app/components/pix-background-header.js
+++ b/app/components/pix-background-header.js
@@ -1,0 +1,1 @@
+export { default } from 'pix-ui/components/pix-background-header';

--- a/app/components/pix-block.js
+++ b/app/components/pix-block.js
@@ -1,0 +1,1 @@
+export { default } from 'pix-ui/components/pix-block';

--- a/tests/integration/components/pix-background-header-test.js
+++ b/tests/integration/components/pix-background-header-test.js
@@ -1,0 +1,51 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+
+module('Integration | Component | pix-background-header', function(hooks) {
+  setupRenderingTest(hooks);
+
+  const BACKGROUND_HEADER_SELECTOR = '.pix-background-header';
+  const BACKGROUND_SELECTOR = `${BACKGROUND_HEADER_SELECTOR} .pix-background-header__background`;
+
+  test('it renders the default PixBackgroundHeader', async function(assert) {
+    // when
+    await render(hbs`
+      <PixBackgroundHeader>
+        Je suis un beau background bleu
+      </PixBackgroundHeader>
+    `);
+    const backgroundHeaderElement = this.element.querySelector(BACKGROUND_HEADER_SELECTOR);
+    const backgroundElement = this.element.querySelector(BACKGROUND_SELECTOR);
+
+    // then
+    assert.equal(backgroundHeaderElement.textContent.trim(), 'Je suis un beau background bleu');
+    assert.equal(backgroundHeaderElement.className, 'pix-background-header');
+    assert.equal(backgroundElement.className, 'pix-background-header__background');
+  });
+
+  module('when there is PixBloc inside PixBackgroundHeader component', function() {
+
+    test('first PixBlock render', async function(assert) {
+      // given
+      this.set('shadowWeight', 'heavy');
+
+      // when
+      await render(hbs`
+        <PixBackgroundHeader>
+          <PixBlock @shadow={{this.shadowWeight}}>Je suis un beau bloc foncé</PixBlock>
+          <PixBlock>Je suis deuxième bloc</PixBlock>
+        </PixBackgroundHeader>
+      `);
+      const firstBlockElement = this.element.querySelector(BACKGROUND_HEADER_SELECTOR).children[1];
+      const lastBlockElement = this.element.querySelector(BACKGROUND_HEADER_SELECTOR).children[2];
+
+      // then
+      assert.equal(firstBlockElement.className, 'pix-block pix-block--shadow-heavy');
+      assert.equal(firstBlockElement.textContent.trim(), 'Je suis un beau bloc foncé');
+      assert.equal(lastBlockElement.className, 'pix-block pix-block--shadow-light');
+      assert.equal(lastBlockElement.textContent.trim(), 'Je suis deuxième bloc');
+    });
+  });
+});

--- a/tests/integration/components/pix-block-test.js
+++ b/tests/integration/components/pix-block-test.js
@@ -1,0 +1,58 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+
+module('Integration | Component | pix-block', function(hooks) {
+  setupRenderingTest(hooks);
+
+  const BLOCK_SELECTOR = '.pix-block';
+
+  test('it renders the default PixBlock', async function(assert) {
+    // when
+    await render(hbs`
+      <PixBlock>
+        Je suis un beau bloc avec une ombre légere
+      </PixBlock>
+    `);
+    const blockElement = this.element.querySelector(BLOCK_SELECTOR);
+
+    // then
+    assert.equal(blockElement.textContent.trim(), 'Je suis un beau bloc avec une ombre légere');
+    assert.equal(blockElement.className, 'pix-block pix-block--shadow-light');
+  });
+
+  test('it can have heavy shadow', async function(assert) {
+    // given
+    this.set('shadowWeight', 'heavy');
+
+    // when
+    await render(hbs`
+      <PixBlock @shadow={{this.shadowWeight}}>
+        Je suis trop d4rk
+      </PixBlock>
+    `);
+    const blockElement = this.element.querySelector(BLOCK_SELECTOR);
+
+    // then
+    assert.equal(blockElement.textContent.trim(), 'Je suis trop d4rk');
+    assert.equal(blockElement.className, 'pix-block pix-block--shadow-heavy');
+  });
+
+  test('it give light bloc even if there is wrong parameters', async function(assert) {
+    // given
+    this.set('shadowWeight', 'normal');
+
+    // when
+    await render(hbs`
+      <PixBlock @shadow={{this.shadowWeight}}>
+        Joli bloc quand même
+      </PixBlock>
+    `);
+    const blockElement = this.element.querySelector(BLOCK_SELECTOR);
+
+    // then
+    assert.equal(blockElement.textContent.trim(), 'Joli bloc quand même');
+    assert.equal(blockElement.className, 'pix-block pix-block--shadow-light');
+  });
+});


### PR DESCRIPTION
## :unicorn: Description du composant
Dans le contexte du [design du nouveau certificat](https://github.com/1024pix/pix/pull/1577) j'en profite pour rajouter ces deux composants à Pix UI : 
- PixBackgroundBlue : la bande bleu en haut de page sur mon-pix
- PixBlocShadow : un bloc blanc avec les bords arrondis

En somme ces deux composants imbriqué, permettent de faire ceci : 
<img width="969" alt="image" src="https://user-images.githubusercontent.com/38167520/85160921-5a02ed80-b25f-11ea-91df-07a09bcbfd88.png">


## :rainbow: Remarques
Les deux composants sont responsives (ensemble et séparément). Leur modèles (version certificat) sont présents sur ce lien : https://app.abstract.com/projects/3e4937ef-48a8-408b-9edd-1f69dab81b39/branches/288b95d2-6697-44a9-a4ba-2339a4480aad/collections/4ea4253d-5685-4ffc-afaa-632e144ec8f4

## :100: Pour tester
- `npm i`
- `npm run storybook` 😉