### PR TITLE
[TECH] Ajout d'un reset CSS

### DIFF
--- a/addon/styles/_pix-message.scss
+++ b/addon/styles/_pix-message.scss
@@ -1,4 +1,6 @@
 .pix-message {
+  @import 'reset-css';
+
   position: relative;
   margin: 0 0 1rem 0;
   padding: 1rem;

--- a/addon/styles/_pix-tag.scss
+++ b/addon/styles/_pix-tag.scss
@@ -1,4 +1,6 @@
 .pix-tag {
+  @import 'reset-css';
+
   display: inline-block;
   box-sizing: border-box;
   text-align: center;

--- a/addon/styles/_pix-tooltip.scss
+++ b/addon/styles/_pix-tooltip.scss
@@ -1,4 +1,6 @@
 .pix-tooltip {
+  @import 'reset-css';
+
   position: relative;
   display: flex;
   justify-content: center;

--- a/addon/styles/_reset-css.scss
+++ b/addon/styles/_reset-css.scss
@@ -1,0 +1,42 @@
+ul, ol, li, form, fieldset, legend
+{
+	margin: 0;
+	padding: 0;
+}
+
+h1, h2, h3, h4, h5, h6, p { margin-top: 0; }
+
+fieldset,img { border: 0; }
+
+legend { color: #000; }
+
+li { list-style: none; }
+
+sup { vertical-align: text-top; }
+
+sub { vertical-align: text-bottom; }
+
+table
+{
+	border-collapse: collapse;
+	border-spacing: 0;
+}
+
+caption, th, td
+{
+	text-align: left;
+	vertical-align: top;
+	font-weight: normal;
+}
+
+input, textarea, select
+{
+	font-size: 110%;
+	line-height: 1.1;
+}
+
+abbr, acronym
+{
+	border-bottom: .1em dotted;
+	cursor: help;
+}


### PR DESCRIPTION
## :unicorn: Description
Certains éléments ne s'affichent pas pareil d'un navigateur à l'autre. 
L'avantage d'un reset CSS est de minimiser ces écarts, et donc moins de soucis de css venant des navigateurs.

[Un peu plus d'explication sur les reset CSS ici.](https://www.alsacreations.com/astuce/lire/36-reset-css.html)

Le reset CSS qu'on a choisis de mettre en place est le suivant : http://maxdesign.com.au/articles/css-reset/. 
Si vous avez d'autres propositions avis n'hésitez pas :) 

## 💯 Solution
Ajouter un fichier reset CSS préfixé par "_" et l'inclure dans chacun de nos composants.
**ATTENTION** : cela implique d'ajouter le reset css dans la classe parent de chaque composant  : 
```scss 
.pix-nom-du-composant {
  @import 'reset-css';

   // le style que je veux ensuite
}
```


## Soucis initial
Avec @D0C702WH0 on était tombé sur des différences d'affichage entre navigateurs lors de [l'implémentation du nouveau macaron du certificat Pix](https://github.com/1024pix/pix/pull/1509). Les dimensions de la même div donnait :  
- Sans le reset CSS : Firefox : 70x**94** VS Chrome : 70x**91**
- Avec le reset CSS : Firefox : 70x**92.5** VS Chrome : 70x**91**

