### PR TITLE
[TECH] Changer le port de l'app Ember Pix UI

### DIFF
--- a/.ember-cli
+++ b/.ember-cli
@@ -5,5 +5,6 @@
 
     Setting `disableAnalytics` to true will prevent any data from being sent.
   */
+  "port": 4204,
   "disableAnalytics": false
 }


### PR DESCRIPTION
## :unicorn: Description du composant
L'app tournait sur le port 4200 (qui est le même que mon-pix). Ce n'est pas pratique lorsqu'on souhaite faire tourner les deux app en parallèle.
Je propose donc de changer ce port pour le 4204 (à la suite de certif qui est le 4203).

## :rainbow: Remarques
https://guides.emberjs.com/release/configuring-ember/configuring-ember-cli/

## :100: Pour tester
- `npm start` > vérifier que le port est bien 4204
- aller sur `localhost:4204/tests` par exemple
