### PR TITLE
[TECH] Correction des warnings de storybook

### DIFF
--- a/.storybook/manager.js
+++ b/.storybook/manager.js
@@ -1,0 +1,6 @@
+import addons from '@storybook/addons';
+import storybookCustomTheme from './storybook-custom-theme';
+
+addons.setConfig({
+  theme: storybookCustomTheme,
+});

--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -1,10 +1,10 @@
 import { addParameters, addDecorator } from '@storybook/ember';
 import storybookCustomTheme from './storybook-custom-theme';
-import { checkA11y } from '@storybook/addon-a11y';
+import { withA11y } from '@storybook/addon-a11y';
 
 addParameters({
   options: {
     theme: storybookCustomTheme,
   },
 });
-addDecorator(checkA11y);
+addDecorator(withA11y);

--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -1,10 +1,4 @@
-import { addParameters, addDecorator } from '@storybook/ember';
-import storybookCustomTheme from './storybook-custom-theme';
+import { addDecorator } from '@storybook/ember';
 import { withA11y } from '@storybook/addon-a11y';
 
-addParameters({
-  options: {
-    theme: storybookCustomTheme,
-  },
-});
 addDecorator(withA11y);

--- a/addon/stories/pix-background-header.stories.js
+++ b/addon/stories/pix-background-header.stories.js
@@ -57,10 +57,4 @@ export const backgroundHeader = () => {
   }
 };
 
-backgroundHeader.story = {
-  parameters: {
-    notes: {
-      markdown,
-    },
-  }
-};
+backgroundHeader.parameters = { notes: { markdown } };

--- a/addon/stories/pix-background-header.stories.js
+++ b/addon/stories/pix-background-header.stories.js
@@ -1,6 +1,6 @@
 import { hbs } from 'ember-cli-htmlbars';
 
-export default { title: 'BackgroundHeader' };
+export default { title: 'Layout/BackgroundHeader' };
 
 const canvasContent = hbs`
 <PixBackgroundHeader @background-color='pink'>
@@ -57,4 +57,5 @@ export const backgroundHeader = () => {
   }
 };
 
+backgroundHeader.storyName = "Background Header";
 backgroundHeader.parameters = { notes: { markdown } };

--- a/addon/stories/pix-block.stories.js
+++ b/addon/stories/pix-block.stories.js
@@ -1,6 +1,6 @@
 import { hbs } from 'ember-cli-htmlbars';
 
-export default { title: 'Block' };
+export default { title: 'Layout/Block' };
 
 const canvasContent = hbs`
 <div style='background-color: #F4F5F7; padding: 30px;'>

--- a/addon/stories/pix-block.stories.js
+++ b/addon/stories/pix-block.stories.js
@@ -52,10 +52,4 @@ export const block = () => {
   }
 };
 
-block.story = {
-  parameters: {
-    notes: {
-      markdown,
-    },
-  }
-};
+block.parameters = { notes: { markdown } };

--- a/addon/stories/pix-link-back.stories.js
+++ b/addon/stories/pix-link-back.stories.js
@@ -77,11 +77,5 @@ export const returnTo = () => {
   }
 };
 
-returnTo.story = {
-  parameters: {
-    notes: {
-      markdown,
-    },
-  },
-  decorators: [centered],
-};
+returnTo.parameters = { notes: { markdown } };
+returnTo.decorators = [centered];

--- a/addon/stories/pix-message.stories.js
+++ b/addon/stories/pix-message.stories.js
@@ -54,11 +54,5 @@ export const message = () => {
   }
 };
 
-message.story = {
-  parameters: {
-    notes: {
-      markdown,
-    },
-  },
-  decorators: [centered],
-};
+message.parameters = { notes: { markdown } };
+message.decorators = [centered];

--- a/addon/stories/pix-tag.stories.js
+++ b/addon/stories/pix-tag.stories.js
@@ -63,12 +63,5 @@ export const tag = () => {
   }
 };
 
-tag.story = {
-  parameters: {
-    notes: {
-      markdown,
-    },
-  },
-  decorators: [centered],
-};
-
+tag.parameters = { notes: { markdown } };
+tag.decorators = [centered];

--- a/addon/stories/pix-tooltip.stories.js
+++ b/addon/stories/pix-tooltip.stories.js
@@ -78,11 +78,5 @@ export const tooltip = () => {
   }
 };
 
-tooltip.story = {
-  parameters: {
-    notes: {
-      markdown,
-    },
-  },
-  decorators: [centered],
-};
+tooltip.parameters = { notes: { markdown } };
+tooltip.decorators = [centered];

--- a/addon/styles/_pix-background-header.scss
+++ b/addon/styles/_pix-background-header.scss
@@ -1,4 +1,6 @@
 .pix-background-header {
+  @import 'reset-css';
+
   position: relative;
   display: flex;
   flex-direction: column;

--- a/addon/styles/_pix-return-to.scss
+++ b/addon/styles/_pix-return-to.scss
@@ -1,4 +1,6 @@
 .pix-return-to {
+  @import 'reset-css';
+
   font-size: 0.813rem;
   font-weight: $font-semi-bold;
   letter-spacing: 0.019rem;


### PR DESCRIPTION
## :unicorn: Description
+ Petites corrections de quelques warnings que lançait storybook : 
<img width="1143" alt="image" src="https://user-images.githubusercontent.com/38167520/88271514-8931d200-ccd7-11ea-81d4-bc117a722123.png">

+ création d'une section "Layout" dans le menu de storybook pour les composants BackgroundHeader & Block
+ rajout du reset.css là où il manquait

## :100: Pour tester
- npm run storybook
- ouvrir la console (fn + F12) : checker qu'il n'y a plus de warnings
