### PR TITLE
[FEATURE] Add support for ember app internal links in PixBanner (PIX-1085).

### DIFF
--- a/addon/components/pix-banner.hbs
+++ b/addon/components/pix-banner.hbs
@@ -1,5 +1,5 @@
 <div class="pix-banner" ...attributes>
-  {{yield}}
+  <div class="pix-banner__content">{{yield}}</div>
   {{#if this.displayAction}}
     {{#if this.isExternalLink}}
       <a class="pix-banner__action" href={{@actionUrl}}>{{@actionLabel}}</a>

--- a/addon/components/pix-banner.hbs
+++ b/addon/components/pix-banner.hbs
@@ -1,6 +1,10 @@
 <div class="pix-banner" ...attributes>
   {{yield}}
   {{#if this.displayAction}}
-    <a class="pix-banner__action" href={{@actionUrl}}>{{@actionLabel}}</a>
+    {{#if this.isExternalLink}}
+      <a class="pix-banner__action" href={{@actionUrl}}>{{@actionLabel}}</a>
+    {{else}}
+      <LinkTo class="pix-banner__action" @route={{@actionUrl}}>{{@actionLabel}}</LinkTo>
+    {{/if}}
   {{/if}}
 </div>

--- a/addon/components/pix-banner.js
+++ b/addon/components/pix-banner.js
@@ -4,4 +4,8 @@ export default class PixBannerComponent extends Component {
   get displayAction() {
     return this.args.actionLabel && this.args.actionUrl;
   }
+
+  get isExternalLink() {
+    return this.args.actionUrl.includes('/')
+  }
 }

--- a/addon/stories/pix-banner.stories.js
+++ b/addon/stories/pix-banner.stories.js
@@ -8,12 +8,19 @@ const canvasContent = hbs`
   Bienvenue sur PixOrga !
 </PixBanner>
 
-<h3>Message important avec action</h3>
+<h3>Message important avec lien externe</h3>
 <PixBanner
   @actionLabel='Ajouter des élèves'
   @actionUrl='https://orga.pix.fr/eleves'
 >
   La liste des élèves est vide, ajouter des élèves pour commencer
+</PixBanner>
+<h3>Message important avec lien-interne</h3>
+<PixBanner
+  @actionLabel='Liste des campagnes'
+  @actionUrl='authenticated.campaigns'
+>
+  Parcours de rentrée 2020 : les codes sont disponibles dans l'onglet campagne. N’oubliez pas de les diffuser aux élèves avant la Toussaint.
 </PixBanner>
 `;
 

--- a/addon/styles/_pix-banner.scss
+++ b/addon/styles/_pix-banner.scss
@@ -7,6 +7,9 @@
   background-color: $dark-orga;
   color: $white;
   font-size: 0.875rem;
+  display: flex;
+  flex-direction: row;
+  align-items: center;
 
   &__action {
     color: $white;
@@ -17,6 +20,7 @@
     margin-left: 18px;
     letter-spacing: 0.028rem;
     transition: background-color 0.3s ease-out;
+    min-width: fit-content;
 
     &:hover {
       background-color: rgba($grey-70, 0.3);
@@ -29,6 +33,19 @@
     &:focus {
       background-color: $yellow;
       color: $grey-90;
+    }
+
+  }
+}
+
+@include device-is('mobile') {
+  .pix-banner {
+    flex-direction: column;
+    align-items: flex-start;
+
+    &__action {
+      margin-left: 0;
+      margin-top: 16px;
     }
   }
 }


### PR DESCRIPTION
## :unicorn: Description du composant
PixBanner crée systématiquement des liens externes à partir de la propriété actionUrl. Le composant ne supporte pas de route ember en entrée (ex: authenticated.sco-students). 

## :rainbow: Remarques
On cherche dans actionUrl un slash pour vérifier si c'est un lien externe ou interne.

## :100: Pour tester
Il n'y a pas de routeur dans storybook pour tester il faut prendre le hash du commit et installer la version de cette branche dans PixOrga.

```sh
npm install git://github.com/1024pix/pix-ui.git#3cf42e16ccabc7b12b5998c3c14d960d4d5248ae
```

Se connecter avec le compte sco et mettre une route en paramètre de PixBanner et constater que en cliquant sur le bouton on est bien redirigé vers la route en question.
