### PR TITLE
[TECH] Eviter de jouer circle-ci sur la branche gh-pages

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,6 +8,10 @@ workflows:
 
 jobs:
   build-and-test:
+    filters:
+      branches:
+        ignore:
+          - gh-pages
     docker:
       - image: circleci/node:12.14.0-browsers
     steps:


### PR DESCRIPTION
## :unicorn: Description du composant
Le build circle-ci échoue sur la branche gh-pages de pix-ui car sa config n'est pas présente.

## :rainbow: Remarques
Eviter de jouer circle-ci sur la branche gh-pages.
