### PR TITLE
[FEATURE] Créer le composant PixActionButton

### DIFF
--- a/addon/components/pix-action-button.hbs
+++ b/addon/components/pix-action-button.hbs
@@ -1,3 +1,3 @@
-<button type="button" class="pix-action-button" ...attributes>
+<button type="button" class="pix-action-button" {{on "click" this.triggerAction}} ...attributes>
   <FaIcon @icon={{this.icon}} />
 </button>

--- a/addon/components/pix-action-button.hbs
+++ b/addon/components/pix-action-button.hbs
@@ -1,0 +1,3 @@
+<button type="button" class="pix-action-button" ...attributes>
+  <FaIcon @icon="plus" />
+</button>

--- a/addon/components/pix-action-button.hbs
+++ b/addon/components/pix-action-button.hbs
@@ -1,3 +1,3 @@
 <button type="button" class="pix-action-button" ...attributes>
-  <FaIcon @icon="plus" />
+  <FaIcon @icon={{this.icon}} />
 </button>

--- a/addon/components/pix-action-button.js
+++ b/addon/components/pix-action-button.js
@@ -1,4 +1,5 @@
 import Component from '@glimmer/component';
+import { action } from '@ember/object';
 
 export default class PixActionButton extends Component {
   text = 'pix-action-button';
@@ -6,5 +7,12 @@ export default class PixActionButton extends Component {
   get icon() {
     const defaultIcon = 'plus';
     return this.args.icon ? this.args.icon : defaultIcon;
+  }
+
+  @action
+  triggerAction() {
+    if (this.args.triggerAction) {
+      this.args.triggerAction();
+    }
   }
 }

--- a/addon/components/pix-action-button.js
+++ b/addon/components/pix-action-button.js
@@ -2,4 +2,9 @@ import Component from '@glimmer/component';
 
 export default class PixActionButton extends Component {
   text = 'pix-action-button';
+
+  get icon() {
+    const defaultIcon = 'plus';
+    return this.args.icon ? this.args.icon : defaultIcon;
+  }
 }

--- a/addon/components/pix-action-button.js
+++ b/addon/components/pix-action-button.js
@@ -1,0 +1,5 @@
+import Component from '@glimmer/component';
+
+export default class PixActionButton extends Component {
+  text = 'pix-action-button';
+}

--- a/addon/stories/pix-action-button.stories.js
+++ b/addon/stories/pix-action-button.stories.js
@@ -4,27 +4,35 @@ import centered from '@storybook/addon-centered/ember';
 export default { title: 'ActionButton' };
 
 const canvasContent = hbs`
-  <PixActionButton>
-  </PixActionButton>
+  <h3>Par défaut:</h3>
+  <PixActionButton />
+  <h3>Avec l'icon 'times':</h3>
+  <PixActionButton @icon='times' />
 `;
 
 const markdown = `
 # ActionButton
-TODO
+Le ActionButton permet de créer un bouton contenant une icône font-awesome.
 
 ## Usage
 
+Par défaut:
+
 ~~~javascript
-<PixActionButton>
-  // TODO
-</PixActionButton>
+<PixActionButton />
+~~~
+
+Avec paramètre:
+
+~~~javascript
+<PixActionButton @icon='times' />
 ~~~
 
 ## Props
 
 | Nom           | Type          |  Valeurs possibles  | Par défaut | Optionnel |
 | ------------- |:-------------:|:-------------------:|:----------:|----------:|
-| | | | | |
+|icon|string|les icons de font-awesome|'plus'|oui|
 
 `
 ;

--- a/addon/stories/pix-action-button.stories.js
+++ b/addon/stories/pix-action-button.stories.js
@@ -1,0 +1,39 @@
+import { hbs } from 'ember-cli-htmlbars';
+import centered from '@storybook/addon-centered/ember';
+
+export default { title: 'ActionButton' };
+
+const canvasContent = hbs`
+  <PixActionButton>
+  </PixActionButton>
+`;
+
+const markdown = `
+# ActionButton
+TODO
+
+## Usage
+
+~~~javascript
+<PixActionButton>
+  // TODO
+</PixActionButton>
+~~~
+
+## Props
+
+| Nom           | Type          |  Valeurs possibles  | Par défaut | Optionnel |
+| ------------- |:-------------:|:-------------------:|:----------:|----------:|
+| | | | | |
+
+`
+;
+
+export const actionButton = () => {
+  return {
+    template: canvasContent,
+  }
+};
+
+actionButton.parameters = { notes: { markdown } };
+actionButton.decorators = [centered];

--- a/addon/stories/pix-action-button.stories.js
+++ b/addon/stories/pix-action-button.stories.js
@@ -33,6 +33,7 @@ Avec paramètre:
 | Nom           | Type          |  Valeurs possibles  | Par défaut | Optionnel |
 | ------------- |:-------------:|:-------------------:|:----------:|----------:|
 |icon|string|les icons de font-awesome|'plus'|oui|
+|triggerAction|function|-|-|oui|
 
 `
 ;

--- a/addon/styles/_pix-action-button.scss
+++ b/addon/styles/_pix-action-button.scss
@@ -1,0 +1,23 @@
+.pix-action-button {
+  @import 'reset-css';
+
+  font-size: 1.25rem;
+  border-radius: 5px;
+  cursor: pointer;
+  border: none;
+  outline: none;
+  padding: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background-color: $grey-15;
+  color: $grey-35;
+  width: 38px;
+  height: 38px;
+
+  &:hover, &:active {
+    transition: background-color 0.2s ease;
+    background-color: $grey-20;
+  }
+
+}

--- a/addon/styles/addon.scss
+++ b/addon/styles/addon.scss
@@ -8,6 +8,7 @@
 @import 'pix-tooltip';
 @import 'pix-tag';
 @import 'pix-banner';
+@import 'pix-action-button';
 
 html {
   font-size: 16px;

--- a/app/components/pix-action-button.js
+++ b/app/components/pix-action-button.js
@@ -1,0 +1,1 @@
+export { default } from 'pix-ui/components/pix-action-button';

--- a/tests/integration/components/pix-action-button-test.js
+++ b/tests/integration/components/pix-action-button-test.js
@@ -1,12 +1,13 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import { render } from '@ember/test-helpers';
+import { click, render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 
 module('Integration | Component | action-button', function(hooks) {
   setupRenderingTest(hooks);
 
-  const iconClass = '.pix-action-button > svg';
+  const buttonClass = '.pix-action-button';
+  const iconClass = `${buttonClass} > svg`;
 
   test('it renders PixActionButton with a default fa-icon', async function(assert) {
     // when
@@ -29,6 +30,21 @@ module('Integration | Component | action-button', function(hooks) {
     // then
     assert.ok(iconElement.classList.contains('fa-times'));
     assert.notOk(iconElement.classList.contains('fa-plus'));
+  });
+
+  test('it should trigger action if given one', async function(assert) {
+    // when
+    this.set('count', 1);
+    this.set('triggerAction', () => {
+      this.count = this.count + 1;
+    });
+    await render(hbs`
+      <PixActionButton @triggerAction={{this.triggerAction}} />
+    `);
+    await click(buttonClass);
+
+    // then
+    assert.equal(this.count, 2);
   });
 
 });

--- a/tests/integration/components/pix-action-button-test.js
+++ b/tests/integration/components/pix-action-button-test.js
@@ -1,0 +1,24 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+
+module('Integration | Component | action-button', function(hooks) {
+  setupRenderingTest(hooks);
+
+  const COMPONENT_SELECTOR = '.pix-action-button';
+
+  test('it renders the default PixActionButton', async function(assert) {
+    // when
+    await render(hbs`
+      <PixActionButton>
+        content
+      </PixActionButton>
+    `);
+    const componentElement = this.element.querySelector(COMPONENT_SELECTOR);
+
+    // then
+    assert.equal(componentElement.textContent.trim(), 'content');
+  });
+
+});

--- a/tests/integration/components/pix-action-button-test.js
+++ b/tests/integration/components/pix-action-button-test.js
@@ -6,19 +6,29 @@ import { hbs } from 'ember-cli-htmlbars';
 module('Integration | Component | action-button', function(hooks) {
   setupRenderingTest(hooks);
 
-  const COMPONENT_SELECTOR = '.pix-action-button';
+  const iconClass = '.pix-action-button > svg';
 
-  test('it renders the default PixActionButton', async function(assert) {
+  test('it renders PixActionButton with a default fa-icon', async function(assert) {
     // when
     await render(hbs`
-      <PixActionButton>
-        content
-      </PixActionButton>
+      <PixActionButton></PixActionButton>
     `);
-    const componentElement = this.element.querySelector(COMPONENT_SELECTOR);
+    const iconElement = this.element.querySelector(iconClass);
 
     // then
-    assert.equal(componentElement.textContent.trim(), 'content');
+    assert.ok(iconElement.classList.contains('fa-plus'));
+  });
+
+  test('it renders PixActionButton with the specified FaIcon', async function(assert) {
+    // when
+    await render(hbs`
+      <PixActionButton @icon='times'></PixActionButton>
+    `);
+    const iconElement = this.element.querySelector(iconClass);
+
+    // then
+    assert.ok(iconElement.classList.contains('fa-times'));
+    assert.notOk(iconElement.classList.contains('fa-plus'));
   });
 
 });


### PR DESCRIPTION
## :unicorn: Description du composant
Mise en place du composant `PixActionButton` qui permet de créer un bouton à partir d'une icon.

Exemple de PixActionButton:
<img width="86" alt="Screenshot 2020-09-15 at 16 52 13" src="https://user-images.githubusercontent.com/11294487/93226644-d7150480-f773-11ea-97f8-b3d065e409d4.png">

## :rainbow: Remarques
Cette PR sera utilisée et mergée lors du bootcamp Pix-UI du 24/09.

## :100: Pour tester
Maquette : 
https://zeroheight.com/8dd127da7/p/20d723-floating-action-button-fab
Implémentation : 
- `npm run storybook`
