### PR TITLE
[FEATURE] Ajout du composant PixStars (pix-1448)

### DIFF
--- a/addon/components/pix-stars.hbs
+++ b/addon/components/pix-stars.hbs
@@ -1,0 +1,20 @@
+<div class={{this.pixStarsClass}} ...attributes>
+  <span class="sr-only">{{@alt}}</span>
+  {{#each this.stars as |star|}}
+    <svg
+      class="pix-stars__{{star}}"
+      data-test-status={{star}}
+      viewBox="0 0 36 36"
+    >
+      <defs>
+        <linearGradient id="pix-stars-default" x1="68.643%" y1="0%" x2="68.643%" y2="100%">
+          <stop stop-color="#FEDC41" offset="0%"/>
+          <stop stop-color="#FF9F00" offset="100%"/>
+        </linearGradient>
+      </defs>
+      <path d="M8.423 35.82c-.761.507-1.765-.125-1.635-1.03l1.619-11.335L.311 15.36a1.059 1.059 0 01.6-1.796l11.268-1.61L17.027.642c.367-.856 1.58-.856 1.946 0l4.848 11.31 11.269 1.61a1.059 1.059 0 01.599 1.797l-8.096 8.096 1.62 11.334c.129.906-.875 1.538-1.636 1.03L18 29.436 8.423 35.82z" />
+    </svg>
+  {{/each}}
+</div>
+
+

--- a/addon/components/pix-stars.js
+++ b/addon/components/pix-stars.js
@@ -1,0 +1,27 @@
+import Component from '@glimmer/component';
+
+const STAR_ACQUIRED = 'acquired';
+const STAR_UNACQUIRED = 'unacquired';
+
+export default class PixStars extends Component {
+  get pixStarsClass() {
+    if (!this.args.color) return "pix-stars";
+    return `pix-stars pix-stars--${this.args.color}`;
+  }
+
+  get stars() {
+    const { count = 0, total = 0 } = this.args;
+    
+    const starsTotal = total || count;
+    
+    const stars = [];
+    for (let index = 0; index < starsTotal; index++) {
+      if (index < count) {
+        stars[index] = STAR_ACQUIRED;
+      } else {
+        stars[index] = STAR_UNACQUIRED;
+      }
+    }
+    return stars;
+  }
+}

--- a/addon/stories/pix-stars.stories.js
+++ b/addon/stories/pix-stars.stories.js
@@ -1,0 +1,72 @@
+import { hbs } from 'ember-cli-htmlbars';
+import centered from '@storybook/addon-centered/ember';
+
+export default { title: 'Stars' };
+
+const canvasContent = hbs`
+  <h2>Differentes couleurs</h2>
+  <PixStars 
+    @count={{2}}
+    @total={{5}}
+    @alt="message alt"
+  />
+
+  <PixStars 
+    @count={{2}}
+    @total={{5}}
+    @alt="message alt"
+    @color="blue"
+  />
+
+  <PixStars 
+    @count={{2}}
+    @total={{5}}
+    @alt="message alt"
+    @color="grey"
+  />
+
+  <h2>Ne pas afficher les étoiles vides</h2>
+  <p>Pour ne pas afficher les étoiles vides, il suffit de ne pas donner le total d'étoiles.</p>
+  <PixStars 
+    @count={{3}}
+    @alt="message alt"
+  />
+`;
+
+const markdown = `
+# Stars
+
+Affiche une série d'étoiles en fonction des paramètres donnés.
+Un texte alternatif peut être renseigné et différents styles sont pré-définis.
+
+## Usage
+
+~~~javascript
+<PixStars 
+  @count={{2}}
+  @total={{5}}
+  @alt="message alternatif"
+  @color="blue"
+/>
+~~~
+
+## Props
+
+| Nom            |  Type   | Valeurs possibles | Par défaut | Optionnel |
+| -------------- | :-----: | :---------------: | :--------: | --------: |
+| count          | number  |         -         |     0      |       oui |
+| total          | number  |         -         |     0      |       oui |
+| alt            | string  |         -         |     -      |       non |
+| color          | string  |  yellow/blue/grey |  yellow    |       oui |
+
+`
+;
+
+export const stars = () => {
+  return {
+    template: canvasContent,
+  }
+};
+
+stars.parameters = { notes: { markdown } };
+stars.decorators = [centered];

--- a/addon/styles/_pix-stars.scss
+++ b/addon/styles/_pix-stars.scss
@@ -1,0 +1,44 @@
+.pix-stars {
+  @import 'reset-css';
+
+  > svg {
+    width: 36px;
+    height: 36px;
+  }
+
+  &--blue > &__acquired {
+    fill: $blue;
+  }
+
+  &--blue > &__unacquired {
+    fill: #e9eafc;
+    stroke: $blue;
+  }
+
+  &--grey > &__acquired {
+    fill: $grey-40;
+  }
+  &--grey > &__unacquired {
+    fill: white;
+    stroke: $grey-40;
+  }
+
+  &__acquired {
+    fill: url(#pix-stars-default);
+  }
+
+  &__unacquired {
+    fill: #e9eafc;
+  }
+}
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0,0,0,0);
+  border: 0;
+}

--- a/addon/styles/addon.scss
+++ b/addon/styles/addon.scss
@@ -10,6 +10,7 @@
 @import 'pix-banner';
 @import 'pix-action-button';
 @import 'pix-button';
+@import 'pix-stars';
 
 html {
   font-size: 16px;

--- a/app/components/pix-stars.js
+++ b/app/components/pix-stars.js
@@ -1,0 +1,1 @@
+export { default } from 'pix-ui/components/pix-stars';

--- a/package-lock.json
+++ b/package-lock.json
@@ -13551,6 +13551,14 @@
         "semver": "^6.3.0"
       }
     },
+    "ember-truth-helpers": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/ember-truth-helpers/-/ember-truth-helpers-3.0.0.tgz",
+      "integrity": "sha512-hPKG9QqruAELh0li5xaiLZtr88ioWYxWCXisAWHWE0qCP4a2hgtuMzKUPpiTCkltvKjuqpzTZCU4VhQ+IlRmew==",
+      "requires": {
+        "ember-cli-babel": "^7.22.1"
+      }
+    },
     "ember-try": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/ember-try/-/ember-try-1.4.0.tgz",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,8 @@
     "ember-cli-babel": "^7.22.1",
     "ember-cli-htmlbars": "^5.3.1",
     "ember-cli-sass": "^10.0.1",
-    "ember-cli-string-utils": "^1.1.0"
+    "ember-cli-string-utils": "^1.1.0",
+    "ember-truth-helpers": "^3.0.0"
   },
   "devDependencies": {
     "@ember/optional-features": "^2.0.0",

--- a/tests/integration/components/pix-stars-test.js
+++ b/tests/integration/components/pix-stars-test.js
@@ -1,0 +1,66 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+
+module('Integration | Component | stars', function(hooks) {
+  setupRenderingTest(hooks);
+
+  test('it renders the default PixStars', async function(assert) {
+    // when
+    await render(hbs`<PixStars />`);
+    const stars = this.element.querySelectorAll('img');
+
+    // then
+    assert.equal(stars.length, 0);
+  });
+
+  test('it renders a total of 5 empty stars', async function(assert) {
+    // when
+    await render(hbs`<PixStars @total={{5}}/>`);
+    const stars = this.element.querySelectorAll('[data-test-status="unacquired"]');
+
+    // then
+    assert.equal(stars.length, 5);
+  });
+
+  test('it renders 3 stars acquired on a total of 5', async function(assert) {
+    // when
+    await render(hbs`<PixStars @count={{3}} @total={{5}}/>`);
+    const acquiredStars = this.element.querySelectorAll('[data-test-status="acquired"]');
+    const unacquiredStars = this.element.querySelectorAll('[data-test-status="unacquired"]');
+
+    // then
+    assert.equal(acquiredStars.length, 3);
+    assert.equal(unacquiredStars.length, 2);
+  });
+
+  test('it renders alternative message', async function(assert) {
+    // when
+    await render(hbs`<PixStars @total={{3}} @alt="message"/>`);
+    const srOnly = this.element.querySelector('.sr-only');
+
+    // then
+    assert.equal(srOnly.textContent.trim(), 'message');
+  });
+
+  test('it renders the acquired start but hide unacquired', async function(assert) {
+    // when
+    await render(hbs`<PixStars @count={{3}} />`);
+    const acquiredStars = this.element.querySelectorAll('[data-test-status="acquired"]');
+    const unacquiredStars = this.element.querySelectorAll('[data-test-status="unacquired"]');
+
+    // then
+    assert.equal(acquiredStars.length, 3);
+    assert.equal(unacquiredStars.length, 0);
+  });
+
+  test('it renders the color', async function(assert) {
+    // when
+    await render(hbs`<PixStars @count={{3}} @total={{5}} @color="blue" />`);
+    const component = this.element.querySelector('.pix-stars--blue');
+
+    // then
+    assert.ok(component);
+  });
+});


### PR DESCRIPTION
## :unicorn: Description du composant

Dans le cadre des paliers, nous avons besoin d'un composant pour afficher des étoiles.

## :rainbow: Remarques

Nous avons un composant `<PixStars>` réutilisable dans de multiples usages:

```
<PixStars 
  @total={{5}}
  @count={{2}}
  @alt="message alt"
  @color="blue"
/>
```

![image](https://user-images.githubusercontent.com/516360/96707075-b1dd6c80-1397-11eb-98c0-68caa9713483.png)

Nous nous sommes basé sur les étoiles (paliers) dans pix-app et sur les [nouvelles maquettes pour pix-orga](https://app.abstract.com/projects/fa298ac7-3ab1-4888-8156-7d142235b3a5/branches/5c9467c8-87f6-4361-aeb5-ee8919476d40/commits/a1b6745e8f75d39a3733d89ca1aae6d59973675d/files/990ED997-76F5-46E7-9A70-DF7994551675/layers/5C18BBF6-9EB2-4024-934D-21AC39E56DAD?collectionId=c101cc47-43bf-43f7-b598-a6b7d4c004bf&collectionLayerId=709abd45-ee59-4eb6-a8b3-9247f0dba7c4&mode=design)


## :100: Pour tester
> _Lien vers Zeroheight (modèle) et Storybook (rendu final)._
