### PR TITLE
[STYLE] Les étoiles bleues "vides" de PixStars ne doivent pas avoir de bordure

### DIFF
--- a/addon/styles/_pix-stars.scss
+++ b/addon/styles/_pix-stars.scss
@@ -12,7 +12,6 @@
 
   &--blue > &__unacquired {
     fill: #e9eafc;
-    stroke: $blue;
   }
 
   &--grey > &__acquired {


### PR DESCRIPTION
## :unicorn: Description du composant

Les étoiles bleues "vides" de PixStars ne doivent pas avoir de bordure.

Résultat:
![image](https://user-images.githubusercontent.com/516360/97188684-13407980-17a4-11eb-856e-0544377692ac.png)

