### PR TITLE
[BUGFIX] Amélioration du Pix-Button pour les formulaire

### DIFF
--- a/addon/components/pix-button.hbs
+++ b/addon/components/pix-button.hbs
@@ -1,4 +1,4 @@
-<button type="button" class="pix-button" {{on "click" this.triggerAction}} ...attributes disabled={{this.isLoading}}>
+<button type={{this.type}} class="pix-button" {{on "click" this.triggerAction}} ...attributes disabled={{this.isLoading}}>
 {{#if this.isLoading}}
   <div class="loader loader--{{this.args.loading-color}}">
     <div class="bounce1"></div>

--- a/addon/components/pix-button.js
+++ b/addon/components/pix-button.js
@@ -6,11 +6,15 @@ export default class PixButton extends Component {
   text = 'pix-button';
   @tracked isLoading = false;
 
+  get type() {
+    return this.args.type || 'button';
+  }
+
   @action
-  async triggerAction() {
+  async triggerAction(params) {
     try {
       this.isLoading = true;
-      await this.args.action()
+      await this.args.action(params)
       this.isLoading = false;
     } catch (e) {
       this.isLoading = false;

--- a/addon/stories/pix-button.stories.js
+++ b/addon/stories/pix-button.stories.js
@@ -49,7 +49,7 @@ Ce composant est un bouton simple qui empêche les clics multiples.
 ## Usage
 
 ~~~javascript
-<PixButton @action={{action yourAction}} @loading-color='grey'>
+<PixButton @action={{action yourAction}} @loading-color='grey' @type='button'>
   Nom du bouton
 </PixButton>
 ~~~
@@ -60,6 +60,7 @@ Ce composant est un bouton simple qui empêche les clics multiples.
 | ------------- |:-------------:|:-------------------:|:----------:|----------:|
 | action | action | | | Non |
 | loading-color | string | white/grey | white | Oui |
+| type | string | button/submit | button | Oui |
 
 `
 ;

--- a/tests/integration/components/pix-button-test.js
+++ b/tests/integration/components/pix-button-test.js
@@ -19,6 +19,20 @@ module('Integration | Component | button', function(hooks) {
 
     // then
     assert.equal(componentElement.textContent.trim(), 'Mon bouton');
+    assert.equal(componentElement.type, 'button');
+  });
+
+  test('it renders the PixButton component with the given type', async function(assert) {
+    // when
+    await render(hbs`
+      <PixButton @type="submit">
+        Mon bouton
+      </PixButton>
+    `);
+    const componentElement = this.element.querySelector(COMPONENT_SELECTOR);
+
+    // then
+    assert.equal(componentElement.type, 'submit');
   });
 
   test('it should call the action', async function(assert) {
@@ -38,4 +52,6 @@ module('Integration | Component | button', function(hooks) {
     assert.equal(this.count, 2);
     assert.equal(componentElement.disabled, false);
   });
+
+
 });


### PR DESCRIPTION
## :unicorn: Correction
- Pouvoir passer le type du bouton, pour pouvoir passer le type submit
- Passer les paramètres reçus à la fonction, pour pouvoir passer notamment les event lors des clics

## :rainbow: Remarques
- Sans type indiqué, le type de base est "button"
