### PR TITLE
[DesignFix] Corriger le design de la PixReturnTo

### DIFF
--- a/addon/styles/_pix-return-to.scss
+++ b/addon/styles/_pix-return-to.scss
@@ -1,9 +1,9 @@
 .pix-return-to {
   @import 'reset-css';
 
-  font-size: 0.813rem;
-  font-weight: $font-semi-bold;
-  letter-spacing: 0.019rem;
+  font-size: 1rem;
+  font-weight: $font-medium;
+  letter-spacing: 0.15px;
   display: inline-flex;
   align-items: center;
   border-bottom: transparent solid 2px;


### PR DESCRIPTION
## :unicorn: Description du composant
La PixReturnTo permet de revenir sur une page précédente.
Selon les pages et le contexte la PixReturnTo paraît petite et peut donc être difficile à lire.

![image](https://user-images.githubusercontent.com/38167520/98269929-a2ad1000-1f8e-11eb-82d3-144218ddfbb9.png)

## :rainbow: Décision
Grossir le texte et enlever un peu de bold.

## :100: Pour tester
> _Lien vers Zeroheight (modèle) et Storybook (rendu final)._
