### PR TITLE
[FEATURE] Ajout du composant pix-select

### DIFF
--- a/addon/components/pix-select.hbs
+++ b/addon/components/pix-select.hbs
@@ -1,0 +1,13 @@
+<div class="pix-select">
+  <select {{on 'change' @onChange}} ...attributes>
+    {{#if (not-eq @emptyOptionLabel undefined)}}
+      <option value="">{{@emptyOptionLabel}}</option>
+    {{/if}}
+    {{#each @options as |opt|}}
+      <option value={{opt.value}} defaultSelected={{eq @selectedOption opt.value}}>
+        {{opt.label}}
+      </option>
+    {{/each}}
+  </select>
+  <FaIcon class='pix-select__icon' @icon="chevron-down" />
+</div>

--- a/addon/stories/pix-select.stories.js
+++ b/addon/stories/pix-select.stories.js
@@ -1,0 +1,72 @@
+import { hbs } from 'ember-cli-htmlbars';
+import centered from '@storybook/addon-centered/ember';
+
+export default { title: 'Form' };
+
+const canvasContent = hbs`
+  <PixSelect
+    @options={{options}}
+    @onChange={{onChange}}
+    @emptyOptionLabel="Sélectionner une option"
+  />
+`;
+
+const markdown = `
+# Select
+
+Affiche un champ Select avec la liste des options fournie.
+
+Les options sont représentées par un tableau d'objet contenant les propriétés value et label.
+
+## Usage
+
+~~~javascript
+<PixSelect
+  @options={{options}}
+  @onChange={{onChange}}
+  @selectedOption="1"
+  @emptyOptionLabel="Empty option"
+/>
+~~~
+
+Exemple d'options:
+
+~~~javascript
+[
+  { value: '1', label: 'Tomate' },
+  { value: '2', label: 'Fromage' },
+  { value: '3', label: 'Gruyère' },
+  { value: '4', label: 'Olive' },
+]
+~~~
+
+## Props
+
+| Nom              |   Type   | Valeurs possibles | Par défaut | Optionnel |
+| ---------------- | :------: | :---------------: | :--------: | --------: |
+| options          |  array   |         -         |     -      |       non |
+| onChange         | function |         -         |     -      |       non |
+| selectedOption   |  string  |         -         |     -      |       oui |
+| emptyOptionLabel |  string  |         -         |     -      |       oui |
+
+
+`
+;
+
+export const select = () => {
+  return {
+    template: canvasContent,
+    context: {
+      options: [
+        { value: '1', label: 'Tomate' },
+        { value: '2', label: 'Fromage' },
+        { value: '3', label: 'Gruyère' },
+        { value: '4', label: 'Olive' },
+      ],
+      onChange: console.log,
+    }
+  }
+};
+
+select.parameters = { notes: { markdown } };
+select.decorators = [centered];

--- a/addon/styles/_pix-select.scss
+++ b/addon/styles/_pix-select.scss
@@ -1,0 +1,50 @@
+.pix-select {
+  @import 'reset-css';
+
+  position: relative;
+  border: 1px $grey-20 solid;
+  height: 46px;
+  width: 100%;
+  background-color: $white;
+  border-radius: 3px;
+  outline: none;
+  box-sizing: border-box;
+  font-size: 1rem;
+
+  &:focus-within {
+    border-color: $blue;
+  }
+
+  select {
+    -webkit-appearance: none;
+    -moz-appearance: none;
+    appearance: none;
+    width: 100%;
+    height: 100%;
+    border: none;
+    outline: none;
+    padding: 0 32px 0 16px;
+    border-radius: 3px;
+    font-size: 1em;
+    font-family: $font-roboto;
+    background: transparent;
+
+    &:focus {
+      outline: none;
+    }
+  }
+
+  select::-ms-expand {
+    display: none;
+  }
+
+  &__icon {
+    font-size: 11px;
+    color: $grey-30;
+    right: 8px;
+    top: calc(50% - 6px);
+    padding: 0 0 2px;
+    position: absolute;
+    pointer-events: none;
+  }
+}

--- a/addon/styles/addon.scss
+++ b/addon/styles/addon.scss
@@ -11,6 +11,7 @@
 @import 'pix-action-button';
 @import 'pix-button';
 @import 'pix-stars';
+@import 'pix-select';
 
 html {
   font-size: 16px;

--- a/app/components/pix-select.js
+++ b/app/components/pix-select.js
@@ -1,0 +1,1 @@
+export { default } from 'pix-ui/components/pix-select';

--- a/package-lock.json
+++ b/package-lock.json
@@ -1992,6 +1992,51 @@
       "integrity": "sha512-ONhaKPIufzzrlNbqtWFFd+jlnemX6lJAgq9ZeiZtS7I1PIf/la7CW4m83rTXRnVnsMbW2k56pGYu7AUFJD9Pow==",
       "dev": true
     },
+    "@sinonjs/commons": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.8.1.tgz",
+      "integrity": "sha512-892K+kWUUi3cl+LlqEWIDrhvLgdL79tECi8JZUyq6IviKy/DNhuzCRlbHUjxK89f4ypPMMaFnFuR9Ie6DoIMsw==",
+      "dev": true,
+      "requires": {
+        "type-detect": "4.0.8"
+      }
+    },
+    "@sinonjs/fake-timers": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-6.0.1.tgz",
+      "integrity": "sha512-MZPUxrmFubI36XS1DI3qmI0YdN1gks62JtFZvxR67ljjSNCeK6U08Zx4msEWOXuofgqUt6zPHSi1H9fbjR/NRA==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/commons": "^1.7.0"
+      }
+    },
+    "@sinonjs/formatio": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/formatio/-/formatio-5.0.1.tgz",
+      "integrity": "sha512-KaiQ5pBf1MpS09MuA0kp6KBQt2JUOQycqVG1NZXvzeaXe5LGFqAKueIS0bw4w0P9r7KuBSVdUk5QjXsUdu2CxQ==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/commons": "^1",
+        "@sinonjs/samsam": "^5.0.2"
+      }
+    },
+    "@sinonjs/samsam": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-5.3.0.tgz",
+      "integrity": "sha512-hXpcfx3aq+ETVBwPlRFICld5EnrkexXuXDwqUNhDdr5L8VjvMeSRwyOa0qL7XFmR+jVWR4rUZtnxlG7RX72sBg==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/commons": "^1.6.0",
+        "lodash.get": "^4.4.2",
+        "type-detect": "^4.0.8"
+      }
+    },
+    "@sinonjs/text-encoding": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/text-encoding/-/text-encoding-0.7.1.tgz",
+      "integrity": "sha512-+iTbntw2IZPb/anVDbypzfQa+ay64MW0Zo8aJ8gZPWMMK6/OubMVb6lUPMagqjOPnmtauXnFCACVl3O7ogjeqQ==",
+      "dev": true
+    },
     "@storybook/addon-a11y": {
       "version": "5.3.19",
       "resolved": "https://registry.npmjs.org/@storybook/addon-a11y/-/addon-a11y-5.3.19.tgz",
@@ -12852,6 +12897,18 @@
         "recast": "^0.18.1"
       }
     },
+    "ember-sinon": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/ember-sinon/-/ember-sinon-5.0.0.tgz",
+      "integrity": "sha512-dTP2vhao1xWm3OlfpOALooso/OLM71SFg7PIBmZ6JdwKCC+CzcPb4BYRAXuoAFYzmhH8z28p8HdemjZBb0B3Bw==",
+      "dev": true,
+      "requires": {
+        "broccoli-funnel": "^2.0.0",
+        "broccoli-merge-trees": "^3.0.0",
+        "ember-cli-babel": "^7.17.2",
+        "sinon": "^9.0.0"
+      }
+    },
     "ember-source": {
       "version": "3.21.1",
       "resolved": "https://registry.npmjs.org/ember-source/-/ember-source-3.21.1.tgz",
@@ -17787,6 +17844,12 @@
         }
       }
     },
+    "just-extend": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-4.1.1.tgz",
+      "integrity": "sha512-aWgeGFW67BP3e5181Ep1Fv2v8z//iBJfrvyTnq8wG86vEESwmonn1zPBJ0VfmT9CJq2FIT0VsETtrNFm2a+SHA==",
+      "dev": true
+    },
     "keyv": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-3.0.0.tgz",
@@ -18131,6 +18194,12 @@
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/lodash.foreach/-/lodash.foreach-4.5.0.tgz",
       "integrity": "sha1-Gmo16s5AEoDH8G3d7DUWWrJ+PlM=",
+      "dev": true
+    },
+    "lodash.get": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
+      "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=",
       "dev": true
     },
     "lodash.isarguments": {
@@ -18898,6 +18967,36 @@
       "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
       "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
       "dev": true
+    },
+    "nise": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/nise/-/nise-4.0.4.tgz",
+      "integrity": "sha512-bTTRUNlemx6deJa+ZyoCUTRvH3liK5+N6VQZ4NIw90AgDXY6iPnsqplNFf6STcj+ePk0H/xqxnP75Lr0J0Fq3A==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/commons": "^1.7.0",
+        "@sinonjs/fake-timers": "^6.0.0",
+        "@sinonjs/text-encoding": "^0.7.1",
+        "just-extend": "^4.0.2",
+        "path-to-regexp": "^1.7.0"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+          "dev": true
+        },
+        "path-to-regexp": {
+          "version": "1.8.0",
+          "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.8.0.tgz",
+          "integrity": "sha512-n43JRhlUKUAlibEJhPeir1ncUID16QnEjNpwzNdO3Lm4ywrBpBZ5oLD0I6br9evr1Y9JTqwRtAh7JLoOzAQdVA==",
+          "dev": true,
+          "requires": {
+            "isarray": "0.0.1"
+          }
+        }
+      }
     },
     "no-case": {
       "version": "3.0.3",
@@ -22398,6 +22497,38 @@
         "simplebar": "^4.2.3"
       }
     },
+    "sinon": {
+      "version": "9.2.1",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-9.2.1.tgz",
+      "integrity": "sha512-naPfsamB5KEE1aiioaoqJ6MEhdUs/2vtI5w1hPAXX/UwvoPjXcwh1m5HiKx0HGgKR8lQSoFIgY5jM6KK8VrS9w==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/commons": "^1.8.1",
+        "@sinonjs/fake-timers": "^6.0.1",
+        "@sinonjs/formatio": "^5.0.1",
+        "@sinonjs/samsam": "^5.2.0",
+        "diff": "^4.0.2",
+        "nise": "^4.0.4",
+        "supports-color": "^7.1.0"
+      },
+      "dependencies": {
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
+    },
     "slash": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz",
@@ -24067,6 +24198,12 @@
       "requires": {
         "prelude-ls": "~1.1.2"
       }
+    },
+    "type-detect": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
+      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
+      "dev": true
     },
     "type-fest": {
       "version": "0.11.0",

--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
     "ember-maybe-import-regenerator": "^0.1.6",
     "ember-qunit": "^4.6.0",
     "ember-resolver": "^8.0.2",
+    "ember-sinon": "^5.0.0",
     "ember-source": "~3.21.1",
     "ember-source-channel-url": "^3.0.0",
     "ember-template-lint": "^2.11.0",

--- a/tests/integration/components/pix-select-test.js
+++ b/tests/integration/components/pix-select-test.js
@@ -1,0 +1,95 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render, fillIn } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+import sinon from 'sinon';
+
+module('Integration | Component | select', function (hooks) {
+  setupRenderingTest(hooks);
+
+  const DEFAULT_OPTIONS = [
+    { value: '1', label: 'Salade' },
+    { value: '2', label: 'Tomate' },
+    { value: '3', label: 'Oignon' },
+  ]
+  const DEFAULT_ON_CHANGE = () => {};
+
+  test('it renders the PixSelect with given options', async function (assert) {
+    // given
+    this.options = DEFAULT_OPTIONS;
+    this.onChange = DEFAULT_ON_CHANGE;
+
+    // when
+    await render(hbs`
+      <PixSelect
+        @options={{options}}
+        @onChange={{onChange}}
+      />
+    `);
+
+    // then
+    const options = this.element.querySelectorAll('option');
+    assert.equal(options.length, 3);
+    assert.equal(options.item(0).value, '1');
+    assert.equal(options.item(0).text, 'Salade');
+  });
+
+  test('it renders the PixSelect with empty label option', async function (assert) {
+    // given
+    this.options = DEFAULT_OPTIONS;
+    this.onChange = DEFAULT_ON_CHANGE;
+
+    // when
+    await render(hbs`
+      <PixSelect
+        @options={{options}}
+        @onChange={{onChange}}
+        @emptyOptionLabel="Empty label"
+      />
+    `);
+
+    // then
+    const options = this.element.querySelectorAll('option');
+    assert.equal(options.length, 4);
+    assert.equal(options.item(0).value, '');
+    assert.equal(options.item(0).text, 'Empty label');
+  });
+
+  test('it renders the PixSelect with default value selected', async function (assert) {
+    // given
+    this.options = DEFAULT_OPTIONS;
+    this.onChange = DEFAULT_ON_CHANGE;
+
+    // when
+    await render(hbs`
+      <PixSelect
+        @options={{options}}
+        @onChange={{onChange}}
+        @selectedOption="2"
+      />
+    `);
+
+    // then
+    const options = this.element.querySelectorAll('option');
+    assert.equal(options.item(1).defaultSelected, true);
+  });
+
+  test('it should trigger onChange function when an item is selected', async function (assert) {
+    // given
+    this.options = DEFAULT_OPTIONS;
+    this.onChange = sinon.spy();
+  
+    await render(hbs`
+      <PixSelect
+        @options={{options}}
+        @onChange={{onChange}}
+      />
+    `);
+
+    // when
+    await fillIn('select', '2')
+
+    // then
+    assert.ok(this.onChange.calledOnce, "the callback should be called once");
+  });
+});


### PR DESCRIPTION
## :unicorn: Description du composant

Dans pix-orga nous utilisons à plusieurs endroits un composant `select` basique avec le style défini par le design system.
Ce composant devrait être partagé pour tout pix.

![image](https://user-images.githubusercontent.com/516360/99402083-3e247600-28e9-11eb-95a9-7748122e51f4.png)


## :rainbow: Remarques

`ember-sinon` a été ajouté afin de pouvoir réaliser les tests

