### PR TITLE
[TECH] Ne pas lancer circle-ci sur la branche gh-pages

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,14 +4,14 @@ workflows:
   version: 2
   build-and-test:
     jobs:
-      - build-and-test
+      - build-and-test:
+          filters:
+            branches:
+              ignore:
+                - gh-pages
 
 jobs:
   build-and-test:
-    filters:
-      branches:
-        ignore:
-          - gh-pages
     docker:
       - image: circleci/node:12.14.0-browsers
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,4 +1,4 @@
-version: 2.0
+version: 2.1
 
 workflows:
   version: 2


### PR DESCRIPTION
## :unicorn: Problème
CircleCi continue de lancer des vérifications sur la branche gh-pages.
<img width="1414" alt="image" src="https://user-images.githubusercontent.com/38167520/99544306-6f1dad00-29b4-11eb-8f43-f08956dc5c03.png">

## :rainbow: Remarques
Une PR sur le sujet avait déjà été ouverte : https://github.com/1024pix/pix-ui/pull/32

Il semblerait que quelqu'un ait déjà eu exactement le même soucis : https://discuss.circleci.com/t/excluding-a-branch-from-ci/17811
Le problème viendrait donc du `filters` qui doit être placé dans la partie `workflow` et non `jobs`. 

Documentation circle ci sur les `fitlers` : https://circleci.com/docs/2.0/configuration-reference/#filters-1

## :100: Pour tester
> _Lien vers Zeroheight (modèle) et Storybook (rendu final)._
