### PR TITLE
[TECH] Skip la CI sur les gh-pages

### DIFF
--- a/package.json
+++ b/package.json
@@ -86,5 +86,8 @@
   },
   "ember-addon": {
     "configPath": "tests/dummy/config"
+  },
+  "storybook-deployer": {
+    "commitMessage": "Deploy Storybook [skip ci]"
   }
 }


### PR DESCRIPTION
## :unicorn: Problème
**Circle Ci se lance à chaque fois sur la branche `gh-pages`.**

La branche `gh-pages` contient uniquement des fichiers buildé afin de déployer, en tant que site statique, notre application storybook :  `1024pix.github.io/pix-ui/`. Par ailleurs, **le contenu de la branche `gh-pages` est généré automatiquement** grâce à la commande `npm run deploy-storybook` (voir [storybook-deployer](https://github.com/storybookjs/storybook-deployer)).

Nous avons fait plusieurs essais pour ne pas déployer la ci sur cette branche là : 
- https://github.com/1024pix/pix-ui/pull/32
- https://github.com/1024pix/pix-ui/pull/43

Mais rien n'était concluant. Après un message sur les forums de circleci **la solution qui a été proposée était de dupliquer le fichier `config.yml` sur la branche `gh-pages`**. Voir discussion ici : https://discuss.circleci.com/t/filters-on-branches-does-not-work-as-expected/38198.

Aujourd'hui, comme nous déployons pix-ui grâce à [Pix-bot](https://github.com/1024pix/pix-bot), il faudrait rajouter dans le script de déploiement de pix-ui un ajout de fichier dans la branche des `gh-pages` après l'avoir buildé (voir https://github.com/1024pix/pix-bot/blob/master/scripts/deploy-pix-ui.sh). 

Cette solution prennant un peu de temps à être mise en place je propose **un quick-win en attendant : rajouter le tag [skip ci] dans les commits sur la branche `gh-pages`.**

