### PR TITLE
[FEATURE] Création du composant de bannière de filtres (PIX-1675).

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Pour visualiser les composants créés, il faut lancer storybook :
 
 Pour créer un composant ainsi que sa story :
 * `ember generate pix-component <nom_du_composant>`
-[Voir la documentation par ici.](/docs/create-component.md)
+[Voir la documentation par ici.](/docs/create-component-and-its-story.md)
 
 
 ## Documentations <a id="Documentation"></a>

--- a/addon/components/pix-filter-banner.hbs
+++ b/addon/components/pix-filter-banner.hbs
@@ -1,0 +1,6 @@
+<div class='pix-filter-banner' ...attributes>
+  {{#if this.displayTitle}}
+    <p class="pix-filter-banner__title">{{@title}}</p>
+  {{/if}}
+  <div>{{yield}}</div>
+</div>

--- a/addon/components/pix-filter-banner.js
+++ b/addon/components/pix-filter-banner.js
@@ -1,0 +1,7 @@
+import Component from '@glimmer/component';
+
+export default class PixFilterBanner extends Component {
+  get displayTitle() {
+    return Boolean(this.args.title);
+  }
+}

--- a/addon/stories/pix-filter-banner.stories.js
+++ b/addon/stories/pix-filter-banner.stories.js
@@ -1,0 +1,57 @@
+import { hbs } from 'ember-cli-htmlbars';
+import centered from '@storybook/addon-centered/ember';
+
+export default { title: 'FilterBanner' };
+
+const canvasContent = hbs`
+<h3>Avec titre</h3>
+  <PixFilterBanner @title="Filtres">
+    <select>
+      <option value="3">
+        classe de 3e
+      </option>
+    </select>
+  </PixFilterBanner>
+
+<h3>Sans titre</h3>
+<PixFilterBanner>
+  <select>
+    <option value="3">
+      classe de 3e
+    </option>
+  </select>
+</PixFilterBanner>
+`;
+
+const markdown = `
+# FilterBanner
+
+Une \`FilterBanner\` permet de wrapper les éléments de filtres (\`Select\`, \`Multi-Select\`, ...).
+
+> Il est possible de surcharger le style d'une \`<PixFilterBanner>\` via l'attribut \`class\` ainsi que de passer n'importe quel attribut sur sa \`div\` wrapper (par exemple, un \`aria-label\`)
+
+## Usage
+
+~~~javascript
+<PixFilterBanner aria-label="Filtres sur les campagnes">
+  // ici ajouter le contenu de la bannière de filtres
+</PixFilterBanner>
+~~~
+
+## Props
+
+| Nom           | Type          |  Valeurs possibles  | Par défaut | Optionnel |
+| ------------- |:-------------:|:-------------------:|:----------:|----------:|
+| title         | string        |                     | null       | oui       |
+
+`
+;
+
+export const filterBanner = () => {
+  return {
+    template: canvasContent,
+  }
+};
+
+filterBanner.parameters = { notes: { markdown } };
+filterBanner.decorators = [centered];

--- a/addon/styles/_pix-filter-banner.scss
+++ b/addon/styles/_pix-filter-banner.scss
@@ -1,0 +1,23 @@
+.pix-filter-banner {
+  @import 'reset-css';
+
+  position: relative;
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  box-sizing: border-box;
+  width: 100%;
+
+  background-color: $white;
+  box-shadow: 0 2px 5px 0 rgba($black, 0.05);
+  min-height: 64px;
+  padding: 14px 24px;
+
+  &__title {
+    color: $grey-60;
+    font-family: $font-roboto;
+    font-size: 0.875rem;
+    padding-right: 24px;
+    margin: 0;
+  }
+}

--- a/addon/styles/addon.scss
+++ b/addon/styles/addon.scss
@@ -12,6 +12,7 @@
 @import 'pix-button';
 @import 'pix-stars';
 @import 'pix-select';
+@import 'pix-filter-banner';
 
 html {
   font-size: 16px;

--- a/app/components/pix-filter-banner.js
+++ b/app/components/pix-filter-banner.js
@@ -1,0 +1,1 @@
+export { default } from 'pix-ui/components/pix-filter-banner';

--- a/tests/integration/components/pix-filter-banner-test.js
+++ b/tests/integration/components/pix-filter-banner-test.js
@@ -1,0 +1,36 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+
+module('Integration | Component | filter-banner', function(hooks) {
+  setupRenderingTest(hooks);
+
+  const COMPONENT_SELECTOR = '.pix-filter-banner';
+
+  test('it renders the default PixFilterBanner', async function(assert) {
+    // when
+    await render(hbs`
+      <PixFilterBanner>
+        content
+      </PixFilterBanner>
+    `);
+    const componentElement = this.element.querySelector(COMPONENT_SELECTOR);
+
+    // then
+    assert.equal(componentElement.textContent.trim(), 'content');
+  });
+
+  test('it renders the PixFilterBanner with title', async function(assert) {
+    // when
+    await render(hbs`
+      <PixFilterBanner @title="Titre de la bannière">
+        content
+      </PixFilterBanner>
+    `);
+    const componentElement = this.element.querySelector('.pix-filter-banner__title');
+
+    // then
+    assert.equal(componentElement.textContent.trim(), 'Titre de la bannière');
+  });
+});


### PR DESCRIPTION
## :unicorn: Description du composant
Ajout d'un composant permettant de wrapper les composants de "select", "input", "multi-select" de manière cohérente et jolie. Les composants que l'on peut mettre à l'intérieur sont configurables.
![image](https://user-images.githubusercontent.com/23451175/100733784-003a4e00-33cf-11eb-9ec8-7294fa6532e5.png)

Dans Pix Orga, cela donne :
![image](https://user-images.githubusercontent.com/23451175/100733975-42fc2600-33cf-11eb-8f27-ddb7cd688f37.png)

## :rainbow: Remarques
Comme le titre est configurable, cela pourrait être une bannière pour wrapper n'importe quoi d'autre. Mais du coup je ne sais pas comment la nommer. Des idées ?

## :100: Pour tester
Sur Storybook
