### PR TITLE
[TECH] Ajouter le linter aux build circle-ci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,4 +17,6 @@ jobs:
     steps:
       - checkout
       - run: npm ci
+      - run: npm run lint:js
+      - run: npm run lint:hbs
       - run: npm test


### PR DESCRIPTION
## :unicorn: Description du composant
Le linter n'est pas exécuté par la CI sur chaque PR, ce qui fait que des PR sont mergées avec un linter invalide.

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
Vérifier que le linter est bien passé dans le build circle-ci de cette PR
