### PR TITLE
[TECH] Ne pas utiliser de mot clé ember comme nom de paramètre

### DIFF
--- a/addon/components/pix-button.js
+++ b/addon/components/pix-button.js
@@ -14,7 +14,7 @@ export default class PixButton extends Component {
   async triggerAction(params) {
     try {
       this.isLoading = true;
-      await this.args.action(params)
+      await this.args.triggerAction(params);
       this.isLoading = false;
     } catch (e) {
       this.isLoading = false;

--- a/addon/stories/pix-button.stories.js
+++ b/addon/stories/pix-button.stories.js
@@ -7,14 +7,14 @@ const canvasContent = {
   template: hbs`
     <h2> Bouton avec loader blanc et une action qui se résout</h2>
     <PixButton
-    @action={{action onClick}}
+    @triggerAction={{action onClick}}
     @loading-color='white'
     >
     Cliquez pour valider !
 </PixButton>
  <h2> Bouton avec loader gris et une action qui se ne résout pas</h2>
     <PixButton
-    @action={{action onClickFailed}}
+    @triggerAction={{action onClickFailed}}
     @loading-color='grey'
     >
     Cliquez pour valider !
@@ -49,7 +49,7 @@ Ce composant est un bouton simple qui empêche les clics multiples.
 ## Usage
 
 ~~~javascript
-<PixButton @action={{action yourAction}} @loading-color='grey' @type='button'>
+<PixButton @triggerAction={{action yourAction}} @loading-color='grey' @type='button'>
   Nom du bouton
 </PixButton>
 ~~~

--- a/tests/integration/components/pix-button-test.js
+++ b/tests/integration/components/pix-button-test.js
@@ -38,11 +38,11 @@ module('Integration | Component | button', function(hooks) {
   test('it should call the action', async function(assert) {
     // when
     this.set('count', 1);
-    this.set('action', () => {
+    this.set('triggerAction', () => {
       this.count = this.count + 1;
     });
     await render(hbs`
-      <PixButton @action={{this.action}} />
+      <PixButton @triggerAction={{this.triggerAction}} />
     `);
 
     await click('button');


### PR DESCRIPTION
## :unicorn: Description du problème
`action` est un mot clé pour ember. Du coup, l'utilisation de PixButton peut déclancher des erreurs, notamment : 
`no-action: Do not use 'action' as {{action ...}}. Instead, use the 'on' modifier and 'fn' helper.`.

Pour plus de détail voir : https://1024pix.slack.com/archives/CFVNK8QQJ/p1607522423009700 

## :rainbow: Solution
Changer le nom du paramètre `action` pour `triggerAction`.

## :100: Pour tester
> _Lien vers Zeroheight (modèle) et Storybook (rendu final)._
