### PR TITLE
[TECH] Envoyer un message d'erreur plus explicite pour le PixButton

### DIFF
--- a/addon/components/pix-button.js
+++ b/addon/components/pix-button.js
@@ -18,6 +18,9 @@ export default class PixButton extends Component {
       this.isLoading = false;
     } catch (e) {
       this.isLoading = false;
+      if(!this.args.triggerAction) {
+        throw(new Error('@triggerAction params is required for PixButton !'));
+      }
       throw(new Error(e))
     }
   }

--- a/addon/stories/pix-button.stories.js
+++ b/addon/stories/pix-button.stories.js
@@ -58,7 +58,7 @@ Ce composant est un bouton simple qui empêche les clics multiples.
 
 | Nom           | Type          |  Valeurs possibles  | Par défaut | Optionnel |
 | ------------- |:-------------:|:-------------------:|:----------:|----------:|
-| action | action | | | Non |
+| triggerAction | action | | | Non |
 | loading-color | string | white/grey | white | Oui |
 | type | string | button/submit | button | Oui |
 


### PR DESCRIPTION
## :unicorn: Description
Lorsqu'on utilise PixButton côté front et qu'on ne met pas le paramètre @triggerAction on a un message d'erreur pas très explicite : `TypeError: this.args.triggerAction is not a function` 
Ce qui peut porter à confusion et faire croire que l'erreur vient côté front, alors qu'elle vient du PixButton.

## :rainbow: Solution
Envoyer un message plus explicite lorsqu'on ne passe pas @triggerAction. 

## :100: Pour tester
> _Lien vers Zeroheight (modèle) et Storybook (rendu final)._
