### PR TITLE
[FEATURE] Ajout des variantes jaunes et grises pour le composant PixTag

### DIFF
--- a/addon/stories/pix-tag.stories.js
+++ b/addon/stories/pix-tag.stories.js
@@ -22,6 +22,10 @@ const canvasContent = hbs`
   This is a yellow tag
 </PixTag>
 
+<PixTag @color='grey'>
+  This is a grey tag
+</PixTag>
+
 <br><br>
 <h3>Light colors</h3>
 
@@ -39,6 +43,10 @@ const canvasContent = hbs`
 
 <PixTag @color='yellow-light'>
   This is a yellow tag
+</PixTag>
+
+<PixTag @color='grey-light'>
+  This is a grey tag
 </PixTag>
 `;
 
@@ -61,7 +69,7 @@ Un \`Tag\` est un type de \`Chips\` qui permet de mettre en avant une informatio
 
 | Nom           | Type          | Valeurs possibles     | Par défaut | Optionnel |
 | ------------- |:-------------:|:---------------------:|:----------:|----------:|
-| color         | string        | blue, blue-light, purple, purple-light, green, green-light, yellow, yellow-light   | blue       | oui       |
+| color         | string        | blue, blue-light, purple, purple-light, green, green-light, yellow, yellow-light, grey, grey-light   | blue       | oui       |
 `
 ;
 

--- a/addon/stories/pix-tag.stories.js
+++ b/addon/stories/pix-tag.stories.js
@@ -18,6 +18,10 @@ const canvasContent = hbs`
   This is a green tag
 </PixTag>
 
+<PixTag @color='yellow'>
+  This is a yellow tag
+</PixTag>
+
 <br><br>
 <h3>Light colors</h3>
 
@@ -31,6 +35,10 @@ const canvasContent = hbs`
 
 <PixTag @color='green-light'>
   This is a green tag
+</PixTag>
+
+<PixTag @color='yellow-light'>
+  This is a yellow tag
 </PixTag>
 `;
 
@@ -53,7 +61,7 @@ Un \`Tag\` est un type de \`Chips\` qui permet de mettre en avant une informatio
 
 | Nom           | Type          | Valeurs possibles     | Par défaut | Optionnel |
 | ------------- |:-------------:|:---------------------:|:----------:|----------:|
-| color         | string        | blue, blue-light, purple, purple-light, green, green-light   | blue       | oui       |
+| color         | string        | blue, blue-light, purple, purple-light, green, green-light, yellow, yellow-light   | blue       | oui       |
 `
 ;
 

--- a/addon/styles/_pix-tag.scss
+++ b/addon/styles/_pix-tag.scss
@@ -25,7 +25,7 @@
   }
 
   &--green {
-    background-color: $dark-green-certif;
+    background-color: darken($dark-green-certif, 2%);
   }
 
   &--green-light {

--- a/addon/styles/_pix-tag.scss
+++ b/addon/styles/_pix-tag.scss
@@ -41,4 +41,14 @@
     color: darken($purple, 10%);
     background-color: lighten($purple, 30%);
   }
+
+  &--yellow {
+    color: $grey-90;
+    background-color: $yellow;
+  }
+
+  &--yellow-light {
+    color: darken($yellow, 25%);
+    background-color: lighten($yellow, 35%);
+  }
 }

--- a/addon/styles/_pix-tag.scss
+++ b/addon/styles/_pix-tag.scss
@@ -51,4 +51,14 @@
     color: darken($yellow, 25%);
     background-color: lighten($yellow, 35%);
   }
+
+  &--grey {
+    color: $grey-15;
+    background-color: $grey-60;
+  }
+
+  &--grey-light {
+    color: $grey-60;
+    background-color: $grey-15;
+  }
 }


### PR DESCRIPTION
## :unicorn: Description du composant

Pour  https://github.com/1024pix/pix/pull/2268 nous avons besoin de la variante jaune du composant `PixTag`. 


## :rainbow: Remarques

Nous avons également rajouter la variante grise qui sera nécessaire dans la page *Mes Parcours*.

En bonus, la variante verte a été modifié pour avoir le contraste minimum pour des raisons d'accessibilité.

## :100: Pour tester

![Screenshot_2020-12-14 Basics Tag - Tag ⋅ Storybook(2)](https://user-images.githubusercontent.com/86659/102095964-705fbf80-3e24-11eb-98ad-4205d532b66f.png)


