### PR TITLE
[Feature] Ajout de l'argument uppercase sur le composant PixTag

### DIFF
--- a/addon/components/pix-tag.hbs
+++ b/addon/components/pix-tag.hbs
@@ -1,3 +1,3 @@
-<div class="pix-tag {{concat "pix-tag--" @color}}" ...attributes>
+<div class="pix-tag {{concat "pix-tag--" @color}} {{if @uppercase "pix-tag--uppercase"}}" ...attributes>
   {{yield}}
 </div>

--- a/addon/stories/pix-tag.stories.js
+++ b/addon/stories/pix-tag.stories.js
@@ -48,6 +48,13 @@ const canvasContent = hbs`
 <PixTag @color='grey-light'>
   This is a grey tag
 </PixTag>
+
+<br><br>
+
+<h3>Modifiers</h3>
+<PixTag @uppercase={{true}}>
+  Uppercase
+</PixTag>
 `;
 
 const markdown = `
@@ -70,6 +77,7 @@ Un \`Tag\` est un type de \`Chips\` qui permet de mettre en avant une informatio
 | Nom           | Type          | Valeurs possibles     | Par défaut | Optionnel |
 | ------------- |:-------------:|:---------------------:|:----------:|----------:|
 | color         | string        | blue, blue-light, purple, purple-light, green, green-light, yellow, yellow-light, grey, grey-light   | blue       | oui       |
+| uppercase     | boolean       | true, false           | false       | oui       |
 `
 ;
 

--- a/addon/styles/_pix-tag.scss
+++ b/addon/styles/_pix-tag.scss
@@ -61,4 +61,8 @@
     color: $grey-60;
     background-color: $grey-15;
   }
+
+  &--uppercase {
+    text-transform: uppercase;
+  }
 }

--- a/tests/integration/components/pix-tag-test.js
+++ b/tests/integration/components/pix-tag-test.js
@@ -16,7 +16,14 @@ module('Integration | Component | pix-tag', function(hooks) {
     await render(hbs`<PixTag @color="purple" />`);
 
     const pixTagElement = this.element.querySelector('.pix-tag');
-    assert.equal(pixTagElement.classList.toString(), 'pix-tag pix-tag--purple');
+    assert.ok(pixTagElement.classList.contains('pix-tag--purple'));
+  });
+
+  test('it renders with the uppercase argument', async function(assert) {
+    await render(hbs`<PixTag @uppercase={{true}} />`);
+
+    const pixTagElement = this.element.querySelector('.pix-tag');
+    assert.ok(pixTagElement.classList.contains('pix-tag--uppercase'));
   });
 
   test('it renders with attributes override', async function(assert) {


### PR DESCRIPTION
## :unicorn: Description du composant

Nous avons besoin d'une variante avec le contenu du tag en majuscule. Nous avons rajouté un argument uppercase pour cela.

## :rainbow: Remarques

_Néant_

## :100: Pour tester

![Screenshot_2020-12-15 Basics Tag - Tag ⋅ Storybook](https://user-images.githubusercontent.com/86659/102228679-41605100-3eeb-11eb-8ab2-b0fe4cadee5d.png)

