### PR TITLE
[TECH] Donner un id fixe directement au mutliselect cherchable

### DIFF
--- a/addon/components/pix-multi-select.hbs
+++ b/addon/components/pix-multi-select.hbs
@@ -1,22 +1,19 @@
 <div class="pix-multi-select" ...attributes {{on-click-outside this.hideDropDown}}>
   {{#if @isSearchable}}
-    <label 
-      class="pix-multi-select-header"
-      for={{concat 'search-input' @id}}>
+    <label class="pix-multi-select-header" for={{@id}}>
 
       <span class="pix-multi-select-header__title">{{@title}}</span>
-      
-      <FaIcon @icon='search'
-              class="pix-multi-select-header__search-icon" />
-      
+      <FaIcon @icon='search' class="pix-multi-select-header__search-icon" />
+
       <input 
         type="text" 
-        id={{concat 'search-input' @id}}
-        name={{concat 'search-input' @id}}
+        id={{@id}}
+        name={{@id}}
         placeholder={{@placeholder}}
         {{on "input" this.updateSearch}}
         {{on "focus" this.showDropDown}}
-        class="pix-multi-select-header__search-input"/>  
+        class="pix-multi-select-header__search-input"/>
+
     </label>
   {{else}}
     <button 

--- a/addon/stories/pix-multi-select.stories.js
+++ b/addon/stories/pix-multi-select.stories.js
@@ -116,6 +116,7 @@ Examples de valeur préselectionné:
 | selected       | array         |                     |    []      |     oui   |
 | showOptionsOnInput | boolean       |     true/false      |    false   |     oui   |
 | isSearchable   | boolean       |     true/false      |    false   |     oui   |
+| strictSearch   | boolean       |     true/false      |    false   |     oui   |
 `;
 
 export const multiSelect = () => {


### PR DESCRIPTION
## :unicorn: Description
Lors de l'utilisation côté front du multiselect le composant donnait : 
```
<input id="search-inputadd-student-list__multi-select" name="search-inputadd-student-list__multi-select" placeholder="Chercher une classe ..." class="pix-multi-select-header__search-input" type="text">
```
Là où avant l'id était directement `add-student-list__multi-select` pour le mode cherchable il concatène la string avec `search-input`, ce qui peut potentiellement casser des tests qui click sur le filtre (s'ils ont selectionné l'élément avec l'id passé au composant).

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
> _Lien vers Zeroheight (modèle) et Storybook (rendu final)._
