### PR TITLE
[FEATURE] Ajout du tri des éléments dans le multi-select (PIX-1685)

### DIFF
--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -10,6 +10,7 @@ export const parameters = {
       return match ? match[1] : src;
     },
   },
+  controls: { expanded: true },
   previewTabs: { 
     'storybook/docs/panel': { index: -1 },
   },

--- a/addon/components/pix-multi-select.hbs
+++ b/addon/components/pix-multi-select.hbs
@@ -10,6 +10,7 @@
         id={{@id}}
         name={{@id}}
         placeholder={{@placeholder}}
+        autocomplete="off"
         {{on "input" this.updateSearch}}
         {{on "focus" this.showDropDown}}
         class="pix-multi-select-header__search-input"/>
@@ -38,7 +39,7 @@
             {{yield option}}
           </label>
         </li>
-        {{/each}}
+      {{/each}}
     {{else}}
         <li class="pix-multi-select-list__item pix-multi-select-list__item--no-result">{{@emptyMessage}}</li>
     {{/if}}

--- a/addon/components/pix-multi-select.js
+++ b/addon/components/pix-multi-select.js
@@ -43,10 +43,10 @@ export default class PixMultiSelect extends Component {
   @action
   onSelect(event) {
     if(event.target.checked) {
-      this._selected = [...this._selected, event.target.value]
-    } else {
+      this._selected = [...this._selected, event.target.value];
+        } else {
       this._selected = this._selected.filter((value) => {
-        return value !== event.target.value
+        return value !== event.target.value;
       });
     }
 

--- a/addon/components/pix-multi-select.js
+++ b/addon/components/pix-multi-select.js
@@ -44,7 +44,6 @@ export default class PixMultiSelect extends Component {
   onSelect(event) {
     if(event.target.checked) {
       this._selected = [...this._selected, event.target.value]
-      console.log(this._selected)
     } else {
       this._selected = this._selected.filter((value) => {
         return value !== event.target.value

--- a/addon/components/pix-multi-select.js
+++ b/addon/components/pix-multi-select.js
@@ -44,6 +44,7 @@ export default class PixMultiSelect extends Component {
   onSelect(event) {
     if(event.target.checked) {
       this._selected = [...this._selected, event.target.value]
+      console.log(this._selected)
     } else {
       this._selected = this._selected.filter((value) => {
         return value !== event.target.value

--- a/addon/stories/pix-multi-select.stories.js
+++ b/addon/stories/pix-multi-select.stories.js
@@ -8,29 +8,6 @@ export const multiSelectSearchable = (args) => {
         @id={{id}}
         @title={{title}}
         @placeholder={{placeholder}}
-        @isSearchable={{true}}
-        @showOptionsOnInput={{showOptionsOnInput}}
-        @strictSearch={{strictSearch}}
-        @onSelect={{doSomething}}
-        @emptyMessage={{emptyMessage}}
-        @selected={{selected}}
-        @options={{options}} as |option|
-      >
-        {{option.label}}
-      </PixMultiSelect>
-    `,
-    context: args,
-  };
-};
-
-export const multiSelect = (args) => {
-  return {
-    template: hbs`
-      <PixMultiSelect
-        style="width:350px"
-        @id={{id}}
-        @title={{title}}
-        @placeholder={{placeholder}}
         @isSearchable={{isSearchable}}
         @showOptionsOnInput={{showOptionsOnInput}}
         @strictSearch={{strictSearch}}
@@ -46,10 +23,38 @@ export const multiSelect = (args) => {
   };
 };
 
+export const multiSelectWithChildComponent = (args) => {
+  return {
+    template: hbs`
+      <PixMultiSelect
+        @title={{titleStars}}
+        @id={{id}}
+        @onSelect={{onSelect}}
+        @emptyMessage={{emptyMessage}}
+        @options={{optionsStars}} as |star|
+      >
+        <PixStars
+          @count={{star.value}}
+          @total={{star.total}}
+        />
+      </PixMultiSelect>
+    `,
+    context: {
+      ...args,
+      titleStars: 'Sélectionner le niveau souhaité',
+      optionsStars: [
+        { value: '1', total: 3 },
+        { value: '2', total: 3 },
+        { value: '3', total: 3 },
+      ],
+    },
+  };
+};
+
 export const argTypes = {
   id: {
     name: 'id',
-    description: 'Permet l‘accessibilité du composant attribuant des ‘for‘ pour chaque entité',
+    description: 'Permet l‘accessibilité du composant attribuant des ``for`` pour chaque entité',
     type: { name: 'string', required: true },
     defaultValue: 'aromate',
   },
@@ -67,13 +72,13 @@ export const argTypes = {
   },
   placeholder: {
     name: 'placeholder',
-    description: 'Donner une liste d‘exemple pour la recherche utilisateur dans le cas ‘isSearchable‘ à ‘true‘',
+    description: 'Donner une liste d‘exemple pour la recherche utilisateur dans le cas ``isSearchable`` à ``true``',
     type: { name: 'string', required: true },
     defaultValue: 'Curcuma, Thym, ...',
   },
   options: {
     name: 'options',
-    description: 'Les options sont représentées par un tableau d‘objet contenant les propriétés value et label. ‘value‘ doit être de type ‘String‘ pour être conforme au traitement des input value.',
+    description: 'Les options sont représentées par un tableau d‘objet contenant les propriétés ``value`` et ``label``. ``value`` doit être de type ``String`` pour être conforme au traitement des input value.',
     type: { name: 'array', required: true },
     defaultValue: [
       {label:"ANETH HERBE AROMATIQUE", value: '1'},
@@ -91,7 +96,7 @@ export const argTypes = {
   },
   onSelect: {
     name: 'onSelect',
-    description: 'une fonction permettant d‘effectuer une action à chaque sélection',
+    description: 'Une fonction permettant d\'effectuer une action à chaque sélection',
     type: { required: true },
   },
   selected: {
@@ -102,7 +107,7 @@ export const argTypes = {
   },
   showOptionsOnInput: {
     name: 'showOptionsOnInput',
-    description: 'Afficher la liste au focus du champs de saisie lorsque ‘isSearchable‘ à ‘true‘',
+    description: 'Afficher la liste au focus du champs de saisie lorsque ``isSearchable`` à ``true``',
     type: { name: 'boolean', required: false },
     defaultValue: false,
   },
@@ -110,11 +115,11 @@ export const argTypes = {
     name: 'isSearchable',
     description: 'Permet de rajouter une saisie utilisateur pour faciliter la recherche',
     type: { name: 'boolean', required: false },
-    defaultValue: false,
+    defaultValue: true,
   },
   strictSearch: {
     name: 'strictSearch',
-    description: 'Permet de rendre sensible à la casse et au diacritiques lorsque ‘isSearchable‘ à ‘true‘',
+    description: 'Permet de rendre sensible à la casse et au diacritiques lorsque ``isSearchable`` à ``true``',
     type: { name: 'boolean', required: false },
     defaultValue: false,
   },

--- a/addon/stories/pix-multi-select.stories.js
+++ b/addon/stories/pix-multi-select.stories.js
@@ -109,7 +109,7 @@ export const argTypes = {
     name: 'showOptionsOnInput',
     description: 'Afficher la liste au focus du champs de saisie lorsque ``isSearchable`` à ``true``',
     type: { name: 'boolean', required: false },
-    defaultValue: false,
+    defaultValue: true,
   },
   isSearchable: {
     name: 'isSearchable',

--- a/addon/stories/pix-multi-select.stories.mdx
+++ b/addon/stories/pix-multi-select.stories.mdx
@@ -12,7 +12,7 @@ import * as stories from './pix-multi-select.stories.js';
 # Pix Multi Select
 
 Un select custom permettant une gestion de la multiselection. Permet de passer soit du texte brut soit des composants à sa liste. (PixStars etc...)
-l'ajout de ``class`` et d'autres attributs comme ``aria-label`` sont possibles.
+L'ajout de ``class`` et d'autres attributs comme ``aria-label`` sont possibles.
 
 <Canvas>
   <Story name="Searchable" story={stories.multiSelectSearchable} />

--- a/addon/stories/pix-multi-select.stories.mdx
+++ b/addon/stories/pix-multi-select.stories.mdx
@@ -12,11 +12,14 @@ import * as stories from './pix-multi-select.stories.js';
 # Pix Multi Select
 
 Un select custom permettant une gestion de la multiselection. Permet de passer soit du texte brut soit des composants à sa liste. (PixStars etc...)
-l'ajout de \`class\` et d'autres attributs comme \`aria-label\` sont possibles.
+l'ajout de ``class`` et d'autres attributs comme ``aria-label`` sont possibles.
 
-<Canvas isColumn>
-  <Story name="Multi Select Searchable" story={stories.multiSelectSearchable} />
-  <Story name="Multi Select" story={stories.multiSelect} />
+<Canvas>
+  <Story name="Searchable" story={stories.multiSelectSearchable} />
+</Canvas>
+
+<Canvas>
+  <Story name="With child component" story={stories.multiSelectWithChildComponent} />
 </Canvas>
 
 ## Usage

--- a/tests/integration/components/pix-multi-select-test.js
+++ b/tests/integration/components/pix-multi-select-test.js
@@ -5,7 +5,7 @@ import { hbs } from 'ember-cli-htmlbars';
 
 import sinon from 'sinon';
 
-module('Integration | Component | multi-select', function(hooks) {
+module('Integration | Component | multi-select', function (hooks) {
   setupRenderingTest(hooks);
 
   const DEFAULT_OPTIONS = [
@@ -14,14 +14,14 @@ module('Integration | Component | multi-select', function(hooks) {
     { value: '3', label: 'Oignon' },
   ];
   const DEFAULT_ON_SELECT = () => {};
-  
-  test('it renders PixMultiSelect with list', async function(assert) {
-      // given
-      this.options = DEFAULT_OPTIONS;
-      this.onSelect = DEFAULT_ON_SELECT;
-      this.emptyMessage = 'no result';
-      this.title = 'MultiSelectTest';
-      this.id = 'id-MultiSelectTest';
+
+  test('it renders PixMultiSelect with list', async function (assert) {
+    // given
+    this.options = DEFAULT_OPTIONS;
+    this.onSelect = DEFAULT_ON_SELECT;
+    this.emptyMessage = 'no result';
+    this.title = 'MultiSelectTest';
+    this.id = 'id-MultiSelectTest';
 
     // when
     await render(hbs`
@@ -43,7 +43,7 @@ module('Integration | Component | multi-select', function(hooks) {
     assert.equal(listElement.length, 3);
   });
 
-  test('it renders the PixMultiSelect with empty message', async function(assert) {
+  test('it renders the PixMultiSelect with empty message', async function (assert) {
     // given
     this.options = [];
     this.onSelect = DEFAULT_ON_SELECT;
@@ -68,12 +68,12 @@ module('Integration | Component | multi-select', function(hooks) {
 
     // then
     assert.equal(buttonElement.textContent.trim(), this.title);
-    
+
     assert.equal(listElement.length, 1);
     assert.equal(listElement.item(0).textContent.trim(), 'no result');
   });
 
-  test('it renders the PixMultiSelect with default checked', async function(assert) {
+  test('it renders the PixMultiSelect with default checked', async function (assert) {
     // given
     this.options = DEFAULT_OPTIONS;
     this.onSelect = DEFAULT_ON_SELECT;
@@ -99,22 +99,22 @@ module('Integration | Component | multi-select', function(hooks) {
 
     // then
     assert.equal(checkboxElement.length, 3);
-    
+
     assert.equal(checkboxElement.item(0).checked, false);
     assert.equal(checkboxElement.item(1).checked, true);
     assert.equal(checkboxElement.item(2).checked, false);
   });
 
   test('it should trigger onSelect function when an item is selected', async function (assert) {
-  // given
-  this.options = DEFAULT_OPTIONS;
+    // given
+    this.options = DEFAULT_OPTIONS;
 
-  this.title = 'MultiSelectTest';
-  this.emptyMessage = 'no result';
-  this.id = 'id-MultiSelectTest';
-  this.onSelect = sinon.spy();
+    this.title = 'MultiSelectTest';
+    this.emptyMessage = 'no result';
+    this.id = 'id-MultiSelectTest';
+    this.onSelect = sinon.spy();
 
-  await render(hbs`
+    await render(hbs`
     <PixMultiSelect
       @onSelect={{onSelect}}
       @title={{title}}
@@ -125,15 +125,15 @@ module('Integration | Component | multi-select', function(hooks) {
     </PixMultiSelect>
   `);
 
-  // when
-  const firstCheckbox = this.element.querySelectorAll('input[type=checkbox]').item(0);
+    // when
+    const firstCheckbox = this.element.querySelectorAll('input[type=checkbox]').item(0);
 
-  await click(firstCheckbox);
+    await click(firstCheckbox);
 
-  // then
-  assert.equal(firstCheckbox.checked, true);
-  assert.ok(this.onSelect.calledOnce, "the callback should be called once");
-  assert.ok(this.onSelect.calledWith, ['1']);
+    // then
+    assert.equal(firstCheckbox.checked, true);
+    assert.ok(this.onSelect.calledOnce, 'the callback should be called once');
+    assert.ok(this.onSelect.calledWith, ['1']);
   });
 
   test('it should unselect item and return selected item of the updated list', async function (assert) {
@@ -142,7 +142,7 @@ module('Integration | Component | multi-select', function(hooks) {
 
     this.title = 'MultiSelectTest';
     this.emptyMessage = 'no result';
-    this.selected= ['1','2'];
+    this.selected = ['1', '2'];
     this.id = 'id-MultiSelectTest';
     this.onSelect = sinon.spy();
 
@@ -166,177 +166,324 @@ module('Integration | Component | multi-select', function(hooks) {
     assert.ok(this.onSelect.calledWith, ['2']);
   });
 
-  test('it should renders searchable PixMultiSelect multi select list', async function (assert) {
-    // given
-    this.options = DEFAULT_OPTIONS;
-    this.onSelect = DEFAULT_ON_SELECT;
-    this.emptyMessage = 'no result';
-    this.title = 'MultiSelectTest';
-    this.id = 'id-MultiSelectTest';
-    this.isSearchable = true;
-    this.placeholder = 'Placeholder test';
+  module('When it is a searchable multiselect', function() {
+    test('it should renders searchable PixMultiSelect multi select list', async function (assert) {
+      // given
+      this.options = DEFAULT_OPTIONS;
+      this.onSelect = DEFAULT_ON_SELECT;
+      this.emptyMessage = 'no result';
+      this.title = 'MultiSelectTest';
+      this.id = 'id-MultiSelectTest';
+      this.isSearchable = true;
+      this.placeholder = 'Placeholder test';
 
-    await render(hbs`
-      <PixMultiSelect
-        @isSearchable={{isSearchable}}
-        @onSelect={{onSelect}}
-        @title={{title}}
-        @placeholder={{placeholder}}
-        @id={{id}}
-        @emptyMessage={{emptyMessage}}
-        @options={{options}} as |option|>
-        {{option.label}}
-      </PixMultiSelect>
-    `);
+      await render(hbs`
+        <PixMultiSelect
+          @isSearchable={{isSearchable}}
+          @onSelect={{onSelect}}
+          @title={{title}}
+          @placeholder={{placeholder}}
+          @id={{id}}
+          @emptyMessage={{emptyMessage}}
+          @options={{options}} as |option|>
+          {{option.label}}
+        </PixMultiSelect>
+      `);
 
-    // when
-    const labelElement = this.element.querySelector('.pix-multi-select-header');
-    const inputElement = this.element.querySelector('.pix-multi-select-header__search-input');
-    const listElement = this.element.querySelectorAll('li');
+      // when
+      const labelElement = this.element.querySelector('.pix-multi-select-header');
+      const inputElement = this.element.querySelector('.pix-multi-select-header__search-input');
+      const listElement = this.element.querySelectorAll('li');
 
-    // then
-    assert.equal(labelElement.textContent.trim(), this.title);
-    assert.equal(inputElement.placeholder, this.placeholder);
-    assert.equal(listElement.length, 3);
-  });
+      // then
+      assert.equal(labelElement.textContent.trim(), this.title);
+      assert.equal(inputElement.placeholder, this.placeholder);
+      assert.equal(listElement.length, 3);
+    });
 
-  test('it should renders filtered given case insensitive', async function (assert) {
-    // given
-    this.options = DEFAULT_OPTIONS;
-    this.onSelect = DEFAULT_ON_SELECT;
-    this.emptyMessage = 'no result';
-    this.title = 'MultiSelectTest';
-    this.id = 'id-MultiSelectTest';
-    this.isSearchable = true;
-    this.placeholder = 'Placeholder test';
+    test('it should renders filtered given case insensitive', async function (assert) {
+      // given
+      this.options = DEFAULT_OPTIONS;
+      this.onSelect = DEFAULT_ON_SELECT;
+      this.emptyMessage = 'no result';
+      this.title = 'MultiSelectTest';
+      this.id = 'id-MultiSelectTest';
+      this.isSearchable = true;
+      this.placeholder = 'Placeholder test';
 
-    await render(hbs`
-      <PixMultiSelect
-        @isSearchable={{isSearchable}}
-        @onSelect={{onSelect}}
-        @title={{title}}
-        @placeholder={{placeholder}}
-        @id={{id}}
-        @emptyMessage={{emptyMessage}}
-        @options={{options}} as |option|>
-        {{option.label}}
-      </PixMultiSelect>
-    `);
+      await render(hbs`
+        <PixMultiSelect
+          @isSearchable={{isSearchable}}
+          @onSelect={{onSelect}}
+          @title={{title}}
+          @placeholder={{placeholder}}
+          @id={{id}}
+          @emptyMessage={{emptyMessage}}
+          @options={{options}} as |option|>
+          {{option.label}}
+        </PixMultiSelect>
+      `);
 
-    // when
-    await fillIn('input', 'tomate');
+      // when
+      await fillIn('input', 'tomate');
 
-    // when
-    const listElement = this.element.querySelectorAll('.pix-multi-select-list__item');
+      // when
+      const listElement = this.element.querySelectorAll('.pix-multi-select-list__item');
 
-    // then
-    assert.equal(listElement.length, 1);
-    assert.equal(listElement.item(0).textContent.trim(), 'Tomate');
-  });
+      // then
+      assert.equal(listElement.length, 1);
+      assert.equal(listElement.item(0).textContent.trim(), 'Tomate');
+    });
 
-  test('it should renders no result given case sensitive', async function (assert) {
-    // given
-    this.options = DEFAULT_OPTIONS;
-    this.onSelect = DEFAULT_ON_SELECT;
-    this.emptyMessage = 'no result';
-    this.title = 'MultiSelectTest';
-    this.id = 'id-MultiSelectTest';
-    this.isSearchable = true;
-    this.strictSearch = true;
-    this.placeholder = 'Placeholder test';
+    test('it should renders no result given case sensitive', async function (assert) {
+      // given
+      this.options = DEFAULT_OPTIONS;
+      this.onSelect = DEFAULT_ON_SELECT;
+      this.emptyMessage = 'no result';
+      this.title = 'MultiSelectTest';
+      this.id = 'id-MultiSelectTest';
+      this.isSearchable = true;
+      this.strictSearch = true;
+      this.placeholder = 'Placeholder test';
 
-    await render(hbs`
-      <PixMultiSelect
-        @isSearchable={{isSearchable}}
-        @strictSearch={{strictSearch}}
-        @onSelect={{onSelect}}
-        @title={{title}}
-        @placeholder={{placeholder}}
-        @id={{id}}
-        @emptyMessage={{emptyMessage}}
-        @options={{options}} as |option|>
-        {{option.label}}
-      </PixMultiSelect>
-    `);
+      await render(hbs`
+        <PixMultiSelect
+          @isSearchable={{isSearchable}}
+          @strictSearch={{strictSearch}}
+          @onSelect={{onSelect}}
+          @title={{title}}
+          @placeholder={{placeholder}}
+          @id={{id}}
+          @emptyMessage={{emptyMessage}}
+          @options={{options}} as |option|>
+          {{option.label}}
+        </PixMultiSelect>
+      `);
 
-    // when
-    await fillIn('input', 'tomate');
+      // when
+      await fillIn('input', 'tomate');
 
-    // when
-    const listElement = this.element.querySelectorAll('.pix-multi-select-list__item');
+      // when
+      const listElement = this.element.querySelectorAll('.pix-multi-select-list__item');
 
-    // then
-    assert.equal(listElement.length, 1);
-    assert.equal(listElement.item(0).textContent.trim(), 'no result');
-  });
+      // then
+      assert.equal(listElement.length, 1);
+      assert.equal(listElement.item(0).textContent.trim(), 'no result');
+    });
 
-  test('it should display list PixMultiSelect on focus', async function (assert) {
-    // given
-    this.options = DEFAULT_OPTIONS;
-    this.onSelect = DEFAULT_ON_SELECT;
-    this.emptyMessage = 'no result';
-    this.title = 'MultiSelectTest';
-    this.id = 'id-MultiSelectTest';
-    this.isSearchable = true;
-    this.showOptionsOnInput = true;
-    this.placeholder = 'Placeholder test';
+    test('it should display list PixMultiSelect on focus', async function (assert) {
+      // given
+      this.options = DEFAULT_OPTIONS;
+      this.onSelect = DEFAULT_ON_SELECT;
+      this.emptyMessage = 'no result';
+      this.title = 'MultiSelectTest';
+      this.id = 'id-MultiSelectTest';
+      this.isSearchable = true;
+      this.showOptionsOnInput = true;
+      this.placeholder = 'Placeholder test';
 
-    await render(hbs`
-      <PixMultiSelect
-        @isSearchable={{isSearchable}}
-        @showOptionsOnInput={{showOptionsOnInput}}
-        @onSelect={{onSelect}}
-        @title={{title}}
-        @placeholder={{placeholder}}
-        @id={{id}}
-        @emptyMessage={{emptyMessage}}
-        @options={{options}} as |option|>
-        {{option.label}}
-      </PixMultiSelect>
-    `);
+      await render(hbs`
+        <PixMultiSelect
+          @isSearchable={{isSearchable}}
+          @showOptionsOnInput={{showOptionsOnInput}}
+          @onSelect={{onSelect}}
+          @title={{title}}
+          @placeholder={{placeholder}}
+          @id={{id}}
+          @emptyMessage={{emptyMessage}}
+          @options={{options}} as |option|>
+          {{option.label}}
+        </PixMultiSelect>
+      `);
 
-    // when
-    await focus('input');
+      // when
+      await focus('input');
 
-    // when
-    const listElement = this.element.querySelector('ul');
+      // when
+      const listElement = this.element.querySelector('ul');
 
-    // then
-    assert.equal(listElement.className.trim(), 'pix-multi-select-list');
-  });
+      // then
+      assert.equal(listElement.className.trim(), 'pix-multi-select-list');
+    });
 
-  test('it should not display list PixMultiSelect on focus', async function (assert) {
-    // given
-    this.options = DEFAULT_OPTIONS;
-    this.onSelect = DEFAULT_ON_SELECT;
-    this.emptyMessage = 'no result';
-    this.title = 'MultiSelectTest';
-    this.id = 'id-MultiSelectTest';
-    this.isSearchable = true;
-    this.showOptionsOnInput = false;
-    this.placeholder = 'Placeholder test';
+    test('it should not display list PixMultiSelect on focus', async function (assert) {
+      // given
+      this.options = DEFAULT_OPTIONS;
+      this.onSelect = DEFAULT_ON_SELECT;
+      this.emptyMessage = 'no result';
+      this.title = 'MultiSelectTest';
+      this.id = 'id-MultiSelectTest';
+      this.isSearchable = true;
+      this.showOptionsOnInput = false;
+      this.placeholder = 'Placeholder test';
 
-    await render(hbs`
-      <PixMultiSelect
-        @isSearchable={{isSearchable}}
-        @showOptionsOnInput={{showOptionsOnInput}}
-        @onSelect={{onSelect}}
-        @title={{title}}
-        @placeholder={{placeholder}}
-        @id={{id}}
-        @emptyMessage={{emptyMessage}}
-        @options={{options}} as |option|>
-        {{option.label}}
-      </PixMultiSelect>
-    `);
+      await render(hbs`
+        <PixMultiSelect
+          @isSearchable={{isSearchable}}
+          @showOptionsOnInput={{showOptionsOnInput}}
+          @onSelect={{onSelect}}
+          @title={{title}}
+          @placeholder={{placeholder}}
+          @id={{id}}
+          @emptyMessage={{emptyMessage}}
+          @options={{options}} as |option|>
+          {{option.label}}
+        </PixMultiSelect>
+      `);
 
-    // when
-    await focus('input');
+      // when
+      await focus('input');
 
-    // when
-    const listElement = this.element.querySelector('ul');
+      // when
+      const listElement = this.element.querySelector('ul');
 
-    // then
-    assert.equal(listElement.className, 'pix-multi-select-list pix-multi-select-list--hidden');
+      // then
+      assert.equal(listElement.className, 'pix-multi-select-list pix-multi-select-list--hidden');
+    });
+
+    test('it should sort default selected items when focused', async function (assert) {
+      // given
+      this.options = DEFAULT_OPTIONS;
+      this.onSelect = DEFAULT_ON_SELECT;
+      this.emptyMessage = 'no result';
+      this.title = 'MultiSelectTest';
+      this.id = 'id-MultiSelectTest';
+      this.isSearchable = true;
+      this.placeholder = 'Placeholder test';
+      this.defaultSelected = ['3'];
+
+      await render(hbs`
+        <PixMultiSelect
+          @isSearchable={{isSearchable}}
+          @onSelect={{onSelect}}
+          @title={{title}}
+          @placeholder={{placeholder}}
+          @id={{id}}
+          @emptyMessage={{emptyMessage}}
+          @selected={{defaultSelected}}
+          @options={{options}} as |option|>
+          {{option.label}}
+        </PixMultiSelect>
+      `);
+
+      // when
+      await focus('input');
+
+      // then
+      const listElement = this.element.querySelectorAll('.pix-multi-select-list__item');
+      assert.equal(listElement.length, 3);
+      assert.equal(listElement.item(0).textContent.trim(), 'Oignon');
+      assert.equal(listElement.item(1).textContent.trim(), 'Salade');
+      assert.equal(listElement.item(2).textContent.trim(), 'Tomate');
+    });
+
+    test('it should not sort when user select item', async function (assert) {
+      // given
+      this.options = DEFAULT_OPTIONS;
+      this.onSelect = DEFAULT_ON_SELECT;
+      this.emptyMessage = 'no result';
+      this.title = 'MultiSelectTest';
+      this.id = 'id-MultiSelectTest';
+      this.isSearchable = true;
+      this.placeholder = 'Placeholder test';
+
+      await render(hbs`
+        <PixMultiSelect
+          @isSearchable={{isSearchable}}
+          @onSelect={{onSelect}}
+          @title={{title}}
+          @placeholder={{placeholder}}
+          @id={{id}}
+          @emptyMessage={{emptyMessage}}
+          @options={{options}} as |option|>
+          {{option.label}}
+        </PixMultiSelect>
+      `);
+    
+      // when
+      const thirdCheckbox = this.element.querySelectorAll('input[type=checkbox]').item(2);
+    
+      await click(thirdCheckbox);
+    
+      // then
+      const listElement = this.element.querySelectorAll('.pix-multi-select-list__item');
+      assert.equal(listElement.length, 3);
+      assert.equal(listElement.item(0).textContent.trim(), 'Salade');
+      assert.equal(listElement.item(1).textContent.trim(), 'Tomate');
+      assert.equal(listElement.item(2).textContent.trim(), 'Oignon');
+    });
+
+    test('it should keep current sort when user search and select item', async function (assert) {
+      // given
+      this.options = DEFAULT_OPTIONS;
+      this.onSelect = DEFAULT_ON_SELECT;
+      this.emptyMessage = 'no result';
+      this.title = 'MultiSelectTest';
+      this.id = 'id-MultiSelectTest';
+      this.isSearchable = true;
+      this.placeholder = 'Placeholder test';
+
+      await render(hbs`
+        <PixMultiSelect
+          @isSearchable={{isSearchable}}
+          @onSelect={{onSelect}}
+          @title={{title}}
+          @placeholder={{placeholder}}
+          @id={{id}}
+          @emptyMessage={{emptyMessage}}
+          @options={{options}} as |option|>
+          {{option.label}}
+        </PixMultiSelect>
+      `);
+    
+      // when
+      await fillIn('input', 'Oi')
+      const checkbox = this.element.querySelectorAll('input[type=checkbox]').item(0);
+      await click(checkbox);
+      await fillIn('input', 'o')
+    
+      // then
+      const listElement = this.element.querySelectorAll('.pix-multi-select-list__item');
+      assert.equal(listElement.length, 2);
+      assert.equal(listElement.item(0).textContent.trim(), 'Tomate');
+      assert.equal(listElement.item(1).textContent.trim(), 'Oignon');
+    });
+
+    test('it should sort items when search is cleaned', async function (assert) {
+      // given
+      this.options = DEFAULT_OPTIONS;
+      this.onSelect = DEFAULT_ON_SELECT;
+      this.emptyMessage = 'no result';
+      this.title = 'MultiSelectTest';
+      this.id = 'id-MultiSelectTest';
+      this.isSearchable = true;
+      this.placeholder = 'Placeholder test';
+
+      await render(hbs`
+        <PixMultiSelect
+          @isSearchable={{isSearchable}}
+          @onSelect={{onSelect}}
+          @title={{title}}
+          @placeholder={{placeholder}}
+          @id={{id}}
+          @emptyMessage={{emptyMessage}}
+          @options={{options}} as |option|>
+          {{option.label}}
+        </PixMultiSelect>
+      `);
+    
+      // when
+      await fillIn('input', 'Oi')
+      const checkbox = this.element.querySelectorAll('input[type=checkbox]').item(0);
+      await click(checkbox);
+      await fillIn('input', '')
+    
+      // then
+      const listElement = this.element.querySelectorAll('.pix-multi-select-list__item');
+      assert.equal(listElement.length, 3);
+      assert.equal(listElement.item(0).textContent.trim(), 'Oignon');
+      assert.equal(listElement.item(1).textContent.trim(), 'Salade');
+      assert.equal(listElement.item(2).textContent.trim(), 'Tomate');
+    });
   });
 });

--- a/tests/integration/components/pix-multi-select-test.js
+++ b/tests/integration/components/pix-multi-select-test.js
@@ -1,6 +1,6 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import { render, click, fillIn, focus } from '@ember/test-helpers';
+import { render, click, fillIn, focus, blur } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 
 import sinon from 'sinon';
@@ -477,6 +477,46 @@ module('Integration | Component | multi-select', function (hooks) {
       const checkbox = this.element.querySelectorAll('input[type=checkbox]').item(0);
       await click(checkbox);
       await fillIn('input', '')
+    
+      // then
+      const listElement = this.element.querySelectorAll('.pix-multi-select-list__item');
+      assert.equal(listElement.length, 3);
+      assert.equal(listElement.item(0).textContent.trim(), 'Oignon');
+      assert.equal(listElement.item(1).textContent.trim(), 'Salade');
+      assert.equal(listElement.item(2).textContent.trim(), 'Tomate');
+    });
+
+    test('it should sort items when search is unfocus', async function (assert) {
+      // given
+      this.options = DEFAULT_OPTIONS;
+      this.onSelect = DEFAULT_ON_SELECT;
+      this.emptyMessage = 'no result';
+      this.title = 'MultiSelectTest';
+      this.id = 'id-MultiSelectTest';
+      this.isSearchable = true;
+      this.placeholder = 'Placeholder test';
+
+      await render(hbs`
+        <PixMultiSelect
+          @isSearchable={{isSearchable}}
+          @onSelect={{onSelect}}
+          @title={{title}}
+          @placeholder={{placeholder}}
+          @id={{id}}
+          @emptyMessage={{emptyMessage}}
+          @options={{options}} as |option|>
+          {{option.label}}
+        </PixMultiSelect>
+      `);
+    
+      // when
+      await fillIn('input', 'Oi')
+      const checkbox = this.element.querySelectorAll('input[type=checkbox]').item(0);
+      await click(checkbox);
+      
+      await blur('input');
+
+      await fillIn('input', '');
     
       // then
       const listElement = this.element.querySelectorAll('.pix-multi-select-list__item');


### PR DESCRIPTION
## :unicorn: Description du composant

Ajout du tri des éléments sélectionnés (en premier dans la liste) quand on ouvre la liste

(le tri est appliqué uniquement quand on ouvre la liste, pas quand on sélectionne des éléments pour éviter les "jump")

## :rainbow: Remarques

La documentation du Multi-select a été mise à jour avec les addons docs et control.

![image](https://user-images.githubusercontent.com/516360/102640426-b9807e00-415a-11eb-8e2b-0d0dee084fd8.png)

