### PR TITLE
[FEATURE] Ajout du composant PixTextarea

### DIFF
--- a/addon/components/pix-textarea.hbs
+++ b/addon/components/pix-textarea.hbs
@@ -5,7 +5,7 @@
       @value={{@value}}
       @maxlength={{@maxlength}}
     />
-    <p>{{this.reportLength}} / {{@maxlength}}</p>
+    <p>{{this.textLengthIndicator}} / {{@maxlength}}</p>
   {{else}}
     <Textarea id={{@id}} @value={{@value}} />
   {{/if}}

--- a/addon/components/pix-textarea.hbs
+++ b/addon/components/pix-textarea.hbs
@@ -1,0 +1,12 @@
+<div class='pix-textarea' ...attributes>
+  {{#if @maxlength}}
+    <Textarea
+      id={{@id}}
+      @value={{@value}}
+      @maxlength={{@maxlength}}
+    />
+    <p>{{this.reportLength}} / {{@maxlength}}</p>
+  {{else}}
+    <Textarea id={{@id}} @value={{@value}} />
+  {{/if}}
+</div>

--- a/addon/components/pix-textarea.js
+++ b/addon/components/pix-textarea.js
@@ -1,7 +1,7 @@
 import Component from '@glimmer/component';
 
 export default class PixTextarea extends Component {
-  get reportLength() {
+  get textLengthIndicator() {
     return this.args.value
       ? this.args.value.length
       : 0;

--- a/addon/components/pix-textarea.js
+++ b/addon/components/pix-textarea.js
@@ -1,0 +1,9 @@
+import Component from '@glimmer/component';
+
+export default class PixTextarea extends Component {
+  get reportLength() {
+    return this.args.value
+      ? this.args.value.length
+      : 0;
+  }
+}

--- a/addon/stories/pix-textarea.stories.js
+++ b/addon/stories/pix-textarea.stories.js
@@ -1,0 +1,37 @@
+import { hbs } from 'ember-cli-htmlbars';
+
+export const textarea = (args) => {
+  return {
+    template: hbs`
+      <PixTextarea 
+        @id={{id}}
+        @value={{value}}
+        @maxlength={{maxlength}}
+      />
+    `,
+    context: args,
+  };
+};
+
+export const argTypes = {
+  id: {
+    name: 'id',
+    description: 'Identifiant du champ permettant de lui attacher un label',
+    type: { name: 'string', required: true },
+    defaultValue: '',
+  },
+
+  value: {
+    name: 'value',
+    description: 'Valeur du champ',
+    type: { name: 'string', required: true },
+    defaultValue: '',
+  },
+
+  maxlength: {
+    name: 'maxlength',
+    description: 'Nombre de caractères maximal à taper dans le champ',
+    type: { name: 'number', required: false },
+    defaultValue: 500,
+  },
+};

--- a/addon/stories/pix-textarea.stories.mdx
+++ b/addon/stories/pix-textarea.stories.mdx
@@ -1,0 +1,35 @@
+import { Meta, Story, Canvas, ArgsTable } from '@storybook/addon-docs/blocks';
+import centered from '@storybook/addon-centered/ember';
+import * as stories from './pix-textarea.stories.js';
+
+<Meta
+  title='Form/Textarea'
+  component='PixTextarea'
+  decorators={[centered]}
+  argTypes={stories.argTypes}
+/>
+
+# PixTextarea
+
+Un textarea permettant d'avoir un champ de saisie libre.
+
+Optionellement, il peut afficher le nombre de caractères tapés ainsi que le nombre de caractères maximum.
+
+> A noter qu'un `id` est nécessaire pour attribuer au textarea un label. Par ailleurs, l'attribut `value` permet de traiter son contenu.
+
+<Canvas>
+  <Story name='PixTextarea' story={stories.textarea} height="100px" />
+</Canvas>
+
+## Usage
+
+```js
+<PixTextarea
+  @id={{id}}
+  @value={{value}}
+  @maxlength={{maxlength}} />
+```
+
+## Arguments
+
+<ArgsTable story="PixTextarea" />

--- a/addon/styles/_pix-textarea.scss
+++ b/addon/styles/_pix-textarea.scss
@@ -1,0 +1,33 @@
+.pix-textarea {
+  @import 'reset-css';
+
+  textarea {
+    box-sizing: border-box;
+    width: 100%;
+    border: 1.6px solid $grey-45;
+    border-style: solid;
+    border-radius: 4px;
+    padding: 8px;
+    font-family: $font-roboto;
+    color: $grey-45;
+    font-size: 1rem;
+
+    &:hover {
+      border-color: $grey-60;
+    }
+
+    &:focus {
+      border: 1.6px solid $blue;
+      outline: none;
+    }
+  }
+
+  p {
+    color: $grey-45;
+    margin-top: 6px;
+    font-size: 12px;
+    display: flex;
+    flex-direction: row-reverse;
+  }
+
+}

--- a/addon/styles/addon.scss
+++ b/addon/styles/addon.scss
@@ -14,6 +14,7 @@
 @import 'pix-select';
 @import 'pix-filter-banner';
 @import 'pix-multi-select';
+@import 'pix-textarea';
 
 html {
   font-size: 16px;

--- a/app/components/pix-textarea.js
+++ b/app/components/pix-textarea.js
@@ -1,0 +1,1 @@
+export { default } from 'pix-ui/components/pix-textarea';

--- a/tests/integration/components/pix-textarea-test.js
+++ b/tests/integration/components/pix-textarea-test.js
@@ -1,0 +1,44 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render, fillIn } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+
+module('Integration | Component | textarea', function(hooks) {
+  setupRenderingTest(hooks);
+
+  const TEXTAREA_SELECTOR = '.pix-textarea textarea';
+  const CHAR_COUNT_SELECTOR = '.pix-textarea p';
+
+  test('it renders PixTextarea with correct id and content', async function(assert) {
+    // given 
+    const newContent = 'Bonjour Pix !';
+
+    // when
+    await render(hbs`<PixTextarea @id=7 @value="old value" />`);
+    await fillIn(TEXTAREA_SELECTOR, newContent);
+
+    // then
+    const textarea = this.element.querySelector(TEXTAREA_SELECTOR);
+    assert.equal(textarea.value.trim(), newContent);
+    assert.equal(textarea.id, 7);
+  });
+
+
+  test('it should count textarea characters length', async function(assert) {
+    // given
+    const defaultValue = '';
+    this.set('value', defaultValue);
+    const maxlength = 20;
+    this.set('maxlength', maxlength);
+
+    // when
+    await render(hbs`<PixTextarea @value={{value}} @maxlength={{maxlength}} />`);
+    await fillIn(TEXTAREA_SELECTOR, 'Hello Pix !');
+
+    // then
+    const textarea = this.element.querySelector(TEXTAREA_SELECTOR);
+    assert.equal(textarea.maxLength, maxlength);
+    assert.dom(CHAR_COUNT_SELECTOR).hasText('11 / 20');
+  });
+
+});


### PR DESCRIPTION
## :unicorn: Description du composant
Un textarea version Pix ! Avec possibilité de limiter le nombre de caractère (et un indicateur).

<img width="238" alt="image" src="https://user-images.githubusercontent.com/38167520/103778066-0789f280-5032-11eb-9575-51eb429d2006.png">


<img width="238" alt="image" src="https://user-images.githubusercontent.com/38167520/103778089-0ce73d00-5032-11eb-99fc-bfb70b4195d7.png">


## :100: Pour tester
- npm run storybook
