### PR TITLE
[FIX] Problème de CSS et de propagation sur le multiselect (PIX-1981)

### DIFF
--- a/addon/components/pix-multi-select.hbs
+++ b/addon/components/pix-multi-select.hbs
@@ -1,4 +1,4 @@
-<div class="pix-multi-select" ...attributes {{on-click-outside this.hideDropDown}}>
+<div class="pix-multi-select" ...attributes {{on-click-outside this.hideDropDown capture=true}}>
   {{#if @isSearchable}}
     <label class="pix-multi-select-header" for={{@id}}>
 

--- a/addon/components/pix-multi-select.js
+++ b/addon/components/pix-multi-select.js
@@ -78,8 +78,13 @@ export default class PixMultiSelect extends Component {
   }
 
   @action
-  hideDropDown() {
+  hideDropDown(event) {
     if(!this.isExpanded) return;
+
+    if (event) {
+      event.stopPropagation();
+      event.preventDefault();
+    }
     this.isExpanded = false;
 
     this.updateCurrentSelectedList();  

--- a/addon/styles/_pix-multi-select.scss
+++ b/addon/styles/_pix-multi-select.scss
@@ -39,7 +39,7 @@
     height: 0;
   }
 
-  &__search-input {
+  input.pix-multi-select-header__search-input {
     height: inherit;
     width: 100%;
     border: none;
@@ -104,7 +104,7 @@
     background: $grey-35;
   }
 
-  &__item {
+  li.pix-multi-select-list__item {
     font-family: $font-roboto;
     position: relative;
     border-bottom: 1px solid $grey-15;


### PR DESCRIPTION
## :unicorn: Description du composant

- ResetCSS surcharge les styles du MultiSelect (search input et résultats vides)
-  Quand on clique hors du multiselect pour le fermer, l'évènement ne doit pas se propager à l'arrière.