### PR TITLE
[STYLE] Correction du style FilterBanner et MultiSelect

### DIFF
--- a/addon/components/pix-filter-banner.hbs
+++ b/addon/components/pix-filter-banner.hbs
@@ -2,5 +2,7 @@
   {{#if this.displayTitle}}
     <p class="pix-filter-banner__title">{{@title}}</p>
   {{/if}}
-  <div>{{yield}}</div>
+  <div class="pix-filter-banner__content">
+    {{yield}}
+  </div>
 </div>

--- a/addon/stories/pix-filter-banner.stories.js
+++ b/addon/stories/pix-filter-banner.stories.js
@@ -4,17 +4,16 @@ export const filterBanner = (args) => {
   return {
     template: hbs`
       <PixFilterBanner @title={{title}}>
-        <select>
-          <option value="22">
-            classe de 2nd
-          </option>
-          <option value="3">
-            classe de 3e
-          </option>
-        </select>
+        <PixSelect @options={{options}} @onChange={{onChange}} />
+        <PixSelect @options={{options}} @onChange={{onChange}} />
       </PixFilterBanner>
     `,
-    context: args,
+    context: {
+      title: 'Filtres',
+      ...args,
+      options:  [{ value: '1', label: 'Tomate' }],
+      onChange: console.log,
+    },
   };
 };
 

--- a/addon/stories/pix-filter-banner.stories.mdx
+++ b/addon/stories/pix-filter-banner.stories.mdx
@@ -16,7 +16,7 @@ Une `FilterBanner` permet de wrapper les éléments de filtres (`Select`, `Multi
 > Il est possible de surcharger le style d'une `<PixFilterBanner>` via l'attribut `class` ainsi que de passer n'importe quel attribut sur sa `div` wrapper (par exemple, un `aria-label`)
 
 <Canvas>
-  <Story name="Filter banner" story={stories.filterBanner} height="60px" />
+  <Story name="Filter banner" story={stories.filterBanner} height="80px" />
 </Canvas>
 
 ## Usage

--- a/addon/styles/_pix-filter-banner.scss
+++ b/addon/styles/_pix-filter-banner.scss
@@ -20,4 +20,16 @@
     padding-right: 24px;
     margin: 0;
   }
+
+  &__content {
+    display: flex;
+
+    > * {
+      margin-right: 16px;
+    }
+
+    > *:last-child {
+      margin-right: 0;
+    }
+  }
 }

--- a/addon/styles/_pix-multi-select.scss
+++ b/addon/styles/_pix-multi-select.scss
@@ -142,8 +142,8 @@
       margin-right: 12px;
       display: inline-block;
       vertical-align: text-top;
-      width: 16px;
-      height: 16px;
+      min-width: 16px;
+      min-height: 16px;
       border-radius: 4px;
       background: $white;
       border: 1px solid $grey-20;


### PR DESCRIPTION
## :unicorn: PixFilterBanner

La contenu de la bannière de filtre n'aligne pas correctement les éléments qu'elle contient (filtres sous forme de select)

Faire en sorte que le contenu de la bannière soit correctement aligné (display: flex)

*Avant:*
![image](https://user-images.githubusercontent.com/516360/105154899-4b88f700-5b0a-11eb-88cc-4e97ab4c61dc.png)

*Après:*
![image](https://user-images.githubusercontent.com/516360/105155194-97d43700-5b0a-11eb-856e-de506a5dbcbe.png)


## :unicorn: PixMultiSelect

La taille de la checkbox du multi-select n'est pas correctement rendue quand le libellé passe sur plusieurs lignes.

*Avant:*
![image](https://user-images.githubusercontent.com/516360/105156282-e8985f80-5b0b-11eb-91ea-836541d11065.png)

*Après:*
![image](https://user-images.githubusercontent.com/516360/105156863-ac193380-5b0c-11eb-9dcb-f5d134e911ae.png)
