### PR TITLE
[TECH] Pouvoir modifier les bords et la couleur de PixButton

### DIFF
--- a/addon/components/pix-button.hbs
+++ b/addon/components/pix-button.hbs
@@ -1,4 +1,8 @@
-<button type={{this.type}} class="pix-button pix-button--{{this.border}}" {{on "click" this.triggerAction}} ...attributes disabled={{this.isLoading}}>
+<button type={{this.type}}
+        class="pix-button pix-button--{{this.border}} pix-button--background-{{this.backgroundColor}}"
+        {{on "click" this.triggerAction}}
+        ...attributes
+        disabled={{this.isLoading}}>
 {{#if this.isLoading}}
   <div class="loader loader--{{@loading-color}}">
     <div class="bounce1"></div>

--- a/addon/components/pix-button.hbs
+++ b/addon/components/pix-button.hbs
@@ -1,4 +1,4 @@
-<button type={{this.type}} class="pix-button" {{on "click" this.triggerAction}} ...attributes disabled={{this.isLoading}}>
+<button type={{this.type}} class="pix-button pix-button--{{this.border}}" {{on "click" this.triggerAction}} ...attributes disabled={{this.isLoading}}>
 {{#if this.isLoading}}
   <div class="loader loader--{{@loading-color}}">
     <div class="bounce1"></div>

--- a/addon/components/pix-button.js
+++ b/addon/components/pix-button.js
@@ -14,6 +14,10 @@ export default class PixButton extends Component {
     return this.args.border || 'squircle-big';
   }
 
+  get backgroundColor() {
+    return this.args.backgroundColor || 'blue';
+  }
+
   @action
   async triggerAction(params) {
     try {

--- a/addon/components/pix-button.js
+++ b/addon/components/pix-button.js
@@ -10,6 +10,10 @@ export default class PixButton extends Component {
     return this.args.type || 'button';
   }
 
+  get border() {
+    return this.args.border || 'squircle-big';
+  }
+
   @action
   async triggerAction(params) {
     try {

--- a/addon/stories/pix-button-border.stories.mdx
+++ b/addon/stories/pix-button-border.stories.mdx
@@ -1,0 +1,33 @@
+import { Meta, Story, Canvas, ArgsTable } from '@storybook/addon-docs/blocks';
+import centered from '@storybook/addon-centered/ember';
+import * as stories from './pix-button.stories.js';
+
+<Meta
+  title='Basics/Button/Border'
+  component='PixButton'
+  decorators={[centered]}
+  argTypes={stories.argsTypes}
+/>
+
+# Pix Button
+
+Ce composant est un bouton simple qui empêche les clics multiples.
+
+<Canvas isColumn>
+  <Story name="Border" story={stories.borderButtons} height="160px" />
+</Canvas>
+
+## Usage
+
+```html
+Par défaut, la bordure est `squircle-big`
+<PixButton
+  @border="squircle-big"
+  >
+  Cliquez pour valider !
+</PixButton>
+```
+
+## Arguments
+
+<ArgsTable story="Border" />

--- a/addon/stories/pix-button-color.stories.mdx
+++ b/addon/stories/pix-button-color.stories.mdx
@@ -1,0 +1,42 @@
+import { Meta, Story, Canvas, ArgsTable } from '@storybook/addon-docs/blocks';
+import centered from '@storybook/addon-centered/ember';
+import * as stories from './pix-button.stories.js';
+
+<Meta
+  title='Basics/Button/Loader'
+  component='PixButton'
+  decorators={[centered]}
+  argTypes={stories.argsTypes}
+/>
+
+# Pix Button
+
+Ce composant est un bouton simple qui empêche les clics multiples.
+
+<Canvas isColumn>
+  Button avec loader gris ou blanc
+  <Story name="Loader" story={stories.loadingButtons} height="60px" />
+</Canvas>
+
+## Usage
+
+```html
+Par défaut, le loader du bouton est blanc
+<PixButton
+  @triggerAction={{action onClick}}
+  >
+  Cliquez pour valider !
+</PixButton>
+
+Bouton avec loader gris et une action qui se résout
+<PixButton
+  @triggerAction={{action onClick}}
+  @loading-color='grey'
+  >
+  Cliquez pour valider !
+</PixButton>
+```
+
+## Arguments
+
+<ArgsTable story="Loader" />

--- a/addon/stories/pix-button-color.stories.mdx
+++ b/addon/stories/pix-button-color.stories.mdx
@@ -3,7 +3,7 @@ import centered from '@storybook/addon-centered/ember';
 import * as stories from './pix-button.stories.js';
 
 <Meta
-  title='Basics/Button/Loader'
+  title='Basics/Button/Color'
   component='PixButton'
   decorators={[centered]}
   argTypes={stories.argsTypes}
@@ -13,25 +13,16 @@ import * as stories from './pix-button.stories.js';
 
 Ce composant est un bouton simple qui empêche les clics multiples.
 
-<Canvas isColumn>
-  Button avec loader gris ou blanc
-  <Story name="Loader" story={stories.loadingButtons} height="60px" />
+<Canvas>
+  <Story name="Color" story={stories.colorButtons} height="300px" />
 </Canvas>
 
 ## Usage
 
 ```html
-Par défaut, le loader du bouton est blanc
+Par défaut, la background-color est blue
 <PixButton
-  @triggerAction={{action onClick}}
-  >
-  Cliquez pour valider !
-</PixButton>
-
-Bouton avec loader gris et une action qui se résout
-<PixButton
-  @triggerAction={{action onClick}}
-  @loading-color='grey'
+  @backgroundColor="blue"
   >
   Cliquez pour valider !
 </PixButton>
@@ -39,4 +30,4 @@ Bouton avec loader gris et une action qui se résout
 
 ## Arguments
 
-<ArgsTable story="Loader" />
+<ArgsTable story="Color" />

--- a/addon/stories/pix-button-loader.stories.mdx
+++ b/addon/stories/pix-button-loader.stories.mdx
@@ -3,7 +3,7 @@ import centered from '@storybook/addon-centered/ember';
 import * as stories from './pix-button.stories.js';
 
 <Meta
-  title='Basics/Button'
+  title='Basics/Button/Loader'
   component='PixButton'
   decorators={[centered]}
   argTypes={stories.argsTypes}
@@ -14,10 +14,8 @@ import * as stories from './pix-button.stories.js';
 Ce composant est un bouton simple qui empêche les clics multiples.
 
 <Canvas isColumn>
-  Button avec loader blanc
-  <Story name="With white loader" story={stories.whiteButton} height="60px" />
-  Button avec loader gris
-  <Story name="With grey loader" story={stories.greyButton} height="60px" />
+  Button avec loader gris ou blanc
+  <Story name="Loader" story={stories.loadingButtons} height="60px" />
 </Canvas>
 
 ## Usage
@@ -41,4 +39,4 @@ Bouton avec loader gris et une action qui se résout
 
 ## Arguments
 
-<ArgsTable story="With white loader" />
+<ArgsTable story="Loader" />

--- a/addon/stories/pix-button.stories.js
+++ b/addon/stories/pix-button.stories.js
@@ -1,27 +1,19 @@
 import { hbs } from 'ember-cli-htmlbars';
 
-export const whiteButton = (args) => {
+export const loadingButtons = (args) => {
   return {
     template: hbs`
       <PixButton
           @triggerAction={{action triggerAction}}
-          @loading-color={{loadingColor}}
+          @loading-color='white'
           @type={{type}}>
-        Nom du bouton
+        Bouton avec loader blanc
       </PixButton>
-    `,
-    context: args,
-  };
-};
-
-export const greyButton = (args) => {
-  return {
-    template: hbs`
       <PixButton
           @triggerAction={{action triggerAction}}
           @loading-color='grey'
           @type={{type}}>
-        Nom du bouton
+        Bouton avec loader gris
       </PixButton>
     `,
     context: args,
@@ -29,6 +21,16 @@ export const greyButton = (args) => {
 };
 
 export const argsTypes = {
+  type: {
+    name: 'type',
+    description: 'fonction à appeler en cas de clic',
+    type: { required: false },
+    control: { disable: true },
+    table: {
+      type: { summary: 'string' },
+      defaultValue: { summary: 'button' },
+    }
+  },
   triggerAction: {
     name: 'triggerAction',
     description: 'fonction à appeler en cas de clic',
@@ -36,24 +38,20 @@ export const argsTypes = {
     defaultValue: () => {
       return new Promise((resolve) => {
         setTimeout(() => {
-          console.log('OK !')
           resolve();
         }, 2000);
       })
     },
+    control: { disable: true },
   },
   loadingColor: {
     name: 'loadingColor',
-    description: 'couleur de chargement',
+    description: 'couleur de chargement: `white`, `grey`',
     type: { name: 'string', required: false },
-    defaultValue: 'white',
-    control: { type: 'select', options: ['white', 'grey'] },
-  },
-  type: {
-    name: 'type',
-    description: 'type du bouton',
-    type: { required: false },
-    defaultValue: 'button',
-    control: { type: 'select', options: ['button', 'submit'] },
+    control: { disable: true },
+    table: {
+      type: { summary: 'string' },
+      defaultValue: { summary: 'white' },
+    }
   },
 };

--- a/addon/stories/pix-button.stories.js
+++ b/addon/stories/pix-button.stories.js
@@ -20,6 +20,46 @@ export const loadingButtons = (args) => {
   };
 };
 
+export const borderButtons = (args) => {
+  return {
+    template: hbs`
+    <section>
+      <PixButton
+          @triggerAction={{action triggerAction}}
+          @loading-color='white'
+          @type={{type}}
+          @border='rounded-big'>
+        Bouton rounded-big
+      </PixButton>
+      <PixButton
+          @triggerAction={{action triggerAction}}
+          @loading-color='white'
+          @type={{type}}
+          @border='rounded-small'>
+        Bouton rounded-small
+      </PixButton>
+    </section>
+    <section>
+      <PixButton
+          @triggerAction={{action triggerAction}}
+          @loading-color='white'
+          @type={{type}}
+          @border='squircle-big'>
+        Bouton squircle-big (default)
+      </PixButton>
+      <PixButton
+          @triggerAction={{action triggerAction}}
+          @loading-color='white'
+          @type={{type}}
+          @border='squircle-small'>
+        Bouton squircle-small
+      </PixButton>
+    </section>
+    `,
+    context: args,
+  };
+};
+
 export const argsTypes = {
   type: {
     name: 'type',
@@ -52,6 +92,16 @@ export const argsTypes = {
     table: {
       type: { summary: 'string' },
       defaultValue: { summary: 'white' },
+    }
+  },
+  border: {
+    name: 'border',
+    description: 'bordure: `rounded-small`, `rounded-big`, `squircle-small`, `squircle-big`',
+    type: { name: 'string', required: false },
+    control: { disable: true },
+    table: {
+      type: { summary: 'string' },
+      defaultValue: { summary: 'squircle-big' },
     }
   },
 };

--- a/addon/stories/pix-button.stories.js
+++ b/addon/stories/pix-button.stories.js
@@ -7,7 +7,7 @@ export const loadingButtons = (args) => {
           @triggerAction={{action triggerAction}}
           @loading-color='white'
           @type={{type}}>
-        Bouton avec loader blanc
+        Bouton avec loader blanc (default)
       </PixButton>
       <PixButton
           @triggerAction={{action triggerAction}}
@@ -60,6 +60,50 @@ export const borderButtons = (args) => {
   };
 };
 
+export const colorButtons = (args) => {
+  return {
+    template: hbs`
+      <section>
+        <PixButton
+            @triggerAction={{action triggerAction}}
+            @loading-color='white'
+            @backgroundColor='blue'
+            @type={{type}}>
+          Bouton avec background blue (default)
+        </PixButton>
+      </section>
+      <section>
+        <PixButton
+            @triggerAction={{action triggerAction}}
+            @loading-color='white'
+            @backgroundColor='green'
+            @type={{type}}>
+          Bouton avec background green
+        </PixButton>
+      </section>
+      <section>
+        <PixButton
+            @triggerAction={{action triggerAction}}
+            @loading-color='white'
+            @backgroundColor='yellow'
+            @type={{type}}>
+          Bouton avec background yellow
+        </PixButton>
+      </section>
+      <section>
+        <PixButton
+            @triggerAction={{action triggerAction}}
+            @loading-color='white'
+            @backgroundColor='transparent'
+            @type={{type}}>
+          Bouton avec background transparent
+        </PixButton>
+      </section>
+    `,
+    context: args,
+  };
+}
+
 export const argsTypes = {
   type: {
     name: 'type',
@@ -102,6 +146,16 @@ export const argsTypes = {
     table: {
       type: { summary: 'string' },
       defaultValue: { summary: 'squircle-big' },
+    }
+  },
+  backgroundColor: {
+    name: 'backgroundColor',
+    description: 'color: `blue`, `green`, `yellow`, `transparent`',
+    type: { name: 'string', required: false },
+    control: { disable: true },
+    table: {
+      type: { summary: 'string' },
+      defaultValue: { summary: 'blue' },
     }
   },
 };

--- a/addon/styles/_pix-button.scss
+++ b/addon/styles/_pix-button.scss
@@ -28,6 +28,26 @@
     animation-delay: -0.16s;
   }
 
+  &--rounded-big {
+    padding: 14px 24px;
+    border-radius: 23px;
+  }
+
+  &--rounded-small {
+    padding: 10px 24px;
+    border-radius: 23px;
+  }
+
+  &--squircle-big {
+    padding: 14px 24px;
+    border-radius: 5px;
+  }
+
+  &--squircle-small {
+    padding: 10px 16px;
+    border-radius: 5px;
+  }
+
   @-webkit-keyframes sk-bouncedelay {
     0%, 80%, 100% { -webkit-transform: scale(0) }
     40% { -webkit-transform: scale(1.0) }

--- a/addon/styles/_pix-button.scss
+++ b/addon/styles/_pix-button.scss
@@ -1,6 +1,14 @@
 .pix-button {
 
   @import 'reset-css';
+  border-color: transparent;
+  color: $white;
+  font-size: 1rem;
+  white-space: nowrap;
+  font-weight: 500;
+  letter-spacing: .012rem;
+  cursor: pointer;
+  font-family: 'Roboto', Arial, sans-serif;
 
   .loader > div {
     width: 10px;
@@ -46,6 +54,25 @@
   &--squircle-small {
     padding: 10px 16px;
     border-radius: 5px;
+  }
+
+  &--background-blue {
+    background-color: $blue;
+  }
+
+  &--background-green {
+    background-color: #037620;
+  }
+
+  &--background-yellow {
+    color: $grey-100;
+    background-color: $warning;
+  }
+
+  &--background-transparent {
+    background-color: transparent;
+    color: $grey-50;
+    border: 1px solid $grey-50;
   }
 
   @-webkit-keyframes sk-bouncedelay {

--- a/addon/styles/addon.scss
+++ b/addon/styles/addon.scss
@@ -23,3 +23,7 @@ html {
 body {
   font-family: $font-roboto;
 }
+
+section {
+  padding: 10px;
+}


### PR DESCRIPTION
## :unicorn: Description du composant
Le composant PixButton ne gère pour l'instant que l'état du bouton afin d'éviter un double-clique.
Cette PR y ajoute les attributs paramétrables:
- border: peut prendre les valeurs `rounded-small`, `rounded-big`, `squircle-small`, `squircle-big`
- backgroundColor: peut prendre les valeurs `blue`, `green`, `yellow`, `transparent`

## :rainbow: Remarques
Certains liens Pix ont un style proche d'un bouton.
Dans ce cas, il faut rendre le composant PixButton paramétrable pour afficher soit un bouton soit un lien.
Cela sera fait dans une prochaine PR.

## :100: Pour tester
Lien ZeroHeight: https://pix-design-system.zeroheight.com/styleguide/s/26079/p/23262d-button
Sur pix-ui, se rendre sur les stories Basics > Button
