### PR TITLE
[TECH] Enrichir la PixActionButton - BREAKING CHANGES.

### DIFF
--- a/addon/components/pix-action-button.hbs
+++ b/addon/components/pix-action-button.hbs
@@ -1,3 +1,3 @@
 <button type="button" class="pix-action-button" {{on "click" this.triggerAction}} ...attributes>
-  <FaIcon @icon={{this.icon}} />
+  <FaIcon @icon={{this.icon}} @prefix={{@iconPrefix}}/>
 </button>

--- a/addon/components/pix-action-button.hbs
+++ b/addon/components/pix-action-button.hbs
@@ -1,3 +1,3 @@
-<button type="button" class="pix-action-button" {{on "click" this.triggerAction}} ...attributes>
+<button type="button" class="pix-action-button {{if @withBackground 'pix-action-button--background'}}" {{on "click" this.triggerAction}} ...attributes>
   <FaIcon @icon={{this.icon}} @prefix={{@iconPrefix}}/>
 </button>

--- a/addon/stories/pix-action-button.stories.js
+++ b/addon/stories/pix-action-button.stories.js
@@ -8,7 +8,11 @@ export const actionButton = (args) => {
         @triggerAction={{triggerAction}}
       />
     `,
-    context: args,
+    context: {
+      icon: 'times',
+      triggerAction: console.log,
+      ...args,
+    }
   };
 };
 
@@ -16,12 +20,12 @@ export const argTypes = {
   icon: {
     name: 'icon',
     description: 'icon fontawesome',
-    type: { name: 'string', required: false },
+    type: { name: 'string', required: true },
     defaultValue: 'times',
   },
   triggerAction: {
     name: 'triggerAction',
     description: 'fonction à appeler au clic du bouton',
-    type: { required: false },
+    type: { required: true },
   },
 };

--- a/addon/stories/pix-action-button.stories.js
+++ b/addon/stories/pix-action-button.stories.js
@@ -7,7 +7,8 @@ export const actionButton = (args) => {
         @icon={{icon}}
         @iconPrefix={{iconPrefix}}
         @triggerAction={{triggerAction}}
-      />
+        @withBackground={{withBackground}}
+        />
     `,
     context: {
       icon: 'times',
@@ -34,5 +35,11 @@ export const argTypes = {
     name: 'triggerAction',
     description: 'fonction à appeler au clic du bouton',
     type: { required: true },
+  },
+  withBackground: {
+    name: 'withBackground',
+    description: 'Affichage du fond grisé',
+    type: { name: 'boolean', required: false },
+    table: { defaultValue: { summary: false } },
   },
 };

--- a/addon/stories/pix-action-button.stories.js
+++ b/addon/stories/pix-action-button.stories.js
@@ -5,6 +5,7 @@ export const actionButton = (args) => {
     template: hbs`
       <PixActionButton
         @icon={{icon}}
+        @iconPrefix={{iconPrefix}}
         @triggerAction={{triggerAction}}
       />
     `,
@@ -19,9 +20,15 @@ export const actionButton = (args) => {
 export const argTypes = {
   icon: {
     name: 'icon',
-    description: 'icon fontawesome',
+    description: 'icône font-awesome',
     type: { name: 'string', required: true },
-    defaultValue: 'times',
+    table: { defaultValue: { summary: 'times' } },
+  },
+  iconPrefix: {
+    name: 'iconPrefix',
+    description: 'prefix de l\'icône font-awesome',
+    type: { name: 'string', required: false },
+    control: { type: 'select', options: ['far', 'fas'] },
   },
   triggerAction: {
     name: 'triggerAction',

--- a/addon/stories/pix-action-button.stories.mdx
+++ b/addon/stories/pix-action-button.stories.mdx
@@ -20,7 +20,7 @@ Le ActionButton permet de créer un bouton contenant une icône font-awesome.
 ## Usage
 
 ```html
-<PixActionButton @icon='times' />
+<PixActionButton @icon='times' @triggerAction="{{triggerAction}}"/>
 ```
 
 <ArgsTable story="Action button" />

--- a/addon/styles/_pix-action-button.scss
+++ b/addon/styles/_pix-action-button.scss
@@ -10,7 +10,7 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  background-color: $grey-15;
+  background-color: transparent;
   color: $grey-35;
   width: 38px;
   height: 38px;
@@ -20,4 +20,7 @@
     background-color: $grey-20;
   }
 
+  &--background {
+    background-color: $grey-15;
+  }
 }

--- a/addon/styles/_pix-action-button.scss
+++ b/addon/styles/_pix-action-button.scss
@@ -2,7 +2,7 @@
   @import 'reset-css';
 
   font-size: 1.25rem;
-  border-radius: 5px;
+  border-radius: 50%;
   cursor: pointer;
   border: none;
   outline: none;


### PR DESCRIPTION
⚠️ Cette PR entraîne des breakings changes, lors de la release, cela nécessite une montée de version majeure !

## :unicorn: Description du composant
Le composant PixActionButton ne gère que la valeur de l'icone.
Cette PR permet d'ajouter plusieurs paramètres:
 - withBackground: permet de déterminer si le background est présent de base sur le bouton, prend les valeurs `true`, `false`.
 - iconPrefix : permet d'avoir un préfix pour les icones font-awesome, prend les valeurs `vide`, `fas`, `far`.

## :rainbow: Remarques
 - ⚠️ le paramètre `withBackground` change le comportement par défaut du bouton, celui-ci est maintenant transparent par défaut. (comportement de base défini par le design system)
 - ⚠️ le fait que maintenant les icônes soient rondes change le comportement par défaut du bouton. (comportement de base défini par le design system)
 - Ajout de la dépendance @fortawesome/free-regular-svg-icons pour l'utilisation du préfix `far` sur les icônes.

## :100: Pour tester
Lien zeroheight: https://zeroheight.com/8dd127da7/p/20d723-floating-action-button-fab
Sur pix-ui, se rendre sur les stories Basics > Action Button
