### PR TITLE
[TECH] Ajout d'une icone facultative pour PixMessage

### DIFF
--- a/addon/components/pix-message.hbs
+++ b/addon/components/pix-message.hbs
@@ -1,1 +1,6 @@
-<p class="pix-message {{concat "pix-message--" this.type}}" ...attributes>{{yield}}</p>
+<p class="pix-message {{concat "pix-message--" this.type}}" ...attributes>
+  {{#if @withIcon}}
+      <FaIcon @icon={{ this.iconClass }} />
+  {{/if}}
+  {{yield}}
+</p>

--- a/addon/components/pix-message.js
+++ b/addon/components/pix-message.js
@@ -1,8 +1,23 @@
 import Component from '@glimmer/component';
 
+const TYPE_INFO = 'info';
+const TYPE_SUCCESS = 'success';
+const TYPE_WARNING = 'warning';
+const TYPE_ALERT = 'alert';
+
 export default class PixMessage extends Component {
   get type() {
-    const correctTypes = ["info", "success", "warning", "alert"];
+    const correctTypes = [TYPE_INFO, TYPE_SUCCESS, TYPE_WARNING, TYPE_ALERT];
     return correctTypes.includes(this.args.type) ? this.args.type : 'info';
+  }
+
+  get iconClass() {
+    const classes = {
+      [TYPE_INFO]: 'info-circle',
+      [TYPE_SUCCESS]: 'check-circle',
+      [TYPE_WARNING]: 'exclamation-circle',
+      [TYPE_ALERT]: 'exclamation-triangle',
+    };
+    return classes[this.type];
   }
 }

--- a/addon/stories/pix-message.stories.js
+++ b/addon/stories/pix-message.stories.js
@@ -1,9 +1,9 @@
 import { hbs } from 'ember-cli-htmlbars';
 
-export const messageInfo = (args) => {
+export const message = (args) => {
   return {
     template: hbs`
-      <PixMessage @type={{type}} @withIcon="true">
+      <PixMessage @type={{type}} @withIcon={{withIcon}}>
         Ceci est un message {{type}}
       </PixMessage>
     `,
@@ -11,35 +11,6 @@ export const messageInfo = (args) => {
   };
 };
 
-export const messageAlert = () => {
-  return {
-    template: hbs`
-      <PixMessage @type='alert'>
-        Ceci est un message d'alert
-      </PixMessage>
-    `,
-  };
-};
-
-export const messageSuccess = () => {
-  return {
-    template: hbs`
-      <PixMessage @type='success'>
-        Ceci est un message de succès
-      </PixMessage>
-    `,
-  };
-};
-
-export const messageWarning = () => {
-  return {
-    template: hbs`
-      <PixMessage @type='warning'>
-        Ceci est un message de warning
-      </PixMessage>
-    `,
-  };
-};
 
 export const argTypes = {
   type: {

--- a/addon/stories/pix-message.stories.js
+++ b/addon/stories/pix-message.stories.js
@@ -3,7 +3,7 @@ import { hbs } from 'ember-cli-htmlbars';
 export const messageInfo = (args) => {
   return {
     template: hbs`
-      <PixMessage @type={{type}}>
+      <PixMessage @type={{type}} @withIcon="true">
         Ceci est un message {{type}}
       </PixMessage>
     `,
@@ -48,5 +48,12 @@ export const argTypes = {
     type: { name: 'string', required: false },
     defaultValue: 'info',
     control: { type: 'select', options: ['info', 'success', 'warning', 'alert'] },
+  },
+  withIcon: {
+    name: 'withIcon',
+    description: 'Icone du message',
+    type: { name: 'boolean', required: false },
+    defaultValue: false,
+    control: { type: 'boolean' },
   },
 }

--- a/addon/stories/pix-message.stories.mdx
+++ b/addon/stories/pix-message.stories.mdx
@@ -11,23 +11,20 @@ import * as stories from './pix-message.stories.js';
 
 # Pix Message
 
-Un bandeau d'information, par défaut de type info.
+Un bandeau d'information, par défaut de type info, avec une icone facultative.
 
 <Canvas isColumn>
-  <Story name="Message Info" story={stories.messageInfo} height="60px" />
-  <Story name="Message Alert" story={stories.messageAlert} height="60px" />
-  <Story name="Message Success" story={stories.messageSuccess} height="60px" />
-  <Story name="Message Warning" story={stories.messageWarning} height="60px" />
+  <Story name="Message" story={stories.message} height="60px" />
 </Canvas>
 
 ## Usage
 
 ```html
-<PixMessage @type='info'>
+<PixMessage @type='info' @withIcon='true'>
   Ceci est un message à caractère informatif.
 </PixMessage>
 ```
 
 ## Arguments
 
-<ArgsTable story="Message Info" />
+<ArgsTable story="Message" />

--- a/addon/styles/_pix-message.scss
+++ b/addon/styles/_pix-message.scss
@@ -6,13 +6,17 @@
   padding: 1rem;
   border-radius: 4px;
 
-  @mixin buttonColor($color){
-    color: darken($color, 15%);
-    background-color: rgba($color, .2);
+  @mixin colorize($color, $percentageDarkenForColor, $percentageLightenForBackground){
+    color: darken($color, $percentageDarkenForColor);
+    background-color: lighten($color, $percentageLightenForBackground);
   }
 
-  &.pix-message--info { @include buttonColor($communication-light); }
-  &.pix-message--success { @include buttonColor($success); }
-  &.pix-message--warning { @include buttonColor($warning); }
-  &.pix-message--alert { @include buttonColor($error); }
+  &.pix-message--info { @include colorize($communication-light, 20%, 35%); }
+  &.pix-message--alert { @include colorize($error, 20%, 40%); }
+  &.pix-message--success { @include colorize($success, 25%, 35%); }
+  &.pix-message--warning { @include colorize($warning, 25%, 35%); }
+
+  svg {
+    margin-right: 6px;
+  }
 }

--- a/tests/integration/components/pix-message-test.js
+++ b/tests/integration/components/pix-message-test.js
@@ -26,5 +26,35 @@ module('Integration | Component | pix-message', function(hooks) {
     assert.equal(pixMessageElement.getAttribute('aria-label'), 'world');
   });
 
+  test('it renders with an icon', async function(assert) {
+    await render(hbs`<PixMessage @withIcon="true" />`);
 
+    const icon = this.element.querySelector('.pix-message svg');
+    assert.dom('.pix-message svg').exists();
+    assert.equal(icon.getAttribute('data-icon'), 'info-circle');
+  });
+
+  test('it renders with a warning icon for warning type', async function(assert) {
+    await render(hbs`<PixMessage @type="warning" @withIcon="true" />`);
+
+    const icon = this.element.querySelector('.pix-message svg');
+    assert.dom('.pix-message svg').exists();
+    assert.equal(icon.getAttribute('data-icon'), 'exclamation-circle');
+  });
+
+  test('it renders with a success icon for success type', async function(assert) {
+    await render(hbs`<PixMessage @type="success" @withIcon="true" />`);
+
+    const icon = this.element.querySelector('.pix-message svg');
+    assert.dom('.pix-message svg').exists();
+    assert.equal(icon.getAttribute('data-icon'), 'check-circle');
+  });
+
+  test('it renders with a alert icon for alert type', async function(assert) {
+    await render(hbs`<PixMessage @type="alert" @withIcon="true" />`);
+
+    const icon = this.element.querySelector('.pix-message svg');
+    assert.dom('.pix-message svg').exists();
+    assert.equal(icon.getAttribute('data-icon'), 'exclamation-triangle');
+  });
 });


### PR DESCRIPTION
## :unicorn: Description du composant
Dans le cadre de PixCertif, nous avons besoin du composant PixMessage, or lors d'une design review avec Quentin nous avons constaté quelques **petites modifications à apporter au composant**.


## :rainbow: Remarques
**Nouveau:** le PixMessage peut prendre un nouveau paramètre `withIcon` (boolean) permettant d'afficher une petite icone avant le message. L'accessibilité du composant a aussi été améliorée et la story simplifiée. 

## :100: Pour tester
- npm run storybook
- aller dans la partie "Notification" > composant "Message" et jouer avec les contrôles (voir onglet Canvas)
