### PR TITLE
[TECH] Corriger les attributs pour la PixTextarea

### DIFF
--- a/addon/components/pix-textarea.hbs
+++ b/addon/components/pix-textarea.hbs
@@ -1,9 +1,10 @@
-<div class='pix-textarea' ...attributes>
+<div class='pix-textarea'>
   {{#if @maxlength}}
     <Textarea
       id={{@id}}
       @value={{@value}}
       @maxlength={{@maxlength}}
+      ...attributes
     />
     <p>{{this.textLengthIndicator}} / {{@maxlength}}</p>
   {{else}}


### PR DESCRIPTION
## :unicorn: Problème
Il n'est pas possible de passer `required` (ou autre) à la PixTextarea.

`...attributes` permet de passer des paramètres au composants depuis là ou on l'appelle.
Hors lorsqu'on utilise PixTextarea on souhaite passer des paramètres à la balise <textarea> et non la div parente (servant pour le style).

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
- npm run storybook
- constater que la PixTextarea n'a pas changé
