### PR TITLE
[STYLE] Corriger l'affichage d'un texte sur deux lignes avec une icone dans PixMessage

### DIFF
--- a/addon/components/pix-message.hbs
+++ b/addon/components/pix-message.hbs
@@ -2,5 +2,7 @@
   {{#if @withIcon}}
       <FaIcon @icon={{ this.iconClass }} />
   {{/if}}
-  {{yield}}
+  <span class="pix-message__content">
+    {{yield}}
+  </span>
 </p>

--- a/addon/stories/pix-button-border.stories.mdx
+++ b/addon/stories/pix-button-border.stories.mdx
@@ -14,7 +14,7 @@ import * as stories from './pix-button.stories.js';
 Ce composant est un bouton simple qui empêche les clics multiples.
 
 <Canvas isColumn>
-  <Story name="Border" story={stories.borderButtons} height="160px" />
+  <Story name="Border" story={stories.borderButtons} height="200px" />
 </Canvas>
 
 ## Usage

--- a/addon/stories/pix-message.stories.js
+++ b/addon/stories/pix-message.stories.js
@@ -6,11 +6,14 @@ export const message = (args) => {
       <PixMessage @type={{type}} @withIcon={{withIcon}}>
         Ceci est un message {{type}}
       </PixMessage>
+      <PixMessage @type={{type}} @withIcon={{true}}>
+        Ceci est un message avec une icone et un texte tellement long<br />
+        qu'il est nécessaire de l'afficher sur deux lignes.
+      </PixMessage>
     `,
     context: args
   };
 };
-
 
 export const argTypes = {
   type: {

--- a/addon/stories/pix-message.stories.mdx
+++ b/addon/stories/pix-message.stories.mdx
@@ -14,7 +14,7 @@ import * as stories from './pix-message.stories.js';
 Un bandeau d'information, par défaut de type info, avec une icone facultative.
 
 <Canvas isColumn>
-  <Story name="Message" story={stories.message} height="60px" />
+  <Story name="Message" story={stories.message} height="140px" />
 </Canvas>
 
 ## Usage

--- a/addon/styles/_pix-message.scss
+++ b/addon/styles/_pix-message.scss
@@ -5,6 +5,8 @@
   margin: 0 0 1rem 0;
   padding: 1rem;
   border-radius: 4px;
+  align-items: center;
+  display: flex;
 
   @mixin colorize($color, $percentageDarkenForColor, $percentageLightenForBackground){
     color: darken($color, $percentageDarkenForColor);
@@ -17,6 +19,6 @@
   &.pix-message--warning { @include colorize($warning, 25%, 35%); }
 
   svg {
-    margin-right: 6px;
+    margin-right: 12px;
   }
 }


### PR DESCRIPTION
## :unicorn: PixMessage
Lorsque le composant PixMessage est affiché avec une icone et un texte assez long pour être affiché sur deux lignes, l'icone est aligné avec la première ligne du texte et le résultat n'est pas très heureux :

![Capture d’écran 2021-01-27 à 17 23 56](https://user-images.githubusercontent.com/5627688/106024876-7d7cf900-60c8-11eb-997c-4f3a520b3962.png)

Cette PR permet de centrer correctement l'icone quelque soit le nombre de ligne.

![Capture d’écran 2021-01-27 à 17 30 14](https://user-images.githubusercontent.com/5627688/106025007-a30a0280-60c8-11eb-918e-8e4e6de572fe.png)
