### PR TITLE
[FEATURE] Ajout du nombre d'éléments filtrés dans le composant filter banner sur Pix-UI(pix-2031).

### DIFF
--- a/addon/components/pix-filter-banner.hbs
+++ b/addon/components/pix-filter-banner.hbs
@@ -1,8 +1,13 @@
 <div class='pix-filter-banner' ...attributes>
-  {{#if this.displayTitle}}
-    <p class="pix-filter-banner__title">{{@title}}</p>
-  {{/if}}
-  <div class="pix-filter-banner__content">
-    {{yield}}
+  <div class='pix-filter-banner__container'>
+    {{#if this.displayTitle}}
+      <p class="pix-filter-banner__title">{{@title}}</p>
+    {{/if}}
+    <div class="pix-filter-banner__content">
+      {{yield}}
+    </div>
   </div>
+  {{#if this.displayDetails}}
+  <p class="pix-filter-banner__details">{{@details}}</p>
+  {{/if}}
 </div>

--- a/addon/components/pix-filter-banner.js
+++ b/addon/components/pix-filter-banner.js
@@ -4,4 +4,7 @@ export default class PixFilterBanner extends Component {
   get displayTitle() {
     return Boolean(this.args.title);
   }
+  get displayDetails() {
+    return Boolean(this.args.details);
+  }
 }

--- a/addon/stories/pix-filter-banner.stories.js
+++ b/addon/stories/pix-filter-banner.stories.js
@@ -3,13 +3,14 @@ import { hbs } from 'ember-cli-htmlbars';
 export const filterBanner = (args) => {
   return {
     template: hbs`
-      <PixFilterBanner @title={{title}}>
+      <PixFilterBanner @title={{title}} @details={{details}}>
         <PixSelect @options={{options}} @onChange={{onChange}} />
         <PixSelect @options={{options}} @onChange={{onChange}} />
       </PixFilterBanner>
     `,
     context: {
       title: 'Filtres',
+      details: 'Des détails sur le filtre',
       ...args,
       options:  [{ value: '1', label: 'Tomate' }],
       onChange: console.log,
@@ -21,6 +22,12 @@ export const argTypes = {
   title: {
     name: 'title',
     description: 'Titre du filtre',
+    type: { name: 'string', required: false },
+    defaultValue: null,
+  },
+  details: {
+    name: 'details',
+    description: 'Détails du filtre',
     type: { name: 'string', required: false },
     defaultValue: null,
   }

--- a/addon/styles/_pix-filter-banner.scss
+++ b/addon/styles/_pix-filter-banner.scss
@@ -4,6 +4,7 @@
   position: relative;
   display: flex;
   flex-direction: row;
+  justify-content: space-between;
   align-items: center;
   box-sizing: border-box;
   width: 100%;
@@ -12,6 +13,11 @@
   box-shadow: 0 2px 5px 0 rgba($black, 0.05);
   min-height: 64px;
   padding: 14px 24px;
+
+  &__container {
+    display: flex;
+    align-items: center;
+  }
 
   &__title {
     color: $grey-60;
@@ -31,5 +37,14 @@
     > *:last-child {
       margin-right: 0;
     }
+  }
+
+  &__details {
+    color: $grey-60;
+    font-family: $font-roboto;
+    font-weight: $font-medium;
+    font-size: 0.875rem;
+    padding-left: 24px;
+    margin: 0;
   }
 }

--- a/tests/integration/components/pix-filter-banner-test.js
+++ b/tests/integration/components/pix-filter-banner-test.js
@@ -33,4 +33,17 @@ module('Integration | Component | filter-banner', function(hooks) {
     // then
     assert.equal(componentElement.textContent.trim(), 'Titre de la bannière');
   });
+
+  test('it renders the PixFilterBanner with details', async function(assert) {
+    // when
+    await render(hbs`
+      <PixFilterBanner @details="5 participants filtrés">
+        content
+      </PixFilterBanner>
+    `);
+    const componentElement = this.element.querySelector('.pix-filter-banner__details');
+
+    // then
+    assert.equal(componentElement.textContent.trim(), '5 participants filtrés');
+  });
 });


### PR DESCRIPTION
## :unicorn: Description du composant
le composant filter banner contient actuellement un seul paramètre, c'est n'est pas possible d'afficher plus d'information sur le filtre, par exemple , les éléments filtrés ou un autre détail. par conséquent, le label "details" à été ajouté en paramètre dans le composant à fin qu'il puisse afficher plus d’informations.

## :rainbow: Remarques
Le paramètre "details" peut être vide car il a une valeur 'null' par défaut.

## :100: Pour tester
le composant modifié peut être trouvé [ici](https://storybook.pix.fr/?path=/docs/form-filter-banner--filter-banner) 