### PR TITLE
[TECH] Toujours passer ...attributes à la PixTextarea

### DIFF
--- a/addon/components/pix-textarea.hbs
+++ b/addon/components/pix-textarea.hbs
@@ -8,6 +8,6 @@
     />
     <p>{{this.textLengthIndicator}} / {{@maxlength}}</p>
   {{else}}
-    <Textarea id={{@id}} @value={{@value}} />
+    <Textarea id={{@id}} @value={{@value}} ...attributes />
   {{/if}}
 </div>

--- a/tests/integration/components/pix-textarea-test.js
+++ b/tests/integration/components/pix-textarea-test.js
@@ -41,4 +41,17 @@ module('Integration | Component | textarea', function(hooks) {
     assert.dom(CHAR_COUNT_SELECTOR).hasText('11 / 20');
   });
 
+  test('it should be possible to add required attributes to PixTextarea', async function(assert) {
+    // given
+    const defaultValue = '';
+    this.set('value', defaultValue);
+
+    // when
+    await render(hbs`<PixTextarea @value={{value}} required="true" />`);
+
+    // then
+    const textarea = this.element.querySelector(TEXTAREA_SELECTOR);
+    assert.equal(textarea.required, true);
+  });
+
 });


### PR DESCRIPTION
## :unicorn: Description du composant
Il n'est pas possible de passer `required` à la PixTextarea sans mettre la propriété `maxlength`.
Il manquait (encore) `...attributes` à la PixTextarea quand on ne précise pas la `maxlength`.

## :100: Pour tester
- npm run storybook
