### PR TITLE
[FEATURE] Ajout d'un bouton permettant de supprimer tous les éléments filtrés d'un seul clic dans le filter banner(PIX-2032).

### DIFF
--- a/addon/components/pix-filter-banner.hbs
+++ b/addon/components/pix-filter-banner.hbs
@@ -1,5 +1,5 @@
 <div class='pix-filter-banner' ...attributes>
-  <div class='pix-filter-banner__container'>
+  <div class='pix-filter-banner__container-left'>
     {{#if this.displayTitle}}
       <p class="pix-filter-banner__title">{{@title}}</p>
     {{/if}}
@@ -7,7 +7,17 @@
       {{yield}}
     </div>
   </div>
-  {{#if this.displayDetails}}
-  <p class="pix-filter-banner__details">{{@details}}</p>
-  {{/if}}
+  <div class="pix-filter-banner__container-right">
+    {{#if this.displayDetails}}
+      <p class="pix-filter-banner__details">{{@details}}</p>
+    {{/if}}
+    {{#if this.displayClearFilters}}
+      <div class="pix-filter-banner__button-container"> 
+        <PixButton class="pix-filter-banner__button" @border="squircle-small" @triggerAction={{@onClearFilters}}>
+          <FaIcon class="pix-filter-banner-button__icon" @icon='trash-alt' @prefix='far'/>
+            {{@clearFiltersLabel}}
+        </PixButton>
+      </div>
+    {{/if}}
+  </div>
 </div>

--- a/addon/components/pix-filter-banner.js
+++ b/addon/components/pix-filter-banner.js
@@ -7,4 +7,7 @@ export default class PixFilterBanner extends Component {
   get displayDetails() {
     return Boolean(this.args.details);
   }
+  get displayClearFilters() {
+    return Boolean(this.args.clearFiltersLabel);
+  }
 }

--- a/addon/stories/pix-filter-banner.stories.js
+++ b/addon/stories/pix-filter-banner.stories.js
@@ -3,7 +3,7 @@ import { hbs } from 'ember-cli-htmlbars';
 export const filterBanner = (args) => {
   return {
     template: hbs`
-      <PixFilterBanner @title={{title}} @details={{details}}>
+      <PixFilterBanner @title={{title}} @details={{details}} @clearFiltersLabel={{clearFiltersLabel}} @onClearFilters={{onClearFilters}}>
         <PixSelect @options={{options}} @onChange={{onChange}} />
         <PixSelect @options={{options}} @onChange={{onChange}} />
       </PixFilterBanner>
@@ -11,6 +11,8 @@ export const filterBanner = (args) => {
     context: {
       title: 'Filtres',
       details: 'Des détails sur le filtre',
+      clearFiltersLabel: 'Effacer les filtres',
+      onClearFilters: console.log,
       ...args,
       options:  [{ value: '1', label: 'Tomate' }],
       onChange: console.log,
@@ -30,5 +32,16 @@ export const argTypes = {
     description: 'Détails du filtre',
     type: { name: 'string', required: false },
     defaultValue: null,
-  }
+  },
+  clearFiltersLabel: {
+    name: 'clearFiltersLabel',
+    description: 'libellé du bouton',
+    type: { name: 'string', required: false },
+    defaultValue: null,
+  },
+  onClearFilters: {
+    name: 'onClearFilters',
+    description: 'fonction à appeler pour déclencher l’action de suppression des filtres',
+    type: { required: false },
+  },
 };

--- a/addon/styles/_pix-filter-banner.scss
+++ b/addon/styles/_pix-filter-banner.scss
@@ -14,9 +14,17 @@
   min-height: 64px;
   padding: 14px 24px;
 
-  &__container {
+  &__container-left {
     display: flex;
     align-items: center;
+    height: 36px;
+  }
+
+  &__container-right {
+    display: flex;
+    align-items: center;
+    justify-content: flex-end;
+    height: 36px;
   }
 
   &__title {
@@ -43,8 +51,25 @@
     color: $grey-60;
     font-family: $font-roboto;
     font-weight: $font-medium;
+    padding-left: 16px;
     font-size: 0.875rem;
-    padding-left: 24px;
     margin: 0;
+    margin-right: 16px;
+    height: 18px;
+    padding-top: 4px;
+    text-align: center;
   }
+
+  &__button-container {
+    border-left: 1px solid $grey-15;
+    padding-left: 16px;
+  }
+
+  &__button {
+    font-size: 0.875rem;
+  }
+}
+
+.pix-filter-banner-button__icon {
+  padding-right: 4px;
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1771,6 +1771,23 @@
         "@fortawesome/fontawesome-common-types": "^0.2.32"
       }
     },
+    "@fortawesome/free-regular-svg-icons": {
+      "version": "5.15.2",
+      "resolved": "https://registry.npmjs.org/@fortawesome/free-regular-svg-icons/-/free-regular-svg-icons-5.15.2.tgz",
+      "integrity": "sha512-Uv5NQCYjyisNVTu/1Xjs+z8vwQjbfT6hiqYvQNfF0n8qdgfWLM581bAfVMQ3BCs1SPy+eEUKNcGkK4n0FihFHg==",
+      "dev": true,
+      "requires": {
+        "@fortawesome/fontawesome-common-types": "^0.2.34"
+      },
+      "dependencies": {
+        "@fortawesome/fontawesome-common-types": {
+          "version": "0.2.34",
+          "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-0.2.34.tgz",
+          "integrity": "sha512-XcIn3iYbTEzGIxD0/dY5+4f019jIcEIWBiHc3KrmK/ROahwxmZ/s+tdj97p/5K0klz4zZUiMfUlYP0ajhSJjmA==",
+          "dev": true
+        }
+      }
+    },
     "@fortawesome/free-solid-svg-icons": {
       "version": "5.15.1",
       "resolved": "https://registry.npmjs.org/@fortawesome/free-solid-svg-icons/-/free-solid-svg-icons-5.15.1.tgz",

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
   "devDependencies": {
     "@ember/optional-features": "^2.0.0",
     "@fortawesome/ember-fontawesome": "^0.2.2",
+    "@fortawesome/free-regular-svg-icons": "^5.15.2",
     "@fortawesome/free-solid-svg-icons": "^5.15.1",
     "@glimmer/component": "^1.0.2",
     "@glimmer/tracking": "^1.0.2",

--- a/tests/integration/components/pix-filter-banner-test.js
+++ b/tests/integration/components/pix-filter-banner-test.js
@@ -1,7 +1,9 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import { render } from '@ember/test-helpers';
+import { click, render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
+import sinon from 'sinon';
+
 
 module('Integration | Component | filter-banner', function(hooks) {
   setupRenderingTest(hooks);
@@ -45,5 +47,39 @@ module('Integration | Component | filter-banner', function(hooks) {
 
     // then
     assert.equal(componentElement.textContent.trim(), '5 participants filtrés');
+  });
+
+  test('it renders the PixFilterBanner with a clearFiltersLabel button', async function(assert) {
+    //given
+    this.clearFiltersLabel = 'Effacer les filtres'
+    this.onClearFilters = sinon.spy();
+
+    // when
+    await render(hbs`
+      <PixFilterBanner @clearFiltersLabel={{clearFiltersLabel}} @onClearFilters={{onClearFilters}}>
+       content
+      </PixFilterBanner>
+    `);
+    
+    // then
+    const button = this.element.querySelector('button');
+    assert.equal(button.textContent.trim(), this.clearFiltersLabel);
+  });
+
+  test('it should trigger onClearFilters when button clicked', async function(assert) {
+    // given
+    this.clearFiltersLabel = 'some label';
+    this.onClearFilters = sinon.spy();
+    
+    //when
+    await render(hbs`
+      <PixFilterBanner @clearFiltersLabel={{clearFiltersLabel}} @onClearFilters={{onClearFilters}}>
+        content
+      </PixFilterBanner>
+    `);
+    await click('button');
+    
+    // then
+    assert.ok(this.onClearFilters.calledOnce, 'the callback should be called once');
   });
 });


### PR DESCRIPTION
## :unicorn: Description du composant
une nouvelle fonctionnalité à été ajoutée au composant filter banner de Pix-Ui pour lui permettre de supprimer tous les éléments filtrés en un seul clic. Le composant prendre désormais deux nouvelles propriétés , clearFiltersLabel comme libellé du bouton et onClearFilters comme un handler pour supprimer les éléments.

## :rainbow: Remarques
N/A

## :100: Pour tester
le composant peut être testé sur [ce](https://storybook.pix.fr/?path=/docs/form-filter-banner--filter-banner) lien storybook.