### PR TITLE
[TECH] Permettre le redimensionnement de la textarea seulement vertical

### DIFF
--- a/addon/styles/_pix-textarea.scss
+++ b/addon/styles/_pix-textarea.scss
@@ -11,6 +11,7 @@
     font-family: $font-roboto;
     color: $grey-45;
     font-size: 1rem;
+    resize: vertical;
 
     &:hover {
       border-color: $grey-60;

--- a/addon/styles/_pix-textarea.scss
+++ b/addon/styles/_pix-textarea.scss
@@ -29,6 +29,7 @@
     font-size: 12px;
     display: flex;
     flex-direction: row-reverse;
+    margin-bottom: 0;
   }
 
 }


### PR DESCRIPTION
## :unicorn: Problème
La PixTextarea peut être redimensionnée verticalement et horizontalement. Mais bien souvent quand on laisse la totale libertée sur le redimensionnement cela peut **casser la mise en page** de certaines pages.

Exemple de design cassé par le redimensionnement : 
![image](https://user-images.githubusercontent.com/38167520/106629912-9cbdcf80-657b-11eb-89ac-5120171c6b66.png)

Permettre de r**edimensionner les textarea est important pour l'accessibilité** : https://catalin.red/css-resize-none-is-bad-for-ux/ 


## 🍐 Solution

Afin de couper la poire en deux entre accessibilité et mise en page il est possible de mettre : `resize: vertically`. Ceci permettant un redimensionnement de la PixTextarea mais uniquement sur la verticale (résolvant une grande majorité de nos soucis de mise en page).
 

## :100: Pour tester
- npm run storybook
- essayer de redimensionner la PixTextarea
- constater que c'est possible mais que verticalement
