### PR TITLE
[TECH] Pouvoir désactiver le PixButton

### DIFF
--- a/addon/components/pix-button.hbs
+++ b/addon/components/pix-button.hbs
@@ -1,8 +1,9 @@
 <button type={{this.type}}
-        class="pix-button pix-button--{{this.border}} pix-button--background-{{this.backgroundColor}}"
+        class="pix-button pix-button--{{this.border}} pix-button--background-{{this.backgroundColor}}{{if this.isDisabled ' pix-button--disabled'}}"
         {{on "click" this.triggerAction}}
         ...attributes
-        disabled={{this.isLoading}}>
+        disabled={{this.isButtonLoadingOrDisabled}}
+        aria-disabled={{this.ariaDisabled}}>
 {{#if this.isLoading}}
   <div class="loader loader--{{@loading-color}}">
     <div class="bounce1"></div>
@@ -12,5 +13,4 @@
 {{else}}
   {{yield}}
 {{/if}}
-
 </button>

--- a/addon/components/pix-button.js
+++ b/addon/components/pix-button.js
@@ -18,6 +18,18 @@ export default class PixButton extends Component {
     return this.args.backgroundColor || 'blue';
   }
 
+  get isDisabled() {
+    return this.args.isDisabled === true || false;
+  }
+
+  get isButtonLoadingOrDisabled() {
+    return this.isLoading || this.isDisabled;
+  }
+
+  get ariaDisabled() {
+    return (this.isLoading || this.isDisabled).toString();
+  }
+
   @action
   async triggerAction(params) {
     try {

--- a/addon/stories/pix-button-disabled.stories.mdx
+++ b/addon/stories/pix-button-disabled.stories.mdx
@@ -1,0 +1,40 @@
+import { Meta, Story, Canvas, ArgsTable } from '@storybook/addon-docs/blocks';
+import centered from '@storybook/addon-centered/ember';
+import * as stories from './pix-button.stories.js';
+
+<Meta
+  title='Basics/Button/Disabled'
+  component='PixButton'
+  decorators={[centered]}
+  argTypes={stories.argsTypes}
+/>
+
+# Pix Button
+
+Ce composant est un bouton simple qui empêche les clics multiples.
+
+<Canvas isColumn>
+  <Story name="Disabled" story={stories.disabledButtons} height="60px" />
+</Canvas>
+
+## Usage
+
+```html
+Par défaut, le bouton est actif
+<PixButton
+  @isDisabled={{false}}
+  >
+  Cliquez pour valider !
+</PixButton>
+
+Bouton désativé
+<PixButton
+  @isDisabled={{true}}
+  >
+  Cliquez pour valider !
+</PixButton>
+```
+
+## Arguments
+
+<ArgsTable story="Disabled" />

--- a/addon/stories/pix-button.stories.js
+++ b/addon/stories/pix-button.stories.js
@@ -104,6 +104,24 @@ export const colorButtons = (args) => {
   };
 }
 
+export const disabledButtons = (args) => {
+  return {
+    template: hbs`
+      <PixButton
+          @triggerAction={{action triggerAction}}
+          @isDisabled={{isDisabled}}>
+        Bouton actif (défaut)
+      </PixButton>
+      <PixButton
+          @triggerAction={{action triggerAction}}
+          @isDisabled={{true}}>
+        Bouton désactivé
+      </PixButton>
+    `,
+    context: args,
+  };
+};
+
 export const argsTypes = {
   type: {
     name: 'type',
@@ -156,6 +174,15 @@ export const argsTypes = {
     table: {
       type: { summary: 'string' },
       defaultValue: { summary: 'blue' },
+    }
+  },
+  isDisabled: {
+    name: 'isDisabled',
+    type: { name: 'boolean', required: false },
+    control: { type: 'boolean' },
+    table: {
+      type: { summary: 'boolean' },
+      defaultValue: { summary: 'false' },
     }
   },
 };

--- a/addon/styles/_pix-button.scss
+++ b/addon/styles/_pix-button.scss
@@ -75,6 +75,11 @@
     border: 1px solid $grey-50;
   }
 
+  &--disabled {
+    opacity: .5;
+    cursor: default;
+  }
+
   @-webkit-keyframes sk-bouncedelay {
     0%, 80%, 100% { -webkit-transform: scale(0) }
     40% { -webkit-transform: scale(1.0) }

--- a/tests/integration/components/pix-button-test.js
+++ b/tests/integration/components/pix-button-test.js
@@ -15,9 +15,9 @@ module('Integration | Component | button', function(hooks) {
         Mon bouton
       </PixButton>
     `);
-    const componentElement = this.element.querySelector(COMPONENT_SELECTOR);
 
     // then
+    const componentElement = this.element.querySelector(COMPONENT_SELECTOR);
     assert.equal(componentElement.textContent.trim(), 'Mon bouton');
     assert.equal(componentElement.type, 'button');
   });
@@ -29,29 +29,53 @@ module('Integration | Component | button', function(hooks) {
         Mon bouton
       </PixButton>
     `);
-    const componentElement = this.element.querySelector(COMPONENT_SELECTOR);
 
     // then
+    const componentElement = this.element.querySelector(COMPONENT_SELECTOR);
     assert.equal(componentElement.type, 'submit');
   });
 
-  test('it should call the action', async function(assert) {
-    // when
+  test('it renders the PixButton component with isDisabled attribute', async function(assert) {
+    // given
     this.set('count', 1);
     this.set('triggerAction', () => {
       this.count = this.count + 1;
     });
+
+    //when
+    await render(hbs`
+      <PixButton
+      @isDisabled={{true}}
+      @triggerAction={{this.triggerAction}}>
+        Mon bouton
+      </PixButton>
+    `);
+
+    await click('button');
+
+    // then
+    const componentElement = this.element.querySelector(COMPONENT_SELECTOR);
+    assert.equal(this.count, 1);
+    assert.equal(componentElement.disabled, true);
+  });
+
+  test('it should call the action', async function(assert) {
+    // given
+    this.set('count', 1);
+    this.set('triggerAction', () => {
+      this.count = this.count + 1;
+    });
+
+    //when
     await render(hbs`
       <PixButton @triggerAction={{this.triggerAction}} />
     `);
 
     await click('button');
-    const componentElement = this.element.querySelector(COMPONENT_SELECTOR);
 
     // then
+    const componentElement = this.element.querySelector(COMPONENT_SELECTOR);
     assert.equal(this.count, 2);
     assert.equal(componentElement.disabled, false);
   });
-
-
 });


### PR DESCRIPTION
## :unicorn: Description du composant
Cette PR ajoute au composant PixButton l'attribut `isDisabled` (booléen) pour pouvoir désactiver le bouton.

Cela nous permettra par exemple de désactiver le bouton tant qu'un utilisateur n'aura pas rempli tous les champs d'un formulaire.

## :rainbow: Remarques
Prise en compte du `aria-disabled` pour l'accessibilité : [lien de la doc A11y](https://a11y-101.com/development/aria-disabled)
## :100: Pour tester
Lancer storybook en local
