### PR TITLE
[TECH] Enrichir Pix Button.

### DIFF
--- a/addon/components/pix-button.hbs
+++ b/addon/components/pix-button.hbs
@@ -1,5 +1,5 @@
 <button type={{this.type}}
-        class="pix-button pix-button--shape-{{this.shape}} pix-button--background-{{this.backgroundColor}}{{if this.isDisabled ' pix-button--disabled'}}"
+        class="pix-button pix-button--shape-{{this.shape}} pix-button--size-{{this.size}} pix-button--background-{{this.backgroundColor}}{{if this.isDisabled ' pix-button--disabled'}}"
         {{on "click" this.triggerAction}}
         ...attributes
         disabled={{this.isButtonLoadingOrDisabled}}

--- a/addon/components/pix-button.hbs
+++ b/addon/components/pix-button.hbs
@@ -1,5 +1,5 @@
 <button type={{this.type}}
-        class="pix-button pix-button--{{this.border}} pix-button--background-{{this.backgroundColor}}{{if this.isDisabled ' pix-button--disabled'}}"
+        class="pix-button pix-button--shape-{{this.shape}} pix-button--background-{{this.backgroundColor}}{{if this.isDisabled ' pix-button--disabled'}}"
         {{on "click" this.triggerAction}}
         ...attributes
         disabled={{this.isButtonLoadingOrDisabled}}

--- a/addon/components/pix-button.hbs
+++ b/addon/components/pix-button.hbs
@@ -1,17 +1,32 @@
-<button type={{this.type}}
-        class="pix-button pix-button--shape-{{this.shape}} pix-button--size-{{this.size}} pix-button--background-{{this.backgroundColor}}{{if this.isDisabled ' pix-button--disabled'}}
-        {{if this.isBorderVisible ' pix-button--border'}}"
-        {{on "click" this.triggerAction}}
-        ...attributes
-        disabled={{this.isButtonLoadingOrDisabled}}
-        aria-disabled={{this.ariaDisabled}}>
-{{#if this.isLoading}}
-  <div class="loader loader--{{@loading-color}}">
-    <div class="bounce1"></div>
-    <div class="bounce2"></div>
-    <div class="bounce3"></div>
- </div>
+{{#if this.isLink}}
+  {{#if @model}}
+  <LinkTo @route={{this.route}} class="pix-button pix-button--shape-{{this.shape}} pix-button--size-{{this.size}} pix-button--background-{{this.backgroundColor}}{{if this.isDisabled ' pix-button--disabled'}}{{if this.isBorderVisible ' pix-button--border'}}"
+          @model={{@model}}
+          ...attributes>
+    {{yield}}
+  </LinkTo>
+  {{else}}
+    <LinkTo @route={{this.route}} class="pix-button pix-button--shape-{{this.shape}} pix-button--size-{{this.size}} pix-button--background-{{this.backgroundColor}}{{if this.isDisabled ' pix-button--disabled'}}{{if this.isBorderVisible ' pix-button--border'}}"
+            ...attributes>
+    {{yield}}
+    </LinkTo>
+  {{/if}}
 {{else}}
-  {{yield}}
+  <button type={{this.type}}
+          class="pix-button pix-button--shape-{{this.shape}} pix-button--size-{{this.size}} pix-button--background-{{this.backgroundColor}}{{if this.isDisabled ' pix-button--disabled'}}
+            {{if this.isBorderVisible ' pix-button--border'}}"
+    {{on "click" this.triggerAction}}
+          ...attributes
+          disabled={{this.isButtonLoadingOrDisabled}}
+          aria-disabled={{this.ariaDisabled}}>
+    {{#if this.isLoading}}
+      <div class="loader loader--{{@loading-color}}">
+        <div class="bounce1"></div>
+        <div class="bounce2"></div>
+        <div class="bounce3"></div>
+      </div>
+    {{else}}
+      {{yield}}
+    {{/if}}
+  </button>
 {{/if}}
-</button>

--- a/addon/components/pix-button.hbs
+++ b/addon/components/pix-button.hbs
@@ -1,5 +1,6 @@
 <button type={{this.type}}
-        class="pix-button pix-button--shape-{{this.shape}} pix-button--size-{{this.size}} pix-button--background-{{this.backgroundColor}}{{if this.isDisabled ' pix-button--disabled'}}"
+        class="pix-button pix-button--shape-{{this.shape}} pix-button--size-{{this.size}} pix-button--background-{{this.backgroundColor}}{{if this.isDisabled ' pix-button--disabled'}}
+        {{if this.isBorderVisible ' pix-button--border'}}"
         {{on "click" this.triggerAction}}
         ...attributes
         disabled={{this.isButtonLoadingOrDisabled}}

--- a/addon/components/pix-button.hbs
+++ b/addon/components/pix-button.hbs
@@ -1,10 +1,10 @@
 {{#if this.isLink}}
   {{#if @model}}
-  <LinkTo @route={{this.route}} class="pix-button pix-button--shape-{{this.shape}} pix-button--size-{{this.size}} pix-button--background-{{this.backgroundColor}}{{if this.isDisabled ' pix-button--disabled'}}{{if this.isBorderVisible ' pix-button--border'}}"
-          @model={{@model}}
-          ...attributes>
-    {{yield}}
-  </LinkTo>
+    <LinkTo @route={{this.route}} class="pix-button pix-button--shape-{{this.shape}} pix-button--size-{{this.size}} pix-button--background-{{this.backgroundColor}}{{if this.isDisabled ' pix-button--disabled'}}{{if this.isBorderVisible ' pix-button--border'}}"
+            @model={{@model}}
+            ...attributes>
+      {{yield}}
+    </LinkTo>
   {{else}}
     <LinkTo @route={{this.route}} class="pix-button pix-button--shape-{{this.shape}} pix-button--size-{{this.size}} pix-button--background-{{this.backgroundColor}}{{if this.isDisabled ' pix-button--disabled'}}{{if this.isBorderVisible ' pix-button--border'}}"
             ...attributes>

--- a/addon/components/pix-button.js
+++ b/addon/components/pix-button.js
@@ -44,8 +44,8 @@ export default class PixButton extends Component {
 
   get route() {
     const routeParam = this.args.route;
-    if( this.isLink ) {
-      if( routeParam === undefined || routeParam.trim() === '') {
+    if (this.isLink) {
+      if (routeParam === undefined || routeParam.trim() === '') {
         throw new Error('ERROR in PixButton component, @route param is not provided');
       }
     }
@@ -60,11 +60,10 @@ export default class PixButton extends Component {
       this.isLoading = false;
     } catch (e) {
       this.isLoading = false;
-      if(!this.args.triggerAction) {
-        throw(new Error('@triggerAction params is required for PixButton !'));
+      if (!this.args.triggerAction) {
+        throw new Error('@triggerAction params is required for PixButton !');
       }
-      throw(new Error(e))
+      throw new Error(e);
     }
   }
-
 }

--- a/addon/components/pix-button.js
+++ b/addon/components/pix-button.js
@@ -10,8 +10,8 @@ export default class PixButton extends Component {
     return this.args.type || 'button';
   }
 
-  get border() {
-    return this.args.border || 'squircle-big';
+  get shape() {
+    return this.args.shape || 'squircle';
   }
 
   get backgroundColor() {

--- a/addon/components/pix-button.js
+++ b/addon/components/pix-button.js
@@ -38,6 +38,20 @@ export default class PixButton extends Component {
     return this.args.isBorderVisible || false;
   }
 
+  get isLink() {
+    return this.args.isLink || false;
+  }
+
+  get route() {
+    const routeParam = this.args.route;
+    if( this.isLink ) {
+      if( routeParam === undefined || routeParam.trim() === '') {
+        throw new Error('ERROR in PixButton component, @route param is not provided');
+      }
+    }
+    return routeParam;
+  }
+
   @action
   async triggerAction(params) {
     try {

--- a/addon/components/pix-button.js
+++ b/addon/components/pix-button.js
@@ -34,6 +34,10 @@ export default class PixButton extends Component {
     return this.args.size || 'big';
   }
 
+  get isBorderVisible() {
+    return this.args.isBorderVisible || false;
+  }
+
   @action
   async triggerAction(params) {
     try {

--- a/addon/components/pix-button.js
+++ b/addon/components/pix-button.js
@@ -30,6 +30,10 @@ export default class PixButton extends Component {
     return (this.isLoading || this.isDisabled).toString();
   }
 
+  get size() {
+    return this.args.size || 'big';
+  }
+
   @action
   async triggerAction(params) {
     try {

--- a/addon/components/pix-filter-banner.hbs
+++ b/addon/components/pix-filter-banner.hbs
@@ -12,8 +12,8 @@
       <p class="pix-filter-banner__details">{{@details}}</p>
     {{/if}}
     {{#if this.displayClearFilters}}
-      <div class="pix-filter-banner__button-container"> 
-        <PixButton class="pix-filter-banner__button" @border="squircle-small" @triggerAction={{@onClearFilters}}>
+      <div class="pix-filter-banner__button-container">
+        <PixButton class="pix-filter-banner__button" @shape="squircle" @triggerAction={{@onClearFilters}}>
           <FaIcon class="pix-filter-banner-button__icon" @icon='trash-alt' @prefix='far'/>
             {{@clearFiltersLabel}}
         </PixButton>

--- a/addon/components/pix-filter-banner.hbs
+++ b/addon/components/pix-filter-banner.hbs
@@ -13,7 +13,7 @@
     {{/if}}
     {{#if this.displayClearFilters}}
       <div class="pix-filter-banner__button-container">
-        <PixButton class="pix-filter-banner__button" @shape="squircle" @triggerAction={{@onClearFilters}}>
+        <PixButton class="pix-filter-banner__button" @shape="squircle" @size="small" @triggerAction={{@onClearFilters}}>
           <FaIcon class="pix-filter-banner-button__icon" @icon='trash-alt' @prefix='far'/>
             {{@clearFiltersLabel}}
         </PixButton>

--- a/addon/stories/pix-button-border.stories.mdx
+++ b/addon/stories/pix-button-border.stories.mdx
@@ -1,0 +1,50 @@
+import { Meta, Story, Canvas, ArgsTable } from '@storybook/addon-docs/blocks';
+import centered from '@storybook/addon-centered/ember';
+import * as stories from './pix-button.stories.js';
+
+<Meta
+  title='Basics/Button/Border'
+  component='PixButton'
+  decorators={[centered]}
+  argTypes={stories.argsTypes}
+/>
+
+# Pix Button
+
+Ce composant est un bouton simple qui empêche les clics multiples.
+
+<Canvas isColumn>
+  <Story name="Border" story={stories.borderButtons} height="300px" />
+</Canvas>
+
+## Usage
+
+```html
+Par défaut, le bouton n'a pas de bordure
+<PixButton
+  @isBorderVisible={{false}}
+  @backgroundColor="transparent-light"
+  >
+  Cliquez pour valider !
+</PixButton>
+
+Bouton avec bordure sur fond clair
+<PixButton
+  @isBorderVisible={{true}}
+  @backgroundColor="transparent-light"
+  >
+  Cliquez pour valider !
+</PixButton>
+
+Bouton avec bordure sur fond sombre
+<PixButton
+  @isBorderVisible={{true}}
+  @backgroundColor="transparent-dark"
+  >
+  Cliquez pour valider !
+</PixButton>
+```
+
+## Arguments
+
+<ArgsTable story="Border" />

--- a/addon/stories/pix-button-link.stories.mdx
+++ b/addon/stories/pix-button-link.stories.mdx
@@ -1,0 +1,41 @@
+import { Meta, Story, Canvas, ArgsTable } from '@storybook/addon-docs/blocks';
+import centered from '@storybook/addon-centered/ember';
+import * as stories from './pix-button.stories.js';
+
+<Meta
+  title='Basics/Button/Link'
+  component='PixButton'
+  decorators={[centered]}
+  argTypes={stories.argsTypes}
+/>
+
+# Pix Button
+
+Ce composant est un bouton simple qui empêche les clics multiples.
+
+<Canvas isColumn>
+  <Story name="Link" story={stories.linkButtons} height="200px" />
+</Canvas>
+
+## Usage
+
+```html
+Par défaut, le composant est un bouton
+<PixButton
+  @isLink={{false}}
+  >
+  Cliquez pour valider !
+</PixButton>
+
+Composant LinkTo
+<PixButton
+  @isLink={{true}}
+  @route='profile'
+  >
+  Cliquez pour valider !
+</PixButton>
+```
+
+## Arguments
+
+<ArgsTable story="Link" />

--- a/addon/stories/pix-button-shape.stories.mdx
+++ b/addon/stories/pix-button-shape.stories.mdx
@@ -3,7 +3,7 @@ import centered from '@storybook/addon-centered/ember';
 import * as stories from './pix-button.stories.js';
 
 <Meta
-  title='Basics/Button/Border'
+  title='Basics/Button/Shape'
   component='PixButton'
   decorators={[centered]}
   argTypes={stories.argsTypes}
@@ -14,15 +14,15 @@ import * as stories from './pix-button.stories.js';
 Ce composant est un bouton simple qui empêche les clics multiples.
 
 <Canvas isColumn>
-  <Story name="Border" story={stories.borderButtons} height="200px" />
+  <Story name="Shape" story={stories.shapeButtons} height="200px" />
 </Canvas>
 
 ## Usage
 
 ```html
-Par défaut, la bordure est `squircle-big`
+Par défaut, la forme est `squircle`
 <PixButton
-  @border="squircle-big"
+  @shape="squircle"
   >
   Cliquez pour valider !
 </PixButton>
@@ -30,4 +30,4 @@ Par défaut, la bordure est `squircle-big`
 
 ## Arguments
 
-<ArgsTable story="Border" />
+<ArgsTable story="Shape" />

--- a/addon/stories/pix-button-size.stories.mdx
+++ b/addon/stories/pix-button-size.stories.mdx
@@ -1,0 +1,33 @@
+import { Meta, Story, Canvas, ArgsTable } from '@storybook/addon-docs/blocks';
+import centered from '@storybook/addon-centered/ember';
+import * as stories from './pix-button.stories.js';
+
+<Meta
+  title='Basics/Button/Size'
+  component='PixButton'
+  decorators={[centered]}
+  argTypes={stories.argsTypes}
+/>
+
+# Pix Button
+
+Ce composant est un bouton simple qui empêche les clics multiples.
+
+<Canvas isColumn>
+  <Story name="Size" story={stories.sizeButtons} height="200px" />
+</Canvas>
+
+## Usage
+
+```html
+Par défaut, la taille est `big`
+<PixButton
+  @size="big"
+  >
+  Cliquez pour valider !
+</PixButton>
+```
+
+## Arguments
+
+<ArgsTable story="Size" />

--- a/addon/stories/pix-button.stories.js
+++ b/addon/stories/pix-button.stories.js
@@ -20,7 +20,7 @@ export const loadingButtons = (args) => {
   };
 };
 
-export const borderButtons = (args) => {
+export const shapeButtons = (args) => {
   return {
     template: hbs`
     <section>
@@ -28,15 +28,8 @@ export const borderButtons = (args) => {
           @triggerAction={{action triggerAction}}
           @loading-color='white'
           @type={{type}}
-          @border='rounded-big'>
-        Bouton rounded-big
-      </PixButton>
-      <PixButton
-          @triggerAction={{action triggerAction}}
-          @loading-color='white'
-          @type={{type}}
-          @border='rounded-small'>
-        Bouton rounded-small
+          @shape='rounded'>
+        Bouton rounded
       </PixButton>
     </section>
     <section>
@@ -44,15 +37,8 @@ export const borderButtons = (args) => {
           @triggerAction={{action triggerAction}}
           @loading-color='white'
           @type={{type}}
-          @border='squircle-big'>
-        Bouton squircle-big (default)
-      </PixButton>
-      <PixButton
-          @triggerAction={{action triggerAction}}
-          @loading-color='white'
-          @type={{type}}
-          @border='squircle-small'>
-        Bouton squircle-small
+          @shape='squircle'>
+        Bouton squircle (default)
       </PixButton>
     </section>
     `,
@@ -174,14 +160,14 @@ export const argsTypes = {
       defaultValue: { summary: 'white' },
     }
   },
-  border: {
-    name: 'border',
-    description: 'bordure: `rounded-small`, `rounded-big`, `squircle-small`, `squircle-big`',
+  shape: {
+    name: 'shape',
+    description: 'forme: `rounded`,`squircle`',
     type: { name: 'string', required: false },
     control: { disable: true },
     table: {
       type: { summary: 'string' },
-      defaultValue: { summary: 'squircle-big' },
+      defaultValue: { summary: 'squircle' },
     }
   },
   backgroundColor: {

--- a/addon/stories/pix-button.stories.js
+++ b/addon/stories/pix-button.stories.js
@@ -90,6 +90,15 @@ export const colorButtons = (args) => {
           Bouton avec background yellow
         </PixButton>
       </section>
+        <section>
+        <PixButton
+            @triggerAction={{action triggerAction}}
+            @loading-color='white'
+            @backgroundColor='grey'
+            @type={{type}}>
+          Bouton avec background grey
+        </PixButton>
+      </section>
       <section>
         <PixButton
             @triggerAction={{action triggerAction}}
@@ -168,7 +177,7 @@ export const argsTypes = {
   },
   backgroundColor: {
     name: 'backgroundColor',
-    description: 'color: `blue`, `green`, `yellow`, `transparent`',
+    description: 'color: `blue`, `green`, `yellow`, `grey`, `transparent`',
     type: { name: 'string', required: false },
     control: { disable: true },
     table: {

--- a/addon/stories/pix-button.stories.js
+++ b/addon/stories/pix-button.stories.js
@@ -183,6 +183,29 @@ export const sizeButtons = (args) => {
   };
 }
 
+export const linkButtons = (args) => {
+  return {
+    template: hbs`
+    <section>
+      <PixButton
+      @isLink={{false}}
+      >
+        Je suis un bouton (défaut)
+      </PixButton>
+    </section>
+    <section>
+      <PixButton
+        @isLink={{true}}
+        @route='profile'
+        >
+        Je suis un Lien
+      </PixButton>
+    </section>
+    `,
+    context: args,
+  };
+};
+
 export const argsTypes = {
   type: {
     name: 'type',
@@ -265,5 +288,26 @@ export const argsTypes = {
       type: { summary: 'boolean' },
       defaultValue: { summary: 'false' },
     }
+  },
+  isLink: {
+    name: 'isLink',
+    description: 'Paramètre pour utiliser un composant LinkTo à la place d\'un bouton',
+    type: { name: 'boolean', required: false },
+    control: { type: 'boolean' },
+    table: {
+      type: { summary: 'boolean' },
+      defaultValue: { summary: 'false' },
+    }
+  },
+  route: {
+    name: 'route',
+    description: 'Route de redirection',
+    type: { name: 'string', required: true },
+    defaultValue: null,
+  },
+  model: {
+    name: 'model',
+    description: 'Model Ember',
+    type: { required: false },
   },
 };

--- a/addon/stories/pix-button.stories.js
+++ b/addon/stories/pix-button.stories.js
@@ -102,10 +102,19 @@ export const colorButtons = (args) => {
       <section>
         <PixButton
             @triggerAction={{action triggerAction}}
-            @loading-color='white'
-            @backgroundColor='transparent'
+            @loading-color='grey'
+            @backgroundColor='transparent-light'
             @type={{type}}>
-          Bouton avec background transparent
+          Bouton avec background transparent-light
+        </PixButton>
+      </section>
+      <section style="background-color: #345193">
+        <PixButton
+            @triggerAction={{action triggerAction}}
+            @loading-color='white'
+            @backgroundColor='transparent-dark'
+            @type={{type}}>
+          Bouton avec background transparent-dark
         </PixButton>
       </section>
     `,
@@ -177,7 +186,7 @@ export const argsTypes = {
   },
   backgroundColor: {
     name: 'backgroundColor',
-    description: 'color: `blue`, `green`, `yellow`, `grey`, `transparent`',
+    description: 'color: `blue`, `green`, `yellow`, `grey`, `transparent-light`, `transparent-dark`',
     type: { name: 'string', required: false },
     control: { disable: true },
     table: {

--- a/addon/stories/pix-button.stories.js
+++ b/addon/stories/pix-button.stories.js
@@ -126,6 +126,32 @@ export const disabledButtons = (args) => {
   };
 };
 
+export const sizeButtons = (args) => {
+  return {
+    template: hbs`
+    <section>
+      <PixButton
+          @triggerAction={{action triggerAction}}
+          @loading-color='white'
+          @type={{type}}
+          @size='small'>
+        Bouton small
+      </PixButton>
+    </section>
+    <section>
+      <PixButton
+          @triggerAction={{action triggerAction}}
+          @loading-color='white'
+          @type={{type}}
+          @size='big'>
+        Bouton big (default)
+      </PixButton>
+    </section>
+    `,
+    context: args,
+  };
+}
+
 export const argsTypes = {
   type: {
     name: 'type',
@@ -187,6 +213,16 @@ export const argsTypes = {
     table: {
       type: { summary: 'boolean' },
       defaultValue: { summary: 'false' },
+    }
+  },
+  size: {
+    name: 'size',
+    description: 'taille: `big`,`small`',
+    type: { name: 'string', required: false },
+    control: { disable: true },
+    table: {
+      type: { summary: 'string' },
+      defaultValue: { summary: 'big' },
     }
   },
 };

--- a/addon/stories/pix-button.stories.js
+++ b/addon/stories/pix-button.stories.js
@@ -126,6 +126,37 @@ export const disabledButtons = (args) => {
   };
 };
 
+export const borderButtons = (args) => {
+  return {
+    template: hbs`
+    <section>
+      <PixButton @isBorderVisible={{false}}
+      @backgroundColor="transparent-light"
+      >
+        Bouton sans bordure (défaut)
+      </PixButton>
+    </section>
+    <section>
+      <PixButton
+        @isBorderVisible={{true}}
+        @backgroundColor="transparent-light"
+        >
+        Bouton avec bordure sur fond clair
+      </PixButton>
+    </section>
+      <section style="background-color: #345193">
+        <PixButton
+          @isBorderVisible={{true}}
+          @backgroundColor="transparent-dark"
+          >
+          Bouton avec bordure sur fond sombre
+        </PixButton>
+      </section>
+    `,
+    context: args,
+  };
+};
+
 export const sizeButtons = (args) => {
   return {
     template: hbs`
@@ -223,6 +254,16 @@ export const argsTypes = {
     table: {
       type: { summary: 'string' },
       defaultValue: { summary: 'big' },
+    }
+  },
+  isBorderVisible: {
+    name: 'isBorderVisible',
+    description: 'Paramètre utilisé seulement quand le `backgroundColor` est `transparent-light` ou `transparent-dark`',
+    type: { name: 'boolean', required: false },
+    control: { type: 'boolean' },
+    table: {
+      type: { summary: 'boolean' },
+      defaultValue: { summary: 'false' },
     }
   },
 };

--- a/addon/stories/pix-button.stories.js
+++ b/addon/stories/pix-button.stories.js
@@ -76,6 +76,15 @@ export const colorButtons = (args) => {
           Bouton avec background yellow
         </PixButton>
       </section>
+      <section>
+        <PixButton
+            @triggerAction={{action triggerAction}}
+            @loading-color='white'
+            @backgroundColor='red'
+            @type={{type}}>
+          Bouton avec background red
+        </PixButton>
+      </section>
         <section>
         <PixButton
             @triggerAction={{action triggerAction}}
@@ -252,7 +261,7 @@ export const argsTypes = {
   },
   backgroundColor: {
     name: 'backgroundColor',
-    description: 'color: `blue`, `green`, `yellow`, `grey`, `transparent-light`, `transparent-dark`',
+    description: 'color: `blue`, `green`, `yellow`, `red`, `grey`, `transparent-light`, `transparent-dark`',
     type: { name: 'string', required: false },
     control: { disable: true },
     table: {

--- a/addon/styles/_colors.scss
+++ b/addon/styles/_colors.scss
@@ -3,6 +3,7 @@
 // primary
 $blue: #3D68FF;
 $yellow: #FFBE00;
+$red: #D63F00;
 $blue-zodiac: #505F79;
 $black: #07142E;
 $white: #ffffff;

--- a/addon/styles/_pix-button.scss
+++ b/addon/styles/_pix-button.scss
@@ -9,6 +9,7 @@
   letter-spacing: .012rem;
   cursor: pointer;
   font-family: 'Roboto', Arial, sans-serif;
+  background-color: $blue;
 
   .loader > div {
     width: 10px;
@@ -66,7 +67,11 @@
 
   &--background-yellow {
     color: $grey-100;
-    background-color: $warning;
+    background-color: $yellow;
+  }
+
+  &--background-grey {
+    background-color: $blue-zodiac;
   }
 
   &--background-transparent {

--- a/addon/styles/_pix-button.scss
+++ b/addon/styles/_pix-button.scss
@@ -112,6 +112,25 @@
     }
   }
 
+  &--background-red {
+    color: $white;
+    background-color: $red;
+
+    &:hover {
+      background-color: darken($red, 4%);
+    }
+
+    &:active {
+      background-color: darken($red, 8%);
+    }
+
+    &:focus {
+      outline-color: $blue;
+      outline-style: auto;
+      outline-offset: 3px;
+    }
+  }
+
   &--background-grey {
     background-color: $blue-zodiac;
 

--- a/addon/styles/_pix-button.scss
+++ b/addon/styles/_pix-button.scss
@@ -8,7 +8,7 @@
   font-weight: 500;
   letter-spacing: .012rem;
   cursor: pointer;
-  font-family: 'Roboto', Arial, sans-serif;
+  font-family: $font-roboto;
   background-color: $blue;
 
   .loader > div {
@@ -17,7 +17,6 @@
     background-color: $white;
     border-radius: 100%;
     display: inline-block;
-    -webkit-animation: sk-bouncedelay 1.4s infinite ease-in-out both;
     animation: sk-bouncedelay 1.4s infinite ease-in-out both;
   }
 
@@ -28,12 +27,10 @@
     background-color: $grey-80;
   }
   .loader .bounce1 {
-    -webkit-animation-delay: -0.32s;
     animation-delay: -0.32s;
   }
 
   .loader .bounce2 {
-    -webkit-animation-delay: -0.16s;
     animation-delay: -0.16s;
   }
 
@@ -57,96 +54,44 @@
     padding: 10px 16px;
   }
 
-  &--background-blue {
-    background-color: $blue;
+  @mixin colorizeBackground($backgroundColor, $outlineColor) {
+    background-color: $backgroundColor;
 
     &:hover {
-      background-color: darken($blue, 4%);
+      background-color: darken($backgroundColor, 4%);
     }
 
     &:active {
-      background-color: darken($blue, 8%);
+      background-color: darken($backgroundColor, 8%);
     }
 
     &:focus {
-      outline-color: $blue;
+      outline-color: $outlineColor;
       outline-style: auto;
       outline-offset: 3px;
     }
   }
 
+  &--background-blue {
+    @include colorizeBackground($blue, $blue);
+  }
+
   &--background-green {
-    background-color: #037620;
-
-    &:hover {
-      background-color: darken(#037620, 4%);
-    }
-
-    &:active {
-      background-color: darken(#037620, 8%);
-    }
-
-    &:focus {
-      outline-color: $blue;
-      outline-style: auto;
-      outline-offset: 3px;
-    }
+    @include colorizeBackground($green, $blue);
   }
 
   &--background-yellow {
     color: $grey-100;
-    background-color: $yellow;
-
-    &:hover {
-      background-color: darken($yellow, 4%);
-    }
-
-    &:active {
-      background-color: darken($yellow, 8%);
-    }
-
-    &:focus {
-      outline-color: $blue;
-      outline-style: auto;
-      outline-offset: 3px;
-    }
+    @include colorizeBackground($yellow, $blue);
   }
 
   &--background-red {
     color: $white;
-    background-color: $red;
-
-    &:hover {
-      background-color: darken($red, 4%);
-    }
-
-    &:active {
-      background-color: darken($red, 8%);
-    }
-
-    &:focus {
-      outline-color: $blue;
-      outline-style: auto;
-      outline-offset: 3px;
-    }
+    @include colorizeBackground($red, $blue);
   }
 
   &--background-grey {
-    background-color: $blue-zodiac;
-
-    &:hover {
-      background-color: darken($blue-zodiac, 4%);
-    }
-
-    &:active {
-      background-color: darken($blue-zodiac, 8%);
-    }
-
-    &:focus {
-      outline-color: $blue;
-      outline-style: auto;
-      outline-offset: 3px;
-    }
+    @include colorizeBackground($blue-zodiac, $blue);
   }
 
   /* deprecated in favor of --background-transparent-light + --border */
@@ -169,10 +114,9 @@
     }
 
     &:focus {
-      outline-color: $yellow;
+      outline-color: $blue;
       outline-style: auto;
       outline-offset: 3px;
-      background-color: $yellow;
     }
 
     &.pix-button--border {
@@ -197,10 +141,9 @@
     }
 
     &:focus {
-      outline-color: $yellow;
+      outline-color: $blue;
       outline-style: auto;
       outline-offset: 3px;
-      background-color: $yellow;
       color: $grey-90;
     }
 
@@ -214,18 +157,11 @@
     cursor: default;
   }
 
-  @-webkit-keyframes sk-bouncedelay {
-    0%, 80%, 100% { -webkit-transform: scale(0) }
-    40% { -webkit-transform: scale(1.0) }
-  }
-
   @keyframes sk-bouncedelay {
     0%, 80%, 100% {
-      -webkit-transform: scale(0);
       transform: scale(0);
     } 40% {
-        -webkit-transform: scale(1.0);
-        transform: scale(1.0);
-      }
+      transform: scale(1.0);
+    }
   }
 }

--- a/addon/styles/_pix-button.scss
+++ b/addon/styles/_pix-button.scss
@@ -37,23 +37,11 @@
     animation-delay: -0.16s;
   }
 
-  &--rounded-big {
-    padding: 14px 24px;
+  &--shape-rounded {
     border-radius: 23px;
   }
 
-  &--rounded-small {
-    padding: 10px 24px;
-    border-radius: 23px;
-  }
-
-  &--squircle-big {
-    padding: 14px 24px;
-    border-radius: 5px;
-  }
-
-  &--squircle-small {
-    padding: 10px 16px;
+  &--shape-squircle {
     border-radius: 5px;
   }
 

--- a/addon/styles/_pix-button.scss
+++ b/addon/styles/_pix-button.scss
@@ -74,10 +74,21 @@
     background-color: $blue-zodiac;
   }
 
+  /* deprecated in favor of --background-transparent-light + --border */
   &--background-transparent {
     background-color: transparent;
     color: $grey-50;
     border: 1px solid $grey-50;
+  }
+
+  &--background-transparent-light {
+    background-color: transparent;
+    color: $grey-60;
+  }
+
+  &--background-transparent-dark {
+    background-color: transparent;
+    color: $white;
   }
 
   &--disabled {

--- a/addon/styles/_pix-button.scss
+++ b/addon/styles/_pix-button.scss
@@ -67,6 +67,12 @@
     &:active {
       background-color: darken($blue, 8%);
     }
+
+    &:focus {
+      outline-color: $blue;
+      outline-style: auto;
+      outline-offset: 3px;
+    }
   }
 
   &--background-green {
@@ -78,6 +84,12 @@
 
     &:active {
       background-color: darken(#037620, 8%);
+    }
+
+    &:focus {
+      outline-color: $blue;
+      outline-style: auto;
+      outline-offset: 3px;
     }
   }
 
@@ -92,6 +104,12 @@
     &:active {
       background-color: darken($yellow, 8%);
     }
+
+    &:focus {
+      outline-color: $blue;
+      outline-style: auto;
+      outline-offset: 3px;
+    }
   }
 
   &--background-grey {
@@ -104,6 +122,12 @@
     &:active {
       background-color: darken($blue-zodiac, 8%);
     }
+
+    &:focus {
+      outline-color: $blue;
+      outline-style: auto;
+      outline-offset: 3px;
+    }
   }
 
   /* deprecated in favor of --background-transparent-light + --border */
@@ -115,7 +139,7 @@
 
   &--background-transparent-light {
     background-color: transparent;
-    color: $grey-60;
+    color: $grey-90;
 
     &:hover {
       background-color: rgba($black, 0.1);
@@ -123,6 +147,13 @@
 
     &:active {
       background-color: rgba($black, 0.2);
+    }
+
+    &:focus {
+      outline-color: $yellow;
+      outline-style: auto;
+      outline-offset: 3px;
+      background-color: $yellow;
     }
 
     &.pix-button--border {
@@ -144,6 +175,14 @@
 
     &:active {
       background-color: rgba($black, 0.2);
+    }
+
+    &:focus {
+      outline-color: $yellow;
+      outline-style: auto;
+      outline-offset: 3px;
+      background-color: $yellow;
+      color: $grey-90;
     }
 
     &.pix-button--border {

--- a/addon/styles/_pix-button.scss
+++ b/addon/styles/_pix-button.scss
@@ -59,19 +59,35 @@
 
   &--background-blue {
     background-color: $blue;
+
+    &:hover {
+      background-color: darken($blue, 4%);
+    }
   }
 
   &--background-green {
     background-color: #037620;
+
+    &:hover {
+      background-color: darken(#037620, 4%);
+    }
   }
 
   &--background-yellow {
     color: $grey-100;
     background-color: $yellow;
+
+    &:hover {
+      background-color: darken($yellow, 4%);
+    }
   }
 
   &--background-grey {
     background-color: $blue-zodiac;
+
+    &:hover {
+      background-color: darken($blue-zodiac, 4%);
+    }
   }
 
   /* deprecated in favor of --background-transparent-light + --border */
@@ -84,11 +100,19 @@
   &--background-transparent-light {
     background-color: transparent;
     color: $grey-60;
+
+    &:hover {
+      background-color: rgba($black, 0.1);
+    }
   }
 
   &--background-transparent-dark {
     background-color: transparent;
     color: $white;
+
+    &:hover {
+      background-color: rgba($black, 0.1);
+    }
   }
 
   &--disabled {

--- a/addon/styles/_pix-button.scss
+++ b/addon/styles/_pix-button.scss
@@ -45,6 +45,18 @@
     border-radius: 5px;
   }
 
+  &--size-big {
+    padding: 14px 24px;
+  }
+
+  &--size-small.pix-button--shape-rounded {
+    padding: 10px 24px;
+  }
+
+  &--size-small.pix-button--shape-squircle {
+    padding: 10px 16px;
+  }
+
   &--background-blue {
     background-color: $blue;
 

--- a/addon/styles/_pix-button.scss
+++ b/addon/styles/_pix-button.scss
@@ -124,6 +124,14 @@
     &:active {
       background-color: rgba($black, 0.2);
     }
+
+    &.pix-button--border {
+      border: 1px solid $grey-50;
+
+      &:hover, &:active {
+        border-color: $grey-80;
+      }
+    }
   }
 
   &--background-transparent-dark {
@@ -136,6 +144,10 @@
 
     &:active {
       background-color: rgba($black, 0.2);
+    }
+
+    &.pix-button--border {
+      border: 1px solid $white;
     }
   }
 

--- a/addon/styles/_pix-button.scss
+++ b/addon/styles/_pix-button.scss
@@ -63,6 +63,10 @@
     &:hover {
       background-color: darken($blue, 4%);
     }
+
+    &:active {
+      background-color: darken($blue, 8%);
+    }
   }
 
   &--background-green {
@@ -70,6 +74,10 @@
 
     &:hover {
       background-color: darken(#037620, 4%);
+    }
+
+    &:active {
+      background-color: darken(#037620, 8%);
     }
   }
 
@@ -80,6 +88,10 @@
     &:hover {
       background-color: darken($yellow, 4%);
     }
+
+    &:active {
+      background-color: darken($yellow, 8%);
+    }
   }
 
   &--background-grey {
@@ -87,6 +99,10 @@
 
     &:hover {
       background-color: darken($blue-zodiac, 4%);
+    }
+
+    &:active {
+      background-color: darken($blue-zodiac, 8%);
     }
   }
 
@@ -104,6 +120,10 @@
     &:hover {
       background-color: rgba($black, 0.1);
     }
+
+    &:active {
+      background-color: rgba($black, 0.2);
+    }
   }
 
   &--background-transparent-dark {
@@ -112,6 +132,10 @@
 
     &:hover {
       background-color: rgba($black, 0.1);
+    }
+
+    &:active {
+      background-color: rgba($black, 0.2);
     }
   }
 

--- a/tests/integration/components/pix-button-test.js
+++ b/tests/integration/components/pix-button-test.js
@@ -78,4 +78,18 @@ module('Integration | Component | button', function(hooks) {
     assert.equal(this.count, 2);
     assert.equal(componentElement.disabled, false);
   });
+
+  test('it renders the PixButton link component', async function(assert) {
+    // when
+    await render(hbs`
+      <PixButton
+      @isLink={{true}}
+      @route='profile'>
+        Mon lien
+      </PixButton>
+    `);
+
+    // then
+    assert.dom('a').exists();
+  });
 });

--- a/tests/unit/components/pix-button-test.js
+++ b/tests/unit/components/pix-button-test.js
@@ -1,0 +1,21 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+import createGlimmerComponent from '../../helpers/create-glimmer-component';
+
+
+module('Unit | Component | pix-button', function(hooks) {
+  setupTest(hooks);
+
+  test('it throws if route param is undefined or empty', function(assert) {
+    // given
+    const componentParams = { isLink: true, route: '  ' };
+    const expectedError = new Error('ERROR in PixButton component, @route param is not provided');
+    const component = createGlimmerComponent('component:pix-button', componentParams);
+
+    // when & then
+    assert.throws(
+      function() { component.route },
+      expectedError
+    );
+  });
+});


### PR DESCRIPTION
## :unicorn: Description du composant
Le composant Pix Button n'est pas complet : 

- [x] il lui manque des couleurs (gris, rouge, transparent sur fond foncé (transparent-dark), transparent sur fond clair (transparent-light))
- [x]  une gestion de la présence de la bordure ou non (isBorderVisible)
- [x] une gestion du hover, active, focus.
- [x] un choix pour avoir un bouton ou bien un lien avec un nouvel attribut `@isLink`

## :rainbow: Remarques
l'utilisation de la couleur `@backgroundColor=transparent` a été dépréciée en faveur de `@backgroundColor=transparent-light @isBorderVisible=true`

L'attribut `@border` s'occupait de deux choses: de la forme ( rounded, squircle ) et de la taille ( big, small ) du bouton.
Nous avons supprimé cet attribut pour le scinder en deux attributs `@shape` (forme) et `@size` (taille).

## :100: Pour tester
En local lancer `npm run storybook`.