### PR TITLE
[TECH] Corrige la doc de l'attribute type du bouton

### DIFF
--- a/addon/stories/pix-button.stories.js
+++ b/addon/stories/pix-button.stories.js
@@ -125,7 +125,7 @@ export const disabledButtons = (args) => {
 export const argsTypes = {
   type: {
     name: 'type',
-    description: 'fonction à appeler en cas de clic',
+    description: 'type du bouton',
     type: { required: false },
     control: { disable: true },
     table: {


### PR DESCRIPTION
## :unicorn: Description du problème
La documentation de l'attribut type n'était pas correct. Je l'ai corrigé.

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
> _Lien vers Zeroheight (modèle) et Storybook (rendu final)._