### PR TITLE
[TECH] Ajout de review app pour Storybook

### DIFF
--- a/.buildpacks
+++ b/.buildpacks
@@ -1,0 +1,2 @@
+https://github.com/Scalingo/nodejs-buildpack
+https://github.com/Scalingo/nginx-buildpack

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "license": "MIT",
   "author": "GIP Pix",
   "engines": {
-    "node": "10.* || >= 12"
+    "node": "14.16.0"
   },
   "ember": {
     "edition": "octane"
@@ -22,7 +22,8 @@
     "test": "tests"
   },
   "scripts": {
-    "build": "ember build --environment=production",
+    "build": "./scripts/build.sh && npm run signal-github",
+    "build-ember": "ember build --environment=production",
     "build-storybook": "ember build && cp -v CNAME dist && build-storybook -s dist",
     "clean": "rm -rf dist node_modules",
     "deploy-storybook": "storybook-to-ghpages",
@@ -32,7 +33,8 @@
     "storybook": "ember build && ember serve & start-storybook -p 9001 -s dist",
     "test": "ember test",
     "test:ember": "ember test",
-    "test:ember-compatibility": "ember try:each"
+    "test:ember-compatibility": "ember try:each",
+    "signal-github": "./scripts/signal-deploy-to-pr.sh"
   },
   "dependencies": {
     "ember-cli-babel": "^7.23.1",

--- a/scalingo.json
+++ b/scalingo.json
@@ -1,0 +1,17 @@
+{
+  "name": "Pix UI Review App",
+  "env": {
+    "REVIEW_APP": {
+      "description": "Indicates that the application is a review app",
+      "value": "true"
+    }
+  },
+  "addons": [
+  ],
+  "formation": {
+    "web": {
+      "amount": 1,
+      "size": "S"
+    }
+  }
+}

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,0 +1,8 @@
+#!/bin/bash -e
+
+if [ "$REVIEW_APP" == "true" ]
+then
+  npm run build-storybook
+else
+  npm run build-ember
+fi

--- a/scripts/signal-deploy-to-pr.sh
+++ b/scripts/signal-deploy-to-pr.sh
@@ -1,0 +1,37 @@
+#!/bin/bash -e
+
+[ "$REVIEW_APP" != "true" ] && {
+	echo '$REVIEW_APP is not true. I will not post a message to GitHub. Bye !'
+	exit 0
+}
+
+[ -z $APP ] && {
+	echo 'FATAL: $APP is absent'
+	exit 1
+}
+
+[ -z $GITHUB_USER ] && {
+	echo 'FATAL: $GITHUB_USER is absent'
+	exit 1
+}
+
+[ -z $GITHUB_USER_TOKEN ] && {
+	echo 'FATAL: $GITHUB_USER_TOKEN is absent'
+	exit 1
+}
+
+PR_NUMBER=$(echo $APP | grep -Po '(?<=-pr)\d+')
+RA_URL="https://ui-pr$PR_NUMBER.review.pix.fr"
+
+MESSAGE_PREFIX="I'm deploying this PR to:"
+
+existing_comments=$(curl -Ssf -u $GITHUB_USER:$GITHUB_USER_TOKEN \
+	"https://api.github.com/repos/1024pix/pix-ui/issues/${PR_NUMBER}/comments")
+
+if [[ $existing_comments == *"${MESSAGE_PREFIX}"* ]]; then
+	echo 'INFO: found a matching comment on the PR, not posting another one.'
+else
+	curl -Ssf -u $GITHUB_USER:$GITHUB_USER_TOKEN \
+		-X POST "https://api.github.com/repos/1024pix/pix-ui/issues/${PR_NUMBER}/comments" \
+    --data "{\"body\":\"$MESSAGE_PREFIX\n\n- Storybook: $RA_URL\n\n Please check it out!\"}"
+fi

--- a/servers.conf.erb
+++ b/servers.conf.erb
@@ -1,0 +1,30 @@
+log_format keyvalue
+  'method=$request_method'
+  ' path="$request_uri"'
+  ' host=$host'
+  ' request_id=$http_x_request_id'
+  ' from="$remote_addr"'
+  ' protocol=$scheme'
+  ' status=$status'
+  ' duration=${request_time}s'
+  ' bytes=$bytes_sent'
+  ' referer="$http_referer"'
+  ' user_agent="$http_user_agent"';
+
+# In order to avoid logging access twice per request
+# it is necessary to turn off the top-level (e.g. http) buildpack default access_log
+# as we are about to override it in the server directive here below
+access_log off;
+
+port_in_redirect off;
+
+server {
+  listen <%= ENV['PORT'] %>;
+
+  charset utf-8;
+
+  # Disable compression that is performed by the Scalingo router anyway
+  gzip off;
+
+  root /app/storybook-static/;
+}


### PR DESCRIPTION
## :unicorn: Description du composant

Déployer automatiquement Storybook sur une review app pour chaque PR.
- Execute le build de storybook en statique
- Démarre un nginx
- Envoi un commentaire dans la PR avec l'URL de la RA.

## :rainbow: Remarques

Nous avons réutilisé le fonctionnement des RAs de pix-site

## Pour tester

Cliquer sur le lien Storybook dans le commentaire ci-dessous ;)