### PR TITLE
[FEATURE] Ajout d'une bordure sur les boutons colorés lors des focus.

### DIFF
--- a/addon/stories/pix-button.stories.js
+++ b/addon/stories/pix-button.stories.js
@@ -206,6 +206,7 @@ export const linkButtons = (args) => {
       <PixButton
         @isLink={{true}}
         @route='profile'
+        href="#"
         >
         Je suis un Lien
       </PixButton>

--- a/addon/styles/_pix-button.scss
+++ b/addon/styles/_pix-button.scss
@@ -1,7 +1,7 @@
 .pix-button {
 
   @import 'reset-css';
-  border-color: transparent;
+  border: 1px solid transparent;
   color: $white;
   font-size: 1rem;
   white-space: nowrap;
@@ -56,19 +56,20 @@
 
   @mixin colorizeBackground($backgroundColor, $outlineColor) {
     background-color: $backgroundColor;
+    border: 1px solid $white;
 
     &:hover {
-      background-color: darken($backgroundColor, 4%);
+      background-color: darken($backgroundColor, 8%);
+      box-shadow: 0 0 0 1px darken($outlineColor, 8%);
     }
 
     &:active {
-      background-color: darken($backgroundColor, 8%);
+      background-color: darken($backgroundColor, 12%);
     }
 
     &:focus {
-      outline-color: $outlineColor;
-      outline-style: auto;
-      outline-offset: 3px;
+      background-color: darken($backgroundColor, 8%);
+      box-shadow: 0 0 0 1px darken($outlineColor, 8%);
     }
   }
 
@@ -77,21 +78,21 @@
   }
 
   &--background-green {
-    @include colorizeBackground($green, $blue);
+    @include colorizeBackground($green, $green);
   }
 
   &--background-yellow {
     color: $grey-100;
-    @include colorizeBackground($yellow, $blue);
+    @include colorizeBackground($yellow, $yellow);
   }
 
   &--background-red {
     color: $white;
-    @include colorizeBackground($red, $blue);
+    @include colorizeBackground($red, $red);
   }
 
   &--background-grey {
-    @include colorizeBackground($blue-zodiac, $blue);
+    @include colorizeBackground($blue-zodiac, $blue-zodiac);
   }
 
   /* deprecated in favor of --background-transparent-light + --border */

--- a/addon/styles/_pix-button.scss
+++ b/addon/styles/_pix-button.scss
@@ -1,7 +1,7 @@
 .pix-button {
 
   @import 'reset-css';
-  border: 1px solid transparent;
+  border: 2px solid transparent;
   color: $white;
   font-size: 1rem;
   white-space: nowrap;
@@ -56,20 +56,16 @@
 
   @mixin colorizeBackground($backgroundColor, $outlineColor) {
     background-color: $backgroundColor;
-    border: 1px solid $white;
+    border: 2px solid $white;
 
-    &:hover {
+    &:hover, &:focus, &:focus-visible {
       background-color: darken($backgroundColor, 8%);
-      box-shadow: 0 0 0 1px darken($outlineColor, 8%);
+      box-shadow: 0 0 0 2px darken($outlineColor, 8%);
+      outline: none;
     }
 
     &:active {
       background-color: darken($backgroundColor, 12%);
-    }
-
-    &:focus {
-      background-color: darken($backgroundColor, 8%);
-      box-shadow: 0 0 0 1px darken($outlineColor, 8%);
     }
   }
 
@@ -99,7 +95,7 @@
   &--background-transparent {
     background-color: transparent;
     color: $grey-50;
-    border: 1px solid $grey-50;
+    border: 2px solid $grey-50;
   }
 
   &--background-transparent-light {
@@ -121,7 +117,7 @@
     }
 
     &.pix-button--border {
-      border: 1px solid $grey-50;
+      border: 2px solid $grey-50;
 
       &:hover, &:active {
         border-color: $grey-80;
@@ -141,15 +137,15 @@
       background-color: rgba($black, 0.2);
     }
 
-    &:focus {
+    &:focus, &:focus-visible {
       outline-color: $blue;
       outline-style: auto;
       outline-offset: 3px;
-      color: $grey-90;
+      color: $yellow;
     }
 
     &.pix-button--border {
-      border: 1px solid $white;
+      border: 2px solid $white;
     }
   }
 

--- a/addon/styles/_pix-button.scss
+++ b/addon/styles/_pix-button.scss
@@ -6,7 +6,7 @@
   font-size: 1rem;
   white-space: nowrap;
   font-weight: 500;
-  letter-spacing: .012rem;
+  letter-spacing: .028rem;
   cursor: pointer;
   font-family: $font-roboto;
   background-color: $blue;
@@ -35,11 +35,11 @@
   }
 
   &--shape-rounded {
-    border-radius: 23px;
+    border-radius: 25px;
   }
 
   &--shape-squircle {
-    border-radius: 5px;
+    border-radius: 8px;
   }
 
   &--size-big {
@@ -48,10 +48,12 @@
 
   &--size-small.pix-button--shape-rounded {
     padding: 10px 24px;
+    font-size: 0.875rem;
   }
 
   &--size-small.pix-button--shape-squircle {
     padding: 10px 16px;
+    font-size: 0.875rem;
   }
 
   @mixin colorizeBackground($backgroundColor, $outlineColor) {


### PR DESCRIPTION
## :unicorn: Description du composant
Pour reprendre l'état actuel des boutons sur Zeroheight et pour améliorer le focus et l'accessibilité, cette PR ajoute une bordure visuelle (faite par un box-shadow) aux boutons colorés.
De plus, pour les mêmes raisons, la couleur du focus a été rendue plus foncée.

## :rainbow: Remarques
Coté accessibilité, il faut deux façons différente de montrer le focus : 
- Ici un changement de couleur
- Plus un changement de design avec le contour
De plus, il faut faire attention que les couleurs gardent un bon contraste.
Sur Pix-site ou sur d'autres boutons sur app, la bordure est rendue plus grosse, pour l'instant cette PR suit Zéro height.

## :100: Pour tester
Voir les boutons sur la RA.