### PR TITLE
[FEATURE] Harmonisation du composant PixBanner (pix-2563)

### DIFF
--- a/addon/components/pix-banner.hbs
+++ b/addon/components/pix-banner.hbs
@@ -1,10 +1,13 @@
-<div class="pix-banner" ...attributes>
-  <div class="pix-banner__content">{{yield}}</div>
-  {{#if this.displayAction}}
-    {{#if this.isExternalLink}}
-      <a class="pix-banner__action" href={{@actionUrl}}>{{@actionLabel}}</a>
-    {{else}}
-      <LinkTo class="pix-banner__action" @route={{@actionUrl}}>{{@actionLabel}}</LinkTo>
+<div class="pix-banner pix-banner-{{this.classNames}}" ...attributes>
+  <div class="pix-banner__content">
+    <FaIcon @icon={{this.icon}} />
+    {{yield}}
+    {{#if this.displayAction}}
+      {{#if this.isExternalLink}}
+        <a class="pix-banner__action" href={{@actionUrl}} target="_blank"  rel="noopener noreferrer">{{@actionLabel}}<FaIcon @icon='external-link-alt' /></a>
+      {{else}}
+        <LinkTo class="pix-banner__action" @route={{@actionUrl}}>{{@actionLabel}}</LinkTo>
+      {{/if}}
     {{/if}}
-  {{/if}}
+  </div>
 </div>

--- a/addon/components/pix-banner.js
+++ b/addon/components/pix-banner.js
@@ -1,6 +1,32 @@
 import Component from '@glimmer/component';
+const TYPE_INFO = 'information';
+const TYPE_ERROR = 'error';
+const TYPE_WARNING = 'warning';
+const TYPE_COMMUNICATION = 'communication';
+
+const types = [TYPE_INFO, TYPE_ERROR, TYPE_WARNING, TYPE_COMMUNICATION];
+const icons = {
+  [TYPE_INFO]: 'info-circle',
+  [TYPE_ERROR]: 'exclamation-triangle',
+  [TYPE_WARNING]: 'exclamation-circle',
+  [TYPE_COMMUNICATION]: 'bullhorn',
+};
 
 export default class PixBanner extends Component {
+  get type() {
+    return types.includes(this.args.type) ? this.args.type : TYPE_INFO;
+  }
+  
+  get icon() {
+    return icons[this.type];
+  }
+
+  get classNames() {
+    let classes = types.includes(this.args.type) ? this.args.type : TYPE_INFO;
+    if (this.args.color) classes += `--${this.args.color}`;
+    return classes;
+  }
+
   get displayAction() {
     return this.args.actionLabel && this.args.actionUrl;
   }

--- a/addon/stories/pix-banner.stories.js
+++ b/addon/stories/pix-banner.stories.js
@@ -12,8 +12,8 @@ export const bannerWithExternalLink = (args) => {
   return {
     template: hbs`
       <PixBanner
-        @actionLabel={{actionLabel}}
-        @actionUrl={{actionUrl}}
+        @actionLabel= "Voir le nouveau site"
+        @actionUrl= "www.test.fr/"
       >Parcours de rentrée 2020 : les codes sont disponibles dans l'onglet campagne. N’oubliez pas de les diffuser aux élèves avant la Toussaint.</PixBanner>
     `,
     context: args,
@@ -24,8 +24,42 @@ export const bannerWithInternalLink = (args) => {
   return {
     template: hbs`
       <PixBanner
-        @actionLabel={{actionLabel}}
-        @actionUrl={{actionUrl}}
+        @actionLabel= "Voir la liste des participants"
+        @actionUrl= "campaign.list"
+      >Parcours de rentrée 2020 : les codes sont disponibles dans l'onglet campagne. N’oubliez pas de les diffuser aux élèves avant la Toussaint.</PixBanner>
+    `,
+    context: args,
+  };
+};
+
+export const warningBanner = (args) => {
+  return {
+    template: hbs`
+      <PixBanner
+        @type="warning"
+      >Parcours de rentrée 2020 : les codes sont disponibles dans l'onglet campagne. N’oubliez pas de les diffuser aux élèves avant la Toussaint.</PixBanner>
+    `,
+    context: args,
+  };
+};
+
+export const errorBanner = (args) => {
+  return {
+    template: hbs`
+      <PixBanner
+        @type="error"
+      >Parcours de rentrée 2020 : les codes sont disponibles dans l'onglet campagne. N’oubliez pas de les diffuser aux élèves avant la Toussaint.</PixBanner>
+    `,
+    context: args,
+  };
+};
+
+export const communicationBanner = (args) => {
+  return {
+    template: hbs`
+      <PixBanner
+        @type="communication"
+        @color="blue"
       >Parcours de rentrée 2020 : les codes sont disponibles dans l'onglet campagne. N’oubliez pas de les diffuser aux élèves avant la Toussaint.</PixBanner>
     `,
     context: args,
@@ -44,5 +78,19 @@ export const argsTypes = {
     description: 'Action link',
     type: { name: 'string', required: false },
     defaultValue: null,
+  },
+  type: {
+    name: 'type',
+    description: 'Définit le type de bannière',
+    type: { name: 'string', required: false },
+    defaultValue: 'information',
+    control: { type: 'select', options: ['information', 'warning', 'error'] },
+  },
+  color: {
+    name: 'color',
+    description: 'Détermine la couleur de la bannière de communication',
+    type: { name: 'string', required: false },
+    defaultValue: 'blue',
+    control: { type: 'select', options: ['blue', 'green', 'yellow', 'purple'] },
   }
 };

--- a/addon/stories/pix-banner.stories.mdx
+++ b/addon/stories/pix-banner.stories.mdx
@@ -16,8 +16,14 @@ Une `Banner` permet de mettre en avant une information importante.
 > Il est possible de surcharger le style d'une `<PixBanner>` via l'attribut `class` ainsi que de passer n'importe quel attribut sur sa `div` wrapper (par exemple, un `aria-label`)
 
 <Canvas isColumn>
-  Bannière sans action
+  Bannière Information (par défault)
   <Story name="Default Banner" story={stories.defaultBanner} height="100px" />
+  Bannière Communication
+  <Story name="Banner with a message" story={stories.communicationBanner} height="100px" />
+  Bannière Warning
+  <Story name="Banner with a warning message" story={stories.warningBanner} height="100px" />
+  Bannière Error
+  <Story name="Banner with a error message" story={stories.errorBanner} height="100px" />
   Bannière avec une route pour lien
   <Story name="Banner with internal link" story={stories.bannerWithInternalLink} height="100px" />
   Bannière avec une route externe
@@ -28,6 +34,18 @@ Une `Banner` permet de mettre en avant une information importante.
 
 ```html
 <PixBanner>Bannière sans action</PixBanner>
+
+<PixBanner @type='communication' @color='blue'>
+  Bannière Communication
+</PixBanner>
+
+<PixBanner @type='warning'>
+  Bannière Warning
+</PixBanner>
+
+<PixBanner @type='error'>
+  Bannière Error
+</PixBanner>
 
 <PixBanner
   @actionLabel='Liste des campagnes'

--- a/addon/styles/_colors.scss
+++ b/addon/styles/_colors.scss
@@ -15,6 +15,16 @@ $dark-orga: #0095C0;
 $green: #038125;
 $orga: #00DDFF;
 $purple: #8845FF;
+
+//banner
+$blue-information: #C5E8FF;
+$yellow-warning: #FFEBB3;
+$red-error: #FFDBCC;
+$information-message: #0069AB;
+$warning-message: #805F00;
+$error-message: #992D00; 
+// status
+
 // gradients
 $pix-gradient: linear-gradient(135deg, $blue 0%, $purple 100%);
 $pix-blue-gradient: linear-gradient(135deg, #12A3FF 0%, #3D68FF 100%);
@@ -65,7 +75,7 @@ $information-dark: #F24645;
 $information-light: #F1A141;
 $security-dark: #AC008D;
 $security-light: #FF3F94;
-// status
+
 $error: #FF4B00;
 $success: #57C884;
 $warning: #FFBE00;

--- a/addon/styles/_pix-banner.scss
+++ b/addon/styles/_pix-banner.scss
@@ -1,43 +1,57 @@
 .pix-banner {
   @import 'reset-css';
-
   font-family: $font-open-sans;
   font-weight: $font-normal;
   padding: 32px 58px;
-  background-color: $dark-orga;
-  color: $white;
   font-size: 0.875rem;
   display: flex;
   flex-direction: row;
   align-items: center;
 
   &__action {
-    color: $white;
-    border: 1px solid $white;
-    border-radius: 4px;
-    padding: 10px 28px;
-    text-decoration: none;
-    margin-left: 18px;
+    font-size: 0.875rem;
+    text-decoration: underline;
     letter-spacing: 0.028rem;
     transition: background-color 0.3s ease-out;
-    min-width: fit-content;
-
-    &:hover {
-      background-color: rgba($grey-70, 0.3);
+    color: inherit;
+    svg {
+      margin-left: 3px;
     }
-
-    &:active {
-      background-color: rgba($grey-70, 0.6);
-    }
-
-    &:focus {
-      background-color: $yellow;
-      color: $grey-90;
-    }
-
   }
 }
 
+.pix-banner-information {
+  background-color: $blue-information;
+  color: $information-message;
+}
+
+.pix-banner-warning {
+  background-color: $yellow-warning;
+  color: $warning-message;
+}
+.pix-banner-communication {
+  
+  &--blue {
+    background-color: $dark-orga;
+    color: $white;
+  }
+  &--yellow {
+    background-color: $yellow;
+  }
+  &--purple {
+    background-color: $purple;
+    color: $white;
+  }
+  &--green {
+    background-color: $dark-green-certif;
+    color: $white;
+  }
+}
+
+.pix-banner-error {
+  background-color: $red-error;
+  color: $error-message;
+}
 @include device-is('mobile') {
   .pix-banner {
     flex-direction: column;

--- a/tests/integration/components/pix-banner-test.js
+++ b/tests/integration/components/pix-banner-test.js
@@ -1,0 +1,97 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+
+module('Integration | Component | Pix Banner', function(hooks) {
+  setupRenderingTest(hooks);
+
+  const COMPONENT_SELECTOR = '.pix-banner';
+
+  test('it renders the default PixBanner', async function(assert) {
+    // when
+    await render(hbs`
+      <PixBanner>
+        Mon texte
+      </PixBanner>
+    `);
+
+    // then
+    const componentElement = this.element.querySelector(COMPONENT_SELECTOR);
+    assert.equal(componentElement.textContent.trim(), 'Mon texte');
+    assert.equal(componentElement.classList.toString().trim(), 'pix-banner pix-banner-information');
+  });
+
+  test('it renders the PixBanner with type warning', async function(assert) {
+    // when
+    await render(hbs`
+      <PixBanner @type='warning'>
+        Mon texte
+      </PixBanner>
+    `);
+
+    // then
+    const componentElement = this.element.querySelector(COMPONENT_SELECTOR);
+    assert.equal(componentElement.textContent.trim(), 'Mon texte');
+    assert.equal(componentElement.classList.toString().trim(), 'pix-banner pix-banner-warning');
+  });
+
+  test('it renders the PixBanner with type error', async function(assert) {
+    // when
+    await render(hbs`
+      <PixBanner @type='error'>
+        Mon texte
+      </PixBanner>
+    `);
+
+    // then
+    const componentElement = this.element.querySelector(COMPONENT_SELECTOR);
+    assert.equal(componentElement.textContent.trim(), 'Mon texte');
+    assert.equal(componentElement.classList.toString().trim(), 'pix-banner pix-banner-error');
+  });
+
+  test('it renders the PixBanner with external url', async function(assert) {
+    // given
+    this.set('actionUrl', 'www.test.fr/');
+    this.set('actionLabel', 'Explorer');
+
+    //when
+    await render(hbs`
+      <PixBanner @actionUrl={{this.actionUrl}} @actionLabel={{this.actionLabel}} />
+    `);
+
+    // then
+    assert.dom('a').exists();
+    assert.equal(this.element.querySelector('a').getAttribute('href'), 'www.test.fr/');
+  });
+
+  test('it renders the PixBanner with internal link', async function(assert) {
+    // given
+  
+    this.set('actionUrl', 'campaign.participants');
+    this.set('actionLabel', 'Explorer');
+
+    //when
+    await render(hbs`
+      <PixBanner @actionUrl={{this.actionUrl}} @actionLabel={{this.actionLabel}} />
+    `);
+
+    // then
+    assert.dom('a').exists();
+  });
+
+  test('it renders the PixBanner communication', async function(assert) {
+    // given
+  
+    this.set('color', 'yellow');
+    this.set('type', 'communication');
+
+    //when
+    await render(hbs`
+      <PixBanner @color={{this.color}} @type={{type}} />
+    `);
+
+    // then
+    assert.dom('.pix-banner-communication--yellow').exists();
+  });
+});


### PR DESCRIPTION
## :unicorn: Description du composant
Le design des bannières d'information et d'alerte a changé. 
On distingue 4 bannières différentes: information , error, warning et communication.
La bannière communication se décline en 2 types: communication-orga et communication-certif.
Pour préciser quelle bannière afficher, on passe l'argument `type` qui peut avoir que 6 valeurs possibles: 
- `information`
-  `error`
- `warning`
- `communication`
- `communication-orga`
- `communication-certif`
 La bannière par défaut est de type information.

## :rainbow: Remarques


## :100: Pour tester
zeroheight => https://zeroheight.com/8dd127da7/p/171be5-banner/i/42384653

