### PR TITLE
[BUGFIX] Corriger la taille de la police du composant Pix Tag

### DIFF
--- a/addon/styles/_pix-tag.scss
+++ b/addon/styles/_pix-tag.scss
@@ -62,7 +62,7 @@
   }
 
   &--compact {
-    font-size: 0.625rem;
+    font-size: 0.6875rem;
     font-weight: $font-medium;
     text-transform: uppercase;
     padding: 4px 13px;


### PR DESCRIPTION
## :unicorn: Problème

Lors de l'utilisation du composant Pix Tag (version compact) nous nous sommes rendu compte que la taille de la police était trop petite (10px), ce qui nuit à la lisibilité.

Nous avons utilisé WAVE sur Firefox 👇

<img width="818" alt="Capture d’écran 2021-05-20 à 16 31 57" src="https://user-images.githubusercontent.com/58915422/119000213-32deff80-b98b-11eb-9a3b-a6378c9daa09.png">


## :rainbow: Solution
Augmenter la taille de la police à 11px.

## :100: Pour tester
Aller sur le composant Pix Tag et vérifier la taille.
