### PR TITLE
Ne pas changer la taille du bouton lors du loading.

### DIFF
--- a/addon/components/pix-button.hbs
+++ b/addon/components/pix-button.hbs
@@ -25,6 +25,7 @@
         <div class="bounce2"></div>
         <div class="bounce3"></div>
       </div>
+      <span class="loader__not-visible-text">{{yield}}</span>
     {{else}}
       {{yield}}
     {{/if}}

--- a/addon/stories/pix-button-loader.stories.mdx
+++ b/addon/stories/pix-button-loader.stories.mdx
@@ -15,7 +15,7 @@ Ce composant est un bouton simple qui empêche les clics multiples.
 
 <Canvas isColumn>
   Button avec loader gris ou blanc
-  <Story name="Loader" story={stories.loadingButtons} height="60px" />
+  <Story name="Loader" story={stories.loadingButtons} height="160px" />
 </Canvas>
 
 ## Usage

--- a/addon/stories/pix-button.stories.js
+++ b/addon/stories/pix-button.stories.js
@@ -3,18 +3,23 @@ import { hbs } from 'ember-cli-htmlbars';
 export const loadingButtons = (args) => {
   return {
     template: hbs`
-      <PixButton
-          @triggerAction={{action triggerAction}}
-          @loading-color='white'
-          @type={{type}}>
-        Bouton avec loader blanc (default)
-      </PixButton>
-      <PixButton
-          @triggerAction={{action triggerAction}}
-          @loading-color='grey'
-          @type={{type}}>
-        Bouton avec loader gris
-      </PixButton>
+      <section>
+        <PixButton
+            @triggerAction={{action triggerAction}}
+            @loading-color='white'
+            @type={{type}}>
+          Bouton avec loader blanc (default)
+        </PixButton>
+      </section>
+      <section>
+        <PixButton
+            @triggerAction={{action triggerAction}}
+            @loading-color='grey'
+            @backgroundColor='yellow'
+            @type={{type}}>
+          Bouton avec loader gris
+        </PixButton>
+      </section>
     `,
     context: args,
   };

--- a/addon/styles/_pix-button.scss
+++ b/addon/styles/_pix-button.scss
@@ -10,7 +10,17 @@
   cursor: pointer;
   font-family: $font-roboto;
   background-color: $blue;
+  display: flex;
+  justify-content: center;
 
+
+  .loader {
+    position: absolute;
+
+    &__not-visible-text {
+      visibility: hidden;
+    }
+  }
   .loader > div {
     width: 10px;
     height: 10px;


### PR DESCRIPTION
## :unicorn: Description du composant
Modification du composant Pix Button : lors du loading, le bouton rétrécit pour prendre la taille du loader, ce qui est inesthétique :) 

## :rainbow: Remarques
Astuce utilisé ici : garder l'affichage du texte mais en non visible.

## :100: Pour tester
Voir le story book.