### PR TITLE
Permettre l'absence de trigger action sur PixButton de type submit

### DIFF
--- a/addon/components/pix-button.hbs
+++ b/addon/components/pix-button.hbs
@@ -1,33 +1,49 @@
 {{#if this.isLink}}
   {{#if @model}}
-    <LinkTo @route={{this.route}} class="pix-button pix-button--shape-{{this.shape}} pix-button--size-{{this.size}} pix-button--background-{{this.backgroundColor}}{{if this.isDisabled ' pix-button--disabled'}}{{if this.isBorderVisible ' pix-button--border'}}"
+    <LinkTo @route={{this.route}}
+            class="pix-button pix-button--shape-{{this.shape}} pix-button--size-{{this.size}} pix-button--background-{{this.backgroundColor}}{{if
+                    this.isDisabled ' pix-button--disabled'}}{{if this.isBorderVisible ' pix-button--border'}}"
             @model={{@model}}
             ...attributes>
       {{yield}}
     </LinkTo>
   {{else}}
-    <LinkTo @route={{this.route}} class="pix-button pix-button--shape-{{this.shape}} pix-button--size-{{this.size}} pix-button--background-{{this.backgroundColor}}{{if this.isDisabled ' pix-button--disabled'}}{{if this.isBorderVisible ' pix-button--border'}}"
+    <LinkTo @route={{this.route}}
+            class="pix-button pix-button--shape-{{this.shape}} pix-button--size-{{this.size}} pix-button--background-{{this.backgroundColor}}{{if
+                    this.isDisabled ' pix-button--disabled'}}{{if this.isBorderVisible ' pix-button--border'}}"
             ...attributes>
-    {{yield}}
+      {{yield}}
     </LinkTo>
   {{/if}}
 {{else}}
-  <button type={{this.type}}
-          class="pix-button pix-button--shape-{{this.shape}} pix-button--size-{{this.size}} pix-button--background-{{this.backgroundColor}}{{if this.isDisabled ' pix-button--disabled'}}
+  {{#if this.enableTriggerAction}}
+    <button type={{this.type}}
+            class="pix-button pix-button--shape-{{this.shape}} pix-button--size-{{this.size}} pix-button--background-{{this.backgroundColor}}{{if this.isDisabled ' pix-button--disabled'}}
             {{if this.isBorderVisible ' pix-button--border'}}"
-    {{on "click" this.triggerAction}}
-          ...attributes
-          disabled={{this.isButtonLoadingOrDisabled}}
-          aria-disabled={{this.ariaDisabled}}>
-    {{#if this.isLoading}}
-      <div class="loader loader--{{@loading-color}}">
-        <div class="bounce1"></div>
-        <div class="bounce2"></div>
-        <div class="bounce3"></div>
-      </div>
-      <span class="loader__not-visible-text">{{yield}}</span>
-    {{else}}
-      {{yield}}
-    {{/if}}
-  </button>
+            {{on "click" this.triggerAction}}
+            ...attributes
+            disabled={{this.isButtonLoadingOrDisabled}}
+            aria-disabled={{this.ariaDisabled}}>
+      {{#if this.isLoading}}
+        <div class="loader loader--{{@loading-color}}">
+          <div class="bounce1"></div>
+          <div class="bounce2"></div>
+          <div class="bounce3"></div>
+        </div>
+        <span class="loader__not-visible-text">{{yield}}</span>
+      {{else}}
+        {{yield}}
+      {{/if}}
+    </button>
+  {{else}}
+    <button type={{this.type}}
+            class="pix-button pix-button--shape-{{this.shape}} pix-button--size-{{this.size}} pix-button--background-{{this.backgroundColor}}{{if this.isDisabled ' pix-button--disabled'}}
+            {{if this.isBorderVisible ' pix-button--border'}}"
+            ...attributes
+            disabled={{this.isButtonLoadingOrDisabled}}
+            aria-disabled={{this.ariaDisabled}}>
+        {{yield}}
+    </button>
+  {{/if}}
+
 {{/if}}

--- a/addon/components/pix-button.js
+++ b/addon/components/pix-button.js
@@ -52,6 +52,10 @@ export default class PixButton extends Component {
     return routeParam;
   }
 
+  get enableTriggerAction(){
+    return !(this.type === 'submit' && !this.args.triggerAction)
+  }
+
   @action
   async triggerAction(params) {
     try {

--- a/addon/stories/pix-button.stories.js
+++ b/addon/stories/pix-button.stories.js
@@ -234,7 +234,7 @@ export const argsTypes = {
   },
   triggerAction: {
     name: 'triggerAction',
-    description: 'fonction à appeler en cas de clic',
+    description: 'fonction à appeler en cas de clic, optionnel si le bouton est de type submit',
     type: { required: true },
     defaultValue: () => {
       return new Promise((resolve) => {

--- a/tests/integration/components/pix-button-test.js
+++ b/tests/integration/components/pix-button-test.js
@@ -79,6 +79,23 @@ module('Integration | Component | button', function(hooks) {
     assert.equal(componentElement.disabled, false);
   });
 
+  module('when type is submit, if no trigger action is defined', ()=>{
+
+    test('if clicked, it should do nothing', async function(assert) {
+      // given
+      await render(hbs`
+      <PixButton @type="submit" />
+      `);
+
+      //  when
+      await click('button');
+
+      // then
+      const componentElement = this.element.querySelector(COMPONENT_SELECTOR);
+      assert.equal(componentElement.type, 'submit');
+    });
+  })
+
   test('it renders the PixButton link component', async function(assert) {
     // when
     await render(hbs`

--- a/tests/unit/components/pix-button-test.js
+++ b/tests/unit/components/pix-button-test.js
@@ -1,5 +1,6 @@
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
+import sinon from 'sinon';
 import createGlimmerComponent from '../../helpers/create-glimmer-component';
 
 
@@ -18,4 +19,43 @@ module('Unit | Component | pix-button', function(hooks) {
       expectedError
     );
   });
+
+  module('#enableTriggerAction', function(){
+
+    test('it should return true if button type is button', function(assert){
+      // given
+      const componentParams = { type: 'button' };
+      const component = createGlimmerComponent('component:pix-button', componentParams);
+
+      // when
+      const result = component.enableTriggerAction;
+
+      // then
+      assert.equal(result, true);
+    })
+
+    test('it should return true if button type is submit and triggerAction is defined', function(assert){
+      // given
+      const componentParams = { type: 'submit', triggerAction: sinon.stub() };
+      const component = createGlimmerComponent('component:pix-button', componentParams);
+
+      // when
+      const result = component.enableTriggerAction;
+
+      // then
+      assert.equal(result, true);
+    })
+
+    test('it should return false if button type is submit and triggerAction is not defined', function(assert){
+      // given
+      const componentParams = { type: 'submit' };
+      const component = createGlimmerComponent('component:pix-button', componentParams);
+
+      // when
+      const result = component.enableTriggerAction;
+
+      // then
+      assert.equal(result, false);
+    })
+  })
 });


### PR DESCRIPTION
## :unicorn: Problème
Sur un bouton de type submit, il peut ne pas y avoir besoin d'action personnalisée, uniquement l'action du formulaire.

## :robot: Solution
Rendre la triggerAction optionelle dans ce cas

