### PR TITLE
[FEATURE] Ne pas pouvoir sélectionner la valeur vide du PixSelect.

### DIFF
--- a/addon/components/pix-select.hbs
+++ b/addon/components/pix-select.hbs
@@ -23,7 +23,11 @@
 
     <select {{on 'change' this.onChange}} ...attributes>
       {{#if (not-eq @emptyOptionLabel undefined)}}
-        <option value="">{{@emptyOptionLabel}}</option>
+        {{#if @emptyOptionNotSelectable}}
+          <option value="" hidden>{{@emptyOptionLabel}}</option>
+        {{else}}
+          <option value="">{{@emptyOptionLabel}}</option>
+        {{/if}}
       {{/if}}
       {{#each @options as |opt|}}
         <option value={{opt.value}} defaultSelected={{eq @selectedOption opt.value}}>

--- a/addon/stories/pix-select.stories.js
+++ b/addon/stories/pix-select.stories.js
@@ -12,6 +12,7 @@ export const select = (args) => {
         @onChange={{onChange}}
         @selectedOption={{selectedOption}}
         @emptyOptionLabel={{emptyOptionLabel}}
+        @emptyOptionNotSelectable={{emptyOptionNotSelectable}}
       />
     `,
     context: args,
@@ -30,6 +31,7 @@ export const searchableSelect = (args) => {
           @onChange={{onChange}}
           @selectedOption={{selectedOption}}
           @emptyOptionLabel={{emptyOptionLabel}}
+          @emptyOptionNotSelectable={{false}}
           @isSearchable={{true}}
           @isValidationActive={{true}}
           placeholder='Fraises, Mangues...'
@@ -100,4 +102,10 @@ export const argTypes = {
       'Rend la bordure du champ vert au focus si la valeur de recherche match une option (c\'est à dire si l\'utilisateur a selectionné une option valable',
     type: { name: "boolean", required: false },
   },
+  emptyOptionNotSelectable: {
+    name: 'emptyOptionNotSelectable',
+    description: 'Rend le premier champ qui est vide non visible une fois sélectionné',
+    type: { name: 'boolean', required: false },
+  },
+
 };

--- a/addon/stories/pix-select.stories.mdx
+++ b/addon/stories/pix-select.stories.mdx
@@ -38,6 +38,7 @@ A défaut d'avoir un label, vous pouvez rajouter l'attribut `aria-label` à l'in
   @emptyOptionLabel="Empty option"
   @isSearchable={{false}}
   @isValidationActive={{false}}
+  @emptyOptionNotSelectable={{false}}
 />
 ```
 


### PR DESCRIPTION
## :unicorn: Description du composant
Modification du composant PixSelect : 
- Dans le cas où il y a une première valeur vide, on peut décider de la cacher une fois qu'on a sélectionné une réponse.


## :rainbow: Remarques

## :100: Pour tester
Sur Storybook : https://ui-pr105.review.pix.fr/?path=/story/form-select--select
- Ajouter par exemple "Liste de fruits" en tant que `emptyOptionLabel` et sélectionner `emptyOptionShouldBeHidden`à `true`