### PR TITLE
[TECH] Ajuster la taille des apperçus des composants dans les stories

### DIFF
--- a/addon/stories/pix-background-header.stories.mdx
+++ b/addon/stories/pix-background-header.stories.mdx
@@ -18,7 +18,7 @@ Les enfants de la bannière se mettrons en colonne.
 > Le `BackgroundHeader` se couple bien avec un ou plusieurs `PixBlock`.
 
 <Canvas>
-  <Story name="Background Header" story={stories.backgroundHeader} height="500px" />
+  <Story name="Background Header" story={stories.backgroundHeader} height={500} />
 </Canvas>
 
 ## Usage

--- a/addon/stories/pix-banner.stories.mdx
+++ b/addon/stories/pix-banner.stories.mdx
@@ -17,17 +17,17 @@ Une `Banner` permet de mettre en avant une information importante.
 
 <Canvas isColumn>
   Bannière Information (par défault)
-  <Story name="Default Banner" story={stories.defaultBanner} height="100px" />
+  <Story name="Default Banner" story={stories.defaultBanner} height={100} />
   Bannière Communication
-  <Story name="Banner with a message" story={stories.communicationBanner} height="100px" />
+  <Story name="Banner with a message" story={stories.communicationBanner} height={100} />
   Bannière Warning
-  <Story name="Banner with a warning message" story={stories.warningBanner} height="100px" />
+  <Story name="Banner with a warning message" story={stories.warningBanner} height={100} />
   Bannière Error
-  <Story name="Banner with a error message" story={stories.errorBanner} height="100px" />
+  <Story name="Banner with a error message" story={stories.errorBanner} height={100} />
   Bannière avec une route pour lien
-  <Story name="Banner with internal link" story={stories.bannerWithInternalLink} height="100px" />
+  <Story name="Banner with internal link" story={stories.bannerWithInternalLink} height={100} />
   Bannière avec une route externe
-  <Story name="Banner with external link" story={stories.bannerWithExternalLink} height="100px" />
+  <Story name="Banner with external link" story={stories.bannerWithExternalLink} height={100} />
 </Canvas>
 
 ## Usage

--- a/addon/stories/pix-block.stories.mdx
+++ b/addon/stories/pix-block.stories.mdx
@@ -23,9 +23,9 @@ Un \`Block\` est un bloc de fond blanc dont les bords sont arrondis et ayant une
 
 <Canvas isColumn>
   Block par défaut, avec shadow='light':
-  <Story name="Default block" story={stories.defaultBlock} height="60px" />
+  <Story name="Default block" story={stories.defaultBlock} height={60} />
   Block avec shadow='heavy':
-  <Story name="Block with specified shadow" story={stories.customizableblock} height="60px" />
+  <Story name="Block with specified shadow" story={stories.customizableblock} height={60} />
 </Canvas>
 
 

--- a/addon/stories/pix-button-border.stories.mdx
+++ b/addon/stories/pix-button-border.stories.mdx
@@ -14,7 +14,7 @@ import * as stories from './pix-button.stories.js';
 Ce composant est un bouton simple qui empêche les clics multiples.
 
 <Canvas isColumn>
-  <Story name="Border" story={stories.borderButtons} height="300px" />
+  <Story name="Border" story={stories.borderButtons} height={300} />
 </Canvas>
 
 ## Usage

--- a/addon/stories/pix-button-color.stories.mdx
+++ b/addon/stories/pix-button-color.stories.mdx
@@ -14,7 +14,7 @@ import * as stories from './pix-button.stories.js';
 Ce composant est un bouton simple qui empêche les clics multiples.
 
 <Canvas>
-  <Story name="Color" story={stories.colorButtons} height="300px" />
+  <Story name="Color" story={stories.colorButtons} height={600} />
 </Canvas>
 
 ## Usage

--- a/addon/stories/pix-button-disabled.stories.mdx
+++ b/addon/stories/pix-button-disabled.stories.mdx
@@ -14,7 +14,7 @@ import * as stories from './pix-button.stories.js';
 Ce composant est un bouton simple qui empêche les clics multiples.
 
 <Canvas isColumn>
-  <Story name="Disabled" story={stories.disabledButtons} height="60px" />
+  <Story name="Disabled" story={stories.disabledButtons} height={175} />
 </Canvas>
 
 ## Usage

--- a/addon/stories/pix-button-link.stories.mdx
+++ b/addon/stories/pix-button-link.stories.mdx
@@ -14,7 +14,7 @@ import * as stories from './pix-button.stories.js';
 Ce composant est un bouton simple qui empêche les clics multiples.
 
 <Canvas isColumn>
-  <Story name="Link" story={stories.linkButtons} height="200px" />
+  <Story name="Link" story={stories.linkButtons} height={200} />
 </Canvas>
 
 ## Usage

--- a/addon/stories/pix-button-loader.stories.mdx
+++ b/addon/stories/pix-button-loader.stories.mdx
@@ -15,7 +15,7 @@ Ce composant est un bouton simple qui empêche les clics multiples.
 
 <Canvas isColumn>
   Button avec loader gris ou blanc
-  <Story name="Loader" story={stories.loadingButtons} height="160px" />
+  <Story name="Loader" story={stories.loadingButtons} height={160} />
 </Canvas>
 
 ## Usage

--- a/addon/stories/pix-button-shape.stories.mdx
+++ b/addon/stories/pix-button-shape.stories.mdx
@@ -14,7 +14,7 @@ import * as stories from './pix-button.stories.js';
 Ce composant est un bouton simple qui empêche les clics multiples.
 
 <Canvas isColumn>
-  <Story name="Shape" story={stories.shapeButtons} height="200px" />
+  <Story name="Shape" story={stories.shapeButtons} height={200} />
 </Canvas>
 
 ## Usage

--- a/addon/stories/pix-button-size.stories.mdx
+++ b/addon/stories/pix-button-size.stories.mdx
@@ -14,7 +14,7 @@ import * as stories from './pix-button.stories.js';
 Ce composant est un bouton simple qui empêche les clics multiples.
 
 <Canvas isColumn>
-  <Story name="Size" story={stories.sizeButtons} height="200px" />
+  <Story name="Size" story={stories.sizeButtons} height={200} />
 </Canvas>
 
 ## Usage

--- a/addon/stories/pix-collapsible.stories.mdx
+++ b/addon/stories/pix-collapsible.stories.mdx
@@ -17,11 +17,11 @@ Par défaut le contenu est masqué et cliquer sur le libellé permet de montrer 
 > Il est possible de cumuler les `PixCollapsible` de sorte à former un accordéon, il suffit de les mettre dans une même div parente.
 
 <Canvas>
-  <Story name='PixCollapsible' story={stories.collapsible} height="120px" />
+  <Story name='PixCollapsible' story={stories.collapsible} height={150} />
 </Canvas>
 
 <Canvas>
-  <Story name='MultiplePixCollapsible' story={stories.multipleCollapsible} height="260px" />
+  <Story name='MultiplePixCollapsible' story={stories.multipleCollapsible} height={260} />
 </Canvas>
 
 ## Usage

--- a/addon/stories/pix-filter-banner.stories.mdx
+++ b/addon/stories/pix-filter-banner.stories.mdx
@@ -16,7 +16,7 @@ Une `FilterBanner` permet de wrapper les éléments de filtres (`Select`, `Multi
 > Il est possible de surcharger le style d'une `<PixFilterBanner>` via l'attribut `class` ainsi que de passer n'importe quel attribut sur sa `div` wrapper (par exemple, un `aria-label`)
 
 <Canvas>
-  <Story name="Filter banner" story={stories.filterBanner} height="80px" />
+  <Story name="Filter banner" story={stories.filterBanner} height={80} />
 </Canvas>
 
 ## Usage

--- a/addon/stories/pix-icon-button.stories.mdx
+++ b/addon/stories/pix-icon-button.stories.mdx
@@ -14,7 +14,7 @@ import * as stories from './pix-icon-button.stories.js';
 Le PixIconButton permet de créer un bouton contenant une icône font-awesome.
 
 <Canvas>
-  <Story name="Icon button" story={stories.iconButton} height="60px" />
+  <Story name="Icon button" story={stories.iconButton} height={60} />
 </Canvas>
 
 ## Usage

--- a/addon/stories/pix-message.stories.mdx
+++ b/addon/stories/pix-message.stories.mdx
@@ -14,7 +14,7 @@ import * as stories from './pix-message.stories.js';
 Un bandeau d'information, par défaut de type info, avec une icone facultative.
 
 <Canvas isColumn>
-  <Story name="Message" story={stories.message} height="140px" />
+  <Story name="Message" story={stories.message} height={140} />
 </Canvas>
 
 ## Usage

--- a/addon/stories/pix-multi-select.stories.mdx
+++ b/addon/stories/pix-multi-select.stories.mdx
@@ -16,12 +16,12 @@ L'ajout de ``class`` et d'autres attributs comme ``aria-label`` sont possibles.
 
 > ⚠️ La démonstration de PixMultiSelect NE fonctionne PAS comme prévu dans storybook (mais fonctionne très bien sur les app fronts). Pour plus d'informations, voir https://github.com/1024pix/pix-ui/pull/76.
 
-<Canvas>
-  <Story name="Searchable" story={stories.multiSelectSearchable} />
+<Canvas isColumn>
+  <Story name="Searchable" story={stories.multiSelectSearchable} height={175}/>
 </Canvas>
 
-<Canvas>
-  <Story name="With child component" story={stories.multiSelectWithChildComponent} />
+<Canvas isColumn>
+  <Story name="With child component" story={stories.multiSelectWithChildComponent} height={100} />
 </Canvas>
 
 ## Usage

--- a/addon/stories/pix-progress-gauge-custom.stories.mdx
+++ b/addon/stories/pix-progress-gauge-custom.stories.mdx
@@ -14,7 +14,7 @@ import * as stories from './pix-progress-gauge.stories.js';
 Permet d'afficher un barre de progression sur un barème de 100%. Des paramètres existent pour changer la position de la tooltip ou la couleur du composant
 
 <Canvas>
-  <Story name='Custom' story={stories.customProgressGauge} height="60px" />
+  <Story name='Custom' story={stories.customProgressGauge} height={60} />
 </Canvas>
 
 ## Usage
@@ -22,9 +22,9 @@ Permet d'afficher un barre de progression sur un barème de 100%. Des paramètre
 ```html
 <PixProgressGauge
   @value="{{@value}}"
-  @color="{{@color}}" 
+  @color="{{@color}}"
   @tooltipText="50%"
-  @isArrowLeft="{{@isArrowLeft}}" 
+  @isArrowLeft="{{@isArrowLeft}}"
   @subTitle="{{@subtitle}}" />
 ```
 

--- a/addon/stories/pix-progress-gauge-white.stories.mdx
+++ b/addon/stories/pix-progress-gauge-white.stories.mdx
@@ -13,7 +13,7 @@ import * as stories from './pix-progress-gauge.stories.js';
 Démonstration d'une barre de progression blanche avec l'info bulle à gauche avec un sous titre
 
 <Canvas>
-  <Story name='White' story={stories.whiteProgressGauge} height="100px" />
+  <Story name='White' story={stories.whiteProgressGauge} height={100} />
 </Canvas>
 
 ## Usage
@@ -23,6 +23,6 @@ Démonstration d'une barre de progression blanche avec l'info bulle à gauche av
   @value="50"
   @tooltipText="50%"
   @color="white"
-  @isArrowLeft="true" 
+  @isArrowLeft="true"
   @subtitle="Avancement" />
 ```

--- a/addon/stories/pix-progress-gauge-yellow.stories.mdx
+++ b/addon/stories/pix-progress-gauge-yellow.stories.mdx
@@ -14,7 +14,7 @@ import * as stories from './pix-progress-gauge.stories.js';
 Démonstration d'une barre de progression jaune, info bulle centré sans sous titre
 
 <Canvas>
-  <Story name='Yellow' story={stories.yellowProgressGauge} height="60px" />
+  <Story name='Yellow' story={stories.yellowProgressGauge} height={60} />
 </Canvas>
 
 ## Usage

--- a/addon/stories/pix-return-to.stories.mdx
+++ b/addon/stories/pix-return-to.stories.mdx
@@ -19,9 +19,9 @@ Le `ReturnTo` est un lien de retour vers uneOpixRe page précédente.
 
 <Canvas isColumn>
   Lien sans texte
-  <Story name="Return To" story={stories.returnTo} height="60px" />
+  <Story name="Return To" story={stories.returnTo} height={60} />
   Lien avec texte
-  <Story name="Return To With Link" story={stories.returnToWithLink} height="60px" />
+  <Story name="Return To With Link" story={stories.returnToWithLink} height={60} />
 </Canvas>
 
 ## Usage

--- a/addon/stories/pix-select.stories.mdx
+++ b/addon/stories/pix-select.stories.mdx
@@ -21,11 +21,11 @@ A défaut d'avoir un label, vous pouvez rajouter l'attribut `aria-label` à l'in
 > Pour aider l'utilisateur avec le PixSelect cherchable, rajoutez un placeholder cohérent !
 
 <Canvas>
-  <Story name="Select" story={stories.select} height="100px" />
+  <Story name="Select" story={stories.select} height={100} />
 </Canvas>
 
 <Canvas>
-  <Story name="SearchableSelect" story={stories.searchableSelect} height="110px" />
+  <Story name="SearchableSelect" story={stories.searchableSelect} height={110} />
 </Canvas>
 
 ## Usage

--- a/addon/stories/pix-stars.stories.mdx
+++ b/addon/stories/pix-stars.stories.mdx
@@ -16,7 +16,7 @@ Un texte alternatif peut être renseigné et différents styles sont pré-défin
 Pour ne pas afficher les étoiles vides, il suffit de ne pas donner le total d'étoiles.
 
 <Canvas>
-  <Story name="PixStars" story={stories.stars} height="60px" />
+  <Story name="PixStars" story={stories.stars} height={60} />
 </Canvas>
 
 ## Usage

--- a/addon/stories/pix-tag.stories.mdx
+++ b/addon/stories/pix-tag.stories.mdx
@@ -17,9 +17,9 @@ Un `Tag` est un type de `Chips` qui permet de mettre en avant une information ou
 
 <Canvas isColumn>
   Tag
-  <Story name="Tag" story={stories.tag} height="60px" />
+  <Story name="Tag" story={stories.tag} height={60} />
   Tag compact
-  <Story name="Compact Tag" story={stories.compactTag} height="60px" />
+  <Story name="Compact Tag" story={stories.compactTag} height={60} />
 </Canvas>
 
 ## Usage

--- a/addon/stories/pix-textarea.stories.mdx
+++ b/addon/stories/pix-textarea.stories.mdx
@@ -18,7 +18,7 @@ Optionellement, il peut afficher le nombre de caractères tapés ainsi que le no
 > A noter qu'un `id` est nécessaire pour attribuer au textarea un label. Par ailleurs, l'attribut `value` permet de traiter son contenu.
 
 <Canvas>
-  <Story name='PixTextarea' story={stories.textarea} height="100px" />
+  <Story name='PixTextarea' story={stories.textarea} height={100} />
 </Canvas>
 
 ## Usage

--- a/addon/stories/pix-tooltip.stories.mdx
+++ b/addon/stories/pix-tooltip.stories.mdx
@@ -18,7 +18,7 @@ Ce composant est utilisé comme wrapper, c'est à dire qu'il encadre l'élément
 > ⚠️ A noter que le wrapper PixTooltip est en `display: flex;`, il s'adaptera donc à la taille de ses enfants. Ainsi si votre élément ne s'affiche plus comme avant après l'ajout de la PixTooltip, veillez à rajouter les dimensions voulues à l'enfant.
 
 <Canvas>
-  <Story name="Tooltip" story={stories.tooltip} height="160px" />
+  <Story name="Tooltip" story={stories.tooltip} height={160} />
 </Canvas>
 
 ## Usage

--- a/blueprints/pix-component/files/addon/stories/pix-__name__.stories.mdx
+++ b/blueprints/pix-component/files/addon/stories/pix-__name__.stories.mdx
@@ -15,7 +15,7 @@ import * as stories from './pix-<%= dasherizedModuleName %>.stories.js';
 TODO: insert component description
 
 <Canvas>
-  <Story name='Pix<%= classifiedModuleName %>' story={stories.<%= camelizedModuleName %>} height="60px" />
+  <Story name='Pix<%= classifiedModuleName %>' story={stories.<%= camelizedModuleName %>} height={60} />
 </Canvas>
 
 ## Usage

--- a/docs/create-component.stories.mdx
+++ b/docs/create-component.stories.mdx
@@ -96,7 +96,7 @@ Un bandeau d'information, par défaut de type info, avec une icône facultative.
 {/* Affiche la prévisualisation du composant telle que définie dans pix-message.stories.js */}
 
 <Canvas isColumn>
-  <Story name="Message" story={stories.message} height="140px" />
+  <Story name="Message" story={stories.message} height={140} />
 </Canvas>
 
 ## Usage


### PR DESCRIPTION
## :unicorn: Description
Certains canvas de la documentation de composant n'avaient pas la bonne hauteur. On a modifié ceux qui en avaient besoin.

## :rainbow: Remarques
On a tenté de rendre la hauteur dynamique plutôt que devoir la forcer nous même comme c'est fait pour React, Vue, et Angular, cependant cela ne semble pas fonctionner pour Emberjs.
On en a profité pour changer la propriété height de chaque Story pour éviter de le mettre en string.
Par exemple `height="100px"` devient `height={100}`

## :100: Pour tester
Vérifier que dans chaque documentation, le contenu est bien affiché dans les canvas sans scrollbar.
