### PR TITLE
[FEATURE] Centrer le contenu de Pix-Button par défaut

### DIFF
--- a/addon/styles/_pix-button.scss
+++ b/addon/styles/_pix-button.scss
@@ -12,7 +12,7 @@
   background-color: $blue;
   display: flex;
   justify-content: center;
-
+  align-items: center;
 
   .loader {
     position: absolute;


### PR DESCRIPTION
## :unicorn: Description du composant
Lorsqu'on met du contenu dans le PixButton il n'est pas centré par défaut. C'est le padding qui gère le fait que le texte soit centré verticalement, mais si on l'enlève le contenu est collé sur le haut du bouton.

Sur PixAdmin on peut observer quelques soucis que cela entraîne.

Comme par exemple sur l'ajout de membres à une orga : 
<img width="1366" alt="image" src="https://user-images.githubusercontent.com/38167520/129012819-7cab6c2d-5c50-4e99-bd12-10faa52f069b.png">`

Ou encore la publication de session : 
<img width="321" alt="image" src="https://user-images.githubusercontent.com/38167520/129012858-ac236983-a300-4bd0-8542-fc6ab2d8c23f.png">

Ou bien le bouton pour recharger le cache : 
<img width="321" alt="image" src="https://user-images.githubusercontent.com/38167520/129012951-18f2881e-270b-4186-9f22-00f8df5117af.png">


## :rainbow: Remarques
Il faudra ensuite mettre à jour Pix-UI dans PixAdmin pour observer les changements.

## :100: Pour tester
Voir sur la RA
