### PR TITLE
[TECH] Ajout de l'auto merge la PR à l'ajout du label (PIX-3001).

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -1,0 +1,21 @@
+name: automerge check
+on:
+  pull_request:
+    types:
+      - labeled
+  check_suite:
+    types:
+      - completed
+jobs:
+  automerge:
+    runs-on: ubuntu-latest
+    steps:
+      - name: automerge
+        uses: "pascalgn/automerge-action@v0.8.3"
+        env:
+          GITHUB_TOKEN: "${{ secrets.PIX_SERVICE_ACTIONS_TOKEN }}"
+          MERGE_LABELS: ":rocket: Ready to Merge"
+          MERGE_COMMIT_MESSAGE: "pull-request-title"
+          UPDATE_LABELS: ":rocket: Ready to Merge"
+          UPDATE_METHOD: "rebase"
+          MERGE_FORKS: "false"

--- a/.github/workflows/on-dev-merge.yml
+++ b/.github/workflows/on-dev-merge.yml
@@ -1,0 +1,33 @@
+name: Merge on Dev
+on:
+  push:
+    branches:
+      - dev
+jobs:
+  transition-issue:
+    name: Transition Issue
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@master
+
+    - name: Login
+      uses: atlassian/gajira-login@master
+      env:
+        JIRA_BASE_URL: ${{ secrets.JIRA_BASE_URL }}
+        JIRA_USER_EMAIL: ${{ secrets.JIRA_USER_EMAIL }}
+        JIRA_API_TOKEN: ${{ secrets.JIRA_API_TOKEN }}
+
+    - name: Find Issue Key
+      id: find
+      uses: atlassian/gajira-find-issue-key@master
+      continue-on-error: true
+      with:
+        from: commits
+
+    - name: Transition issue
+      uses: atlassian/gajira-transition@master
+      if: ${{ steps.find.outputs.issue }}
+      with:
+        issue: ${{ steps.find.outputs.issue }}
+        transition: "Move to 'Deployed in Integration'"


### PR DESCRIPTION
## :unicorn: Description 
Contrairement au repo pix, quand on met le label `Ready to merge` sur une PR, elle n'est pas automatiquement merged sur dev. Pour éviter de se coordonner au moment du merge, vu que nous sommes plus actifs sur le repo, on veut automatiser le processus.
