### PR TITLE
[TECH] Réparer le merge automatique (PIX-3001).

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -13,7 +13,7 @@ jobs:
       - name: automerge
         uses: "pascalgn/automerge-action@v0.8.3"
         env:
-          GITHUB_TOKEN: "${{ secrets.PIX_SERVICE_ACTIONS_TOKEN }}"
+          GITHUB_TOKEN: "${{ github.token }}"
           MERGE_LABELS: ":rocket: Ready to Merge"
           MERGE_COMMIT_MESSAGE: "pull-request-title"
           UPDATE_LABELS: ":rocket: Ready to Merge"


### PR DESCRIPTION
## :unicorn: Description du composant
Le merge automatique des PR ne fonctionne pas comme prévu ([voir la PR introduisant le merge auto](https://github.com/1024pix/pix-ui/pull/113))
<img width="1551" alt="image" src="https://user-images.githubusercontent.com/38167520/129371662-50d89cd4-70cd-4aaf-a535-8b6683cc5690.png">

(Cependant le déplacement des tickets Jira fonctionne comme prévu)

D'après la doc : 
> GitHub automatically creates a GITHUB_TOKEN secret to use in your workflow. You can use the GITHUB_TOKEN to authenticate in a workflow run.

> The token is also available in the github.token context. For more information, see "Context and expression syntax for GitHub Actions."

Ou bien voir https://www.youtube.com/watch?v=jEK07KPEjnY 

Donc à priori pas besoin de créer un token nous même github le fait déjà.

