### PR TITLE
[TECH] S'assurer des règles d'a11y du linter (PIX-3033)

### DIFF
--- a/.template-lintrc.js
+++ b/.template-lintrc.js
@@ -1,5 +1,5 @@
 'use strict';
 
 module.exports = {
-  extends: 'octane'
+  extends: ['recommended', 'a11y'],
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1674,15 +1674,15 @@
       "integrity": "sha512-tGRdvgC9/QMQSuSuJV45xoyhI0Pzjm7A9o/MVVA3HakXIImJbbzx/k/6dO9CUEQXIyS2y0fW6C1XaYOG7rY0FQ=="
     },
     "@ember-template-lint/todo-utils": {
-      "version": "8.0.0-beta.3",
-      "resolved": "https://registry.npmjs.org/@ember-template-lint/todo-utils/-/todo-utils-8.0.0-beta.3.tgz",
-      "integrity": "sha512-L0XXY8U6Jk4c4OGSydhxa5K3/kyUpaqc6IpYW4wU8g1yu/zOj7XgKgmp48+t3dt1p6Xa+CHKnD1I86m99BEYXg==",
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@ember-template-lint/todo-utils/-/todo-utils-10.0.0.tgz",
+      "integrity": "sha512-US8VKnetBOl8KfKz+rXGsosz6rIETNwSz2F2frM8hIoJfF/d6ME1Iz1K7tPYZEE6SoKqZFlBs5XZPSmzRnabjA==",
       "dev": true,
       "requires": {
-        "@types/eslint": "^7.2.6",
-        "fs-extra": "^9.0.1",
+        "@types/eslint": "^7.2.13",
+        "fs-extra": "^9.1.0",
         "slash": "^3.0.0",
-        "tslib": "^2.1.0"
+        "tslib": "^2.2.0"
       },
       "dependencies": {
         "slash": {
@@ -1692,9 +1692,9 @@
           "dev": true
         },
         "tslib": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.1.0.tgz",
-          "integrity": "sha512-hcVC3wYEziELGGmEEXue7D75zbwIIVUMWAVbHItGPx0ziyXxrOMQx4rQEVEV45Ut/1IotuEvwqPopzIOkDMf0A==",
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+          "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
           "dev": true
         }
       }
@@ -3198,9 +3198,9 @@
       "dev": true
     },
     "@glimmer/global-context": {
-      "version": "0.65.2",
-      "resolved": "https://registry.npmjs.org/@glimmer/global-context/-/global-context-0.65.2.tgz",
-      "integrity": "sha512-BUWgPmPoWb6ILnJxvG0WgASJ9RVjhd3wSZwEpUIVGdOc9CHfD+4WhpYJNjPPoYMbq2NS5B6QXT1MP66hyGqq8Q==",
+      "version": "0.65.3",
+      "resolved": "https://registry.npmjs.org/@glimmer/global-context/-/global-context-0.65.3.tgz",
+      "integrity": "sha512-XvO7EESyshbbMFfucrnLXDMRtlZvI9JIjpRLpVPa7MJAU9jRmIMtmjtXOX2cy/i9XMfnAHu/PGIgBN9L03HLzA==",
       "dev": true,
       "requires": {
         "@glimmer/env": "^0.1.7"
@@ -7190,9 +7190,9 @@
       }
     },
     "@types/eslint": {
-      "version": "7.2.6",
-      "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-7.2.6.tgz",
-      "integrity": "sha512-I+1sYH+NPQ3/tVqCeUSBwTE/0heyvtXqpIopUUArlBm0Kpocb8FbMa3AZ/ASKIFpN3rnEx932TTXDbt9OXsNDw==",
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-7.28.0.tgz",
+      "integrity": "sha512-07XlgzX0YJUn4iG1ocY4IX9DzKSmMGUs6ESKlxWhZRaa0fatIWaHWUVapcuGa8r5HFnTqzj+4OCjd5f7EZ/i/A==",
       "dev": true,
       "requires": {
         "@types/estree": "*",
@@ -13602,6 +13602,12 @@
         "whatwg-url": "^8.0.0"
       }
     },
+    "date-fns": {
+      "version": "2.23.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.23.0.tgz",
+      "integrity": "sha512-5ycpauovVyAk0kXNZz6ZoB9AYMZB4DObse7P3BPWmyEjXNORTI8EJ6X0uaSAq4sCHzM1uajzrkr6HnsLQpxGXA==",
+      "dev": true
+    },
     "debug": {
       "version": "4.3.1",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
@@ -16738,31 +16744,27 @@
       }
     },
     "ember-template-lint": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/ember-template-lint/-/ember-template-lint-3.0.0.tgz",
-      "integrity": "sha512-A3X5Ff2LCdFOr9Sf764sdkL1Q0mg3kWL1Os+2zqjZZZR6wCziyE4vyiPb3VthBnl1BUYAeivu9A76SKC+Qff2w==",
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/ember-template-lint/-/ember-template-lint-3.6.0.tgz",
+      "integrity": "sha512-t3tzOTqYi0+Fphj35i8uHB5wwrPcBcSh+YnzaVAz+kNwVO2adiUlKn8+ZIUSJg/pIMMrZjcIu+GJzd5g2T9SHg==",
       "dev": true,
       "requires": {
-        "@ember-template-lint/todo-utils": "^8.0.0-beta.3",
-        "chalk": "^4.0.0",
-        "ember-template-recast": "^5.0.1",
+        "@ember-template-lint/todo-utils": "^10.0.0",
+        "chalk": "^4.1.2",
+        "date-fns": "^2.23.0",
+        "ember-template-recast": "^5.0.3",
         "find-up": "^5.0.0",
         "fuse.js": "^6.4.6",
         "get-stdin": "^8.0.0",
-        "globby": "^11.0.2",
+        "globby": "^11.0.4",
         "is-glob": "^4.0.1",
-        "micromatch": "^4.0.2",
+        "micromatch": "^4.0.4",
+        "requireindex": "^1.2.0",
         "resolve": "^1.20.0",
-        "v8-compile-cache": "^2.2.0",
+        "v8-compile-cache": "^2.3.0",
         "yargs": "^16.2.0"
       },
       "dependencies": {
-        "@nodelib/fs.stat": {
-          "version": "2.0.4",
-          "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.4.tgz",
-          "integrity": "sha512-IYlHJA0clt2+Vg7bccq+TzRdJvv19c2INqBSsoOLp1je7xjtr7J26+WXR72MCdvU9q1qTzIWDfhMf+DRvQJK4Q==",
-          "dev": true
-        },
         "ansi-styles": {
           "version": "4.3.0",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
@@ -16772,16 +16774,10 @@
             "color-convert": "^2.0.1"
           }
         },
-        "array-union": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
-          "integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
-          "dev": true
-        },
         "chalk": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
-          "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
           "dev": true,
           "requires": {
             "ansi-styles": "^4.1.0",
@@ -16814,29 +16810,6 @@
           "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
           "dev": true
         },
-        "dir-glob": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
-          "integrity": "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==",
-          "dev": true,
-          "requires": {
-            "path-type": "^4.0.0"
-          }
-        },
-        "fast-glob": {
-          "version": "3.2.5",
-          "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.5.tgz",
-          "integrity": "sha512-2DtFcgT68wiTTiwZ2hNdJfcHNke9XOfnwmBRWXhmeKM8rF0TGwmC/Qto3S7RoZKp5cilZbxzO5iTNTQsJ+EeDg==",
-          "dev": true,
-          "requires": {
-            "@nodelib/fs.stat": "^2.0.2",
-            "@nodelib/fs.walk": "^1.2.3",
-            "glob-parent": "^5.1.0",
-            "merge2": "^1.3.0",
-            "micromatch": "^4.0.2",
-            "picomatch": "^2.2.1"
-          }
-        },
         "find-up": {
           "version": "5.0.0",
           "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
@@ -16859,19 +16832,10 @@
           "integrity": "sha512-sY22aA6xchAzprjyqmSEQv4UbAAzRN0L2dQB0NlN5acTTK9Don6nhoc3eAbUnpZiCANAMfd/+40kVdKfFygohg==",
           "dev": true
         },
-        "glob-parent": {
-          "version": "5.1.1",
-          "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.1.tgz",
-          "integrity": "sha512-FnI+VGOpnlGHWZxthPGR+QhR78fuiK0sNLkHQv+bL9fQi57lNNdquIbna/WrfROrolq8GK5Ek6BiMwqL/voRYQ==",
-          "dev": true,
-          "requires": {
-            "is-glob": "^4.0.1"
-          }
-        },
         "globby": {
-          "version": "11.0.2",
-          "resolved": "https://registry.npmjs.org/globby/-/globby-11.0.2.tgz",
-          "integrity": "sha512-2ZThXDvvV8fYFRVIxnrMQBipZQDr7MxKAmQK1vujaj9/7eF0efG7BPUKJ7jP7G5SLF37xKDXvO4S/KKLj/Z0og==",
+          "version": "11.0.4",
+          "resolved": "https://registry.npmjs.org/globby/-/globby-11.0.4.tgz",
+          "integrity": "sha512-9O4MVG9ioZJ08ffbcyVYyLOJLk5JQ688pJ4eMGLpdWLHq/Wr1D9BlriLQyL0E+jbkuePVZXYFj47QM/v093wHg==",
           "dev": true,
           "requires": {
             "array-union": "^2.1.0",
@@ -16903,6 +16867,16 @@
             "p-locate": "^5.0.0"
           }
         },
+        "micromatch": {
+          "version": "4.0.4",
+          "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.4.tgz",
+          "integrity": "sha512-pRmzw/XUcwXGpD9aI9q/0XOwLNygjETJ8y0ao0wdqprrzDa4YnxLcz7fQRZr8voh8V10kGhABbNcHVk5wHgWwg==",
+          "dev": true,
+          "requires": {
+            "braces": "^3.0.1",
+            "picomatch": "^2.2.3"
+          }
+        },
         "p-limit": {
           "version": "3.1.0",
           "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
@@ -16925,6 +16899,12 @@
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
           "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+          "dev": true
+        },
+        "picomatch": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.0.tgz",
+          "integrity": "sha512-lY1Q/PiJGC2zOv/z391WOTD+Z02bCgsFfvxoXXf6h7kv9o+WmsmzYqrAwY63sNgOxE4xEdq0WyUnXfKeBrSvYw==",
           "dev": true
         },
         "resolve": {
@@ -16952,6 +16932,12 @@
             "has-flag": "^4.0.0"
           }
         },
+        "v8-compile-cache": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.3.0.tgz",
+          "integrity": "sha512-l8lCEmLcLYZh4nbunNZvQCJc5pv7+RCwa8q/LdUx8u7lsWvPDKmpodJAJNwkAhJC//dFY48KuIEmjtd4RViDrA==",
+          "dev": true
+        },
         "wrap-ansi": {
           "version": "7.0.0",
           "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
@@ -16964,9 +16950,9 @@
           }
         },
         "y18n": {
-          "version": "5.0.5",
-          "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.5.tgz",
-          "integrity": "sha512-hsRUr4FFrvhhRH12wOdfs38Gy7k2FFzB9qgN9v3aLykRq0dRcdcpz5C9FxdS2NuhOrI/628b/KSTJ3rwHysYSg==",
+          "version": "5.0.8",
+          "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+          "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
           "dev": true
         },
         "yargs": {
@@ -16985,17 +16971,17 @@
           }
         },
         "yargs-parser": {
-          "version": "20.2.6",
-          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.6.tgz",
-          "integrity": "sha512-AP1+fQIWSM/sMiET8fyayjx/J+JmTPt2Mr0FkrgqB4todtfa53sOsrSAcIrJRD5XS20bKUwaDIuMkWKCEiQLKA==",
+          "version": "20.2.9",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
+          "integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
           "dev": true
         }
       }
     },
     "ember-template-recast": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/ember-template-recast/-/ember-template-recast-5.0.1.tgz",
-      "integrity": "sha512-MtjyYtr5jnE72i/jVkI3m2QOdozglLwXS3HN74Ge9cm7dz5GoDszVvUksyj/9xqpIP31LMXjs2bZetRGvinU1Q==",
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/ember-template-recast/-/ember-template-recast-5.0.3.tgz",
+      "integrity": "sha512-qsJYQhf29Dk6QMfviXhUPE+byMOs6iRQxUDHgkj8yqjeppvjHaFG96hZi/NAXJTm/M7o3PpfF5YlmeaKtI9UeQ==",
       "dev": true,
       "requires": {
         "@glimmer/reference": "^0.65.0",
@@ -17003,74 +16989,68 @@
         "@glimmer/validator": "^0.65.0",
         "async-promise-queue": "^1.0.5",
         "colors": "^1.4.0",
-        "commander": "^6.2.0",
-        "globby": "^11.0.1",
-        "ora": "^5.1.0",
+        "commander": "^6.2.1",
+        "globby": "^11.0.3",
+        "ora": "^5.4.0",
         "slash": "^3.0.0",
         "tmp": "^0.2.1",
-        "workerpool": "^6.0.3"
+        "workerpool": "^6.1.4"
       },
       "dependencies": {
         "@glimmer/interfaces": {
-          "version": "0.65.2",
-          "resolved": "https://registry.npmjs.org/@glimmer/interfaces/-/interfaces-0.65.2.tgz",
-          "integrity": "sha512-/YdkmFFB4c7TAF71fhsQCLM1HUOuYp19bnKv+gAdlK3R2TooOpfg+ijoaAzI9WXgTK9V6zA5SE42ncLREBRGdQ==",
+          "version": "0.65.3",
+          "resolved": "https://registry.npmjs.org/@glimmer/interfaces/-/interfaces-0.65.3.tgz",
+          "integrity": "sha512-DP38dx0ai3xBPdYXRxxv3Ix5CbQHJZwI8PPUkDXv0pyua7/XEsSkiv7heXaaXgihSOGGHgrUa96/Nu82R6UtYw==",
           "dev": true,
           "requires": {
             "@simple-dom/interface": "^1.4.0"
           }
         },
         "@glimmer/reference": {
-          "version": "0.65.2",
-          "resolved": "https://registry.npmjs.org/@glimmer/reference/-/reference-0.65.2.tgz",
-          "integrity": "sha512-koGW9mGyFhVKykDrINdiqD9l/Q8TFv2okmrTvCFleS9+2kJ56x3V3wa5xQU2cRIAewkbXCWNiNbyDz5EVq9alw==",
+          "version": "0.65.3",
+          "resolved": "https://registry.npmjs.org/@glimmer/reference/-/reference-0.65.3.tgz",
+          "integrity": "sha512-Ew8QNXRu2BkK6g8A4T+0dMNvv3yampiPMO/SGYlyRpXK1Ehm7nWVC+lSi/gfKW1N8iWPwa3ClIIxDekS52/FFw==",
           "dev": true,
           "requires": {
             "@glimmer/env": "^0.1.7",
-            "@glimmer/global-context": "0.65.2",
-            "@glimmer/interfaces": "0.65.2",
-            "@glimmer/util": "0.65.2",
-            "@glimmer/validator": "0.65.2"
+            "@glimmer/global-context": "0.65.3",
+            "@glimmer/interfaces": "0.65.3",
+            "@glimmer/util": "0.65.3",
+            "@glimmer/validator": "0.65.3"
           }
         },
         "@glimmer/syntax": {
-          "version": "0.65.2",
-          "resolved": "https://registry.npmjs.org/@glimmer/syntax/-/syntax-0.65.2.tgz",
-          "integrity": "sha512-cfAqRgka8EVhDgDJKu3d1WMOZLJu1H+tuOb4J4LutcbYRswLYkvPYED2UA8Bw6oekpN34GYFRzwb/JODAWNBpA==",
+          "version": "0.65.3",
+          "resolved": "https://registry.npmjs.org/@glimmer/syntax/-/syntax-0.65.3.tgz",
+          "integrity": "sha512-2AdC5rJy+z1e6G29BXy2MLa9dXQgUTalH8qy1UkQ54stwQ8r3ZI6aO0IQYh5tiO0Hu2hAY/xy7UyjZc256zwQg==",
           "dev": true,
           "requires": {
-            "@glimmer/interfaces": "0.65.2",
-            "@glimmer/util": "0.65.2",
+            "@glimmer/interfaces": "0.65.3",
+            "@glimmer/util": "0.65.3",
             "@handlebars/parser": "^1.1.0",
             "simple-html-tokenizer": "^0.5.10"
           }
         },
         "@glimmer/util": {
-          "version": "0.65.2",
-          "resolved": "https://registry.npmjs.org/@glimmer/util/-/util-0.65.2.tgz",
-          "integrity": "sha512-xLjmGBSCTfDhi4tskVzg1M/Ii90wPL711O3TNLZF//ztv8SFRGNzh73oVbBzdYmEWR1OdED73ZTYL5MGzqBWLw==",
+          "version": "0.65.3",
+          "resolved": "https://registry.npmjs.org/@glimmer/util/-/util-0.65.3.tgz",
+          "integrity": "sha512-3qXYC9GpHipAXT0oVec6vQ3xsZaWIgLxyN62S0l/xHnIa5pXu3vnX73zan282IS6Mi0RetxwGNyEBT9OPsYkqQ==",
           "dev": true,
           "requires": {
             "@glimmer/env": "0.1.7",
-            "@glimmer/interfaces": "0.65.2",
+            "@glimmer/interfaces": "0.65.3",
             "@simple-dom/interface": "^1.4.0"
           }
         },
         "@glimmer/validator": {
-          "version": "0.65.2",
-          "resolved": "https://registry.npmjs.org/@glimmer/validator/-/validator-0.65.2.tgz",
-          "integrity": "sha512-IQxvCueyORlwa5kDd0AwFvVLYAaIKvT4EeMvOCqOp/jJ32dGGSXG++V37UY0cYUc9Ir3gTPE7bE9/0piTXSdag==",
+          "version": "0.65.3",
+          "resolved": "https://registry.npmjs.org/@glimmer/validator/-/validator-0.65.3.tgz",
+          "integrity": "sha512-XoQ+5fN4MLzbS5uhAnaQzbgC7du2rgznTlM7W4WH+97ijHZ8JU5j6+3LIrwwZPPgVPlLlg8z3y6Wv3gEIQMpNA==",
           "dev": true,
           "requires": {
             "@glimmer/env": "^0.1.7",
-            "@glimmer/global-context": "0.65.2"
+            "@glimmer/global-context": "0.65.3"
           }
-        },
-        "@nodelib/fs.stat": {
-          "version": "2.0.4",
-          "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.4.tgz",
-          "integrity": "sha512-IYlHJA0clt2+Vg7bccq+TzRdJvv19c2INqBSsoOLp1je7xjtr7J26+WXR72MCdvU9q1qTzIWDfhMf+DRvQJK4Q==",
-          "dev": true
         },
         "ansi-styles": {
           "version": "4.3.0",
@@ -17081,16 +17061,10 @@
             "color-convert": "^2.0.1"
           }
         },
-        "array-union": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
-          "integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
-          "dev": true
-        },
         "chalk": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
-          "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
           "dev": true,
           "requires": {
             "ansi-styles": "^4.1.0",
@@ -17118,42 +17092,10 @@
           "integrity": "sha512-U7VdrJFnJgo4xjrHpTzu0yrHPGImdsmD95ZlgYSEajAn2JKzDhDTPG9kBTefmObL2w/ngeZnilk+OV9CG3d7UA==",
           "dev": true
         },
-        "dir-glob": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
-          "integrity": "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==",
-          "dev": true,
-          "requires": {
-            "path-type": "^4.0.0"
-          }
-        },
-        "fast-glob": {
-          "version": "3.2.5",
-          "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.5.tgz",
-          "integrity": "sha512-2DtFcgT68wiTTiwZ2hNdJfcHNke9XOfnwmBRWXhmeKM8rF0TGwmC/Qto3S7RoZKp5cilZbxzO5iTNTQsJ+EeDg==",
-          "dev": true,
-          "requires": {
-            "@nodelib/fs.stat": "^2.0.2",
-            "@nodelib/fs.walk": "^1.2.3",
-            "glob-parent": "^5.1.0",
-            "merge2": "^1.3.0",
-            "micromatch": "^4.0.2",
-            "picomatch": "^2.2.1"
-          }
-        },
-        "glob-parent": {
-          "version": "5.1.1",
-          "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.1.tgz",
-          "integrity": "sha512-FnI+VGOpnlGHWZxthPGR+QhR78fuiK0sNLkHQv+bL9fQi57lNNdquIbna/WrfROrolq8GK5Ek6BiMwqL/voRYQ==",
-          "dev": true,
-          "requires": {
-            "is-glob": "^4.0.1"
-          }
-        },
         "globby": {
-          "version": "11.0.2",
-          "resolved": "https://registry.npmjs.org/globby/-/globby-11.0.2.tgz",
-          "integrity": "sha512-2ZThXDvvV8fYFRVIxnrMQBipZQDr7MxKAmQK1vujaj9/7eF0efG7BPUKJ7jP7G5SLF37xKDXvO4S/KKLj/Z0og==",
+          "version": "11.0.4",
+          "resolved": "https://registry.npmjs.org/globby/-/globby-11.0.4.tgz",
+          "integrity": "sha512-9O4MVG9ioZJ08ffbcyVYyLOJLk5JQ688pJ4eMGLpdWLHq/Wr1D9BlriLQyL0E+jbkuePVZXYFj47QM/v093wHg==",
           "dev": true,
           "requires": {
             "array-union": "^2.1.0",
@@ -17177,26 +17119,28 @@
           "dev": true
         },
         "log-symbols": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-4.0.0.tgz",
-          "integrity": "sha512-FN8JBzLx6CzeMrB0tg6pqlGU1wCrXW+ZXGH481kfsBqer0hToTIiHdjH4Mq8xJUbvATujKCvaREGWpGUionraA==",
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-4.1.0.tgz",
+          "integrity": "sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==",
           "dev": true,
           "requires": {
-            "chalk": "^4.0.0"
+            "chalk": "^4.1.0",
+            "is-unicode-supported": "^0.1.0"
           }
         },
         "ora": {
-          "version": "5.3.0",
-          "resolved": "https://registry.npmjs.org/ora/-/ora-5.3.0.tgz",
-          "integrity": "sha512-zAKMgGXUim0Jyd6CXK9lraBnD3H5yPGBPPOkC23a2BG6hsm4Zu6OQSjQuEtV0BHDf4aKHcUFvJiGRrFuW3MG8g==",
+          "version": "5.4.1",
+          "resolved": "https://registry.npmjs.org/ora/-/ora-5.4.1.tgz",
+          "integrity": "sha512-5b6Y85tPxZZ7QytO+BQzysW31HJku27cRIlkbAXaNx+BdcVi+LlRFmVXzeF6a7JCwJpyw5c4b+YSVImQIrBpuQ==",
           "dev": true,
           "requires": {
-            "bl": "^4.0.3",
+            "bl": "^4.1.0",
             "chalk": "^4.1.0",
             "cli-cursor": "^3.1.0",
             "cli-spinners": "^2.5.0",
             "is-interactive": "^1.0.0",
-            "log-symbols": "^4.0.0",
+            "is-unicode-supported": "^0.1.0",
+            "log-symbols": "^4.1.0",
             "strip-ansi": "^6.0.0",
             "wcwidth": "^1.0.1"
           }
@@ -17232,9 +17176,9 @@
           }
         },
         "workerpool": {
-          "version": "6.1.0",
-          "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-6.1.0.tgz",
-          "integrity": "sha512-toV7q9rWNYha963Pl/qyeZ6wG+3nnsyvolaNUS8+R5Wtw6qJPTxIlOP1ZSvcGhEJw+l3HMMmtiNo9Gl61G4GVg==",
+          "version": "6.1.5",
+          "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-6.1.5.tgz",
+          "integrity": "sha512-XdKkCK0Zqc6w3iTxLckiuJ81tiD/o5rBE/m+nXpRCB+/Sq4DqkfXZ/x0jW02DG1tGsfUGXbTJyZDP+eu67haSw==",
           "dev": true
         }
       }
@@ -21477,6 +21421,12 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
       "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
+    },
+    "is-unicode-supported": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz",
+      "integrity": "sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==",
+      "dev": true
     },
     "is-whitespace-character": {
       "version": "1.0.4",
@@ -27742,6 +27692,12 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
       "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg=="
+    },
+    "requireindex": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/requireindex/-/requireindex-1.2.0.tgz",
+      "integrity": "sha512-L9jEkOi3ASd9PYit2cwRfyppc9NoABujTP8/5gFcbERmo5jUoAKovIC3fsF17pkTnGsrByysqX+Kxd2OTNI1ww==",
+      "dev": true
     },
     "requires-port": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "ember-sinon": "^5.0.0",
     "ember-source": "^3.23.1",
     "ember-source-channel-url": "^3.0.0",
-    "ember-template-lint": "^3.0.0",
+    "ember-template-lint": "^3.6.0",
     "ember-try": "^1.4.0",
     "eslint": "^7.21.0",
     "eslint-plugin-ember": "^10.2.0",


### PR DESCRIPTION
## :unicorn: Description

L'a11y est un point important d'une librairie de composants, nous voulons nous assurer que le linter utilisé applique bien les règles de vérification d'accessibilité.

Le linter utilisé est https://github.com/ember-template-lint

Ce qui a été fait:
- Mettre à jour le linter 3.0.0 => 3.6.0
- Utiliser le preset `recommended` (preset de base depuis la version 3.0.0)
- Ajouter le preset `a11y` (ajoute quelques règles non incluses dans `recommended`)

