### PR TITLE
[BUGFIX] Permettre de passer des paramètres au PixButton de type lien (PIX-3036).

### DIFF
--- a/addon/components/pix-button.hbs
+++ b/addon/components/pix-button.hbs
@@ -4,7 +4,7 @@
             @route={{this.route}}
             class={{this.className}}
             @model={{@model}}
-            ..attributes
+            ...attributes
     >
       {{yield}}
     </LinkTo>

--- a/addon/components/pix-button.hbs
+++ b/addon/components/pix-button.hbs
@@ -1,7 +1,7 @@
-{{#if this.isLink}}
+{{#if @route}}
   {{#if @model}}
     <LinkTo
-            @route={{this.route}}
+            @route={{@route}}
             class={{this.className}}
             @model={{@model}}
             ...attributes
@@ -10,7 +10,7 @@
     </LinkTo>
   {{else}}
     <LinkTo
-            @route={{this.route}}
+            @route={{@route}}
             class={{this.className}}
             ...attributes
     >

--- a/addon/components/pix-button.js
+++ b/addon/components/pix-button.js
@@ -34,10 +34,6 @@ export default class PixButton extends Component {
     return this.args.size || 'big';
   }
 
-  get isBorderVisible() {
-    return this.args.isBorderVisible;
-  }
-
   get className() {
     const classNames = [
       'pix-button',
@@ -46,7 +42,7 @@ export default class PixButton extends Component {
       `pix-button--background-${this.backgroundColor}`
     ];
     this.args.isDisabled && classNames.push('pix-button--disabled');
-    this.isBorderVisible && classNames.push('pix-button--border');
+    this.args.isBorderVisible && classNames.push('pix-button--border');
     return classNames.join(' ')
   }
 

--- a/addon/components/pix-button.js
+++ b/addon/components/pix-button.js
@@ -42,10 +42,6 @@ export default class PixButton extends Component {
     return this.args.isBorderVisible;
   }
 
-  get isLink() {
-    return this.args.isLink;
-  }
-
   get className() {
     const classNames = [
       'pix-button',
@@ -56,16 +52,6 @@ export default class PixButton extends Component {
     this.isDisabled && classNames.push('pix-button--disabled');
     this.isBorderVisible && classNames.push('pix-button--border');
     return classNames.join(' ')
-  }
-
-  get route() {
-    const routeParam = this.args.route;
-    if (this.isLink) {
-      if (routeParam === undefined || routeParam.trim() === '') {
-        throw new Error('ERROR in PixButton component, @route param is not provided');
-      }
-    }
-    return routeParam;
   }
 
   get enableTriggerAction(){

--- a/addon/components/pix-button.js
+++ b/addon/components/pix-button.js
@@ -22,12 +22,8 @@ export default class PixButton extends Component {
     return this.args.backgroundColor || 'blue';
   }
 
-  get isDisabled() {
-    return this.args.isDisabled;
-  }
-
   get isButtonLoadingOrDisabled() {
-    return this.isLoading || this.isDisabled;
+    return this.isLoading || this.args.isDisabled;
   }
 
   get ariaDisabled() {
@@ -49,7 +45,7 @@ export default class PixButton extends Component {
       `pix-button--size-${this.size}`,
       `pix-button--background-${this.backgroundColor}`
     ];
-    this.isDisabled && classNames.push('pix-button--disabled');
+    this.args.isDisabled && classNames.push('pix-button--disabled');
     this.isBorderVisible && classNames.push('pix-button--border');
     return classNames.join(' ')
   }

--- a/addon/stories/pix-button.stories.js
+++ b/addon/stories/pix-button.stories.js
@@ -9,7 +9,6 @@ const Template = args => ({
         @shape={{shape}}
         @backgroundColor={{backgroundColor}}
         @isDisabled={{isDisabled}}
-        @isLink={{isLink}}
         @size={{size}}
         @isBorderVisible={{isBorderVisible}}
         @route={{route}}
@@ -25,7 +24,6 @@ const Template = args => ({
           @shape={{button.shape}}
           @backgroundColor={{button.backgroundColor}}
           @isDisabled={{button.isDisabled}}
-          @isLink={{button.isLink}}
           @size={{button.size}}
           @isBorderVisible={{button.isBorderVisible}}
           @route={{button.route}}
@@ -117,7 +115,6 @@ export const link = Template.bind({});
 link.args = {
   ...Default.args,
   label: 'Je suis un lien',
-  isLink: true,
   route: 'profile',
 };
 
@@ -230,19 +227,9 @@ export const argsTypes = {
       defaultValue: { summary: 'false' },
     }
   },
-  isLink: {
-    name: 'isLink',
-    description: 'Paramètre pour utiliser un composant LinkTo à la place d\'un bouton',
-    type: { name: 'boolean', required: false },
-    control: { type: 'boolean' },
-    table: {
-      type: { summary: 'boolean' },
-      defaultValue: { summary: 'false' },
-    }
-  },
   route: {
     name: 'route',
-    description: 'Route de redirection',
+    description: 'Paramètre à renseigner pour utiliser un composant LinkTo à la place d\'un bouton. Il prend comme valeur la route de redirection',
     type: { name: 'string', required: true },
     defaultValue: null,
   },

--- a/addon/stories/pix-button.stories.mdx
+++ b/addon/stories/pix-button.stories.mdx
@@ -86,10 +86,8 @@ Un petit bouton avec les bords arrondis en fond transparent avec une bordure
   @shape="squircle"
   @backgroundColor="transparent-light"
   @isDisabled={{false}}
-  @isLink={{false}}
   @size="small"
   @isBorderVisible={{true}}
-  @route="profile"
 >
   Cliquez-moi
 </PixButton>

--- a/tests/integration/components/pix-button-test.js
+++ b/tests/integration/components/pix-button-test.js
@@ -100,7 +100,6 @@ module('Integration | Component | button', function(hooks) {
     // when
     await render(hbs`
       <PixButton
-        @isLink={{true}}
         @route='profile'
         class="very-small">
           Mon lien

--- a/tests/integration/components/pix-button-test.js
+++ b/tests/integration/components/pix-button-test.js
@@ -100,13 +100,29 @@ module('Integration | Component | button', function(hooks) {
     // when
     await render(hbs`
       <PixButton
-      @isLink={{true}}
-      @route='profile'>
-        Mon lien
+        @isLink={{true}}
+        @route='profile'
+        class="very-small">
+          Mon lien
       </PixButton>
     `);
 
     // then
-    assert.dom('a').exists();
+    assert.dom('a.very-small').exists();
+  });
+
+  test('it renders the PixButton link component with model', async function(assert) {
+    // when
+    await render(hbs`
+      <PixButton
+        @route='profile'
+        class="smaller"
+        @model={{1}}>
+          Mon lien
+      </PixButton>
+    `);
+
+    // then
+    assert.dom('a.smaller').exists();
   });
 });

--- a/tests/unit/components/pix-button-test.js
+++ b/tests/unit/components/pix-button-test.js
@@ -7,19 +7,6 @@ import createGlimmerComponent from '../../helpers/create-glimmer-component';
 module('Unit | Component | pix-button', function(hooks) {
   setupTest(hooks);
 
-  test('it throws if route param is undefined or empty', function(assert) {
-    // given
-    const componentParams = { isLink: true, route: '  ' };
-    const expectedError = new Error('ERROR in PixButton component, @route param is not provided');
-    const component = createGlimmerComponent('component:pix-button', componentParams);
-
-    // when & then
-    assert.throws(
-      function() { component.route },
-      expectedError
-    );
-  });
-
   module('#enableTriggerAction', function(){
 
     test('it should return true if button type is button', function(assert){


### PR DESCRIPTION
## :unicorn: Description du composant
Il y a eu une suppression par erreur lors de cette [PR](https://github.com/1024pix/pix-ui/pull/111).
En effet, un "." a été supprimé dans `...attributes` ceci entraînant des soucis lors de l'utilisation du PixButton sous sa forme Link.

## :rainbow: Remarques
Quelques petits refacto ont été rajoutés pour le PixButton : 
- suppression du paramètre  `isLink` qui était redondant avec l'information `route`.
- suppression de 2 getters non utiles dans le `.js`

## :100: Pour tester
- Lancer les tests (npm start -> localhost:4204/tests)
- Regarder si tout va bien dans la doc du PixButton (npm run storybook)
