### PR TITLE
[FEATURE] Alignement du PixButton avec le design system

### DIFF
--- a/.storybook/fonts.css
+++ b/.storybook/fonts.css
@@ -1,0 +1,1 @@
+@import url('https://fonts.googleapis.com/css2?family=Open+Sans:wght@300;400;600;700&family=Roboto:wght@300;400;500;700;900&display=swap');

--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -1,3 +1,5 @@
+import './fonts.css';
+
 export const parameters = {
   a11y: {
     element: '#root',

--- a/addon/components/pix-button.hbs
+++ b/addon/components/pix-button.hbs
@@ -1,18 +1,18 @@
 {{#if @route}}
   {{#if @model}}
     <LinkTo
-            @route={{@route}}
-            class={{this.className}}
-            @model={{@model}}
-            ...attributes
+      @route={{@route}}
+      class={{this.className}}
+      @model={{@model}}
+      ...attributes
     >
       {{yield}}
     </LinkTo>
   {{else}}
     <LinkTo
-            @route={{@route}}
-            class={{this.className}}
-            ...attributes
+      @route={{@route}}
+      class={{this.className}}
+      ...attributes
     >
       {{yield}}
     </LinkTo>
@@ -20,12 +20,12 @@
 {{else}}
   {{#if this.enableTriggerAction}}
     <button
-            type={{this.type}}
-            class={{this.className}}
-            {{on "click" this.triggerAction}}
-            ...attributes
-            disabled={{this.isButtonLoadingOrDisabled}}
-            aria-disabled={{this.ariaDisabled}}
+      type={{this.type}}
+      class={{this.className}}
+      {{on "click" this.triggerAction}}
+      ...attributes
+      disabled={{this.isButtonLoadingOrDisabled}}
+      aria-disabled={{this.ariaDisabled}}
     >
       {{#if this.isLoading}}
         <div class="loader loader--{{this.loadingColor}}">
@@ -40,11 +40,11 @@
     </button>
   {{else}}
     <button
-            type={{this.type}}
-            class={{this.className}}
-            ...attributes
-            disabled={{this.isButtonLoadingOrDisabled}}
-            aria-disabled={{this.ariaDisabled}}
+      type={{this.type}}
+      class={{this.className}}
+      ...attributes
+      disabled={{this.isButtonLoadingOrDisabled}}
+      aria-disabled={{this.ariaDisabled}}
     >
       {{yield}}
     </button>

--- a/addon/components/pix-button.js
+++ b/addon/components/pix-button.js
@@ -4,7 +4,11 @@ import { tracked } from '@glimmer/tracking';
 
 export default class PixButton extends Component {
   text = 'pix-button';
-  @tracked isLoading = false;
+  @tracked isTriggering = false;
+
+  get isLoading() {
+    return this.args.isLoading || this.isTriggering;
+  }
 
   get type() {
     return this.args.type || 'button';
@@ -53,11 +57,11 @@ export default class PixButton extends Component {
   @action
   async triggerAction(params) {
     try {
-      this.isLoading = true;
+      this.isTriggering = true;
       await this.args.triggerAction(params);
-      this.isLoading = false;
+      this.isTriggering = false;
     } catch (e) {
-      this.isLoading = false;
+      this.isTriggering = false;
       if (!this.args.triggerAction) {
         throw new Error('@triggerAction params is required for PixButton !');
       }

--- a/addon/stories/pix-button.stories.js
+++ b/addon/stories/pix-button.stories.js
@@ -9,6 +9,7 @@ const Template = args => ({
         @shape={{shape}}
         @backgroundColor={{backgroundColor}}
         @isDisabled={{isDisabled}}
+        @isLoading={{isLoading}}
         @size={{size}}
         @isBorderVisible={{isBorderVisible}}
         @route={{route}}
@@ -24,6 +25,7 @@ const Template = args => ({
           @shape={{button.shape}}
           @backgroundColor={{button.backgroundColor}}
           @isDisabled={{button.isDisabled}}
+          @isLoading={{button.isLoading}}
           @size={{button.size}}
           @isBorderVisible={{button.isBorderVisible}}
           @route={{button.route}}
@@ -37,13 +39,18 @@ const Template = args => ({
 
 export const Default = Template.bind({});
 Default.args = {
-  route: '/',
   loadingColor: 'white',
   shape: 'squircle',
   size: 'big',
   backgroundColor: 'blue',
   label: 'Bouton',
-  style: 'background-color: transparent',
+  triggerAction: () => {
+    return new Promise((resolve) => {
+      setTimeout(() => {
+        resolve();
+      }, 2000);
+    })
+  },
 };
 
 export const borders = Template.bind({});
@@ -121,9 +128,16 @@ link.args = {
 export const loader = Template.bind({});
 loader.args = {
   ...Default.args,
-  label: 'Bouton avec loader gris',
+  label: 'Bouton avec loader au clic',
   backgroundColor: 'yellow',
   loadingColor: 'grey',
+  extraButtons: [
+    {
+      ...Default.args,
+      triggerAction: () => {},
+      isLoading: true,
+    }
+  ]
 };
 
 export const shape = Template.bind({});
@@ -155,13 +169,6 @@ export const argsTypes = {
     name: 'triggerAction',
     description: 'fonction à appeler en cas de clic, optionnel si le bouton est de type submit',
     type: { required: true },
-    defaultValue: () => {
-      return new Promise((resolve) => {
-        setTimeout(() => {
-          resolve();
-        }, 2000);
-      })
-    },
     control: { disable: true },
   },
   loadingColor: {
@@ -199,6 +206,16 @@ export const argsTypes = {
   },
   isDisabled: {
     name: 'isDisabled',
+    type: { name: 'boolean', required: false },
+    control: { type: 'boolean' },
+    table: {
+      type: { summary: 'boolean' },
+      defaultValue: { summary: 'false' },
+    }
+  },
+  isLoading: {
+    name: 'isLoading',
+    description: 'Affiche un loader. Si `@triggerAction` retourne une promesse alors le loading est géré automatiquement.',
     type: { name: 'boolean', required: false },
     control: { type: 'boolean' },
     table: {

--- a/addon/stories/pix-button.stories.mdx
+++ b/addon/stories/pix-button.stories.mdx
@@ -53,10 +53,13 @@ Le bouton en lien
 
 ## Loader
 
-Le bouton avec loader gris
+Le bouton avec loader.
+Le loader peut être affiché de deux façons :
+- En passant une promesse dans l'attribut `@triggerAction`
+- En passant directement l'attribut `@isLoading={{true}}`
 
 <Canvas>
-  <Story story={stories.loader} height={75} />
+  <Story story={stories.loader} height={150} />
 </Canvas>
 
 ## Shape

--- a/addon/styles/_pix-button.scss
+++ b/addon/styles/_pix-button.scss
@@ -163,7 +163,7 @@
 
   &--disabled {
     opacity: .5;
-    cursor: default;
+    cursor: not-allowed;
   }
 
   @keyframes sk-bouncedelay {

--- a/addon/styles/_pix-button.scss
+++ b/addon/styles/_pix-button.scss
@@ -1,18 +1,19 @@
 .pix-button {
-
   @import 'reset-css';
-  border: 2px solid transparent;
+
   color: $white;
-  font-size: 1rem;
-  white-space: nowrap;
+  font-family: $font-roboto;
+  font-size: 0.875rem;
   font-weight: 500;
+  white-space: nowrap;
   letter-spacing: .028rem;
   cursor: pointer;
-  font-family: $font-roboto;
   background-color: $blue;
+  border: 2px solid transparent;
   display: flex;
   justify-content: center;
   align-items: center;
+  text-decoration: none;
 
   .loader {
     position: absolute;
@@ -21,6 +22,7 @@
       visibility: hidden;
     }
   }
+  
   .loader > div {
     width: 10px;
     height: 10px;
@@ -49,31 +51,30 @@
   }
 
   &--shape-squircle {
-    border-radius: 8px;
+    border-radius: 4px;
   }
 
   &--size-big {
-    padding: 14px 24px;
+    padding: 12px 24px;
   }
 
   &--size-small.pix-button--shape-rounded {
     padding: 10px 24px;
-    font-size: 0.875rem;
   }
 
   &--size-small.pix-button--shape-squircle {
     padding: 10px 16px;
-    font-size: 0.875rem;
   }
 
   @mixin colorizeBackground($backgroundColor, $outlineColor) {
     background-color: $backgroundColor;
-    border: 2px solid $white;
+    border-color: $backgroundColor;
 
     &:not(.pix-button--disabled) {
       &:hover, &:focus, &:focus-visible {
         background-color: darken($backgroundColor, 8%);
         box-shadow: 0 0 0 2px darken($outlineColor, 8%);
+        border-color: $white;
         outline: none;
       }
 
@@ -114,26 +115,22 @@
 
   &--background-transparent-light {
     background-color: transparent;
+    border-color: transparent;
     color: $grey-90;
 
     &:not(.pix-button--disabled) {
-      &:hover {
+      &:hover, &:focus, &:focus-visible {
         background-color: rgba($black, 0.1);
+        outline: none;
       }
 
       &:active {
         background-color: rgba($black, 0.2);
       }
-
-      &:focus {
-        outline-color: $blue;
-        outline-style: auto;
-        outline-offset: 3px;
-      }
     }
 
     &.pix-button--border {
-      border: 2px solid $grey-50;
+      border-color: $grey-50;
 
       &:not(.pix-button--disabled) {
         &:hover, &:active {
@@ -145,27 +142,22 @@
 
   &--background-transparent-dark {
     background-color: transparent;
+    border-color: transparent;
     color: $white;
 
     &:not(.pix-button--disabled) {
-      &:hover {
+      &:hover, &:focus, &:focus-visible {
         background-color: rgba($black, 0.1);
+        outline: none;
       }
 
       &:active {
         background-color: rgba($black, 0.2);
       }
-
-      &:focus, &:focus-visible {
-        outline-color: $blue;
-        outline-style: auto;
-        outline-offset: 3px;
-        color: $yellow;
-      }
     }
 
     &.pix-button--border {
-      border: 2px solid $white;
+      border-color: $white;
     }
   }
 

--- a/tests/integration/components/pix-button-test.js
+++ b/tests/integration/components/pix-button-test.js
@@ -2,6 +2,7 @@ import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { click, render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
+import sinon from 'sinon';
 
 module('Integration | Component | button', function(hooks) {
   setupRenderingTest(hooks);
@@ -123,5 +124,52 @@ module('Integration | Component | button', function(hooks) {
 
     // then
     assert.dom('a.smaller').exists();
+  });
+
+  module('when the button has a trigger action with a promise', function(hooks) {
+    let clock;
+
+    hooks.beforeEach(function() {
+      clock = sinon.useFakeTimers();
+    })
+
+    hooks.afterEach(function() {
+      clock.restore();
+    })
+
+    test('should display a loading state', async function(assert) {
+      // given
+      this.set('triggerAction', () => {
+        return new Promise((resolve) => {
+          let wait = setTimeout(() => {
+            clearTimeout(wait);
+            resolve();
+          }, 1)
+        });
+      });
+
+      // when
+      await render(hbs`<PixButton @triggerAction={{this.triggerAction}} />`);
+      await click('button');
+
+      // then
+      const loadingComponent = this.element.querySelector('.loader');
+      assert.ok(loadingComponent);
+    });
+  });
+
+  module('when the button has isLoading to true', function() {
+    test('should display a loading state', async function(assert) {
+      // given
+      this.set('triggerAction', () => {});
+      this.set('isLoading', true);
+
+      // when
+      await render(hbs`<PixButton @isLoading={{isLoading}} />`);
+
+      // then
+      const loadingComponent = this.element.querySelector('.loader');
+      assert.ok(loadingComponent);
+    });
   });
 });


### PR DESCRIPTION
## :unicorn: Description du composant

Le style actuel du PixButton diffère de ce qui est défini dans le design system
- taille de la police
- hauteur du bouton en version normale
- souligné quand href présent
- version “clair”: la hauteur n’est pas la même qu’un bouton primaire (à cause de la bordure)
- Ajout de l'attribut `isLoading`

https://zeroheight.com/8dd127da7/p/23262d-buttons/b/396f7d

## :rainbow: Remarques

J'ai ajouter les polices Roboto et Open sans dans storybook pour avoir le bon rendu des composants.

## :100: Pour tester

Vérifier le style des boutons dans Storybook.
