### PR TITLE
[FEATURE] Ajout du composant PixButtonUpload

### DIFF
--- a/addon/components/pix-button-upload.hbs
+++ b/addon/components/pix-button-upload.hbs
@@ -1,0 +1,10 @@
+<label for={{@id}} class={{this.className}} role="button">
+  {{yield}}
+</label>
+<input
+  id={{@id}}
+  type="file"
+  class="pix-button-upload__input"
+  {{on "change" this.handleChange}}
+  ...attributes
+/>

--- a/addon/components/pix-button-upload.js
+++ b/addon/components/pix-button-upload.js
@@ -1,0 +1,15 @@
+import PixButtonBase from './pix-button-base';
+import { action } from '@ember/object';
+
+export default class PixButtonUpload extends PixButtonBase {
+  get className() {
+    return super.baseClassNames.join(' ');
+  }
+
+  @action
+  handleChange(e) {
+    if (e.target && e.target.files && e.target.files.length) {
+      this.args.onChange(e.target.files);
+    }
+  }
+}

--- a/addon/stories/pix-button-upload.stories.js
+++ b/addon/stories/pix-button-upload.stories.js
@@ -1,0 +1,82 @@
+import { hbs } from 'ember-cli-htmlbars';
+import { action } from '@storybook/addon-actions';
+
+export const buttonUpload = (args) => {
+  return {
+    template: hbs`
+      <PixButtonUpload
+        @id="id"
+        @onChange={{onChange}}
+        @shape={{shape}}
+        @backgroundColor={{backgroundColor}}
+        @size={{size}}
+        @isBorderVisible={{isBorderVisible}}
+      >
+        Cliquer pour uploader un fichier
+      </PixButtonUpload>
+    `,
+    context: args,
+  };
+};
+
+buttonUpload.args = {
+  onChange: action('onChange'),
+}
+
+export const argTypes = {
+  id: {
+    name: 'id',
+    description: 'identifiant du bouton d\'upload',
+    type: { name: 'string', required: true },
+    defaultValue: 'file-upload',
+  },
+  onChange: {
+    name: 'onChange',
+    description: 'fonction à exécuter au moment de l\'upload du fichier, elle prend en entrée la liste des fichiers uploadés.',
+    type: { name: 'function', required: true },
+    defaultValue: null,
+  },
+  shape: {
+    name: 'shape',
+    description: 'forme: `rounded`,`squircle`',
+    type: { name: 'string', required: false },
+    options: ['rounded', 'squircle'],
+    control: { type: 'select' },
+    table: {
+      type: { summary: 'string' },
+      defaultValue: { summary: 'squircle' },
+    }
+  },
+  backgroundColor: {
+    name: 'backgroundColor',
+    description: 'color: `blue`, `green`, `yellow`, `red`, `grey`, `transparent-light`, `transparent-dark`',
+    options: ['blue', 'green', 'yellow', 'red', 'grey', 'transparent-light', 'transparent-dark'],
+    type: { name: 'string', required: false },
+    control: { type: 'select' },
+    table: {
+      type: { summary: 'string' },
+      defaultValue: { summary: 'blue' },
+    }
+  },
+  size: {
+    name: 'size',
+    description: 'taille: `big`,`small`',
+    options: ['big', 'small'],
+    type: { name: 'string', required: false },
+    control: { type: 'select' },
+    table: {
+      type: { summary: 'string' },
+      defaultValue: { summary: 'big' },
+    }
+  },
+  isBorderVisible: {
+    name: 'isBorderVisible',
+    description: 'Paramètre utilisé seulement quand le `backgroundColor` est `transparent-light` ou `transparent-dark`',
+    type: { name: 'boolean', required: false },
+    control: { type: 'boolean' },
+    table: {
+      type: { summary: 'boolean' },
+      defaultValue: { summary: 'false' },
+    }
+  },
+};

--- a/addon/stories/pix-button-upload.stories.mdx
+++ b/addon/stories/pix-button-upload.stories.mdx
@@ -1,0 +1,39 @@
+import { Meta, Story, Canvas, ArgsTable } from '@storybook/addon-docs/blocks';
+import centered from '@storybook/addon-centered/ember';
+
+import * as stories from './pix-button-upload.stories.js';
+
+<Meta
+  title='Basics/ButtonUpload'
+  component='PixButtonUpload'
+  decorators={[centered]}
+  argTypes={stories.argTypes}
+/>
+
+# PixButtonUpload
+
+Affiche un bouton d'upload de fichiers.
+
+Hérite des styles de base de `PixButton` (`shape`, `backgroundColor`, `size`, `isBorderVisible`)
+
+Toutes les [propriétés HTML d'un input de type file](https://developer.mozilla.org/fr/docs/Web/HTML/Element/Input/file) sont supportées.
+
+<Canvas>
+  <Story name='PixButtonUpload' story={stories.buttonUpload} height={60} />
+</Canvas>
+
+```html
+<PixButtonUpload
+  @id="file-upload"
+  @onChange={{this.uploadFile}}
+  accept=".csv"
+>
+  Libellé du bouton
+</PixButtonUpload>
+```
+
+Le callback `@onChange` prend en paramètre le tableau de fichiers uploadés.
+
+## Arguments
+
+<ArgsTable story="PixButtonUpload" />

--- a/addon/styles/_pix-button-upload.scss
+++ b/addon/styles/_pix-button-upload.scss
@@ -1,0 +1,5 @@
+.pix-button-upload {
+  &__input {
+    display: none;
+  }
+}

--- a/addon/styles/addon.scss
+++ b/addon/styles/addon.scss
@@ -19,6 +19,7 @@
 @import 'pix-textarea';
 @import 'pix-tooltip';
 @import 'pix-button-link';
+@import 'pix-button-upload';
 
 html {
   font-size: 16px;

--- a/app/components/pix-button-upload.js
+++ b/app/components/pix-button-upload.js
@@ -1,0 +1,1 @@
+export { default } from 'pix-ui/components/pix-button-upload';

--- a/tests/integration/components/pix-button-upload-test.js
+++ b/tests/integration/components/pix-button-upload-test.js
@@ -1,0 +1,24 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+
+module('Integration | Component | button-upload', function(hooks) {
+  setupRenderingTest(hooks);
+
+  const COMPONENT_SELECTOR = '.pix-button';
+
+  test('it renders the default PixButtonUpload', async function(assert) {
+    // when
+    await render(hbs`
+      <PixButtonUpload @id="1">
+        content
+      </PixButtonUpload>
+    `);
+    const componentElement = this.element.querySelector(COMPONENT_SELECTOR);
+
+    // then
+    assert.equal(componentElement.textContent.trim(), 'content');
+  });
+
+});


### PR DESCRIPTION
## :unicorn: Description du composant

Création d'un composant `<PixButtonUpload />` permettant un bouton d'upload de fichier

Le composant réutilise le style de `<PixButtonUpload />` qui a été factorisé dans `PixButtonBase`. Par conséquent `PixButtonLink` hérite des propriétés `shape`, `backgroundColor`, `size` et `isBorderVisible`.

## :100: Pour tester

Aller sur le composant `PixButtonUpload` dans Storybook.
