### PR TITLE
[FEATURE] Création du composant PixInput (PIX-3014).

### DIFF
--- a/addon/components/pix-input.hbs
+++ b/addon/components/pix-input.hbs
@@ -6,10 +6,18 @@
     <label for={{this.id}} class="pix-input__information">{{@information}}</label>
   {{/if}}
 
-  <input id={{this.id}} class="{{if @errorMessage "pix-input__input--error"}}" ...attributes />
+  <input
+    id={{this.id}}
+    class="{{if @errorMessage "pix-input__input--error"}} {{if @icon "pix-input__input--icon"}}"
+    ...attributes />
 
   {{#if @errorMessage}}
     <FaIcon @icon="times" class="pix-input__error-icon" />
     <label for={{this.id}} class="pix-input__error-message">{{@errorMessage}}</label>
   {{/if}}
+
+  {{#if @icon}}
+    <FaIcon @icon={{@icon}} class="pix-input__icon" />
+  {{/if}}
+
 </div>

--- a/addon/components/pix-input.hbs
+++ b/addon/components/pix-input.hbs
@@ -1,6 +1,9 @@
 <div class='pix-input'>
   {{#if @label}}
-    <label for={{this.id}}>{{@label}}</label>
+    <label for={{this.id}} class="pix-input__label">{{@label}}</label>
+  {{/if}}
+  {{#if @information}}
+    <label for={{this.id}} class="pix-input__information">{{@information}}</label>
   {{/if}}
   <input id={{this.id}} ...attributes />
 </div>

--- a/addon/components/pix-input.hbs
+++ b/addon/components/pix-input.hbs
@@ -8,7 +8,11 @@
 
   <input
     id={{this.id}}
-    class="{{if @errorMessage "pix-input__input--error"}} {{if @icon "pix-input__input--icon"}}"
+    class="
+      {{if @errorMessage "pix-input__input--error"}}
+      {{if @icon " pix-input__input--icon"}}
+      {{if @isIconLeft " pix-input__input--icon-left"}}
+    "
     ...attributes />
 
   {{#if @errorMessage}}
@@ -17,7 +21,7 @@
   {{/if}}
 
   {{#if @icon}}
-    <FaIcon @icon={{@icon}} class="pix-input__icon" />
+    <FaIcon @icon={{@icon}} class="pix-input__icon {{if @isIconLeft "pix-input__icon--left"}}" />
   {{/if}}
 
 </div>

--- a/addon/components/pix-input.hbs
+++ b/addon/components/pix-input.hbs
@@ -1,0 +1,6 @@
+<div class='pix-input'>
+  {{#if @label}}
+    <label for={{this.id}}>{{@label}}</label>
+  {{/if}}
+  <input id={{this.id}} ...attributes />
+</div>

--- a/addon/components/pix-input.hbs
+++ b/addon/components/pix-input.hbs
@@ -5,5 +5,11 @@
   {{#if @information}}
     <label for={{this.id}} class="pix-input__information">{{@information}}</label>
   {{/if}}
-  <input id={{this.id}} ...attributes />
+
+  <input id={{this.id}} class="{{if @errorMessage "pix-input__input--error"}}" ...attributes />
+
+  {{#if @errorMessage}}
+    <FaIcon @icon="times" class="pix-input__error-icon" />
+    <label for={{this.id}} class="pix-input__error-message">{{@errorMessage}}</label>
+  {{/if}}
 </div>

--- a/addon/components/pix-input.js
+++ b/addon/components/pix-input.js
@@ -1,0 +1,12 @@
+import Component from '@glimmer/component';
+
+export default class PixInput extends Component {
+  text = 'pix-input';
+
+  get id() {
+    if (!this.args.id || !this.args.id.trim()) {
+      throw new Error('ERROR in PixInput component, @id param is not provided');
+    }
+    return this.args.id;
+  }
+}

--- a/addon/stories/pix-input.stories.js
+++ b/addon/stories/pix-input.stories.js
@@ -1,21 +1,37 @@
 import { hbs } from 'ember-cli-htmlbars';
 
-export const input = (args) => {
+export const Template = (args) => {
   return {
     template: hbs`
       <PixInput
         @id={{id}}
         @label={{label}}
         @information={{information}}
+        @errorMessage={{errorMessage}}
         placeholder='Jeanne, Pierre ...' />
     `,
     context: args,
   };
 };
+
+export const Default = Template.bind({});
+Default.args = {
+  id: 'firstName',
+}
+
+export const input = Template.bind({});
 input.args = {
   id: 'firstName',
   label: 'Prénom',
   information: 'a small information',
+}
+
+export const inError = Template.bind({});
+inError.args = {
+  id: 'firstName',
+  label: 'Prénom',
+  information: 'a small information',
+  errorMessage: 'un message d\'erreur',
 }
 
 export const argTypes = {
@@ -34,6 +50,12 @@ export const argTypes = {
   information: {
     name: 'information',
     description: 'Un descriptif complétant le label',
+    type: { name: 'string', required: false },
+    defaultValue: null,
+  },
+  errorMessage: {
+    name: 'errorMessage',
+    description: 'Affiche le message d\'erreur donné et encadre en rouge le champ',
     type: { name: 'string', required: false },
     defaultValue: null,
   },

--- a/addon/stories/pix-input.stories.js
+++ b/addon/stories/pix-input.stories.js
@@ -3,7 +3,11 @@ import { hbs } from 'ember-cli-htmlbars';
 export const input = (args) => {
   return {
     template: hbs`
-      <PixInput @id={{id}} @label={{label}} placeholder='Jeanne, Pierre ...' />
+      <PixInput
+        @id={{id}}
+        @label={{label}}
+        @information={{information}}
+        placeholder='Jeanne, Pierre ...' />
     `,
     context: args,
   };
@@ -11,6 +15,7 @@ export const input = (args) => {
 input.args = {
   id: 'firstName',
   label: 'Prénom',
+  information: 'a small information',
 }
 
 export const argTypes = {
@@ -23,6 +28,12 @@ export const argTypes = {
   label: {
     name: 'label',
     description: 'Le label de l\'input',
+    type: { name: 'string', required: false },
+    defaultValue: null,
+  },
+  information: {
+    name: 'information',
+    description: 'Un descriptif complétant le label',
     type: { name: 'string', required: false },
     defaultValue: null,
   },

--- a/addon/stories/pix-input.stories.js
+++ b/addon/stories/pix-input.stories.js
@@ -21,8 +21,8 @@ Default.args = {
   id: 'firstName',
 }
 
-export const input = Template.bind({});
-input.args = {
+export const withLabel = Template.bind({});
+withLabel.args = {
   id: 'firstName',
   label: 'Prénom',
   information: 'a small information',
@@ -70,13 +70,13 @@ export const argTypes = {
   },
   icon: {
     name: 'icon',
-    description: 'Affiche l\'icone choisie à la fin de l\'input',
+    description: 'Affiche l\'icône choisie à la fin de l\'input',
     type: { name: 'string', required: false },
     defaultValue: null,
   },
   isIconLeft: {
     name: 'isIconLeft',
-    description: 'Permet d\'afficher l\'icone choisie à la gauche',
+    description: 'Permet d\'afficher l\'icône choisie sur la gauche',
     type: { name: 'boolean', required: false },
     control: { type: 'boolean' },
     defaultValue: false,

--- a/addon/stories/pix-input.stories.js
+++ b/addon/stories/pix-input.stories.js
@@ -9,6 +9,7 @@ export const Template = (args) => {
         @information={{information}}
         @errorMessage={{errorMessage}}
         @icon={{icon}}
+        @isIconLeft={{isIconLeft}}
         placeholder='Jeanne, Pierre ...' />
     `,
     context: args,
@@ -69,8 +70,19 @@ export const argTypes = {
   },
   icon: {
     name: 'icon',
-    description: 'Affiche l\'icon choisie à la fin de l\'input',
+    description: 'Affiche l\'icone choisie à la fin de l\'input',
     type: { name: 'string', required: false },
     defaultValue: null,
+  },
+  isIconLeft: {
+    name: 'isIconLeft',
+    description: 'Permet d\'afficher l\'icone choisie à la gauche',
+    type: { name: 'boolean', required: false },
+    control: { type: 'boolean' },
+    defaultValue: false,
+    table: {
+      type: { summary: 'boolean' },
+      defaultValue: { summary: 'false' },
+    }
   },
 };

--- a/addon/stories/pix-input.stories.js
+++ b/addon/stories/pix-input.stories.js
@@ -27,8 +27,8 @@ input.args = {
   information: 'a small information',
 }
 
-export const inError = Template.bind({});
-inError.args = {
+export const withErrorMessage = Template.bind({});
+withErrorMessage.args = {
   id: 'firstName',
   label: 'Prénom',
   information: 'a small information',

--- a/addon/stories/pix-input.stories.js
+++ b/addon/stories/pix-input.stories.js
@@ -1,0 +1,29 @@
+import { hbs } from 'ember-cli-htmlbars';
+
+export const input = (args) => {
+  return {
+    template: hbs`
+      <PixInput @id={{id}} @label={{label}} placeholder='Jeanne, Pierre ...' />
+    `,
+    context: args,
+  };
+};
+input.args = {
+  id: 'firstName',
+  label: 'Prénom',
+}
+
+export const argTypes = {
+  id: {
+    name: 'id',
+    description: 'Identifiant du champ permettant de lui attacher un label',
+    type: { name: 'string', required: true },
+    defaultValue: null,
+  },
+  label: {
+    name: 'label',
+    description: 'Le label de l\'input',
+    type: { name: 'string', required: false },
+    defaultValue: null,
+  },
+};

--- a/addon/stories/pix-input.stories.js
+++ b/addon/stories/pix-input.stories.js
@@ -8,6 +8,7 @@ export const Template = (args) => {
         @label={{label}}
         @information={{information}}
         @errorMessage={{errorMessage}}
+        @icon={{icon}}
         placeholder='Jeanne, Pierre ...' />
     `,
     context: args,
@@ -34,6 +35,13 @@ inError.args = {
   errorMessage: 'un message d\'erreur',
 }
 
+export const withIcon = Template.bind({});
+withIcon.args = {
+  id: 'firstName',
+  label: 'Prénom',
+  icon: 'eye',
+}
+
 export const argTypes = {
   id: {
     name: 'id',
@@ -56,6 +64,12 @@ export const argTypes = {
   errorMessage: {
     name: 'errorMessage',
     description: 'Affiche le message d\'erreur donné et encadre en rouge le champ',
+    type: { name: 'string', required: false },
+    defaultValue: null,
+  },
+  icon: {
+    name: 'icon',
+    description: 'Affiche l\'icon choisie à la fin de l\'input',
     type: { name: 'string', required: false },
     defaultValue: null,
   },

--- a/addon/stories/pix-input.stories.mdx
+++ b/addon/stories/pix-input.stories.mdx
@@ -46,7 +46,9 @@ Le PixInput permet de créer un champ de texte.
   @id='firstName'
   @label='Prénom'
   @information='Complément du label'
-  @errorMessage="Un message d'erreur" />
+  @errorMessage="Un message d'erreur"
+  @icon="eye"
+  @isIconLeft={{false}} />
 ```
 
 ## Arguments

--- a/addon/stories/pix-input.stories.mdx
+++ b/addon/stories/pix-input.stories.mdx
@@ -18,13 +18,13 @@ Le PixInput permet de créer un champ de texte.
 ## Default
 
 <Canvas>
-  <Story name='PixInput' story={stories.Default} height={100} />
+  <Story name='Default' story={stories.Default} height={100} />
 </Canvas>
 
 ## With label and information
 
 <Canvas>
-  <Story story={stories.input} height={100} />
+  <Story story={stories.withLabel} height={100} />
 </Canvas>
 
 ## With error message

--- a/addon/stories/pix-input.stories.mdx
+++ b/addon/stories/pix-input.stories.mdx
@@ -33,6 +33,12 @@ Le PixInput permet de créer un champ de texte.
   <Story story={stories.inError} height={130} />
 </Canvas>
 
+## With icon
+
+<Canvas>
+  <Story story={stories.withIcon} height={130} />
+</Canvas>
+
 ## Usage
 
 ```html

--- a/addon/stories/pix-input.stories.mdx
+++ b/addon/stories/pix-input.stories.mdx
@@ -14,14 +14,33 @@ import * as stories from './pix-input.stories.js';
 
 Le PixInput permet de créer un champ de texte.
 
+
+## Default
+
 <Canvas>
-  <Story name='PixInput' story={stories.input} height={160} />
+  <Story name='PixInput' story={stories.Default} height={100} />
+</Canvas>
+
+## With label and information
+
+<Canvas>
+  <Story story={stories.input} height={100} />
+</Canvas>
+
+## In error
+
+<Canvas>
+  <Story story={stories.inError} height={130} />
 </Canvas>
 
 ## Usage
 
 ```html
-<PixInput @id='firstName' @label='Prénom' @information='Complément du label' />
+<PixInput
+  @id='firstName'
+  @label='Prénom'
+  @information='Complément du label'
+  @errorMessage="Un message d'erreur" />
 ```
 
 ## Arguments

--- a/addon/stories/pix-input.stories.mdx
+++ b/addon/stories/pix-input.stories.mdx
@@ -21,7 +21,7 @@ Le PixInput permet de créer un champ de texte.
 ## Usage
 
 ```html
-<PixInput @id='firstName' @label='Prénom' />
+<PixInput @id='firstName' @label='Prénom' @information='Complément du label' />
 ```
 
 ## Arguments

--- a/addon/stories/pix-input.stories.mdx
+++ b/addon/stories/pix-input.stories.mdx
@@ -1,0 +1,29 @@
+import { Meta, Story, Canvas, ArgsTable } from '@storybook/addon-docs/blocks';
+import centered from '@storybook/addon-centered/ember';
+
+import * as stories from './pix-input.stories.js';
+
+<Meta
+  title='Form/Input'
+  component='PixInput'
+  decorators={[centered]}
+  argTypes={stories.argTypes}
+/>
+
+# PixInput
+
+Le PixInput permet de créer un champ de texte.
+
+<Canvas>
+  <Story name='PixInput' story={stories.input} height={160} />
+</Canvas>
+
+## Usage
+
+```html
+<PixInput @id='firstName' @label='Prénom' />
+```
+
+## Arguments
+
+<ArgsTable story="PixInput" />

--- a/addon/stories/pix-input.stories.mdx
+++ b/addon/stories/pix-input.stories.mdx
@@ -27,10 +27,10 @@ Le PixInput permet de créer un champ de texte.
   <Story story={stories.input} height={100} />
 </Canvas>
 
-## In error
+## With error message
 
 <Canvas>
-  <Story story={stories.inError} height={130} />
+  <Story story={stories.withErrorMessage} height={130} />
 </Canvas>
 
 ## With icon

--- a/addon/styles/_pix-input.scss
+++ b/addon/styles/_pix-input.scss
@@ -1,0 +1,36 @@
+.pix-input {
+  @import 'reset-css';
+
+  display: flex;
+  flex-direction: column;
+
+  label {
+    font-family: $font-roboto;
+    font-size: 0.875rem;
+    color: $grey-70;
+    margin-bottom: 4px;
+  }
+
+  input {
+    padding: 10px 16px;
+    border: 1.5px solid $grey-40;
+    border-radius: 4px;
+    font-family: $font-roboto;
+    font-size: 0.875rem;
+    font-weight: 400;
+    color: $grey-90;
+
+    &:hover {
+      cursor: pointer;
+    }
+
+    &:focus {
+      border: 1.5px solid $blue;
+      outline: 0.5px solid $blue;
+    }
+
+    &::placeholder {
+      color: $grey-30;
+    }
+  }
+}

--- a/addon/styles/_pix-input.scss
+++ b/addon/styles/_pix-input.scss
@@ -24,6 +24,10 @@
     bottom: 10px;
     right: 6px;
     color: $grey-25;
+
+    &--left {
+      left: 6px;
+    }
   }
 
   svg ~ svg.pix-input__icon {
@@ -84,7 +88,11 @@
       padding-right: 30px;
     }
 
-    &.pix-input__input--error.pix-input__input--icon {
+    &.pix-input__input--icon.pix-input__input--icon-left {
+      padding-left: 30px;
+    }
+
+    &.pix-input__input--error.pix-input__input--icon:not(.pix-input__input--icon-left) {
       padding-right: 46px;
     }
   }

--- a/addon/styles/_pix-input.scss
+++ b/addon/styles/_pix-input.scss
@@ -18,6 +18,18 @@
     margin-top: 4px;
   }
 
+  svg.pix-input__icon {
+    position: absolute;
+    bottom: 10px;
+    right: 6px;
+    color: $grey-25;
+    margin-right: 6px;
+  }
+
+  svg ~ svg.pix-input__icon {
+    right: calc(6px + 12px + 2px);
+  }
+
   svg.pix-input__error-icon {
     position: absolute;
     bottom: 10px;
@@ -70,6 +82,10 @@
       &:focus {
         outline-color: $red;
       }
+    }
+
+    &.pix-input__input--error.pix-input__input--icon {
+      padding-right: 46px;
     }
   }
 }

--- a/addon/styles/_pix-input.scss
+++ b/addon/styles/_pix-input.scss
@@ -4,14 +4,21 @@
   display: flex;
   flex-direction: column;
 
-  label {
+  &__label {
     font-family: $font-roboto;
     font-size: 0.875rem;
     color: $grey-70;
-    margin-bottom: 4px;
+  }
+
+  &__information {
+    font-family: $font-roboto;
+    font-size: 0.75rem;
+    color: $blue-zodiac;
+    margin-top: 4px;
   }
 
   input {
+    margin-top: 4px;
     padding: 10px 16px;
     border: 1.5px solid $grey-40;
     border-radius: 4px;

--- a/addon/styles/_pix-input.scss
+++ b/addon/styles/_pix-input.scss
@@ -9,13 +9,14 @@
     font-family: $font-roboto;
     font-size: 0.875rem;
     color: $grey-70;
+    margin-bottom: 4px;
   }
 
   &__information {
     font-family: $font-roboto;
     font-size: 0.75rem;
     color: $blue-zodiac;
-    margin-top: 4px;
+    margin-bottom: 4px;
   }
 
   svg.pix-input__icon {
@@ -23,11 +24,11 @@
     bottom: 10px;
     right: 6px;
     color: $grey-25;
-    margin-right: 6px;
   }
 
   svg ~ svg.pix-input__icon {
     right: calc(6px + 12px + 2px);
+    padding-right: 6px;
   }
 
   svg.pix-input__error-icon {
@@ -45,7 +46,7 @@
 
   &__error-message {
     position: absolute;
-    bottom: calc(-4px - 1.5px - 0.75rem);
+    bottom: calc(-4px - 1px - 0.75rem);
     font-family: $font-roboto;
     font-size: 0.75rem;
     color: $red;
@@ -53,10 +54,9 @@
   }
 
   input {
-    margin-top: 4px;
     padding: 10px 16px;
     padding-right: 26px;
-    border: 1.5px solid $grey-40;
+    border: 1px solid $grey-40;
     border-radius: 4px;
     font-family: $font-roboto;
     font-size: 0.875rem;
@@ -68,8 +68,8 @@
     }
 
     &:focus {
-      border: 1.5px solid $blue;
-      outline: 0.5px solid $blue;
+      border: 1px solid $blue;
+      outline: none;
     }
 
     &::placeholder {
@@ -78,10 +78,10 @@
 
     &.pix-input__input--error {
       border-color: $red;
+    }
 
-      &:focus {
-        outline-color: $red;
-      }
+    &.pix-input__input--icon {
+      padding-right: 30px;
     }
 
     &.pix-input__input--error.pix-input__input--icon {

--- a/addon/styles/_pix-input.scss
+++ b/addon/styles/_pix-input.scss
@@ -3,6 +3,7 @@
 
   display: flex;
   flex-direction: column;
+  position: relative;
 
   &__label {
     font-family: $font-roboto;
@@ -17,9 +18,32 @@
     margin-top: 4px;
   }
 
+  svg.pix-input__error-icon {
+    position: absolute;
+    bottom: 10px;
+    right: 6px;
+    color: $white;
+    background: $red;
+    border-radius: 50%;
+    font-size: 0.6rem;
+    padding: 2px;
+    width: 12px;
+    height: 12px;
+  }
+
+  &__error-message {
+    position: absolute;
+    bottom: calc(-4px - 1.5px - 0.75rem);
+    font-family: $font-roboto;
+    font-size: 0.75rem;
+    color: $red;
+    margin-top: 4px;
+  }
+
   input {
     margin-top: 4px;
     padding: 10px 16px;
+    padding-right: 26px;
     border: 1.5px solid $grey-40;
     border-radius: 4px;
     font-family: $font-roboto;
@@ -38,6 +62,14 @@
 
     &::placeholder {
       color: $grey-30;
+    }
+
+    &.pix-input__input--error {
+      border-color: $red;
+
+      &:focus {
+        outline-color: $red;
+      }
     }
   }
 }

--- a/addon/styles/_pix-input.scss
+++ b/addon/styles/_pix-input.scss
@@ -68,11 +68,12 @@
     color: $grey-90;
 
     &:hover {
-      cursor: pointer;
+      box-shadow: inset 0px 0px 0px 0.6px $grey-40;
     }
 
     &:focus {
-      border: 1px solid $blue;
+      border-color: $blue;
+      box-shadow: inset 0px 0px 0px 0.6px $blue;
       outline: none;
     }
 
@@ -82,6 +83,7 @@
 
     &.pix-input__input--error {
       border-color: $red;
+      box-shadow: inset 0px 0px 0px 0.6px $red;
     }
 
     &.pix-input__input--icon {

--- a/addon/styles/addon.scss
+++ b/addon/styles/addon.scss
@@ -20,6 +20,7 @@
 @import 'pix-tooltip';
 @import 'pix-button-link';
 @import 'pix-button-upload';
+@import 'pix-input';
 
 html {
   font-size: 16px;

--- a/app/components/pix-input.js
+++ b/app/components/pix-input.js
@@ -1,0 +1,1 @@
+export { default } from 'pix-ui/components/pix-input';

--- a/tests/integration/components/pix-input-test.js
+++ b/tests/integration/components/pix-input-test.js
@@ -1,0 +1,50 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render, fillIn } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+import createGlimmerComponent from '../../helpers/create-glimmer-component';
+
+module('Integration | Component | input', function(hooks) {
+  setupRenderingTest(hooks);
+
+  const INPUT_SELECTOR = '.pix-input input';
+  const LABEL_SELECTOR = '.pix-input label';
+
+  test('it renders the default PixInput', async function(assert) {
+    // when
+    await render(hbs`<PixInput @id="firstName" />`);
+    await fillIn(INPUT_SELECTOR, 'Jeanne');
+
+    // then
+    const selectorElement = this.element.querySelector(INPUT_SELECTOR);
+    assert.equal(selectorElement.value, 'Jeanne');
+  });
+
+  test('it should throw an error if there is no id', async function(assert) {
+    // given
+    const componentParams = { id: '   ' };
+    const component = createGlimmerComponent('component:pix-input', componentParams);
+
+    // when & then
+    const expectedError = new Error('ERROR in PixInput component, @id param is not provided');
+    assert.throws(function() { component.id }, expectedError);
+  });
+
+  test('it should be possible to give a label to input', async function(assert) {
+    // given
+    await render(hbs`<PixInput @label="Prénom" @id="firstName" />`);
+
+    // when & then
+    const selectorElement = this.element.querySelector(LABEL_SELECTOR);
+    assert.equal(selectorElement.innerHTML, 'Prénom');
+  });
+
+  test('it should be possible to give more params to input', async function(assert) {
+    // given
+    await render(hbs`<PixInput @label="Prénom" @id="firstName" value='Jeanne' />`);
+
+    // when & then
+    const selectorElement = this.element.querySelector(INPUT_SELECTOR);
+    assert.equal(selectorElement.value, 'Jeanne');
+  });
+});

--- a/tests/integration/components/pix-input-test.js
+++ b/tests/integration/components/pix-input-test.js
@@ -67,6 +67,14 @@ module('Integration | Component | input', function(hooks) {
     assert.dom('.pix-input__icon').exists();
   });
 
+  test('it should be possible to put an icon to the left of input', async function(assert) {
+    // given
+    await render(hbs`<PixInput @id="firstName" @icon="times" @isIconLeft={{true}} />`);
+
+    // when & then
+    assert.dom('.pix-input__icon.pix-input__icon--left').exists();
+  });
+
   test('it should be possible to give more params to input', async function(assert) {
     // given
     await render(hbs`<PixInput @label="Prénom" @id="firstName" value='Jeanne' />`);

--- a/tests/integration/components/pix-input-test.js
+++ b/tests/integration/components/pix-input-test.js
@@ -59,6 +59,14 @@ module('Integration | Component | input', function(hooks) {
     assert.equal(selectorElement.innerHTML, 'Seul les caractères alphanumériques sont autorisés');
   });
 
+  test('it should be possible to give an icon to input', async function(assert) {
+    // given
+    await render(hbs`<PixInput @id="firstName" @icon="times" />`);
+
+    // when & then
+    assert.dom('.pix-input__icon').exists();
+  });
+
   test('it should be possible to give more params to input', async function(assert) {
     // given
     await render(hbs`<PixInput @label="Prénom" @id="firstName" value='Jeanne' />`);

--- a/tests/integration/components/pix-input-test.js
+++ b/tests/integration/components/pix-input-test.js
@@ -8,7 +8,8 @@ module('Integration | Component | input', function(hooks) {
   setupRenderingTest(hooks);
 
   const INPUT_SELECTOR = '.pix-input input';
-  const LABEL_SELECTOR = '.pix-input label';
+  const LABEL_SELECTOR = '.pix-input__label';
+  const INFORMATION_SELECTOR = '.pix-input__information';
 
   test('it renders the default PixInput', async function(assert) {
     // when
@@ -37,6 +38,15 @@ module('Integration | Component | input', function(hooks) {
     // when & then
     const selectorElement = this.element.querySelector(LABEL_SELECTOR);
     assert.equal(selectorElement.innerHTML, 'Prénom');
+  });
+
+  test('it should be possible to give an extra information to input', async function(assert) {
+    // given
+    await render(hbs`<PixInput @id="firstName" @label="Prénom" @information="a small information" />`);
+
+    // when & then
+    const selectorElement = this.element.querySelector(INFORMATION_SELECTOR);
+    assert.equal(selectorElement.innerHTML, 'a small information');
   });
 
   test('it should be possible to give more params to input', async function(assert) {

--- a/tests/integration/components/pix-input-test.js
+++ b/tests/integration/components/pix-input-test.js
@@ -10,6 +10,7 @@ module('Integration | Component | input', function(hooks) {
   const INPUT_SELECTOR = '.pix-input input';
   const LABEL_SELECTOR = '.pix-input__label';
   const INFORMATION_SELECTOR = '.pix-input__information';
+  const ERROR_SELECTOR = '.pix-input__error-message';
 
   test('it renders the default PixInput', async function(assert) {
     // when
@@ -47,6 +48,15 @@ module('Integration | Component | input', function(hooks) {
     // when & then
     const selectorElement = this.element.querySelector(INFORMATION_SELECTOR);
     assert.equal(selectorElement.innerHTML, 'a small information');
+  });
+
+  test('it should be possible to give an error message to input', async function(assert) {
+    // given
+    await render(hbs`<PixInput @id="firstName" @errorMessage="Seul les caractères alphanumériques sont autorisés" />`);
+
+    // when & then
+    const selectorElement = this.element.querySelector(ERROR_SELECTOR);
+    assert.equal(selectorElement.innerHTML, 'Seul les caractères alphanumériques sont autorisés');
   });
 
   test('it should be possible to give more params to input', async function(assert) {


### PR DESCRIPTION
## :unicorn: Description du composant
Champ de formulaire basique.

⚠️ **Certains éléments sont à valider avec Quentin** ⚠️ : 
- As t'on bien 2 tailles d'input pour les formulaire 44px et 36px de hauteur ? -> 36px
- Quelle est la taille par défaut des composants de formulaire ? (big ou small) -> pas de big
- Quelle est la taille de la police pour les 2 hauteurs (big et small) ? -> small
- Quelle est la taille des bordures (1px, 1.6px) ? -> 1px , sauf hover/ actif : 1.6px -> avec `box-shadow: inset` pour ne pas que ça décale le reste
- Comment gérer l'outline au focus des champs de formulaires pour qu'il soit "jolie", consistent et accessible ? 
- Avoir un cursor: pointer au dessus d'un champs texte n'est pas standard, est-ce qu'on ne garderait pas le standard ? -> non pas de cursor, comportement de base
- Les éléments label / information / error sont-ils également applicables aux composants `PixSelect`, `PixMultiSelect`, `PixTextarea` ? -> oui mais en option

## :rainbow: Remarques
La version avec icone ne contient actuellement pas de comportement (l'icone n'est pas cliquable).
Peut être ce serait la responsabilité d'un PixPasswordField d'implémenter un comportement avec une icone "eye" ? 

## :100: Pour tester
- npm run storybook
- lire la documentation du PixInput et jouer avec les contrôles 
