### PR TITLE
[TECH] Aligner le style des composants de formulaire avec le design system - BREAKING CHANGES (PIX-3052).

### DIFF
--- a/addon/components/pix-multi-select.hbs
+++ b/addon/components/pix-multi-select.hbs
@@ -1,11 +1,17 @@
 <div class="pix-multi-select" ...attributes {{on-click-outside this.hideDropDown capture=true}}>
+
+  {{#if this.label}}
+    <label for={{@id}} class="pix-multi-select__label">{{this.label}}</label>
+  {{/if}}
+
   {{#if @isSearchable}}
     <label class="pix-multi-select-header {{if this.isBig "pix-multi-select-header--big"}}">
 
       <span class="pix-multi-select-header__title">{{@title}}</span>
       <FaIcon @icon='search' class="pix-multi-select-header__search-icon" />
 
-      <input 
+      <input
+        id={{@id}}
         type="text"
         name={{@id}}
         placeholder={{@placeholder}}
@@ -16,7 +22,8 @@
 
     </label>
   {{else}}
-    <button 
+    <button
+      id={{@id}}
       type="button" 
       class="pix-multi-select-header {{if this.isBig "pix-multi-select-header--big"}}"
       {{on "click" this.toggleDropDown}}
@@ -30,7 +37,9 @@
     {{#if (gt this.results.length 0)}}
       {{#each this.results as |option|}} 
         <li class="pix-multi-select-list__item">
-          <input class="pix-multi-select-list__checkbox  {{if @isSearchable 'pix-multi-select-list__checkbox--searchable' }}" 
+          <input
+            class="pix-multi-select-list__checkbox
+              {{if @isSearchable ' pix-multi-select-list__checkbox--searchable' }}" 
             type="checkbox" 
             checked={{option.checked}} 
             id={{concat @id '-' option.value}} 

--- a/addon/components/pix-multi-select.hbs
+++ b/addon/components/pix-multi-select.hbs
@@ -1,6 +1,6 @@
 <div class="pix-multi-select" ...attributes {{on-click-outside this.hideDropDown capture=true}}>
   {{#if @isSearchable}}
-    <label class="pix-multi-select-header">
+    <label class="pix-multi-select-header {{if this.isSmall "pix-multi-select-header--small"}}">
 
       <span class="pix-multi-select-header__title">{{@title}}</span>
       <FaIcon @icon='search' class="pix-multi-select-header__search-icon" />
@@ -18,7 +18,9 @@
   {{else}}
     <button 
       type="button" 
-      class="pix-multi-select-header" {{on "click" this.toggleDropDown}}>
+      class="pix-multi-select-header {{if this.isSmall "pix-multi-select-header--small"}}"
+      {{on "click" this.toggleDropDown}}
+    >
       {{@title}}
       <FaIcon class="pix-multi-select-header__dropdown-icon  {{if this.isExpanded 'pix-multi-select-header__dropdown-icon--expand' }}" @icon={{if this.isExpanded "chevron-up" "chevron-down"}}/>
     </button>

--- a/addon/components/pix-multi-select.hbs
+++ b/addon/components/pix-multi-select.hbs
@@ -1,6 +1,6 @@
 <div class="pix-multi-select" ...attributes {{on-click-outside this.hideDropDown capture=true}}>
   {{#if @isSearchable}}
-    <label class="pix-multi-select-header {{if this.isSmall "pix-multi-select-header--small"}}">
+    <label class="pix-multi-select-header {{if this.isBig "pix-multi-select-header--big"}}">
 
       <span class="pix-multi-select-header__title">{{@title}}</span>
       <FaIcon @icon='search' class="pix-multi-select-header__search-icon" />
@@ -18,7 +18,7 @@
   {{else}}
     <button 
       type="button" 
-      class="pix-multi-select-header {{if this.isSmall "pix-multi-select-header--small"}}"
+      class="pix-multi-select-header {{if this.isBig "pix-multi-select-header--big"}}"
       {{on "click" this.toggleDropDown}}
     >
       {{@title}}

--- a/addon/components/pix-multi-select.js
+++ b/addon/components/pix-multi-select.js
@@ -25,8 +25,8 @@ export default class PixMultiSelect extends Component {
     this._setDisplayedOptions(this.args.selected, true);
   }
 
-  get isSmall() {
-    return this.args.size === 'small';
+  get isBig() {
+    return this.args.size === 'big';
   }
 
   get results() {

--- a/addon/components/pix-multi-select.js
+++ b/addon/components/pix-multi-select.js
@@ -25,6 +25,10 @@ export default class PixMultiSelect extends Component {
     this._setDisplayedOptions(this.args.selected, true);
   }
 
+  get isSmall() {
+    return this.args.size === 'small';
+  }
+
   get results() {
     if (this.args.isSearchable && this.searchData) {
       return this.options.filter(({ label }) => this._search(label));

--- a/addon/components/pix-multi-select.js
+++ b/addon/components/pix-multi-select.js
@@ -25,6 +25,16 @@ export default class PixMultiSelect extends Component {
     this._setDisplayedOptions(this.args.selected, true);
   }
 
+  get label() {
+    const labelIsDefined = this.args.label && this.args.label.trim();
+    const idIsNotDefined = this.args.id && !this.args.id.trim();
+
+    if (labelIsDefined && idIsNotDefined) {
+      throw new Error('ERROR in PixMultiSelect component, @id param is necessary when giving @label');
+    }
+    return this.args.label || null;
+  }
+
   get isBig() {
     return this.args.size === 'big';
   }

--- a/addon/components/pix-select.hbs
+++ b/addon/components/pix-select.hbs
@@ -5,7 +5,7 @@
     <input
       list="{{this.datalistId}}"
       {{on "input" this.onChange}}
-      class="{{if this.isValid "pix-select--is-valid"}} {{if this.isSmall "pix-select--small"}}"
+      class="{{if this.isValid "pix-select--is-valid"}} {{if this.isBig "pix-select--big"}}"
       ...attributes
     />
 
@@ -18,7 +18,7 @@
   {{else}}
 
     <select
-      class="{{if this.isSmall "pix-select--small"}}"
+      class="{{if this.isBig "pix-select--big"}}"
       {{on 'change' this.onChange}}
       ...attributes
     >

--- a/addon/components/pix-select.hbs
+++ b/addon/components/pix-select.hbs
@@ -2,21 +2,12 @@
 
   {{#if @isSearchable}}
 
-    {{#if @isValidationActive}}
-      <input
-        list="{{this.datalistId}}"
-        {{on "input" this.onChange}}
-        class="{{if this.isValueAValidOption "pix-select--is-valid"}} {{if this.isSmall "pix-select--small"}}"
-        ...attributes
-      />
-    {{else}}
-      <input
-        list="{{this.datalistId}}"
-        {{on "input" this.onChange}}
-        class="{{if this.isSmall "pix-select--small"}}"
-        ...attributes
-      />
-    {{/if}}
+    <input
+      list="{{this.datalistId}}"
+      {{on "input" this.onChange}}
+      class="{{if this.isValid "pix-select--is-valid"}} {{if this.isSmall "pix-select--small"}}"
+      ...attributes
+    />
 
     <datalist id={{this.datalistId}}>
       {{#each @options as |opt|}}

--- a/addon/components/pix-select.hbs
+++ b/addon/components/pix-select.hbs
@@ -6,11 +6,16 @@
       <input
         list="{{this.datalistId}}"
         {{on "input" this.onChange}}
-        class={{if this.isValueAValidOption "pix-select--is-valid"}}
+        class="{{if this.isValueAValidOption "pix-select--is-valid"}} {{if this.isSmall "pix-select--small"}}"
         ...attributes
       />
     {{else}}
-      <input list="{{this.datalistId}}" {{on "input" this.onChange}} ...attributes />
+      <input
+        list="{{this.datalistId}}"
+        {{on "input" this.onChange}}
+        class="{{if this.isSmall "pix-select--small"}}"
+        ...attributes
+      />
     {{/if}}
 
     <datalist id={{this.datalistId}}>
@@ -21,7 +26,11 @@
 
   {{else}}
 
-    <select {{on 'change' this.onChange}} ...attributes>
+    <select
+      class="{{if this.isSmall "pix-select--small"}}"
+      {{on 'change' this.onChange}}
+      ...attributes
+    >
       {{#if (not-eq @emptyOptionLabel undefined)}}
         {{#if @emptyOptionNotSelectable}}
           <option value="" hidden>{{@emptyOptionLabel}}</option>

--- a/addon/components/pix-select.hbs
+++ b/addon/components/pix-select.hbs
@@ -1,8 +1,13 @@
 <div class="pix-select">
 
+  {{#if this.label}}
+    <label for={{@id}} class="pix-select__label">{{this.label}}</label>
+  {{/if}}
+
   {{#if @isSearchable}}
 
     <input
+      id={{@id}}
       list="{{this.datalistId}}"
       {{on "input" this.onChange}}
       class="{{if this.isValid "pix-select--is-valid"}} {{if this.isBig "pix-select--big"}}"
@@ -18,6 +23,7 @@
   {{else}}
 
     <select
+      id={{@id}}
       class="{{if this.isBig "pix-select--big"}}"
       {{on 'change' this.onChange}}
       ...attributes

--- a/addon/components/pix-select.js
+++ b/addon/components/pix-select.js
@@ -18,6 +18,10 @@ export default class PixSelect extends Component {
     return this.args.size === 'small';
   }
 
+  get isValid() {
+    return this.args.isValidationActive && this.isValueAValidOption;
+  }
+
   @action
   onChange(event) {
     if (this.args.onChange) {

--- a/addon/components/pix-select.js
+++ b/addon/components/pix-select.js
@@ -14,6 +14,10 @@ export default class PixSelect extends Component {
     }
   }
 
+  get isSmall() {
+    return this.args.size === 'small';
+  }
+
   @action
   onChange(event) {
     if (this.args.onChange) {

--- a/addon/components/pix-select.js
+++ b/addon/components/pix-select.js
@@ -14,8 +14,8 @@ export default class PixSelect extends Component {
     }
   }
 
-  get isSmall() {
-    return this.args.size === 'small';
+  get isBig() {
+    return this.args.size === 'big';
   }
 
   get isValid() {

--- a/addon/components/pix-select.js
+++ b/addon/components/pix-select.js
@@ -13,6 +13,16 @@ export default class PixSelect extends Component {
       this.datalistId = 'pix-select-list-' + guidFor(this);
     }
   }
+  
+  get label() {
+    const labelIsDefined = this.args.label && this.args.label.trim();
+    const idIsNotDefined = this.args.id && !this.args.id.trim();
+
+    if (labelIsDefined && idIsNotDefined) {
+      throw new Error('ERROR in PixSelect component, @id param is necessary when giving @label');
+    }
+    return this.args.label || null;
+  }
 
   get isBig() {
     return this.args.size === 'big';

--- a/addon/components/pix-textarea.hbs
+++ b/addon/components/pix-textarea.hbs
@@ -1,4 +1,9 @@
 <div class='pix-textarea'>
+
+  {{#if this.label}}
+    <label for={{@id}} class="pix-textarea__label">{{this.label}}</label>
+  {{/if}}
+
     <Textarea
       id={{@id}}
       @value={{@value}}

--- a/addon/components/pix-textarea.hbs
+++ b/addon/components/pix-textarea.hbs
@@ -8,9 +8,14 @@
       id={{@id}}
       @value={{@value}}
       maxlength={{if @maxlength @maxlength}}
+      class="{{if @errorMessage "pix-textarea--error"}}"
       ...attributes
     />
   {{#if @maxlength}}
     <p>{{this.textLengthIndicator}} / {{@maxlength}}</p>
+  {{/if}}
+
+  {{#if @errorMessage}}
+    <label for={{this.id}} class="pix-textarea__error-message">{{@errorMessage}}</label>
   {{/if}}
 </div>

--- a/addon/components/pix-textarea.js
+++ b/addon/components/pix-textarea.js
@@ -6,4 +6,15 @@ export default class PixTextarea extends Component {
       ? this.args.value.length
       : 0;
   }
+
+  get label() {
+    const labelIsDefined = this.args.label && this.args.label.trim();
+    const idIsNotDefined = this.args.id && !this.args.id.trim();
+
+    if (labelIsDefined && idIsNotDefined) {
+      throw new Error('ERROR in PixTextarea component, @id param is necessary when giving @label');
+    }
+    return this.args.label || null;
+  }
+
 }

--- a/addon/stories/form.stories.js
+++ b/addon/stories/form.stories.js
@@ -1,0 +1,56 @@
+import { hbs } from 'ember-cli-htmlbars';
+import { action } from '@storybook/addon-actions';
+
+export const form = (args) => {
+  return {
+    template: hbs`
+      <PixInput @id='firstName' @label='Prénom' />
+      <br>
+
+      <PixMultiSelect
+        @title="A quel point aimez vous Pix-UI ?"
+        @id="form__pix-mutli-select"
+        @onSelect={{onSelect}}
+        @selected={{selected}}
+        @options={{options}} as |star|
+      >
+        <PixStars @count={{star.value}} @total={{star.total}} />
+      </PixMultiSelect>
+      <br><br>
+
+      <PixSelect
+        id="form__searchable-pix-select"
+        @options={{selectOptions}}
+        @isSearchable={{true}}
+        @isValidationActive={{true}}
+        placeholder='Fraises, Mangues...'
+      />
+      <br>
+
+      <PixTextarea @id="form__pix-textarea" @value="" @maxlength={{200}} />
+    `,
+    context: args,
+  };
+};
+form.args = {
+  selected: ['1','4'],
+  options: [
+    { value: '1', total: 3 },
+    { value: '2', total: 3 },
+    { value: '3', total: 3 },
+  ],
+  onSelect: action('onSelect'),
+  selectOptions: [
+    { value: 'Figues', label: 'Figues' },
+    { value: 'Bananes', label: 'Bananes' },
+    { value: 'Noix', label: 'Noix' },
+    { value: 'Papayes', label: 'Papayes' },
+    { value: 'Fèves de chocolat', label: 'Fèves de chocolat' },
+    { value: 'Dattes', label: 'Dattes' },
+    { value: 'Mangues', label: 'Mangues' },
+    { value: 'Jujube', label: 'Jujube' },
+    { value: 'Avocat', label: 'Avocat' },
+    { value: 'Fraises', label: 'Fraises' },
+    { value: 'Kaki', label: 'Kaki' },
+  ],
+}

--- a/addon/stories/form.stories.js
+++ b/addon/stories/form.stories.js
@@ -5,7 +5,7 @@ export const form = (args) => {
   return {
     template: hbs`
     <form>
-      <PixInput @id='firstName' @label='Prénom' />
+      <PixInput @id='firstName' @label='Prénom' @errorMessage={{genericErrorMessage}} />
       <br>
 
       <PixMultiSelect
@@ -30,7 +30,12 @@ export const form = (args) => {
       />
       <br>
 
-      <PixTextarea @id="form__pix-textarea" @value="" @maxlength={{200}} @label="Un commentaire ?" />
+      <PixTextarea
+        @id="form__pix-textarea"
+        @value=""
+        @maxlength={{200}}
+        @label="Un commentaire ?"
+        @errorMessage={{genericErrorMessage}} />
       <br>
 
       <div class="pix-form__actions">
@@ -45,6 +50,7 @@ export const form = (args) => {
   };
 };
 form.args = {
+  genericErrorMessage: '',
   selected: ['1','4'],
   options: [
     { value: '1', total: 3 },

--- a/addon/stories/form.stories.js
+++ b/addon/stories/form.stories.js
@@ -4,6 +4,7 @@ import { action } from '@storybook/addon-actions';
 export const form = (args) => {
   return {
     template: hbs`
+    <form>
       <PixInput @id='firstName' @label='Prénom' />
       <br>
 
@@ -28,6 +29,15 @@ export const form = (args) => {
       <br>
 
       <PixTextarea @id="form__pix-textarea" @value="" @maxlength={{200}} />
+      <br>
+
+      <div class="pix-form__actions">
+        <PixButton @triggerAction={{cancel}} @backgroundColor="transparent-light" @isBorderVisible={{true}}>
+          Annuler
+        </PixButton>
+        <PixButton @type="submit">Envoyer mes réponses</PixButton>
+      </div>
+    </form>
     `,
     context: args,
   };
@@ -39,6 +49,7 @@ form.args = {
     { value: '2', total: 3 },
     { value: '3', total: 3 },
   ],
+  cancel: action('cancel'),
   onSelect: action('onSelect'),
   selectOptions: [
     { value: 'Figues', label: 'Figues' },

--- a/addon/stories/form.stories.js
+++ b/addon/stories/form.stories.js
@@ -30,7 +30,7 @@ export const form = (args) => {
       />
       <br>
 
-      <PixTextarea @id="form__pix-textarea" @value="" @maxlength={{200}} />
+      <PixTextarea @id="form__pix-textarea" @value="" @maxlength={{200}} @label="Un commentaire ?" />
       <br>
 
       <div class="pix-form__actions">

--- a/addon/stories/form.stories.js
+++ b/addon/stories/form.stories.js
@@ -20,7 +20,8 @@ export const form = (args) => {
       <br><br>
 
       <PixSelect
-        id="form__searchable-pix-select"
+        @id="form__searchable-pix-select"
+        @label="Votre fruit préféré est : "
         @options={{selectOptions}}
         @isSearchable={{true}}
         @isValidationActive={{true}}

--- a/addon/stories/form.stories.js
+++ b/addon/stories/form.stories.js
@@ -9,8 +9,9 @@ export const form = (args) => {
       <br>
 
       <PixMultiSelect
-        @title="A quel point aimez vous Pix-UI ?"
+        @title="Votre notation en étoiles..."
         @id="form__pix-mutli-select"
+        @label="A quel point aimez vous Pix-UI ?"
         @onSelect={{onSelect}}
         @selected={{selected}}
         @options={{options}} as |star|

--- a/addon/stories/form.stories.mdx
+++ b/addon/stories/form.stories.mdx
@@ -1,0 +1,16 @@
+import { Meta, Story, Canvas, ArgsTable } from '@storybook/addon-docs/blocks';
+import centered from '@storybook/addon-centered/ember';
+import * as stories from './form.stories.js';
+
+<Meta
+  title='Form/Example'
+  decorators={[centered]}
+/>
+
+# Formulaire avec les composants Pix-UI
+
+Un formulaire complet avec les composants Pix-UI :
+
+<Canvas>
+  <Story name="Form" story={stories.form} height={500} />
+</Canvas>

--- a/addon/stories/pix-input.stories.mdx
+++ b/addon/stories/pix-input.stories.mdx
@@ -53,4 +53,4 @@ Le PixInput permet de créer un champ de texte.
 
 ## Arguments
 
-<ArgsTable story="PixInput" />
+<ArgsTable story="Default" />

--- a/addon/stories/pix-multi-select.stories.js
+++ b/addon/stories/pix-multi-select.stories.js
@@ -10,7 +10,6 @@ export const multiSelectWithChildComponent = (args) => {
         @id={{id}}
         @onSelect={{onSelect}}
         @emptyMessage={{emptyMessage}}
-        @size={{size}}
         @options={{options}} as |star|
       >
         <PixStars
@@ -133,13 +132,12 @@ export const argTypes = {
   },
   size: {
     name: 'size',
-    description: 'taille: `big`,`small`',
+    description: '⚠️ **Propriété dépréciée** ⚠️ , désormais tous les éléments de formulaires feront 36px de hauteur.',
     options: ['big', 'small'],
     type: { name: 'string', required: false },
-    control: { type: 'select' },
     table: {
       type: { summary: 'string' },
-      defaultValue: { summary: 'big' },
+      defaultValue: { summary: 'small' },
     }
   },
 };

--- a/addon/stories/pix-multi-select.stories.js
+++ b/addon/stories/pix-multi-select.stories.js
@@ -10,6 +10,7 @@ export const multiSelectWithChildComponent = (args) => {
         @id={{id}}
         @onSelect={{onSelect}}
         @emptyMessage={{emptyMessage}}
+        @label={{label}}
         @options={{options}} as |star|
       >
         <PixStars
@@ -18,9 +19,7 @@ export const multiSelectWithChildComponent = (args) => {
         />
       </PixMultiSelect>
     `,
-    context: {
-      ...args,
-    },
+    context: args,
   };
 };
 multiSelectWithChildComponent.args = {
@@ -66,9 +65,18 @@ export const argTypes = {
   },
   title: {
     name: 'title',
-    description: 'Donner un titre à sa liste de choix multiple',
+    description: 'Donne un titre à sa liste de choix multiple.',
     type: { name: 'string', required: true },
     defaultValue: 'Rechercher un condiment',
+  },
+  label: {
+    name: 'label',
+    description: 'Donne un label au champ, le paramètre @id devient obligatoire avec ce paramètre.',
+    type: { name: 'string', required: false },
+    table: {
+      type: { summary: 'string' },
+      defaultValue: { summary: null },
+    }
   },
   emptyMessage: {
     name: 'emptyMessage',

--- a/addon/stories/pix-multi-select.stories.js
+++ b/addon/stories/pix-multi-select.stories.js
@@ -10,6 +10,7 @@ export const multiSelectWithChildComponent = (args) => {
         @id={{id}}
         @onSelect={{onSelect}}
         @emptyMessage={{emptyMessage}}
+        @size={{size}}
         @options={{options}} as |star|
       >
         <PixStars
@@ -46,6 +47,7 @@ export const multiSelectSearchable = (args) => {
         @strictSearch={{strictSearch}}
         @onSelect={{doSomething}}
         @emptyMessage={{emptyMessage}}
+        @size={{size}}
         @selected={{selected}}
         @options={{options}} as |option|
       >
@@ -128,5 +130,16 @@ export const argTypes = {
     description: 'Permet de rendre sensible à la casse et au diacritiques lorsque ``isSearchable`` à ``true``',
     type: { name: 'boolean', required: false },
     defaultValue: false,
+  },
+  size: {
+    name: 'size',
+    description: 'taille: `big`,`small`',
+    options: ['big', 'small'],
+    type: { name: 'string', required: false },
+    control: { type: 'select' },
+    table: {
+      type: { summary: 'string' },
+      defaultValue: { summary: 'big' },
+    }
   },
 };

--- a/addon/stories/pix-select.stories.js
+++ b/addon/stories/pix-select.stories.js
@@ -13,7 +13,6 @@ export const select = (args) => {
         @emptyOptionNotSelectable={{emptyOptionNotSelectable}}
         @isSearchable={{isSearchable}}
         @isValidationActive={{isValidationActive}}
-        @size={{size}}
       />
     `,
     context: args,
@@ -33,7 +32,6 @@ export const searchableSelect = (args) => {
         @isSearchable={{isSearchable}}
         @isValidationActive={{isValidationActive}}
         placeholder={{this.placeholder}}
-        @size={{size}}
       />
     `,
     context: args,
@@ -118,13 +116,12 @@ export const argTypes = {
   },
   size: {
     name: 'size',
-    description: 'taille: `big`,`small`',
+    description: '⚠️ **Propriété dépréciée** ⚠️ , désormais tous les éléments de formulaires feront 36px de hauteur.',
     options: ['big', 'small'],
     type: { name: 'string', required: false },
-    control: { type: 'select' },
     table: {
       type: { summary: 'string' },
-      defaultValue: { summary: 'big' },
+      defaultValue: { summary: 'small' },
     }
   },
 };

--- a/addon/stories/pix-select.stories.js
+++ b/addon/stories/pix-select.stories.js
@@ -13,6 +13,7 @@ export const select = (args) => {
         @emptyOptionNotSelectable={{emptyOptionNotSelectable}}
         @isSearchable={{isSearchable}}
         @isValidationActive={{isValidationActive}}
+        @size={{size}}
       />
     `,
     context: args,
@@ -32,6 +33,7 @@ export const searchableSelect = (args) => {
         @isSearchable={{isSearchable}}
         @isValidationActive={{isValidationActive}}
         placeholder={{this.placeholder}}
+        @size={{size}}
       />
     `,
     context: args,
@@ -113,5 +115,16 @@ export const argTypes = {
     description: 'Rend le premier champ qui est vide non visible une fois sélectionné',
     control: { type: 'boolean' },
     type: { name: 'boolean', required: false },
+  },
+  size: {
+    name: 'size',
+    description: 'taille: `big`,`small`',
+    options: ['big', 'small'],
+    type: { name: 'string', required: false },
+    control: { type: 'select' },
+    table: {
+      type: { summary: 'string' },
+      defaultValue: { summary: 'big' },
+    }
   },
 };

--- a/addon/stories/pix-select.stories.js
+++ b/addon/stories/pix-select.stories.js
@@ -1,11 +1,10 @@
 import { hbs } from 'ember-cli-htmlbars';
 import { action } from '@storybook/addon-actions';
 
-export const select = (args) => {
-  return {
+const Template = args => ({
     template: hbs`
       <PixSelect
-        id="default-pix-select"
+        @id={{id}}
         @options={{options}}
         @onChange={{onChange}}
         @selectedOption={{selectedOption}}
@@ -13,48 +12,44 @@ export const select = (args) => {
         @emptyOptionNotSelectable={{emptyOptionNotSelectable}}
         @isSearchable={{isSearchable}}
         @isValidationActive={{isValidationActive}}
+        @label={{label}}
       />
     `,
     context: args,
-  };
-};
+});
 
-export const searchableSelect = (args) => {
-  return {
-    template: hbs`
-      <PixSelect
-        id="searchable-pix-select"
-        @options={{options}}
-        @onChange={{onChange}}
-        @selectedOption={{selectedOption}}
-        @emptyOptionLabel={{emptyOptionLabel}}
-        @emptyOptionNotSelectable={{emptyOptionNotSelectable}}
-        @isSearchable={{isSearchable}}
-        @isValidationActive={{isValidationActive}}
-        placeholder={{this.placeholder}}
-      />
-    `,
-    context: args,
-  };
-};
+export const Default = Template.bind({});
+Default.args = {
+  options: [
+    { value: '1', label: 'Figues' },
+    { value: '2', label: 'Bananes' },
+    { value: '3', label: 'Noix' },
+    { value: '4', label: 'Papayes' },
+    { value: '5', label: 'Fèves de chocolat' },
+    { value: '6', label: 'Dattes' },
+    { value: '7', label: 'Mangues' },
+    { value: '8', label: 'Jujube' },
+    { value: '9', label: 'Avocat' },
+    { value: '10', label: 'Fraises' },
+    { value: '11', label: 'Kaki' },
+  ],
+  onChange: action('onChange'),
+}
+
+export const withLabel = Template.bind({});
+withLabel.args = {
+  ...Default.args,
+  id: 'pix-select-with-label',
+  label: 'Ton fruit préféré: ',
+}
+
+export const searchableSelect = Template.bind({});
 searchableSelect.args = {
+  ...Default.args,
   emptyOptionNotSelectable: false,
   isSearchable: true,
   isValidationActive: true,
   placeholder: 'Fraises, Mangues...',
-  options: [
-    { value: 'Figues', label: 'Figues' },
-    { value: 'Bananes', label: 'Bananes' },
-    { value: 'Noix', label: 'Noix' },
-    { value: 'Papayes', label: 'Papayes' },
-    { value: 'Fèves de chocolat', label: 'Fèves de chocolat' },
-    { value: 'Dattes', label: 'Dattes' },
-    { value: 'Mangues', label: 'Mangues' },
-    { value: 'Jujube', label: 'Jujube' },
-    { value: 'Avocat', label: 'Avocat' },
-    { value: 'Fraises', label: 'Fraises' },
-    { value: 'Kaki', label: 'Kaki' },
-  ]
 }
 
 export const argTypes = {
@@ -62,44 +57,42 @@ export const argTypes = {
     name: 'options',
     description: 'Les options sont représentées par un tableau d‘objet contenant les propriétés ``value`` et ``label``. ``value`` doit être de type ``String`` pour être que le champ puisse être cherchable',
     type: { name: 'object', required: true },
-    defaultValue: [
-      { value: '1', label: 'Figues' },
-      { value: '2', label: 'Bananes' },
-      { value: '3', label: 'Noix' },
-      { value: '4', label: 'Papayes' },
-      { value: '5', label: 'Fèves de chocolat' },
-      { value: '6', label: 'Dattes' },
-      { value: '7', label: 'Mangues' },
-      { value: '8', label: 'Jujube' },
-      { value: '9', label: 'Avocat' },
-      { value: '10', label: 'Fraises' },
-      { value: '11', label: 'Kaki' },
-    ],
   },
   onChange: {
     name: 'onChange',
     description: 'Fonction à appeler si une option est sélectionnée',
     type: { required: true },
-    defaultValue: action('onChange'),
     control: { disable: true },
   },
   selectedOption: {
     name: 'selectedOption',
     description: 'Option sélectionnée',
-    control: { type: 'string' },
+    options: [ '1', '2', '3', '4', '5', '6', '7', '8', '9', '10'],
+    control: { type: 'select' },
     type: { name: 'string', required: false },
+    table: {
+      type: { summary: 'string' },
+      defaultValue: { summary: null },
+    }
   },
   emptyOptionLabel: {
     name: 'emptyOptionLabel',
     description: 'Texte à afficher si aucune option n‘est sélectionnée',
-    control: { type: 'string' },
     type: { name: 'string', required: false },
+    table: {
+      type: { summary: 'string' },
+      defaultValue: { summary: null },
+    }
   },
   isSearchable: {
     name: 'isSearchable',
     description: 'Rend le champ cherchable',
     control: { type: 'boolean' },
     type: { name: 'boolean', required: false },
+    table: {
+      type: { summary: 'boolean' },
+      defaultValue: { summary: false },
+    }
   },
   isValidationActive: {
     name: 'isValidationActive',
@@ -107,12 +100,20 @@ export const argTypes = {
       'Rend la bordure du champ vert au focus si la valeur de recherche match une option (c\'est à dire si l\'utilisateur a selectionné une option valable',
     control: { type: 'boolean' },
     type: { name: "boolean", required: false },
+    table: {
+      type: { summary: 'boolean' },
+      defaultValue: { summary: false },
+    }
   },
   emptyOptionNotSelectable: {
     name: 'emptyOptionNotSelectable',
     description: 'Rend le premier champ qui est vide non visible une fois sélectionné',
     control: { type: 'boolean' },
     type: { name: 'boolean', required: false },
+    table: {
+      type: { summary: 'boolean' },
+      defaultValue: { summary: false },
+    }
   },
   size: {
     name: 'size',
@@ -124,4 +125,13 @@ export const argTypes = {
       defaultValue: { summary: 'small' },
     }
   },
+  label: {
+    name: 'label',
+    description: 'Donne un label au champ, le paramètre @id devient obligatoire avec ce paramètre.',
+    type: { name: 'string', required: false },
+    table: {
+      type: { summary: 'string' },
+      defaultValue: { summary: null },
+    }
+  }
 };

--- a/addon/stories/pix-select.stories.mdx
+++ b/addon/stories/pix-select.stories.mdx
@@ -23,7 +23,13 @@ A défaut d'avoir un label, vous pouvez rajouter l'attribut `aria-label` à l'in
 ## Default
 
 <Canvas>
-  <Story name="Select" story={stories.select} height={100} />
+  <Story name="Select" story={stories.Default} height={100} />
+</Canvas>
+
+## With label
+
+<Canvas>
+  <Story story={stories.withLabel} height={100} />
 </Canvas>
 
 ## Searchable

--- a/addon/stories/pix-textarea.stories.js
+++ b/addon/stories/pix-textarea.stories.js
@@ -8,6 +8,7 @@ export const textarea = (args) => {
         @value={{value}}
         @maxlength={{maxlength}}
         @label={{label}}
+        @errorMessage={{errorMessage}}
       />
     `,
     context: args,
@@ -44,5 +45,15 @@ export const argTypes = {
       type: { summary: 'string' },
       defaultValue: { summary: null },
     }
-  }
+  },
+
+  errorMessage: {
+    name: 'errorMessage',
+    description: 'Affiche une erreur en dessous du champ.',
+    type: { name: 'string', required: false },
+    table: {
+      type: { summary: 'string' },
+      defaultValue: { summary: null },
+    }
+  },
 };

--- a/addon/stories/pix-textarea.stories.js
+++ b/addon/stories/pix-textarea.stories.js
@@ -7,6 +7,7 @@ export const textarea = (args) => {
         @id={{id}}
         @value={{value}}
         @maxlength={{maxlength}}
+        @label={{label}}
       />
     `,
     context: args,
@@ -34,4 +35,14 @@ export const argTypes = {
     type: { name: 'number', required: false },
     defaultValue: 500,
   },
+
+  label: {
+    name: 'label',
+    description: 'Donne un label au champ.',
+    type: { name: 'string', required: false },
+    table: {
+      type: { summary: 'string' },
+      defaultValue: { summary: null },
+    }
+  }
 };

--- a/addon/stories/pix-textarea.stories.mdx
+++ b/addon/stories/pix-textarea.stories.mdx
@@ -27,7 +27,8 @@ Optionellement, il peut afficher le nombre de caractères tapés ainsi que le no
 <PixTextarea
   @id={{id}}
   @value={{value}}
-  @maxlength={{maxlength}} />
+  @maxlength={{maxlength}}
+  @errorMessage={{errorMessage}} />
 ```
 
 ## Arguments

--- a/addon/styles/_form.scss
+++ b/addon/styles/_form.scss
@@ -30,11 +30,9 @@
 
 @mixin errorMessage() {
   position: absolute;
-  bottom: calc(-4px - 1px - 0.75rem);
   font-family: $font-roboto;
   font-size: 0.75rem;
   color: $red;
-  margin-top: 4px;
 }
 
 @mixin formElementInError() {

--- a/addon/styles/_form.scss
+++ b/addon/styles/_form.scss
@@ -20,6 +20,28 @@
   }
 }
 
+@mixin label() {
+  display: block;
+  font-family: $font-roboto;
+  font-size: 0.875rem;
+  color: $grey-70;
+  margin-bottom: 4px;
+}
+
+@mixin errorMessage() {
+  position: absolute;
+  bottom: calc(-4px - 1px - 0.75rem);
+  font-family: $font-roboto;
+  font-size: 0.75rem;
+  color: $red;
+  margin-top: 4px;
+}
+
+@mixin formElementInError() {
+  border-color: $red;
+  box-shadow: inset 0px 0px 0px 0.6px $red;
+}
+
 .pix-form__actions {
   display: flex;
 

--- a/addon/styles/_form.scss
+++ b/addon/styles/_form.scss
@@ -19,3 +19,11 @@
     outline: none;
   }
 }
+
+.pix-form__actions {
+  display: flex;
+
+  & > .pix-button:first-child {
+    margin-right: 10px;
+  }
+}

--- a/addon/styles/_form.scss
+++ b/addon/styles/_form.scss
@@ -1,0 +1,21 @@
+@mixin hoverFormElement(){
+  &:hover {
+    box-shadow: inset 0px 0px 0px 0.6px $grey-40;
+  }
+}
+
+@mixin focusFormElement(){
+  &:focus {
+    border-color: $blue;
+    box-shadow: inset 0px 0px 0px 0.6px $blue;
+    outline: none;
+  }
+}
+
+@mixin focusWithinFormElement(){
+  &:focus {
+    border-color: $blue;
+    box-shadow: inset 0px 0px 0px 0.6px $blue;
+    outline: none;
+  }
+}

--- a/addon/styles/_pix-button-base.scss
+++ b/addon/styles/_pix-button-base.scss
@@ -28,11 +28,11 @@
   }
 
   &--size-small.pix-button--shape-rounded {
-    padding: 10px 24px;
+    padding: 8px 24px;
   }
 
   &--size-small.pix-button--shape-squircle {
-    padding: 10px 16px;
+    padding: 8px 16px;
   }
 
   &--disabled {

--- a/addon/styles/_pix-input.scss
+++ b/addon/styles/_pix-input.scss
@@ -58,8 +58,12 @@
   }
 
   input {
-    padding: 10px 16px;
-    padding-right: 26px;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    padding: 0 26px 0 16px;
+    height: calc(36px - 2px);
+    line-height: 0;
     border: 1px solid $grey-40;
     border-radius: 4px;
     font-family: $font-roboto;

--- a/addon/styles/_pix-input.scss
+++ b/addon/styles/_pix-input.scss
@@ -6,10 +6,7 @@
   position: relative;
 
   &__label {
-    font-family: $font-roboto;
-    font-size: 0.875rem;
-    color: $grey-70;
-    margin-bottom: 4px;
+    @include label();
   }
 
   &__information {
@@ -49,12 +46,7 @@
   }
 
   &__error-message {
-    position: absolute;
-    bottom: calc(-4px - 1px - 0.75rem);
-    font-family: $font-roboto;
-    font-size: 0.75rem;
-    color: $red;
-    margin-top: 4px;
+    @include errorMessage();
   }
 
   input {
@@ -79,8 +71,7 @@
     }
 
     &.pix-input__input--error {
-      border-color: $red;
-      box-shadow: inset 0px 0px 0px 0.6px $red;
+      @include formElementInError();
     }
 
     &.pix-input__input--icon {

--- a/addon/styles/_pix-input.scss
+++ b/addon/styles/_pix-input.scss
@@ -47,6 +47,8 @@
 
   &__error-message {
     @include errorMessage();
+    margin-top: 4px;
+    bottom: calc(-4px - 1px - 0.75rem);
   }
 
   input {

--- a/addon/styles/_pix-input.scss
+++ b/addon/styles/_pix-input.scss
@@ -67,15 +67,8 @@
     font-weight: 400;
     color: $grey-90;
 
-    &:hover {
-      box-shadow: inset 0px 0px 0px 0.6px $grey-40;
-    }
-
-    &:focus {
-      border-color: $blue;
-      box-shadow: inset 0px 0px 0px 0.6px $blue;
-      outline: none;
-    }
+    @include hoverFormElement();
+    @include focusFormElement();
 
     &::placeholder {
       color: $grey-30;

--- a/addon/styles/_pix-input.scss
+++ b/addon/styles/_pix-input.scss
@@ -53,10 +53,11 @@
 
   input {
     display: flex;
+    box-sizing: border-box;
     flex-direction: column;
     justify-content: center;
-    padding: 0 26px 0 16px;
-    height: calc(36px - 2px);
+    padding: 0 16px 0 16px;
+    height: 36px;
     line-height: 0;
     border: 1px solid $grey-40;
     border-radius: 4px;
@@ -73,19 +74,20 @@
     }
 
     &.pix-input__input--error {
+      padding-right: 32px;
       @include formElementInError();
     }
 
     &.pix-input__input--icon {
-      padding-right: 30px;
+      padding-right: 32px;
     }
 
     &.pix-input__input--icon.pix-input__input--icon-left {
-      padding-left: 30px;
+      padding-left: 32px;
     }
 
     &.pix-input__input--error.pix-input__input--icon:not(.pix-input__input--icon-left) {
-      padding-right: 46px;
+      padding-right: 32px;
     }
   }
 }

--- a/addon/styles/_pix-multi-select.scss
+++ b/addon/styles/_pix-multi-select.scss
@@ -12,20 +12,24 @@
   font-family: $font-roboto;
   font-weight: $font-normal;
   position: relative;
-  border: 1px $grey-20 solid;
-  height: 35px;
-  padding: 8px 36px 8px 16px;
+  border: 1px $grey-40 solid;
+  height: 44px;
+  padding: 0px 32px 0px 16px;
   width: 100%;
   background-color: $white;
-  border-radius: 3px;
-  margin:0 1px;
+  border-radius: 4px;
   outline: none;
   box-sizing: border-box;
-  font-size: 0.9rem;
+  font-size: 0.875rem;
   cursor: pointer;
+  color: $grey-90;
 
   &:focus-within, &:hover {
     border-color: $blue;
+  }
+
+  &--small {
+    height: 36px;
   }
 
   &__search-icon {
@@ -46,7 +50,8 @@
     outline: none;
     padding: 0 10px;
     border-radius: 3px;
-    font-size: 1em;
+    font-size: 0.875rem;
+    color: $grey-90;
     background: transparent;
 
     &:focus {
@@ -55,10 +60,10 @@
   }
 
   &__dropdown-icon {
-    font-size: 16px;
-    color: $grey-25;
-    right: 16px;
-    top: calc(50% - 8px);
+    font-size: 11px;
+    color: $grey-30;
+    right: 10px;
+    top: calc(50% - 6px);
     padding: 0 0 2px;
     position: absolute;
     pointer-events: none;

--- a/addon/styles/_pix-multi-select.scss
+++ b/addon/styles/_pix-multi-select.scss
@@ -2,7 +2,7 @@
   display: inline-block;
   position: relative;
   min-width: 250px;
-  max-width: 450px;
+  width: 100%;
 }
 
 .pix-multi-select-header {

--- a/addon/styles/_pix-multi-select.scss
+++ b/addon/styles/_pix-multi-select.scss
@@ -3,6 +3,10 @@
   position: relative;
   min-width: 250px;
   width: 100%;
+
+  &__label {
+    @include label();
+  }
 }
 
 .pix-multi-select-header {

--- a/addon/styles/_pix-multi-select.scss
+++ b/addon/styles/_pix-multi-select.scss
@@ -24,9 +24,8 @@
   cursor: pointer;
   color: $grey-90;
 
-  &:focus-within, &:hover {
-    border-color: $blue;
-  }
+  @include hoverFormElement();
+  @include focusWithinFormElement();
 
   &--big {
     height: 44px;
@@ -53,10 +52,6 @@
     font-size: 0.875rem;
     color: $grey-90;
     background: transparent;
-
-    &:focus {
-      outline: none;
-    }
   }
 
   &__dropdown-icon {
@@ -116,6 +111,8 @@
     list-style: none;
     font-size: 0.9rem;
 
+    @include hoverFormElement();  
+
     &--no-result {
       text-align: center;
       padding: 12px 0;
@@ -124,10 +121,6 @@
     &:last-of-type {
       border-bottom: none;
     }
-    
-    &:hover, &:focus-within {
-      background-color: $grey-10;
-    }   
   }
   
   &__checkbox {

--- a/addon/styles/_pix-multi-select.scss
+++ b/addon/styles/_pix-multi-select.scss
@@ -13,7 +13,7 @@
   font-weight: $font-normal;
   position: relative;
   border: 1px $grey-40 solid;
-  height: 44px;
+  height: 36px;
   padding: 0px 32px 0px 16px;
   width: 100%;
   background-color: $white;
@@ -28,8 +28,8 @@
     border-color: $blue;
   }
 
-  &--small {
-    height: 36px;
+  &--big {
+    height: 44px;
   }
 
   &__search-icon {

--- a/addon/styles/_pix-select.scss
+++ b/addon/styles/_pix-select.scss
@@ -14,10 +14,9 @@
     height: 36px;
     width: 100%;
 
-    &:focus, &:focus-within {
-      border-color: $blue;
-      outline: none;
-    }
+    @include hoverFormElement();
+    @include focusFormElement();
+    @include focusWithinFormElement();
   }
 
   select {

--- a/addon/styles/_pix-select.scss
+++ b/addon/styles/_pix-select.scss
@@ -11,7 +11,7 @@
     color: $grey-90;
     font-family: $font-roboto;
     font-size: 0.875rem;
-    height: 44px;
+    height: 36px;
     width: 100%;
 
     &:focus, &:focus-within {
@@ -24,8 +24,8 @@
     @include pixSelect;
     padding: 0 32px 0 16px;
 
-    &.pix-select--small {
-      height: 36px;
+    &.pix-select--big {
+      height: 44px;
     }
 
     &::-ms-expand {
@@ -37,8 +37,8 @@
     @include pixSelect;
     padding: 0 8px 0 16px;
 
-    &.pix-select--small {
-      height: 36px;
+    &.pix-select--big {
+      height: 44px;
     }
   
     // Remove arrow for Chrome

--- a/addon/styles/_pix-select.scss
+++ b/addon/styles/_pix-select.scss
@@ -5,24 +5,28 @@
 
   @mixin pixSelect {
     appearance: none;
-    border: 1.5px $grey-20 solid;
+    border: 1px $grey-40 solid;
     box-sizing: border-box;
-    border-radius: 3px;
-    color: $black;
+    border-radius: 4px;
+    color: $grey-90;
     font-family: $font-roboto;
-    font-size: 1rem;
-    height: 46px;
+    font-size: 0.875rem;
+    height: 44px;
     width: 100%;
 
     &:focus, &:focus-within {
-      box-shadow: 0 0 0 1.8pt $blue;
-      outline: solid 1px $blue;
+      border-color: $blue;
+      outline: none;
     }
   }
 
   select {
     @include pixSelect;
     padding: 0 32px 0 16px;
+
+    &.pix-select--small {
+      height: 36px;
+    }
 
     &::-ms-expand {
       display: none;
@@ -31,7 +35,11 @@
 
   input {
     @include pixSelect;
-    padding: 0 8px;
+    padding: 0 8px 0 16px;
+
+    &.pix-select--small {
+      height: 36px;
+    }
   
     // Remove arrow for Chrome
     &::-webkit-calendar-picker-indicator {
@@ -40,15 +48,14 @@
 
     &.pix-select--is-valid:focus,
     &.pix-select--is-valid:focus-within {
-      box-shadow: 0 0 0 1.8pt $green;
-      outline-color: $green;
+      border-color: $green;
     }
   }
 
   &__icon {
     font-size: 11px;
     color: $grey-30;
-    right: 8px;
+    right: 10px;
     top: calc(50% - 6px);
     padding: 0 0 2px;
     position: absolute;

--- a/addon/styles/_pix-select.scss
+++ b/addon/styles/_pix-select.scss
@@ -60,4 +60,12 @@
     position: absolute;
     pointer-events: none;
   }
+
+  &__label {
+    @include label();
+  }
+
+  .pix-select__label ~ .pix-select__icon {
+    top: calc(50% + 6px);
+  } 
 }

--- a/addon/styles/_pix-textarea.scss
+++ b/addon/styles/_pix-textarea.scss
@@ -7,7 +7,7 @@
     border: 1px solid $grey-40;
     border-style: solid;
     border-radius: 4px;
-    padding: 8px;
+    padding: 10px 16px;
     font-family: $font-roboto;
     color: $grey-90;
     font-size: 0.875rem;

--- a/addon/styles/_pix-textarea.scss
+++ b/addon/styles/_pix-textarea.scss
@@ -13,14 +13,8 @@
     font-size: 0.875rem;
     resize: vertical;
 
-    &:hover {
-      border-color: $grey-60;
-    }
-
-    &:focus {
-      border: 1px solid $blue;
-      outline: none;
-    }
+    @include hoverFormElement();
+    @include focusFormElement();
   }
 
   p {

--- a/addon/styles/_pix-textarea.scss
+++ b/addon/styles/_pix-textarea.scss
@@ -4,13 +4,13 @@
   textarea {
     box-sizing: border-box;
     width: 100%;
-    border: 1.6px solid $grey-45;
+    border: 1px solid $grey-40;
     border-style: solid;
     border-radius: 4px;
     padding: 8px;
     font-family: $font-roboto;
-    color: $grey-45;
-    font-size: 1rem;
+    color: $grey-90;
+    font-size: 0.875rem;
     resize: vertical;
 
     &:hover {
@@ -18,7 +18,7 @@
     }
 
     &:focus {
-      border: 1.6px solid $blue;
+      border: 1px solid $blue;
       outline: none;
     }
   }

--- a/addon/styles/_pix-textarea.scss
+++ b/addon/styles/_pix-textarea.scss
@@ -26,4 +26,7 @@
     margin-bottom: 0;
   }
 
+  &__label{
+    @include label();
+  }
 }

--- a/addon/styles/_pix-textarea.scss
+++ b/addon/styles/_pix-textarea.scss
@@ -15,6 +15,10 @@
 
     @include hoverFormElement();
     @include focusFormElement();
+
+    &.pix-textarea--error {
+      @include formElementInError();
+    }
   }
 
   p {
@@ -28,5 +32,9 @@
 
   &__label{
     @include label();
+  }
+
+  &__error-message {
+    @include errorMessage();
   }
 }

--- a/addon/styles/addon.scss
+++ b/addon/styles/addon.scss
@@ -2,6 +2,7 @@
 @import 'colors';
 @import 'fonts';
 @import 'spacing';
+@import 'form';
 @import 'pix-background-header';
 @import 'pix-banner';
 @import 'pix-block';

--- a/tests/integration/components/pix-multi-select-test.js
+++ b/tests/integration/components/pix-multi-select-test.js
@@ -2,7 +2,7 @@ import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { render, click, fillIn, focus, blur } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
-
+import createGlimmerComponent from '../../helpers/create-glimmer-component';
 import sinon from 'sinon';
 
 module('Integration | Component | multi-select', function (hooks) {
@@ -13,6 +13,8 @@ module('Integration | Component | multi-select', function (hooks) {
     { value: '2', label: 'Tomate' },
     { value: '3', label: 'Oignon' },
   ];
+  const LABEL_SELECTOR = '.pix-multi-select__label';
+
   test('it renders PixMultiSelect with list', async function (assert) {
     // given
     this.options = DEFAULT_OPTIONS;
@@ -618,5 +620,34 @@ module('Integration | Component | multi-select', function (hooks) {
       assert.equal(listElement.item(1).textContent.trim(), 'Salade');
       assert.equal(listElement.item(2).textContent.trim(), 'Tomate');
     });
+  });
+
+  test('it should be possible to give a label', async function(assert) {
+    // given
+    this.options = DEFAULT_OPTIONS;
+    this.selected = [];
+    this.onSelect = (selected) => this.set('selected', selected);
+    await render(hbs`
+      <PixMultiSelect
+        @id="pix-select-with-label"
+        @label="Votre choix:"
+        @options={{options}}
+        @onChange={{onChange}}
+      />
+    `);
+
+    // when & then
+    const selectorElement = this.element.querySelector(LABEL_SELECTOR);
+    assert.equal(selectorElement.innerHTML, 'Votre choix:');
+  });
+
+  test('it should throw an error if no id is provided when there is a label', async function(assert) {
+    // given
+    const componentParams = { id: '   ', label: 'Votre choix: ', options: DEFAULT_OPTIONS };
+    const component = createGlimmerComponent('component:pix-multi-select', componentParams);
+
+    // when & then
+    const expectedError = new Error('ERROR in PixMultiSelect component, @id param is necessary when giving @label');
+    assert.throws(function() { component.label }, expectedError);
   });
 });

--- a/tests/integration/components/pix-select-test.js
+++ b/tests/integration/components/pix-select-test.js
@@ -3,6 +3,7 @@ import { setupRenderingTest } from 'ember-qunit';
 import { render, fillIn } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import sinon from 'sinon';
+import createGlimmerComponent from '../../helpers/create-glimmer-component';
 
 module('Integration | Component | select', function (hooks) {
   setupRenderingTest(hooks);
@@ -14,6 +15,7 @@ module('Integration | Component | select', function (hooks) {
   ]
   const DEFAULT_ON_CHANGE = () => {};
   const SEARCHABLE_SELECT_SELECTOR = '.pix-select input';
+  const LABEL_SELECTOR = '.pix-select label'
 
   test('it renders the PixSelect with given options', async function (assert) {
     // given
@@ -159,5 +161,33 @@ module('Integration | Component | select', function (hooks) {
       });
     });
 
+  });
+
+  test('it should be possible to give a label', async function(assert) {
+    // given
+    this.options = DEFAULT_OPTIONS;
+    this.onChange = DEFAULT_ON_CHANGE;
+    await render(hbs`
+      <PixSelect
+        @id="pix-select-with-label"
+        @label="Votre ville"
+        @options={{options}}
+        @onChange={{onChange}}
+      />
+    `);
+
+    // when & then
+    const selectorElement = this.element.querySelector(LABEL_SELECTOR);
+    assert.equal(selectorElement.innerHTML, 'Votre ville');
+  });
+
+  test('it should throw an error if no id is provided when there is a label', async function(assert) {
+    // given
+    const componentParams = { id: '   ', label: 'Votre ville', options: DEFAULT_OPTIONS };
+    const component = createGlimmerComponent('component:pix-select', componentParams);
+
+    // when & then
+    const expectedError = new Error('ERROR in PixSelect component, @id param is necessary when giving @label');
+    assert.throws(function() { component.label }, expectedError);
   });
 });

--- a/tests/integration/components/pix-textarea-test.js
+++ b/tests/integration/components/pix-textarea-test.js
@@ -2,12 +2,14 @@ import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { render, fillIn } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
+import createGlimmerComponent from '../../helpers/create-glimmer-component';
 
 module('Integration | Component | textarea', function(hooks) {
   setupRenderingTest(hooks);
 
   const TEXTAREA_SELECTOR = '.pix-textarea textarea';
   const CHAR_COUNT_SELECTOR = '.pix-textarea p';
+  const LABEL_SELECTOR = '.pix-textarea__label';
 
   test('it renders PixTextarea with correct id and content', async function(assert) {
     // given 
@@ -52,6 +54,31 @@ module('Integration | Component | textarea', function(hooks) {
     // then
     const textarea = this.element.querySelector(TEXTAREA_SELECTOR);
     assert.equal(textarea.required, true);
+  });
+
+
+  test('it should be possible to give a label', async function(assert) {
+    // given
+    await render(hbs`
+      <PixTextarea
+        @id="pix-select-with-label"
+        @label="Décrivez votre problème"
+      />
+    `);
+
+    // when & then
+    const selectorElement = this.element.querySelector(LABEL_SELECTOR);
+    assert.equal(selectorElement.innerHTML, 'Décrivez votre problème');
+  });
+
+  test('it should throw an error if no id is provided when there is a label', async function(assert) {
+    // given
+    const componentParams = { id: '   ', label: 'Décrivez votre problème' };
+    const component = createGlimmerComponent('component:pix-textarea', componentParams);
+
+    // when & then
+    const expectedError = new Error('ERROR in PixTextarea component, @id param is necessary when giving @label');
+    assert.throws(function() { component.label }, expectedError);
   });
 
 });

--- a/tests/integration/components/pix-textarea-test.js
+++ b/tests/integration/components/pix-textarea-test.js
@@ -10,6 +10,7 @@ module('Integration | Component | textarea', function(hooks) {
   const TEXTAREA_SELECTOR = '.pix-textarea textarea';
   const CHAR_COUNT_SELECTOR = '.pix-textarea p';
   const LABEL_SELECTOR = '.pix-textarea__label';
+  const ERROR_SELECTOR = '.pix-textarea__error-message';
 
   test('it renders PixTextarea with correct id and content', async function(assert) {
     // given 
@@ -80,5 +81,19 @@ module('Integration | Component | textarea', function(hooks) {
     const expectedError = new Error('ERROR in PixTextarea component, @id param is necessary when giving @label');
     assert.throws(function() { component.label }, expectedError);
   });
+
+  test('it should be possible to show an error message', async function(assert) {
+    // given
+    await render(hbs`
+      <PixTextarea
+        @id="pix-textarea-with-error"
+        @errorMessage="Veuillez remplir ce champ."
+      />
+    `);
+
+    // when & then
+    const selectorElement = this.element.querySelector(ERROR_SELECTOR);
+    assert.equal(selectorElement.innerHTML, 'Veuillez remplir ce champ.');
+  })
 
 });


### PR DESCRIPTION
## BREAKING CHANGES
> ToDo

## :unicorn: Description du composant

Les composants de formulaires ne correspondent pas à ce qui est défini dans le design system.

## Breaking Change

La taille des champs de formulaire (attribut `size`) passent à `small` par défaut (hauteur de 36px)

Dans le design system, tous les champs de formulaire doivent avoir une taille de 36px.

Il est toujours possible de passer la valeur `big`, mais celle-ci est dépréciée et pourrait être supprimer dans le futur.

Les champs de formulaire impactés sont:
- `<PixInput />`
- `<PixMultiSelect />`
- `<PixSelect />`

## Composants

### `<PixButton />`

Correction de la hauteur à `36px` par défaut.

### `<PixSelect />`

- Modification de la largeur et couleur des bordures
- Modification de border radius (4px)
- Modification des hauteurs
  - `@size=small`: 36px (default)
  - `@size=big`: 44px

### `<PixMultiSelect />`

- Modification de la largeur et couleur des bordures
- Modification de border radius (4px)
- Modification des hauteurs
  - `@size=small`: 36px (default)
  - `@size=big`: 44px

### `<PixTextarea />`

- Modification de la largeur et couleur des bordures
- Modification de border radius (4px)
- Modification de la couleur de la police