### PR TITLE
[FEATURE] Aligner le style du PixIconButton avec le design system - BREAKING CHANGES (PIX-3017).

### DIFF
--- a/addon/components/pix-icon-button.hbs
+++ b/addon/components/pix-icon-button.hbs
@@ -1,5 +1,6 @@
 <button
   type="button"
+  aria-label={{this.ariaLabel}}
   class="pix-icon-button pix-icon-button--{{this.size}} pix-icon-button--{{this.color}} {{if @withBackground 'pix-icon-button--background'}}"
   {{on "click" this.triggerAction}}
   ...attributes>

--- a/addon/components/pix-icon-button.js
+++ b/addon/components/pix-icon-button.js
@@ -17,6 +17,13 @@ export default class PixIconButton extends Component {
     return this.args.color || 'light-grey';
   }
 
+  get ariaLabel() {
+    if (!this.args.ariaLabel || !this.args.ariaLabel.trim()) {
+      throw new Error('ERROR in PixIconButton component, @ariaLabel param is not provided.');
+    }
+    return this.args.ariaLabel;
+  }
+
   @action
   triggerAction() {
     if (this.args.triggerAction) {

--- a/addon/stories/pix-icon-button.stories.js
+++ b/addon/stories/pix-icon-button.stories.js
@@ -5,6 +5,7 @@ const Template = (args) => {
   return {
     template: hbs`
       <PixIconButton
+        @ariaLabel={{ariaLabel}}
         @icon={{icon}}
         @iconPrefix={{iconPrefix}}
         @triggerAction={{triggerAction}}
@@ -18,6 +19,7 @@ const Template = (args) => {
 
 export const DefaultSmall = Template.bind({});
 DefaultSmall.args = {
+  ariaLabel: 'Action du bouton',
   icon: 'arrow-down',
   size: 'small',
   withBackground: true,
@@ -25,6 +27,7 @@ DefaultSmall.args = {
 
 export const DefaultBig = Template.bind({});
 DefaultBig.args = {
+  ariaLabel: 'Action du bouton',
   icon: 'times',
   size: 'big',
   withBackground: true,
@@ -37,6 +40,12 @@ withoutBackground.args = {
 };
 
 export const argTypes = {
+  ariaLabel: {
+    name: 'ariaLabel',
+    description: 'l\'action du bouton, pour l\'accessibilité',
+    type: { name: 'string', required: true },
+    table: { defaultValue: { summary: 'times' } },
+  },
   icon: {
     name: 'icon',
     description: 'icône font-awesome',

--- a/addon/stories/pix-icon-button.stories.js
+++ b/addon/stories/pix-icon-button.stories.js
@@ -17,26 +17,25 @@ const Template = (args) => {
   };
 };
 
-export const DefaultSmall = Template.bind({});
-DefaultSmall.args = {
-  ariaLabel: 'Action du bouton',
-  icon: 'arrow-down',
-  size: 'small',
-  withBackground: true,
-};
-
-export const DefaultBig = Template.bind({});
-DefaultBig.args = {
+export const Default = Template.bind({});
+Default.args = {
   ariaLabel: 'Action du bouton',
   icon: 'times',
-  size: 'big',
-  withBackground: true,
+  triggerAction: () => {
+    return (new Promise()).resolves()
+  },
 };
 
-export const withoutBackground = Template.bind({});
-withoutBackground.args = {
-  ...DefaultSmall.args,
-  withBackground: false,
+export const small = Template.bind({});
+small.args = {
+  ...Default.args,
+  size: 'small',
+};
+
+export const withBackground = Template.bind({});
+withBackground.args = {
+  ...Default.args,
+  withBackground: true,
 };
 
 export const argTypes = {
@@ -48,19 +47,19 @@ export const argTypes = {
   },
   icon: {
     name: 'icon',
-    description: 'icône font-awesome',
+    description: 'Icône font-awesome',
     type: { name: 'string', required: true },
     table: { defaultValue: { summary: 'times' } },
   },
   iconPrefix: {
     name: 'iconPrefix',
-    description: 'prefix de l\'icône font-awesome',
+    description: 'Prefix de l\'icône font-awesome',
     type: { name: 'string', required: false },
     control: { type: 'select', options: ['far', 'fas'] },
   },
   triggerAction: {
     name: 'triggerAction',
-    description: 'fonction à appeler au clic du bouton',
+    description: 'Fonction à appeler au clic du bouton',
     type: { required: true },
     defaultValue: action('triggerAction'),
   },
@@ -75,7 +74,7 @@ export const argTypes = {
   },
   size: {
     name: 'size',
-    description: 'size: `small`, `big`',
+    description: 'Size: `small`, `big`',
     type: { name: 'string', required: false },
     control: { type: 'select', options: ['big', 'small'] },
     table: {
@@ -85,7 +84,7 @@ export const argTypes = {
   },
   color: {
     name: 'color',
-    description: 'Propriété dépréciée. Color: `light-grey`, `dark-grey`',
+    description: ' ⚠️ **Propriété dépréciée** ⚠️ Color: `light-grey`, `dark-grey`',
     type: { name: 'string', required: false },
     control: { type: 'select', options: ['light-grey', 'dark-grey'] },
     table: {

--- a/addon/stories/pix-icon-button.stories.js
+++ b/addon/stories/pix-icon-button.stories.js
@@ -1,7 +1,7 @@
 import { hbs } from 'ember-cli-htmlbars';
 import { action } from '@storybook/addon-actions';
 
-export const iconButton = (args) => {
+const Template = (args) => {
   return {
     template: hbs`
       <PixIconButton
@@ -16,9 +16,26 @@ export const iconButton = (args) => {
     context: args
   };
 };
-iconButton.args = {
+
+export const DefaultSmall = Template.bind({});
+DefaultSmall.args = {
+  icon: 'arrow-down',
+  size: 'small',
+  withBackground: true,
+};
+
+export const DefaultBig = Template.bind({});
+DefaultBig.args = {
   icon: 'times',
-}
+  size: 'big',
+  withBackground: true,
+};
+
+export const withoutBackground = Template.bind({});
+withoutBackground.args = {
+  ...DefaultSmall.args,
+  withBackground: false,
+};
 
 export const argTypes = {
   icon: {

--- a/addon/stories/pix-icon-button.stories.js
+++ b/addon/stories/pix-icon-button.stories.js
@@ -10,7 +10,6 @@ const Template = (args) => {
         @triggerAction={{triggerAction}}
         @withBackground={{withBackground}}
         @size={{size}}
-        @color={{color}}
         />
     `,
     context: args
@@ -77,7 +76,7 @@ export const argTypes = {
   },
   color: {
     name: 'color',
-    description: 'color: `light-grey`, `dark-grey`',
+    description: 'Propriété dépréciée. Color: `light-grey`, `dark-grey`',
     type: { name: 'string', required: false },
     control: { type: 'select', options: ['light-grey', 'dark-grey'] },
     table: {

--- a/addon/stories/pix-icon-button.stories.mdx
+++ b/addon/stories/pix-icon-button.stories.mdx
@@ -13,28 +13,28 @@ import * as stories from './pix-icon-button.stories.js';
 
 Le PixIconButton permet de créer un bouton contenant une icône font-awesome.
 
-## Default / Boutons d'action
+## Default
 
-Le bouton par défaut. En small avec fond grisé.
+Le bouton en version big et sans fond grisé.
 
 <Canvas>
-  <Story name="Default Small" story={stories.DefaultSmall} height={60} />
+  <Story name="Default" story={stories.Default} height={60} />
 </Canvas>
 
-## Default / Bouton de fermeture
+## Small
 
-Le bouton par défaut. En big avec fond grisé.
+Le bouton en version small.
 
 <Canvas>
-  <Story name="Default Big" story={stories.DefaultBig} height={60} />
+  <Story name="Small" story={stories.small} height={60} />
 </Canvas>
 
-## Without Background
+## With Background
 
-Le bouton sans le fond grisé, pour les tableaux par exemple.
+Le bouton avec le fond grisé.
 
 <Canvas>
-  <Story name="Without Background" story={stories.withoutBackground} height={60} />
+  <Story name="With Background" story={stories.withBackground} height={60} />
 </Canvas>
 
 ## Accessibilité / aria-label
@@ -43,7 +43,7 @@ L'attribut `aria-label` étant indispensable pour l'accessibilité de ce composa
 
 ## Color
 
-Cette propriété est dépréciée. L'icône du bouton ne peut avoir qu'une seule couleur.
+⚠️ Cette propriété est **dépréciée**. L'icône du bouton ne peut avoir qu'une seule couleur.
 
 ## Usage
 
@@ -51,9 +51,28 @@ Par défaut
 ```html
 <PixIconButton
     @ariaLabel="L'action du bouton"
-    @icon='times'
-    @triggerAction="{{triggerAction}}"
-    @size='small'
+    @icon="icon"
+    @triggerAction={{triggerAction}}
+/>
+```
+
+Bouton de fermeture
+```html
+<PixIconButton
+    @ariaLabel="L'action du bouton"
+    @icon="times"
+    @triggerAction={{triggerAction}}
+    @withBackground={{true}}
+/>
+```
+
+Bouton d'action
+```html
+<PixIconButton
+    @ariaLabel="L'action du bouton"
+    @icon="arrow-left"
+    @triggerAction={{triggerAction}}
+    @size="small"
     @withBackground={{true}}
 />
 ```
@@ -61,11 +80,11 @@ Par défaut
 État disabled
 ```html
 <PixIconButton
-    @icon='times'
-    @triggerAction="{{triggerAction}}"
+    @ariaLabel="L'action du bouton"
+    @icon="times"
     disabled={{true}}
-    aria-disabled="{{true}}"
+    aria-disabled={{true}}
 />
 ```
 
-<ArgsTable story="Default Small" />
+<ArgsTable story="Default" />

--- a/addon/stories/pix-icon-button.stories.mdx
+++ b/addon/stories/pix-icon-button.stories.mdx
@@ -37,6 +37,10 @@ Le bouton sans le fond grisé, pour les tableaux par exemple.
   <Story name="Without Background" story={stories.withoutBackground} height={60} />
 </Canvas>
 
+## Accessibilité / aria-label
+
+L'attribut `aria-label` étant indispensable pour l'accessibilité de ce composant, la propriété `ariaLabel` a été ajouté.
+
 ## Color
 
 Cette propriété est dépréciée. L'icône du bouton ne peut avoir qu'une seule couleur.
@@ -46,6 +50,7 @@ Cette propriété est dépréciée. L'icône du bouton ne peut avoir qu'une seul
 Par défaut
 ```html
 <PixIconButton
+    @ariaLabel="L'action du bouton"
     @icon='times'
     @triggerAction="{{triggerAction}}"
     @size='small'

--- a/addon/stories/pix-icon-button.stories.mdx
+++ b/addon/stories/pix-icon-button.stories.mdx
@@ -13,20 +13,50 @@ import * as stories from './pix-icon-button.stories.js';
 
 Le PixIconButton permet de créer un bouton contenant une icône font-awesome.
 
+## Default / Boutons d'action
+
+Le bouton par défaut. En small avec fond grisé.
+
 <Canvas>
-  <Story name="Icon button" story={stories.iconButton} height={60} />
+  <Story name="Default Small" story={stories.DefaultSmall} height={60} />
+</Canvas>
+
+## Default / Bouton de fermeture
+
+Le bouton par défaut. En big avec fond grisé.
+
+<Canvas>
+  <Story name="Default Big" story={stories.DefaultBig} height={60} />
+</Canvas>
+
+## Without Background
+
+Le bouton sans le fond grisé, pour les tableaux par exemple.
+
+<Canvas>
+  <Story name="Without Background" story={stories.withoutBackground} height={60} />
 </Canvas>
 
 ## Usage
 
-état enabled
+Par défaut
 ```html
-<PixIconButton @icon='times' @triggerAction="{{triggerAction}}"/>
+<PixIconButton
+    @icon='times'
+    @triggerAction="{{triggerAction}}"
+    @size='small'
+    @withBackground={{true}}
+/>
 ```
 
-état disabled
+État disabled
 ```html
-<PixIconButton @icon='times' @triggerAction="{{triggerAction}}" disabled={{true}} aria-disabled="{{true}}"/>
+<PixIconButton
+    @icon='times'
+    @triggerAction="{{triggerAction}}"
+    disabled={{true}}
+    aria-disabled="{{true}}"
+/>
 ```
 
-<ArgsTable story="Icon button" />
+<ArgsTable story="Default Small" />

--- a/addon/stories/pix-icon-button.stories.mdx
+++ b/addon/stories/pix-icon-button.stories.mdx
@@ -37,6 +37,10 @@ Le bouton sans le fond grisé, pour les tableaux par exemple.
   <Story name="Without Background" story={stories.withoutBackground} height={60} />
 </Canvas>
 
+## Color
+
+Cette propriété est dépréciée. L'icône du bouton ne peut avoir qu'une seule couleur.
+
 ## Usage
 
 Par défaut

--- a/addon/styles/_pix-icon-button.scss
+++ b/addon/styles/_pix-icon-button.scss
@@ -16,17 +16,22 @@
     cursor: default;
   }
 
-  &:hover, &:active {
+  &:hover, &:focus {
     transition: background-color 0.2s ease;
-    background-color: $grey-20;
+    background-color: $grey-15;
     &:disabled {
       background-color: transparent;
     }
   }
 
+  &:active {
+    transition: background-color 0.2s ease;
+    background-color: $grey-20;
+  }
+
   &--background {
-    background-color: $grey-15;
-    &:hover, &:active {
+    background-color: $grey-10;
+    &:hover, &:focus, &:active {
       &:disabled {
         background-color: $grey-15;
       }

--- a/addon/styles/_pix-icon-button.scss
+++ b/addon/styles/_pix-icon-button.scss
@@ -55,6 +55,6 @@
   }
 
   &--light-grey {
-    color: $grey-35;
+    color: $grey-60;
   }
 }

--- a/tests/integration/components/pix-icon-button-test.js
+++ b/tests/integration/components/pix-icon-button-test.js
@@ -2,6 +2,7 @@ import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { click, render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
+import createGlimmerComponent from "../../helpers/create-glimmer-component";
 
 module('Integration | Component | icon-button', function(hooks) {
   setupRenderingTest(hooks);
@@ -12,7 +13,7 @@ module('Integration | Component | icon-button', function(hooks) {
   test('it renders PixIconButton with a default fa-icon', async function(assert) {
     // when
     await render(hbs`
-      <PixIconButton></PixIconButton>
+      <PixIconButton @ariaLabel="action du bouton" />
     `);
     const iconElement = this.element.querySelector(iconClass);
 
@@ -23,7 +24,7 @@ module('Integration | Component | icon-button', function(hooks) {
   test('it renders PixIconButton with the specified FaIcon', async function(assert) {
     // when
     await render(hbs`
-      <PixIconButton @icon='times'></PixIconButton>
+      <PixIconButton @icon='times' @ariaLabel="action du bouton" />
     `);
     const iconElement = this.element.querySelector(iconClass);
 
@@ -39,7 +40,7 @@ module('Integration | Component | icon-button', function(hooks) {
       this.count = this.count + 1;
     });
     await render(hbs`
-      <PixIconButton @triggerAction={{this.triggerAction}} />
+      <PixIconButton @triggerAction={{this.triggerAction}} @ariaLabel="action du bouton" />
     `);
     await click('button');
 
@@ -53,12 +54,25 @@ module('Integration | Component | icon-button', function(hooks) {
 
     //when
     await render(hbs`
-      <PixIconButton @triggerAction={{this.triggerAction}} disabled={{true}} />
+      <PixIconButton @triggerAction={{this.triggerAction}} disabled={{true}} @ariaLabel="L'action du bouton" />
     `);
     await click('button');
 
     // then
     const componentElement = this.element.querySelector(COMPONENT_SELECTOR);
     assert.equal(componentElement.disabled, true);
+  });
+
+  test('it should not show PixIconButton if ariaLabel is not provided', async function(assert) {
+    // given
+    const componentParams = { ariaLabel:'   ' };
+    const component = createGlimmerComponent('component:pix-icon-button', componentParams);
+
+    // when & then
+    const expectedError = new Error('ERROR in PixIconButton component, @ariaLabel param is not provided.');
+    assert.throws(
+      function() { component.ariaLabel },
+      expectedError
+    );
   });
 });


### PR DESCRIPTION
## :unicorn: Problème
Les composants Pix UI ne correspondent pas tous à ce qui est défini dans le design system. Il faut également veiller à ce qu'ils soit accessibles et responsive.

Le composant `PixIconButton` ne correspond pas avec le design system sur les points suivants : 
 - nom du composant ( voir avec Quentin ) 
 - la propriété `color`, il n'existe qu'une couleur d'icône sur ZH. Si cette propriété est maintenu, le `light-grey` (grey-35) présente un problème coté contraste. (voir Remarques).

## :rainbow: Remarques

**Vu avec Quentin :**
 - Sur ZeroHeight, la couleur de l'icône et la couleur de fond du bouton manque de contraste, selon la norme WCAG. Nous gardons donc le `dark-grey` en `grey-60` pour l'icône. Cela devra être modifié sur ZeroHeight.
 - Déprécier la propriété `color`, car il n'y a qu'une couleur pour l'icône. `light-grey` n'est d'ailleurs pas utilisé dans les apps actuellement.

Coté accessibilité, il manquait aussi un aria-label. Comme ce composant est utilisé pour plusieurs actions, je ne pouvais pas mettre un aria-label par défaut. Je l'ai donc ajouté en tant que propriété du composant.  **( BREAKING CHANGES )**
**Cette propriété est obligatoire, sinon le composant ne s'affiche plus. ( BREAKING CHANGES )**

## :100: Pour tester
ZeroHeight : https://zeroheight.com/8dd127da7/p/20d723-floating-action-button-fab/i/50632906

Comparer ZeroHeight et Storybook : https://ui-pr123.review.pix.fr
