### PR TITLE
[FEATURE] Aligner le style du PixMessage avec le design system (PIX-3021).

### DIFF
--- a/addon/components/pix-message.js
+++ b/addon/components/pix-message.js
@@ -4,10 +4,14 @@ const TYPE_INFO = 'info';
 const TYPE_SUCCESS = 'success';
 const TYPE_WARNING = 'warning';
 const TYPE_ALERT = 'alert';
+const TYPE_ERROR = 'error';
 
 export default class PixMessage extends Component {
   get type() {
-    const correctTypes = [TYPE_INFO, TYPE_SUCCESS, TYPE_WARNING, TYPE_ALERT];
+    const correctTypes = [TYPE_INFO, TYPE_SUCCESS, TYPE_WARNING, TYPE_ALERT, TYPE_ERROR];
+    if (this.args.type === 'alert'){
+      console.warn('ERROR in PixMessage component, "alert" type is deprecated. Use "error" type instead.');
+    }
     return correctTypes.includes(this.args.type) ? this.args.type : 'info';
   }
 
@@ -17,6 +21,7 @@ export default class PixMessage extends Component {
       [TYPE_SUCCESS]: 'check-circle',
       [TYPE_WARNING]: 'exclamation-circle',
       [TYPE_ALERT]: 'exclamation-triangle',
+      [TYPE_ERROR]: 'exclamation-triangle',
     };
     return classes[this.type];
   }

--- a/addon/stories/pix-message.stories.js
+++ b/addon/stories/pix-message.stories.js
@@ -1,18 +1,42 @@
 import { hbs } from 'ember-cli-htmlbars';
 
-export const message = (args) => {
+const Template = (args) => {
   return {
     template: hbs`
-      <PixMessage @type={{type}} @withIcon={{withIcon}}>
-        Ceci est un message {{type}}
-      </PixMessage>
-      <PixMessage @type={{type}} @withIcon={{true}}>
-        Ceci est un message avec une icone et un texte tellement long<br />
-        qu'il est nécessaire de l'afficher sur deux lignes.
+      <PixMessage
+      @type={{type}}
+      @withIcon={{withIcon}}
+      >
+        Ceci est un message {{type}} avec un texte tellement long qu'il est nécessaire <br /> de l'afficher sur deux lignes.
       </PixMessage>
     `,
     context: args
   };
+};
+
+export const Default = Template.bind({});
+
+export const error = Template.bind({});
+error.args = {
+  type: 'error',
+  withIcon: true,
+};
+
+export const warning = Template.bind({});
+warning.args = {
+  type: 'warning',
+  withIcon: true,
+};
+
+export const success = Template.bind({});
+success.args = {
+  type: 'success',
+  withIcon: true,
+};
+
+export const withIcon = Template.bind({});
+withIcon.args = {
+  withIcon: true,
 };
 
 export const argTypes = {
@@ -21,11 +45,11 @@ export const argTypes = {
     description: 'Type du message',
     type: { name: 'string', required: false },
     defaultValue: 'info',
-    control: { type: 'select', options: ['info', 'success', 'warning', 'alert'] },
+    control: { type: 'select', options: ['info', 'success', 'warning', 'alert', 'error'] },
   },
   withIcon: {
     name: 'withIcon',
-    description: 'Icone du message',
+    description: 'Icône du message',
     type: { name: 'boolean', required: false },
     defaultValue: false,
     control: { type: 'boolean' },

--- a/addon/stories/pix-message.stories.mdx
+++ b/addon/stories/pix-message.stories.mdx
@@ -11,20 +11,61 @@ import * as stories from './pix-message.stories.js';
 
 # Pix Message
 
-Un bandeau d'information, par défaut de type info, avec une icone facultative.
+Un bandeau d'information avec une icône facultative.
 
-<Canvas isColumn>
-  <Story name="Message" story={stories.message} height={140} />
+## Default / Info
+
+Le bandeau est de type informatif sans icône (par défaut).
+
+<Canvas>
+  <Story name="Default" story={stories.Default} height={110} />
 </Canvas>
+
+## With icon
+
+Le bandeau avec une icône.
+
+<Canvas>
+  <Story name="With icon" story={stories.withIcon} height={110} />
+</Canvas>
+
+## Warning
+
+Le bandeau en cas d'alerte.
+
+<Canvas>
+  <Story name="Warning" story={stories.warning} height={110} />
+</Canvas>
+
+## Success
+
+Le bandeau en cas de validation.
+
+<Canvas>
+  <Story name="Success" story={stories.success} height={110} />
+</Canvas>
+
+## Error
+
+Le bandeau en cas de d'erreur.
+
+<Canvas>
+  <Story name="Error" story={stories.error} height={110} />
+</Canvas>
+
+## Alert
+
+⚠️ Ce type est déprécié, utilisez le type `error` à la place.
 
 ## Usage
 
+Par défaut
 ```html
-<PixMessage @type='info' @withIcon='true'>
+<PixMessage>
   Ceci est un message à caractère informatif.
 </PixMessage>
 ```
 
 ## Arguments
 
-<ArgsTable story="Message" />
+<ArgsTable story="Default" />

--- a/addon/styles/_colors.scss
+++ b/addon/styles/_colors.scss
@@ -71,6 +71,15 @@ $information-dark: #F24645;
 $information-light: #F1A141;
 $security-dark: #AC008D;
 $security-light: #FF3F94;
+$pink-alert-light: #FFE1E1;
+$pink-alert-dark: #A71E1A;
+$blue-alert-light: #DCF1FF;
+$blue-alert-dark: #0D25B3;
+$green-alert-light: #EFFFD8;
+$green-alert-dark: #006134;
+$yellow-alert-light: #FFF1C5;
+$yellow-alert-dark: #A95800;
+
 
 // status
 $error: #FF4B00;

--- a/addon/styles/_pix-message.scss
+++ b/addon/styles/_pix-message.scss
@@ -10,6 +10,7 @@
 
   &.pix-message--info { @include colorize($communication-light, 20%, 35%); }
   &.pix-message--alert { @include colorize($error, 20%, 40%); }
+  &.pix-message--error { @include colorize($error, 20%, 40%); }
   &.pix-message--success { @include colorize($success, 25%, 35%); }
   &.pix-message--warning { @include colorize($warning, 25%, 35%); }
 

--- a/addon/styles/_pix-message.scss
+++ b/addon/styles/_pix-message.scss
@@ -1,20 +1,35 @@
 .pix-message {
   @import 'reset-css';
 
-  position: relative;
-  margin: 0 0 1rem 0;
-  padding: 1rem;
+  margin: 0;
+  padding: 0.75rem 1rem;
+  font-size: 0.875rem;
   border-radius: 4px;
   align-items: center;
   display: flex;
 
-  &.pix-message--info { @include colorize($communication-light, 20%, 35%); }
-  &.pix-message--alert { @include colorize($error, 20%, 40%); }
-  &.pix-message--error { @include colorize($error, 20%, 40%); }
-  &.pix-message--success { @include colorize($success, 25%, 35%); }
-  &.pix-message--warning { @include colorize($warning, 25%, 35%); }
+  &.pix-message--info {
+    color: $blue-alert-dark;
+    background-color: $blue-alert-light;
+  }
+  &.pix-message--alert {
+    color: $pink-alert-dark;
+    background-color: $pink-alert-light;
+  }
+  &.pix-message--error {
+    color: $pink-alert-dark;
+    background-color: $pink-alert-light;
+  }
+  &.pix-message--success {
+    color: $green-alert-dark;
+    background-color: $green-alert-light;
+  }
+  &.pix-message--warning {
+    color: $yellow-alert-dark;
+    background-color: $yellow-alert-light;
+  }
 
   svg {
-    margin-right: 12px;
+    margin-right: 8px;
   }
 }

--- a/tests/integration/components/pix-message-test.js
+++ b/tests/integration/components/pix-message-test.js
@@ -50,8 +50,8 @@ module('Integration | Component | pix-message', function(hooks) {
     assert.equal(icon.getAttribute('data-icon'), 'check-circle');
   });
 
-  test('it renders with a alert icon for alert type', async function(assert) {
-    await render(hbs`<PixMessage @type="alert" @withIcon="true" />`);
+  test('it renders with a alert icon for error type', async function(assert) {
+    await render(hbs`<PixMessage @type="error" @withIcon="true" />`);
 
     const icon = this.element.querySelector('.pix-message svg');
     assert.dom('.pix-message svg').exists();

--- a/tests/integration/components/pix-message-test.js
+++ b/tests/integration/components/pix-message-test.js
@@ -71,4 +71,14 @@ module('Integration | Component | pix-message', function(hooks) {
     assert.dom('.pix-message svg').exists();
     assert.equal(icon.getAttribute('data-icon'), 'exclamation-triangle');
   });
+
+  test('it renders with a alert icon for alert type', async function(assert) {
+    // given
+    await render(hbs`<PixMessage @type="alert" @withIcon="true" />`);
+
+    // when & then
+    const icon = this.element.querySelector('.pix-message svg');
+    assert.dom('.pix-message svg').exists();
+    assert.equal(icon.getAttribute('data-icon'), 'exclamation-triangle');
+  });
 });

--- a/tests/integration/components/pix-message-test.js
+++ b/tests/integration/components/pix-message-test.js
@@ -7,52 +7,66 @@ module('Integration | Component | pix-message', function(hooks) {
   setupRenderingTest(hooks);
 
   test('it renders the given content', async function(assert) {
+    // given
     await render(hbs`<PixMessage>Message text</PixMessage>`);
 
+    // when & then
     assert.equal(this.element.textContent.trim(), 'Message text');
   });
 
   test('it renders with the given type', async function(assert) {
+    // given
     await render(hbs`<PixMessage @type="info" />`);
 
+    // when & then
     const pixMessageElement = this.element.querySelector('.pix-message');
     assert.equal(pixMessageElement.classList.toString(), 'pix-message pix-message--info');
   });
 
   test('it renders with attributes override', async function(assert) {
+    // given
     await render(hbs`<PixMessage aria-label="world" />`);
 
+    // when & then
     const pixMessageElement = this.element.querySelector('.pix-message');
     assert.equal(pixMessageElement.getAttribute('aria-label'), 'world');
   });
 
   test('it renders with an icon', async function(assert) {
+    // given
     await render(hbs`<PixMessage @withIcon="true" />`);
 
+    // when & then
     const icon = this.element.querySelector('.pix-message svg');
     assert.dom('.pix-message svg').exists();
     assert.equal(icon.getAttribute('data-icon'), 'info-circle');
   });
 
   test('it renders with a warning icon for warning type', async function(assert) {
+    // given
     await render(hbs`<PixMessage @type="warning" @withIcon="true" />`);
 
+    // when & then
     const icon = this.element.querySelector('.pix-message svg');
     assert.dom('.pix-message svg').exists();
     assert.equal(icon.getAttribute('data-icon'), 'exclamation-circle');
   });
 
   test('it renders with a success icon for success type', async function(assert) {
+    // given
     await render(hbs`<PixMessage @type="success" @withIcon="true" />`);
 
+    // when & then
     const icon = this.element.querySelector('.pix-message svg');
     assert.dom('.pix-message svg').exists();
     assert.equal(icon.getAttribute('data-icon'), 'check-circle');
   });
 
   test('it renders with a alert icon for error type', async function(assert) {
+    // given
     await render(hbs`<PixMessage @type="error" @withIcon="true" />`);
 
+    // when & then
     const icon = this.element.querySelector('.pix-message svg');
     assert.dom('.pix-message svg').exists();
     assert.equal(icon.getAttribute('data-icon'), 'exclamation-triangle');


### PR DESCRIPTION
## :unicorn: Problème
Les composants Pix UI ne correspondent pas tous à ce qui est défini dans le design system. Il faut également veiller à ce qu'ils soit accessibles et responsive.

Le composant PixMessage ne correspond pas avec le design system sur les points suivants :

 - les couleurs et taille de police à changer.
 - Le nom du composant est amené à devenir PixSectionMessage, mais sera modifié dans une future PR.
 - la propriété `withIcon`, il n'y a pas de message sans icône sur ZH.

## :rainbow: Remarques

- Déprécier le type 'alert' pour un 'error', comme spécifié dans ZeroHeight
- Après discussion avec Quentin la propriété `withIcon` ne sera pas dépréciée, l'icône reste facultative. En effet, nous avons constaté que ce composant était bien plus utilisé sans icône, ce qui reflète un besoin d'avoir cette version là.

## :100: Pour tester
ZeroHeight : https://zeroheight.com/8dd127da7/p/053ae9-inline-message

Comparer ZH et Storybook : https://ui-pr124.review.pix.fr
