### PR TITLE
[FEATURE] Ne pas afficher la tooltip si le texte est vide

### DIFF
--- a/addon/components/pix-tooltip.hbs
+++ b/addon/components/pix-tooltip.hbs
@@ -2,9 +2,11 @@
 
   {{yield}}
 
+  {{#if @text}}
   <span class='pix-tooltip__content pix-tooltip__content--{{this.position}} {{if @isInline 'pix-tooltip__content--inline'}}
     {{if @isLight 'pix-tooltip__content--light'}} {{if @isWide 'pix-tooltip__content--wide'}}'>
     {{@text}}
   </span>
+  {{/if}}
 
 </div>

--- a/addon/stories/pix-tooltip.stories.js
+++ b/addon/stories/pix-tooltip.stories.js
@@ -4,11 +4,11 @@ export const tooltip = (args) => {
   return {
     template: hbs`
       <PixTooltip
-        @text={{text}}
-        @position={{position}}
-        @isLight={{isLight}}
-        @isInline={{isInline}}
-        @isWide={{isWide}}
+        @text={{this.text}}
+        @position={{this.position}}
+        @isLight={{this.isLight}}
+        @isInline={{this.isInline}}
+        @isWide={{this.isWide}}
         >
           <div>Elément à survoler pour voir la tooltip</div>
       </PixTooltip>

--- a/addon/stories/pix-tooltip.stories.js
+++ b/addon/stories/pix-tooltip.stories.js
@@ -20,6 +20,7 @@ export const tooltip = (args) => {
 export const argTypes = {
   text: {
     name: 'text',
+    defaultValue: 'Tooltiptop',
     description: 'Texte à afficher',
     type: { name: 'string', required: false },
   },

--- a/addon/stories/pix-tooltip.stories.mdx
+++ b/addon/stories/pix-tooltip.stories.mdx
@@ -17,6 +17,8 @@ Ce composant est utilisé comme wrapper, c'est à dire qu'il encadre l'élément
 
 > ⚠️ A noter que le wrapper PixTooltip est en `display: flex;`, il s'adaptera donc à la taille de ses enfants. Ainsi si votre élément ne s'affiche plus comme avant après l'ajout de la PixTooltip, veillez à rajouter les dimensions voulues à l'enfant.
 
+> ⚠️ L'infobulle ne s'affichera pas si le texte est vide.
+
 <Canvas>
   <Story name="Tooltip" story={stories.tooltip} height={160} />
 </Canvas>
@@ -36,7 +38,7 @@ Ce composant est utilisé comme wrapper, c'est à dire qu'il encadre l'élément
 <PixTooltip
   @text='A looooooong looooooong text but in a single line'
   @position='left'
-  @isInline=true
+  @isInline={{true}}
   >
   <button>Tooltip inline left</button>
 </PixTooltip>
@@ -46,7 +48,7 @@ Ce composant est utilisé comme wrapper, c'est à dire qu'il encadre l'élément
 <PixTooltip
   @text='In accumsan scelerisque sapien, et lacinia nisi efficitur a.'
   @position='bottom'
-  @isLight=true
+  @isLight={{true}}
   >
   <button>Tooltip bottom light</button>
 </PixTooltip>
@@ -56,8 +58,8 @@ Ce composant est utilisé comme wrapper, c'est à dire qu'il encadre l'élément
 <PixTooltip
   @text='Lorem Ipsum is simply dummy text of the printing and typesetting industry.'
   @position='bottom-left'
-  @isLight=true
-  @wide=true
+  @isLight={{true}}
+  @isWide={{true}}
   >
   <button>Tooltip bottom left wide light</button>
 </PixTooltip>

--- a/tests/integration/components/pix-tooltip-test.js
+++ b/tests/integration/components/pix-tooltip-test.js
@@ -7,24 +7,10 @@ module('Integration | Component | pix-tooltip', function(hooks) {
   setupRenderingTest(hooks);
 
   const TOOLTIP_SELECTOR = '.pix-tooltip span';
-
-  test('it renders the default tooltip', async function(assert) {
-    // when
-    await render(hbs`
-      <PixTooltip>
-        template block text
-      </PixTooltip>
-    `);
-    const tooltipContentElement = this.element.querySelector(TOOLTIP_SELECTOR);
-
-    // then
-    assert.equal(this.element.textContent.trim(), 'template block text');
-    assert.equal(tooltipContentElement.classList.toString().trim(), 'pix-tooltip__content pix-tooltip__content--top');
-  });
+  const text = 'Un text à afficher au survol du contenu de la tooltip';
 
   test('it renders the tooltip text', async function(assert) {
     // given
-    const text = 'Un text à afficher au survol du contenu de la tooltip';
     this.set('text', text);
 
     // when
@@ -37,6 +23,20 @@ module('Integration | Component | pix-tooltip', function(hooks) {
 
     // then
     assert.equal(tooltipContentElement.innerHTML.trim(), text);
+  });
+
+  test('it renders only the inner data if there is no tooltip text', async function(assert) {
+    // when
+    await render(hbs`
+      <PixTooltip>
+        template block text
+      </PixTooltip>
+    `);
+    const tooltipContentElement = this.element.querySelector(TOOLTIP_SELECTOR);
+
+    // then
+    assert.equal(this.element.textContent.trim(), 'template block text');
+    assert.notOk(tooltipContentElement);
   });
 
   module('tooltip position', function() {
@@ -55,12 +55,12 @@ module('Integration | Component | pix-tooltip', function(hooks) {
     ].forEach(function(position) {
       test(`it can render ${position}`, async function(assert) {
         // given
+        this.set('text', text);
         this.set('position', position);
 
         // when
         await render(hbs`
-          <PixTooltip @position={{this.position}}>
-          </PixTooltip>
+          <PixTooltip @position={{this.position}} @text={{this.text}}></PixTooltip>
         `);
         const tooltipContentElement = this.element.querySelector(TOOLTIP_SELECTOR);
 
@@ -75,9 +75,12 @@ module('Integration | Component | pix-tooltip', function(hooks) {
     const LIGHT_CLASS = 'pix-tooltip__content--light';
 
     test('it can render in dark mode', async function(assert) {
+      // given
+      this.set('text', text);
+
       // when
       await render(hbs`
-        <PixTooltip>
+        <PixTooltip @text={{this.text}}>
         </PixTooltip>
       `);
       const tooltipContentElement = this.element.querySelector(TOOLTIP_SELECTOR);
@@ -88,9 +91,12 @@ module('Integration | Component | pix-tooltip', function(hooks) {
     });
 
     test('it can render in light mode', async function(assert) {
+      // given
+      this.set('text', text);
+
       // when
       await render(hbs`
-        <PixTooltip @isLight={{true}}>
+        <PixTooltip @isLight={{true}} @text={{this.text}}>
         </PixTooltip>
       `);
       const tooltipContentElement = this.element.querySelector(TOOLTIP_SELECTOR);
@@ -105,9 +111,12 @@ module('Integration | Component | pix-tooltip', function(hooks) {
     const INLINE_CLASS = 'pix-tooltip__content--inline';
 
     test('it can render in multiple lines', async function(assert) {
+      // given
+      this.set('text', text);
+
       // when
       await render(hbs`
-        <PixTooltip>
+        <PixTooltip @text={{this.text}}>
         </PixTooltip>
       `);
       const tooltipContentElement = this.element.querySelector(TOOLTIP_SELECTOR);
@@ -118,9 +127,12 @@ module('Integration | Component | pix-tooltip', function(hooks) {
     });
 
     test('it can render inline', async function(assert) {
+      // given
+      this.set('text', text);
+
       // when
       await render(hbs`
-        <PixTooltip @isInline={{true}}>
+        <PixTooltip @isInline={{true}} @text={{this.text}}>
         </PixTooltip>
       `);
       const tooltipContentElement = this.element.querySelector(TOOLTIP_SELECTOR);
@@ -135,9 +147,12 @@ module('Integration | Component | pix-tooltip', function(hooks) {
     const WIDE_CLASS = 'pix-tooltip__content--wide';
 
     test('it can render not widely', async function(assert) {
+      // given
+      this.set('text', text);
+
       // when
       await render(hbs`
-        <PixTooltip>
+        <PixTooltip @text={{this.text}}>
         </PixTooltip>
       `);
       const tooltipContentElement = this.element.querySelector(TOOLTIP_SELECTOR);
@@ -148,9 +163,12 @@ module('Integration | Component | pix-tooltip', function(hooks) {
     });
 
     test('it can render widely', async function(assert) {
+      // given
+      this.set('text', text);
+
       // when
       await render(hbs`
-        <PixTooltip @isWide={{true}}>
+        <PixTooltip @isWide={{true}} @text={{this.text}}>
         </PixTooltip>
       `);
       const tooltipContentElement = this.element.querySelector(TOOLTIP_SELECTOR);


### PR DESCRIPTION
## :unicorn: Description du composant
Problème: Le tooltip s'affiche vide si le texte fournit est vide
Solution: ne pas afficher le tooltip si le texte est vide

## 💥 Type de changement
Mineur (mise à jour de l'API, pas de régression)

## :100: Pour tester
ZeroHeight : https://zeroheight.com/8dd127da7/p/053ae9-inline-message

Comparer ZH et Storybook : https://ui-pr125.review.pix.fr
