### PR TITLE
[FEATURE] Permettre d'afficher du code formatté HTML dans la tooltip

### DIFF
--- a/addon/components/pix-tooltip.hbs
+++ b/addon/components/pix-tooltip.hbs
@@ -12,7 +12,7 @@
         {{if @isLight 'pix-tooltip__content--light'}}
         {{if @isWide 'pix-tooltip__content--wide'}}'
       >
-      {{@text}}
+      {{this.text}}
     </span>
   {{/if}}
 

--- a/addon/components/pix-tooltip.js
+++ b/addon/components/pix-tooltip.js
@@ -1,9 +1,19 @@
 import Component from '@glimmer/component';
+import { htmlSafe } from '@ember/template';
+
 
 export default class PixTooltip extends Component {
   get position() {
     const correctsPosition = ['top', 'right', 'bottom', 'bottom-left', 'bottom-right', 'left', 'top-left', 'top-right'];
     return correctsPosition.includes(this.args.position) ? this.args.position : 'top';
+  }
+
+  get text() {
+    if(this.args.unescapeHtml) {
+      return htmlSafe(this.args.text);
+    } else {
+      return this.args.text;
+    }
   }
 }
 

--- a/addon/stories/pix-tooltip.stories.js
+++ b/addon/stories/pix-tooltip.stories.js
@@ -10,6 +10,7 @@ const Template = (args) => {
         @isLight={{this.isLight}}
         @isInline={{this.isInline}}
         @isWide={{this.isWide}}
+        @unescapeHtml={{this.unescapeHtml}}
       >
         <PixButton aria-describedby="tooltip-1">
           {{this.label}}
@@ -69,6 +70,14 @@ bottom.args = {
   position: 'bottom'
 };
 
+export const unescapeHtml = Template.bind({});
+unescapeHtml.args = {
+  ... Default.args,
+  text: 'Hello <b style="color: red;">W</b>orld',
+  label: 'J\'affiche du html',
+  unescapeHtml: true,
+};
+
 export const argTypes = {
   id: {
     name: 'id',
@@ -103,6 +112,12 @@ export const argTypes = {
   isWide: {
     name: 'isWide',
     description: 'Affichage large',
+    type: { name: 'boolean', required: false },
+    table: { defaultValue: { summary: false } },
+  },
+  unescapeHtml: {
+    name: 'unescapeHtml',
+    description: 'Évite d\'échapper les caractères HTML',
     type: { name: 'boolean', required: false },
     table: { defaultValue: { summary: false } },
   },

--- a/addon/stories/pix-tooltip.stories.mdx
+++ b/addon/stories/pix-tooltip.stories.mdx
@@ -84,6 +84,14 @@ Infobulle dont le contenu reste sur une ligne.
   <Story name="Is Inline" story={stories.isInline} height={200} />
 </Canvas>
 
+## unescape HTML
+
+N'échappe pas l'HTML (Affiche du HTML formaté)
+
+<Canvas>
+    <Story name="unescape HTML" story={stories.unescapeHtml} height={200} />
+</Canvas>
+
 ## Usage
 
 ```html
@@ -102,7 +110,7 @@ Infobulle dont le contenu reste sur une ligne.
 
 <PixTooltip
   @text='Hey'
-  @isInline={{true}}
+  @isLight={{true}}
 >
   <button>Tooltip sur une ligne</button>
 </PixTooltip>
@@ -110,15 +118,23 @@ Infobulle dont le contenu reste sur une ligne.
 <PixTooltip
   @text='Hey'
   @position='bottom'
->
+  @isLight={{true}}
+  >
   <button>Tooltip apparaissant en bas</button>
 </PixTooltip>
 
 <PixTooltip
   @text='Hey'
   @isWide={{true}}
->
+  >
   <button>Tooltip en mode large</button>
+</PixTooltip>
+
+<PixTooltip
+  @text='Super <b style="color: green">i</b>n<b style="color: green">f</b>o'
+  @unescapeHtml={{true}}
+  >
+  <button>Html tooltip</button>
 </PixTooltip>
 ```
 

--- a/tests/integration/components/pix-tooltip-test.js
+++ b/tests/integration/components/pix-tooltip-test.js
@@ -177,4 +177,38 @@ module('Integration | Component | pix-tooltip', function(hooks) {
       assert.ok(tooltipContentElement.classList.toString().includes(WIDE_CLASS));
     });
   });
+
+  module('tooltip unescape html', function() {
+    const htmlText = '<b>Tooltip</b>'
+
+    test('it renders escaped html', async function(assert) {
+      // given
+      this.set('text', htmlText);
+
+      // when
+      await render(hbs`
+        <PixTooltip @text={{this.text}} @unescapeHtml={{false}}></PixTooltip>
+      `);
+      const tooltipContentElement = this.element.querySelector(TOOLTIP_SELECTOR);
+
+      // then
+      const displayedText = decodeURI(tooltipContentElement.innerHTML.trim());
+      assert.equal(displayedText, "&lt;b&gt;Tooltip&lt;/b&gt;");
+    });
+
+    test('it renders unescaped html', async function(assert) {
+      // given
+      this.set('text', htmlText);
+
+      // when
+      await render(hbs`
+        <PixTooltip @text={{this.text}} @unescapeHtml={{true}}></PixTooltip>
+      `);
+      const tooltipContentElement = this.element.querySelector(TOOLTIP_SELECTOR);
+
+      // then
+      const displayedText = decodeURI(tooltipContentElement.innerHTML.trim());
+      assert.equal(displayedText, "<b>Tooltip</b>");
+    });
+  });
 });


### PR DESCRIPTION
## :unicorn: Description du composant
Problème: On souhaite afficher du texte formaté (html) dans un tooltip
Solution: Ajouter une option _unescapeHtml_

## 💥 Type de changement
Mineur

## :100: Pour tester
ZeroHeight : https://zeroheight.com/8dd127da7/p/27df2f-tooltips

Comparer ZH et Storybook : https://ui-pr126.review.pix.fr
