### PR TITLE
[FEATURE] Aligner le style du PixBanner avec le design system (PIX-3022).

### DIFF
--- a/addon/stories/pix-banner.stories.js
+++ b/addon/stories/pix-banner.stories.js
@@ -1,69 +1,59 @@
 import { hbs } from 'ember-cli-htmlbars';
 
-export const defaultBanner = (args) => {
-  return {
-    template: hbs`
-      <PixBanner @type={{type}} >Parcours de rentrée 2020 : les codes sont disponibles dans l'onglet campagne. N’oubliez pas de les diffuser aux élèves avant la Toussaint.</PixBanner>
-    `,
-    context: args,
-  };
-};
-
-export const bannerWithExternalLink = (args) => {
+const Template = (args) => {
   return {
     template: hbs`
       <PixBanner
-        @actionLabel= "Voir le nouveau site"
-        @actionUrl= "www.test.fr/"
-      >Parcours de rentrée 2020 : les codes sont disponibles dans l'onglet campagne. N’oubliez pas de les diffuser aux élèves avant la Toussaint.</PixBanner>
+        @type={{type}}
+        @actionLabel={{actionLabel}}
+        @actionUrl={{actionUrl}}
+      >
+        Parcours de rentrée 2020 : les codes sont disponibles dans l'onglet campagne. N’oubliez pas de les diffuser aux élèves avant la Toussaint.
+      </PixBanner>
     `,
-    context: args,
+    context: args
   };
 };
 
-export const bannerWithInternalLink = (args) => {
-  return {
-    template: hbs`
-      <PixBanner
-        @actionLabel= "Voir la liste des participants"
-        @actionUrl= "campaign.list"
-      >Parcours de rentrée 2020 : les codes sont disponibles dans l'onglet campagne. N’oubliez pas de les diffuser aux élèves avant la Toussaint.</PixBanner>
-    `,
-    context: args,
-  };
+export const Default = Template.bind({});
+
+export const warning = Template.bind({});
+warning.args = {
+  type:'warning'
 };
 
-export const warningBanner = (args) => {
-  return {
-    template: hbs`
-      <PixBanner
-        @type="warning"
-      >Parcours de rentrée 2020 : les codes sont disponibles dans l'onglet campagne. N’oubliez pas de les diffuser aux élèves avant la Toussaint.</PixBanner>
-    `,
-    context: args,
-  };
+export const error = Template.bind({});
+error.args = {
+  type:'error'
 };
 
-export const errorBanner = (args) => {
-  return {
-    template: hbs`
-      <PixBanner
-        @type="error"
-      >Parcours de rentrée 2020 : les codes sont disponibles dans l'onglet campagne. N’oubliez pas de les diffuser aux élèves avant la Toussaint.</PixBanner>
-    `,
-    context: args,
-  };
+export const communicationPixApp = Template.bind({});
+communicationPixApp.args = {
+  type:'communication'
 };
 
-export const communicationBanner = (args) => {
-  return {
-    template: hbs`
-      <PixBanner
-        @type="communication"
-      >Parcours de rentrée 2020 : les codes sont disponibles dans l'onglet campagne. N’oubliez pas de les diffuser aux élèves avant la Toussaint.</PixBanner>
-    `,
-    context: args,
-  };
+export const communicationPixOrga = Template.bind({});
+communicationPixOrga.args = {
+  type:'communication-orga'
+};
+
+export const communicationPixCertif = Template.bind({});
+communicationPixCertif.args = {
+  type:'communication-certif'
+};
+
+export const withExternalLink = Template.bind({});
+withExternalLink.args = {
+  type:'info',
+  actionLabel: 'Voir le nouveau site',
+  actionUrl: 'www.test.fr/',
+};
+
+export const withInternalLink = Template.bind({});
+withInternalLink.args = {
+  type:'info',
+  actionLabel: 'Voir la liste des participants',
+  actionUrl: 'campaign.list',
 };
 
 export const argsTypes = {
@@ -75,7 +65,7 @@ export const argsTypes = {
   },
   actionUrl: {
     name: 'actionUrl',
-    description: 'Action link',
+    description: 'Lien de l‘action',
     type: { name: 'string', required: false },
     control: { disable: true },
   },

--- a/addon/stories/pix-banner.stories.js
+++ b/addon/stories/pix-banner.stories.js
@@ -61,13 +61,13 @@ export const argsTypes = {
     name: 'actionLabel',
     description: 'Nom de l‘action',
     type: { name: 'string', required: false },
-    control: { disable: true },
+    defaultValue: '',
   },
   actionUrl: {
     name: 'actionUrl',
     description: 'Lien de l‘action',
     type: { name: 'string', required: false },
-    control: { disable: true },
+    defaultValue: '',
   },
   type: {
     name: 'type',

--- a/addon/stories/pix-banner.stories.mdx
+++ b/addon/stories/pix-banner.stories.mdx
@@ -15,28 +15,67 @@ Une `Banner` permet de mettre en avant une information importante.
 
 > Il est possible de surcharger le style d'une `<PixBanner>` via l'attribut `class` ainsi que de passer n'importe quel attribut sur sa `div` wrapper (par exemple, un `aria-label`)
 
+
+## Default
+
+Bannière Information (par défaut).
+
+<Canvas>
+  <Story name="Default" story={stories.Default} height={75} />
+</Canvas>
+
+## Warning
+
+Bannière pour les alertes.
+
+<Canvas>
+  <Story name="Warning" story={stories.warning} height={75} />
+</Canvas>
+
+## Error
+
+Bannière pour les erreurs.
+
+<Canvas>
+  <Story name="Error" story={stories.error} height={75} />
+</Canvas>
+
+## Communication
+
 <Canvas isColumn>
-  Bannière Information (par défault)
-  <Story name="Default Banner" story={stories.defaultBanner} height={100} />
-  Bannière Communication
-  <Story name="Banner with a message" story={stories.communicationBanner} height={100} />
-  Bannière Warning
-  <Story name="Banner with a warning message" story={stories.warningBanner} height={100} />
-  Bannière Error
-  <Story name="Banner with a error message" story={stories.errorBanner} height={100} />
-  Bannière avec une route pour lien
-  <Story name="Banner with internal link" story={stories.bannerWithInternalLink} height={100} />
-  Bannière avec une route externe
-  <Story name="Banner with external link" story={stories.bannerWithExternalLink} height={100} />
+  Bannière pour Pix App
+  <Story name="Communication Pix App" story={stories.communicationPixApp} height={75} />
+  Bannière pour Pix Orga
+  <Story name="Pix Orga" story={stories.communicationPixOrga} height={75} />
+  Bannière pour Pix Certif
+  <Story name="Pix Certif" story={stories.communicationPixCertif} height={75} />
+</Canvas>
+
+## With Internal Link
+
+Bannière contenant un lien interne.
+
+<Canvas>
+  <Story name="With internal link" story={stories.withInternalLink} height={100} />
+</Canvas>
+
+## With External Link
+
+Bannière contenant un lien externe.
+
+<Canvas>
+  <Story name="With external link" story={stories.withExternalLink} height={100} />
 </Canvas>
 
 ## Usage
 
 ```html
-<PixBanner>Bannière sans action</PixBanner>
+<PixBanner>
+Bannière Info par défaut
+</PixBanner>
 
 <PixBanner @type='communication'>
-  Bannière Communication
+  Bannière Communication pour Pix App
 </PixBanner>
 
 <PixBanner @type='warning'>
@@ -65,4 +104,4 @@ Une `Banner` permet de mettre en avant une information importante.
 
 ## Arguments
 
-<ArgsTable story="Banner with internal link" />
+<ArgsTable story="Default" />

--- a/addon/styles/_breakpoints.scss
+++ b/addon/styles/_breakpoints.scss
@@ -1,8 +1,8 @@
 $breakpoints: (
-  'mobile': (max-width: 767px),
-  'tablet': (min-width: 768px),
-  'desktop': (min-width: 980px),
-  'large-screen': (min-width: 1261px),
+  'mobile': (max-width: 768px),
+  'tablet': (min-width: 769px),
+  'desktop': (min-width: 992px),
+  'large-screen': (min-width: 1200px),
 ) !default;
 
 @mixin device-is($breakpoint) {

--- a/addon/styles/_colors.scss
+++ b/addon/styles/_colors.scss
@@ -10,8 +10,8 @@ $white: #ffffff;
 // secondary
 $blue-hover: #3257D9;
 $dark-blue-pro: #1A38A0;
-$dark-green-certif: #1A8C89;
-$dark-orga: #0095C0;
+$dark-green-certif: #17817E;
+$dark-orga: #006C87;
 $green: #038125;
 $orga: #00DDFF;
 $purple: #8845FF;

--- a/addon/styles/_pix-banner.scss
+++ b/addon/styles/_pix-banner.scss
@@ -1,6 +1,6 @@
 .pix-banner {
   @import 'reset-css';
-  font-family: $font-open-sans;
+  font-family: $font-roboto;
   font-weight: $font-normal;
   padding: 10px 16px;
   display: flex;
@@ -8,7 +8,7 @@
   font-size: 0.75rem;
 
   @include device-is('tablet') {
-    padding: 32px 58px;
+    padding: 20px 60px;
     font-size: 0.875rem;
   }
 
@@ -27,35 +27,38 @@
   }
 
   &__icon {
-    font-size: 1rem;
-    margin-right: 10px;
+    font-size: 0.875rem;
+    margin-right: $spacing-xs;
 
     @include device-is('tablet') {
-      font-size: 1.25rem;
+      font-size: 1rem;
     }
   }
 
   &--information {
-    @include colorize($communication-light, 20%, 35%);
+    background-color: $blue-alert-light;
+    color: $blue-alert-dark;
   }
-  
+
   &--warning {
-    @include colorize($warning, 25%, 35%);
+    background-color: $yellow-alert-light;
+    color: $yellow-alert-dark;
   }
 
   &--error {
-    @include colorize($error, 20%, 40%);
+    background-color: $pink-alert-light;
+    color: $pink-alert-dark;
   }
 
   &--communication {
     background-color: $blue;
     color: $white;
-  
+
     &-orga {
       background-color: $dark-orga;
       color: $white;
     }
-  
+
     &-certif {
       background-color: $dark-green-certif;
       color: $white;

--- a/addon/styles/_spacing.scss
+++ b/addon/styles/_spacing.scss
@@ -1,0 +1,9 @@
+// See https://zeroheight.com/8dd127da7/p/6877af-layout/t/053b83
+
+$spacing-xxs: 4px;
+$spacing-xs: 8px;
+$spacing-s: 16px;
+$spacing-m: 24px;
+$spacing-l: 32px;
+$spacing-xl: 40px;
+$spacing-xxl: 48px;

--- a/addon/styles/addon.scss
+++ b/addon/styles/addon.scss
@@ -1,6 +1,7 @@
 @import 'breakpoints';
 @import 'colors';
 @import 'fonts';
+@import 'spacing';
 @import 'pix-background-header';
 @import 'pix-banner';
 @import 'pix-block';


### PR DESCRIPTION
## :unicorn: Problème
Les composants Pix UI ne correspondent pas tous à ce qui est défini dans le design system. Il faut également veiller à ce qu'ils soit accessibles et responsive.

Le composant PixBanner ne correspond pas avec le design system sur les points suivants :

- les couleurs et taille de police à changer.

## :rainbow: Remarques

Pour être en conformité avec le design system sur les breakpoints, colors et spacing: 
 - Ajout du fichier des [variables Sass spacing](https://zeroheight.com/8dd127da7/p/6877af-layout/t/053b83)
 - Mise à jour des [breakpoints](https://zeroheight.com/8dd127da7/p/6877af-layout/t/47086b).
 - Mise à jour de [deux couleurs](https://zeroheight.com/8dd127da7/p/839645-couleurs/t/535301), `$dark-orga` et `$dark-green-certif`.

## :100: Pour tester
ZH : https://zeroheight.com/8dd127da7/p/171be5-banners