### PR TITLE
[FEATURE] Aligner le style du PixTooltip avec le design system (PIX-3019).

### DIFF
--- a/addon/components/pix-tooltip.hbs
+++ b/addon/components/pix-tooltip.hbs
@@ -3,10 +3,17 @@
   {{yield}}
 
   {{#if @text}}
-  <span class='pix-tooltip__content pix-tooltip__content--{{this.position}} {{if @isInline 'pix-tooltip__content--inline'}}
-    {{if @isLight 'pix-tooltip__content--light'}} {{if @isWide 'pix-tooltip__content--wide'}}'>
-    {{@text}}
-  </span>
+    <span
+      id={{@id}}
+      role="tooltip"
+      class='
+        pix-tooltip__content pix-tooltip__content--{{this.position}}
+        {{if @isInline 'pix-tooltip__content--inline'}}
+        {{if @isLight 'pix-tooltip__content--light'}}
+        {{if @isWide 'pix-tooltip__content--wide'}}'
+      >
+      {{@text}}
+    </span>
   {{/if}}
 
 </div>

--- a/addon/components/pix-tooltip.hbs
+++ b/addon/components/pix-tooltip.hbs
@@ -1,4 +1,4 @@
-<div class='pix-tooltip' ...attributes>
+<span class='pix-tooltip' ...attributes>
 
   {{yield}}
 
@@ -16,4 +16,4 @@
     </span>
   {{/if}}
 
-</div>
+</span>

--- a/addon/stories/pix-tooltip.stories.js
+++ b/addon/stories/pix-tooltip.stories.js
@@ -4,13 +4,16 @@ const Template = (args) => {
   return {
     template: hbs`
       <PixTooltip
+        @id="tooltip-1"
         @text={{this.text}}
         @position={{this.position}}
         @isLight={{this.isLight}}
         @isInline={{this.isInline}}
         @isWide={{this.isWide}}
-        >
-          <PixButton>{{this.label}}</PixButton>
+      >
+        <PixButton aria-describedby="tooltip-1">
+          {{this.label}}
+        </PixButton>
       </PixTooltip>
     `,
     context: args,
@@ -67,6 +70,11 @@ bottom.args = {
 };
 
 export const argTypes = {
+  id: {
+    name: 'id',
+    description: 'Identifiant permettant de référencer le déclencheur via aria-describedby',
+    type: { name: 'string', required: true },
+  },
   text: {
     name: 'text',
     defaultValue: 'Tooltiptop',

--- a/addon/stories/pix-tooltip.stories.js
+++ b/addon/stories/pix-tooltip.stories.js
@@ -1,6 +1,6 @@
 import { hbs } from 'ember-cli-htmlbars';
 
-export const tooltip = (args) => {
+const Template = (args) => {
   return {
     template: hbs`
       <PixTooltip
@@ -10,11 +10,60 @@ export const tooltip = (args) => {
         @isInline={{this.isInline}}
         @isWide={{this.isWide}}
         >
-          <div>Elément à survoler pour voir la tooltip</div>
+          <PixButton>{{this.label}}</PixButton>
       </PixTooltip>
     `,
     context: args,
   };
+};
+
+export const Default = Template.bind({});
+Default.args = {
+  text: 'Hello World',
+  label: 'À survoler pour voir la tooltip',
+};
+
+export const isLight = Template.bind({});
+isLight.args = {
+  ... Default.args,
+  isLight: true
+};
+
+export const isWide = Template.bind({});
+isWide.args = {
+  ... Default.args,
+  text: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Ut egestas molestie mauris vel viverra.',
+  isWide: true
+};
+
+export const isInline = Template.bind({});
+isInline.args = {
+  ... Default.args,
+  text: 'Je suis une trèèèèèèèès longue information',
+  isInline: true
+};
+
+export const left = Template.bind({});
+left.args = {
+  ... Default.args,
+  label:'Mon infobulle apparaît à gauche',
+  position: 'left',
+  isInline: true
+};
+
+export const right = Template.bind({});
+right.args = {
+  ... Default.args,
+  label: 'Mon infobulle apparaît à droite',
+  position: 'right',
+  isInline: true
+};
+
+export const bottom = Template.bind({});
+bottom.args = {
+  ... Default.args,
+  label: 'Mon infobulle apparaît en bas',
+  position: 'bottom'
 };
 
 export const argTypes = {

--- a/addon/stories/pix-tooltip.stories.mdx
+++ b/addon/stories/pix-tooltip.stories.mdx
@@ -19,8 +19,47 @@ Ce composant est utilisé comme wrapper, c'est à dire qu'il encadre l'élément
 
 > ⚠️ L'infobulle ne s'affichera pas si le texte est vide.
 
+## Default
+
+Infobulle en position `top`, fond sombre (par défaut).
+
 <Canvas>
-  <Story name="Tooltip" story={stories.tooltip} height={160} />
+  <Story name="Default" story={stories.Default} height={130} />
+</Canvas>
+
+## Is Light
+
+Infobulle en mode clair.
+
+<Canvas>
+  <Story name="Is Light" story={stories.isLight} height={130} />
+</Canvas>
+
+## Position
+
+Différentes positions de l'infobulle.
+Existe aussi `top-left`, `top-right`, `bottom-left` et `bottom-right`.
+
+<Canvas isColumn>
+  <Story name="Left" story={stories.left} height={100} />
+  <Story name="Right" story={stories.right} height={100} />
+  <Story name="Bottom" story={stories.bottom} height={130} />
+</Canvas>
+
+## Is Wide
+
+Infobulle en plus large.
+
+<Canvas>
+  <Story name="Is Wide" story={stories.isWide} height={180} />
+</Canvas>
+
+## Is Inline
+
+Infobulle dont le contenu reste sur une ligne.
+
+<Canvas>
+  <Story name="Is Inline" story={stories.isInline} height={130} />
 </Canvas>
 
 ## Usage
@@ -28,43 +67,39 @@ Ce composant est utilisé comme wrapper, c'est à dire qu'il encadre l'élément
 ```html
 <PixTooltip
   @text='Hey'
-  @position='top'
-  >
-  <button>Tooltip top</button>
+>
+  <button>Tooltip par défaut</button>
 </PixTooltip>
 
-<br><br>
+<PixTooltip
+  @text='Hey'
+  @isLight={{true}}
+>
+  <button>Tooltip en mode clair</button>
+</PixTooltip>
 
 <PixTooltip
-  @text='A looooooong looooooong text but in a single line'
-  @position='left'
+  @text='Hey'
   @isInline={{true}}
-  >
-  <button>Tooltip inline left</button>
+>
+  <button>Tooltip sur une ligne</button>
 </PixTooltip>
 
-<br><br>
-
 <PixTooltip
-  @text='In accumsan scelerisque sapien, et lacinia nisi efficitur a.'
+  @text='Hey'
   @position='bottom'
-  @isLight={{true}}
-  >
-  <button>Tooltip bottom light</button>
+>
+  <button>Tooltip apparaissant en bas</button>
 </PixTooltip>
 
-<br><br>
-
 <PixTooltip
-  @text='Lorem Ipsum is simply dummy text of the printing and typesetting industry.'
-  @position='bottom-left'
-  @isLight={{true}}
+  @text='Hey'
   @isWide={{true}}
-  >
-  <button>Tooltip bottom left wide light</button>
+>
+  <button>Tooltip en mode large</button>
 </PixTooltip>
 ```
 
 ## Arguments
 
-<ArgsTable story="Tooltip" />
+<ArgsTable story="Default" />

--- a/addon/stories/pix-tooltip.stories.mdx
+++ b/addon/stories/pix-tooltip.stories.mdx
@@ -19,20 +19,42 @@ Ce composant est utilisé comme wrapper, c'est à dire qu'il encadre l'élément
 
 > ⚠️ L'infobulle ne s'affichera pas si le texte est vide.
 
+## Accessibilité
+
+Les tooltips doivent être appliquées de préférences sur des éléments nativement focusable comme `<button>` ou `<input>`.
+
+Si vous utilisez un élément `<div>` ou `<span>`, il faut ajouter `tabindex="0"` pour qu'il prenne le focus.
+
+```html
+<PixTooltip @text="My tooltip">
+  <span tabindex="0">Mon span</span>
+</PixTooltip>
+```
+
+Les tooltips doivent prendre un `@id` et être référencées par leur élément déclencheur via `aria-describedby`:
+
+```html
+<PixTooltip @id="tooltip-1" @text="My tooltip">
+  <PixButton aria-describedby="tooltip-1">Mon bouton</PixButton>
+</PixTooltip>
+```
+
 ## Default
 
 Infobulle en position `top`, fond sombre (par défaut).
 
 <Canvas>
-  <Story name="Default" story={stories.Default} height={130} />
+  <Story name="Default" story={stories.Default} height={200} />
 </Canvas>
 
 ## Is Light
 
 Infobulle en mode clair.
 
+> ⚠️ le tooltip "light" est à utiliser de préférence sur fond coloré ! Mais ce n'est pas obligatoire.
+
 <Canvas>
-  <Story name="Is Light" story={stories.isLight} height={130} />
+  <Story name="Is Light" story={stories.isLight} height={200} />
 </Canvas>
 
 ## Position
@@ -43,7 +65,7 @@ Existe aussi `top-left`, `top-right`, `bottom-left` et `bottom-right`.
 <Canvas isColumn>
   <Story name="Left" story={stories.left} height={100} />
   <Story name="Right" story={stories.right} height={100} />
-  <Story name="Bottom" story={stories.bottom} height={130} />
+  <Story name="Bottom" story={stories.bottom} height={150} />
 </Canvas>
 
 ## Is Wide
@@ -51,7 +73,7 @@ Existe aussi `top-left`, `top-right`, `bottom-left` et `bottom-right`.
 Infobulle en plus large.
 
 <Canvas>
-  <Story name="Is Wide" story={stories.isWide} height={180} />
+  <Story name="Is Wide" story={stories.isWide} height={200} />
 </Canvas>
 
 ## Is Inline
@@ -59,7 +81,7 @@ Infobulle en plus large.
 Infobulle dont le contenu reste sur une ligne.
 
 <Canvas>
-  <Story name="Is Inline" story={stories.isInline} height={130} />
+  <Story name="Is Inline" story={stories.isInline} height={200} />
 </Canvas>
 
 ## Usage

--- a/addon/styles/_pix-tooltip.scss
+++ b/addon/styles/_pix-tooltip.scss
@@ -6,7 +6,8 @@
   justify-content: center;
   align-items: center;
 
-  & > *:first-child:hover + .pix-tooltip__content {
+  & > *:first-child:hover + .pix-tooltip__content,
+  & > *:first-child:focus + .pix-tooltip__content{
     opacity: 1;
   }
 }
@@ -14,11 +15,10 @@
 .pix-tooltip__content {
   opacity: 0;
   pointer-events: none;
-  background-color: $black;
+  background-color: $grey-100;
   position: absolute;
   z-index: 100;
-  margin: 0;
-  padding: 10px 16px;
+  padding: 8px 16px;
   left: auto;
   color: $white;
   font-size: 0.875rem;
@@ -38,14 +38,13 @@
 
   &--wide {
     width: 382px;
-    padding: 16px;
   }
 
   &--light {
     background-color: $white;
     color: $grey-60;
     border: 1px solid $grey-40;
-    box-shadow: -2px 4px 4px 2px rgba($black, 0.1);
+    box-shadow: -2px 4px 4px 2px rgba($grey-100, 0.1);
 
     &::before {
       border-width: 1px;
@@ -62,7 +61,7 @@
   &::before {
     top: calc(50% - 5px); // 50% is the height of the parent and 5px the height of the triangle
     left: -10px; // 10px is width of the ::before elmt
-    border-color: transparent $black transparent transparent;
+    border-color: transparent $grey-100 transparent transparent;
   }
 
   &.pix-tooltip__content--light::before {
@@ -80,7 +79,7 @@
   &::before {
     top: 100%;
     left: calc(50% - 5px);
-    border-color: $black transparent transparent transparent;
+    border-color: $grey-100 transparent transparent transparent;
   }
 
   &.pix-tooltip__content--light::before {
@@ -97,7 +96,7 @@
   &::before {
     top: 100%;
     left: calc(100% - 27px);
-    border-color: $black transparent transparent transparent;
+    border-color: $grey-100 transparent transparent transparent;
   }
 
   &.pix-tooltip__content--light::before {
@@ -114,7 +113,7 @@
 
   &::before {
     top: 100%;
-    border-color: $black transparent transparent transparent;
+    border-color: $grey-100 transparent transparent transparent;
   }
 
   &.pix-tooltip__content--light::before {
@@ -132,7 +131,7 @@
   &::before {
     top: -10px;
     left: calc(50% - 5px);
-    border-color: transparent transparent $black transparent;
+    border-color: transparent transparent $grey-100 transparent;
   }
 
   &.pix-tooltip__content--light::before {
@@ -149,7 +148,7 @@
   &::before {
     top: -10px;
     left: calc(100% - 27px);
-    border-color: transparent transparent $black transparent;
+    border-color: transparent transparent $grey-100 transparent;
   }
 
   &.pix-tooltip__content--light::before {
@@ -166,7 +165,7 @@
 
   &::before {
     top: -10px;
-    border-color: transparent transparent $black transparent;
+    border-color: transparent transparent $grey-100 transparent;
   }
 
   &.pix-tooltip__content--light::before {
@@ -182,7 +181,7 @@
   &::before {
     top: calc(50% - 5px);
     right: -10px;
-    border-color: transparent transparent transparent $black;
+    border-color: transparent transparent transparent $grey-100;
   }
 
   &.pix-tooltip__content--light::before {

--- a/addon/styles/_pix-tooltip.scss
+++ b/addon/styles/_pix-tooltip.scss
@@ -8,11 +8,13 @@
 
   & > *:first-child:hover + .pix-tooltip__content,
   & > *:first-child:focus + .pix-tooltip__content{
+    display: block;
     opacity: 1;
   }
 }
 
 .pix-tooltip__content {
+  display: none;
   opacity: 0;
   pointer-events: none;
   background-color: $grey-100;

--- a/addon/styles/_pix-tooltip.scss
+++ b/addon/styles/_pix-tooltip.scss
@@ -21,8 +21,10 @@
   padding: 8px 16px;
   left: auto;
   color: $white;
+  font-family: $font-roboto;
   font-size: 0.875rem;
-  border-radius: 4px;
+  border-radius: 6px;
+  line-height: 1.4rem;
   transition: opacity 0.3s;
 
   &--inline {
@@ -41,13 +43,13 @@
   }
 
   &--light {
+    font-weight: $font-medium;
     background-color: $white;
     color: $grey-60;
-    border: 1px solid $grey-40;
-    box-shadow: -2px 4px 4px 2px rgba($grey-100, 0.1);
+    box-shadow: 0px 6px 24px 0px rgba($grey-70, 0.14);
 
     &::before {
-      border-width: 1px;
+      border-width: 0px;
       height: 8px;
       width: 8px;
       background-color: $white;


### PR DESCRIPTION
## :unicorn: Problème
Les composants Pix UI ne correspondent pas tous à ce qui est défini dans le design system. Il faut également veiller à ce qu'ils soit accessibles et responsive.

Le composant PixTooltip ne correspond pas avec le design system sur les points suivants :

- Couleur de fond pour le mode foncé.

![image](https://user-images.githubusercontent.com/516360/131646232-3fbd5d68-49fe-4336-856c-697defc5f35a.png)

- Bordure pour le mode clair.

![image](https://user-images.githubusercontent.com/516360/131646263-08ead7aa-c14d-40ed-9cf4-42be995f9c4c.png)

## :rainbow: Remarques
- Le tooltip est désormais visible au focus.
- Cacher la tooltip dans le DOM (`display: none`) pour éviter d'avoir le focus sur des éléments à l'intérieur de la tooltip quand celle-ci n'est pas affichée.

Des éléments d'accessibilité ont été ajouté au niveau du composant ont été ajouté (ex: `role="tooltip"`).

Également une documentation plus précise des éléments d'a11y à prendre en compte à l'utilisation de `PixTooltip` : 

![image](https://user-images.githubusercontent.com/516360/131646731-c333e0b4-f045-421c-a5e9-8a94177c8c16.png)


## :100: Pour tester
Lien vers Zeroheight https://zeroheight.com/8dd127da7/p/27df2f-tooltips et Storybook https://ui-pr129.review.pix.fr
