### PR TITLE
[FEATURE] Centrer les boutons d'un formulaire par défaut

### DIFF
--- a/addon/styles/_form.scss
+++ b/addon/styles/_form.scss
@@ -42,6 +42,7 @@
 
 .pix-form__actions {
   display: flex;
+  justify-content: center;
 
   & > .pix-button:first-child {
     margin-right: 10px;


### PR DESCRIPTION
## :unicorn: Description du composant
Une classe d'aide a été introduite pour l'harmonisation des composants de formulaire : `.pix-form__actions`.
Cette dernière permet d'espacer 2 boutons d'actions comme on a souvent en fin de formulaire.

Cependant lorsqu'on a 1 seul bouton, ou bien que le formulaire est bien large, il est souvent souhaité que les boutons soient centrés.

## :rainbow: Remarques
NE PAS MERGER CETTE PR
Elle servira aux tests du "ready-to-merge" de Pix-UI.

## :100: Pour tester
> _Lien vers Zeroheight (modèle) et Storybook (rendu final)._
