### PR TITLE
[TECH] Enlever le padding des section mis globalement

### DIFF
--- a/addon/styles/addon.scss
+++ b/addon/styles/addon.scss
@@ -31,7 +31,3 @@ html {
 body {
   font-family: $font-roboto;
 }
-
-section {
-  padding: 10px;
-}


### PR DESCRIPTION
## :unicorn: Description du problème
Il existe un `section{ padding: 10px }`, introduit dans un commit par erreur (https://github.com/1024pix/pix-ui/pull/66/commits/a586698ecf128cb28ec238a792850e48f0390f9c) qui pose des soucis dans nos applications front : 
![image](https://user-images.githubusercontent.com/38167520/131977944-03268be3-e323-452d-ba80-f2eab14db538.png)
(voir https://github.com/1024pix/pix/pull/3441#issuecomment-912330279)

Ce padding ne devrait pas être présent sur un style global.

## :100: Pour tester
> _Lien vers Zeroheight (modèle) et Storybook (rendu final)._
