### PR TITLE
[TECH] Exclure des fichiers de l'archive pix-ui

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,13 @@
+.circleci export-ignore
+.gitattribute export-ignore
+.github export-ignore
+.storybook export-ignore
+.docs export-ignore
+scripts export-ignore
+.buildpacks export-ignore
+.editorconfig export-ignore
+.gitattributes export-ignore
+.gitignore export-ignore
+scalingo.json export-ignore
+servers.conf.erb export-ignore
+

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "license": "MIT",
   "author": "GIP Pix",
   "engines": {
-    "node": "14.16.0"
+    "node": "^14.16.0"
   },
   "ember": {
     "edition": "octane"


### PR DESCRIPTION
## :unicorn: Description
Github permet de récupérer des archives du repo via une url: 
[https://github.com/1024pix/pix-ui/tarball/v5.5.0](https://github.com/1024pix/pix-ui/tarball/v5.5.0) permet d'acceder à l'archive contenant le code lié au tag 5.5.0.
C'est utile lors de l'installation via npm, on peut alors utiliser:
utiliser `npm install https://github.com/1024pix/pix-ui/tarball/v5.5.0"` qui va ajouter la ligne dans le package.json: `"pix-ui": "https://github.com/1024pix/pix-ui/tarball/v5.5.0",`

Il est possible d'exclure des fichiers de l'archive afin d'alleger celle-çi
    

## :rainbow: Remarques
Mise à jour de la version node à 'compatible' pour éviter un warning lors d'une installation depuis un projet avec une version de node compatible.

## :100: Pour tester

- Supprimer la dépendance de pix-ui sur un projet (si deja existant)
- Ajouter la dépendance `npm install https://github.com/1024pix/pix-ui/tarball/v5.5.0"` (reprendre la version désinstallée)
- Verifier que les composants `pix-ui` sont bien importés
- Verifier que `node_modules/pix-ui` ne contient pas la partie storybook, github etc...
