### PR TITLE
[BUGFIX] Pouvoir uploader le même nom de fichier 2 fois de suite

### DIFF
--- a/addon/components/pix-button-upload.hbs
+++ b/addon/components/pix-button-upload.hbs
@@ -5,6 +5,7 @@
   id={{@id}}
   type="file"
   class="pix-button-upload__input"
-  {{on "change" this.handleChange}}
+  value={{this.files}}
+  {{on "input" this.handleChange}}
   ...attributes
 />

--- a/addon/components/pix-button-upload.js
+++ b/addon/components/pix-button-upload.js
@@ -1,15 +1,20 @@
 import PixButtonBase from './pix-button-base';
 import { action } from '@ember/object';
+import { tracked } from '@glimmer/tracking';
 
 export default class PixButtonUpload extends PixButtonBase {
+  @tracked
+  files = [];
+
   get className() {
     return super.baseClassNames.join(' ');
   }
 
   @action
-  handleChange(e) {
-    if (e.target && e.target.files && e.target.files.length) {
-      this.args.onChange(e.target.files);
+  async handleChange(e) {
+    if (e.target?.files?.length) {
+      await this.args.onChange(e.target.files);
     }
+    this.files = [];
   }
 }


### PR DESCRIPTION
## :unicorn: Problème

Quand on essaye d'uploader 2 fois de suite un fichier avec le même nom, celui-ci n'est pas uploader la seconde fois car le nom du fichier n'a pas changé donc l'évènement ne se déclenche pas.

Vous pouvez observer dans l'onglet "Actions" du canvas que l'action ne se déclenche qu'une seule fois quand on importe 2 fois le même fichier: https://storybook.pix.fr/?path=/story/basics-buttonupload--button-upload

## :rainbow: Solution

Gérer un état interne avec les fichiers et réinitialiser cet état quand l'upload a été effectué.

## :100: Pour tester

Dans storybook, uploader 2 fois de suite le même fichier et voir dans l'onglet "Action" qu'il y a 2 logs (une pour chaque upload). Ce qui n'est pas le cas dans le version actuelle de Pix UI
https://ui-pr136.review.pix.fr/?path=/story/basics-buttonupload--button-upload
