### PR TITLE
[TECH] Restreindre les permissions par défaut du github token

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -1,4 +1,5 @@
 name: automerge check
+
 on:
   pull_request:
     types:
@@ -6,6 +7,11 @@ on:
   check_suite:
     types:
       - completed
+
+permissions:
+  contents: read
+  pull-requests: write
+
 jobs:
   automerge:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## :unicorn: Description du composant
Une bonne pratique lors de la mise en place de workflows avec un github token est de restreindre au maximum les permissions de ce dernier. 
> As a good security practice, you should grant the GITHUB_TOKEN the least required access.

> When the permissions key is used, all unspecified permissions are set to no access, with the exception of the metadata scope, which always gets read **access.**

Pour plus d'info : https://docs.github.com/en/actions/security-guides/automatic-token-authentication#modifying-the-permissions-for-the-github_token

Le fichier yaml de l'auto-merge a donc été adapté pour autoriser l'écriture au merge.
Pour la permissions de lecture et d'écriture je me suis basée sur l'example suivant : 
https://docs.github.com/en/actions/security-guides/automatic-token-authentication#example-1-passing-the-github_token-as-an-input 

## :100: Pour tester
Il faut merger une autre PR avec le ready-to-merge et vérifier que ça fonctionne comme prévu.
