### PR TITLE
[TECH] Ajout du helper contains

### DIFF
--- a/tests/helpers/contains.js
+++ b/tests/helpers/contains.js
@@ -1,0 +1,31 @@
+import { getRootElement } from '@ember/test-helpers';
+
+function _isTextInElement(element, text) {
+  const isTextFoundInElement = element.textContent?.trim().includes(text) || element.value?.trim().includes(text);
+
+  if (isTextFoundInElement) {
+    return true;
+  }
+
+  const hasElementChildren = element.children.length > 0;
+  if (hasElementChildren) {
+    for (let i = 0; i < element.children.length; i++) {
+      if (_isTextInElement(element.children[i], text)) {
+        return true;
+      }
+    }
+  }
+
+  return false;
+}
+
+export function contains(text) {
+  const result = _isTextInElement(getRootElement(), text);
+
+  let message = `There is no elements with "${ text }"`;
+  if (result) {
+    message = `Element with "${ text }" found`;
+  }
+
+  this.pushResult({ result, message });
+}

--- a/tests/integration/components/pix-background-header-test.js
+++ b/tests/integration/components/pix-background-header-test.js
@@ -20,7 +20,7 @@ module('Integration | Component | pix-background-header', function(hooks) {
     const backgroundElement = this.element.querySelector(BACKGROUND_SELECTOR);
 
     // then
-    assert.equal(backgroundHeaderElement.textContent.trim(), 'Je suis un beau background bleu');
+    assert.contains('Je suis un beau background bleu');
     assert.equal(backgroundHeaderElement.className, 'pix-background-header');
     assert.equal(backgroundElement.className, 'pix-background-header__background');
   });
@@ -35,7 +35,7 @@ module('Integration | Component | pix-background-header', function(hooks) {
       await render(hbs`
         <PixBackgroundHeader>
           <PixBlock @shadow={{this.shadowWeight}}>Je suis un beau bloc foncé</PixBlock>
-          <PixBlock>Je suis deuxième bloc</PixBlock>
+          <PixBlock>Je suis un deuxième bloc</PixBlock>
         </PixBackgroundHeader>
       `);
       const firstBlockElement = this.element.querySelector(BACKGROUND_HEADER_SELECTOR).children[1];
@@ -43,9 +43,9 @@ module('Integration | Component | pix-background-header', function(hooks) {
 
       // then
       assert.equal(firstBlockElement.className, 'pix-block pix-block--shadow-heavy');
-      assert.equal(firstBlockElement.textContent.trim(), 'Je suis un beau bloc foncé');
+      assert.contains('Je suis un beau bloc foncé');
       assert.equal(lastBlockElement.className, 'pix-block pix-block--shadow-light');
-      assert.equal(lastBlockElement.textContent.trim(), 'Je suis deuxième bloc');
+      assert.contains('Je suis un deuxième bloc');
     });
   });
 });

--- a/tests/integration/components/pix-banner-test.js
+++ b/tests/integration/components/pix-banner-test.js
@@ -17,8 +17,8 @@ module('Integration | Component | Pix Banner', function(hooks) {
     `);
 
     // then
+    assert.contains('Mon texte');
     const componentElement = this.element.querySelector(COMPONENT_SELECTOR);
-    assert.equal(componentElement.textContent.trim(), 'Mon texte');
     assert.equal(componentElement.classList.toString().trim(), 'pix-banner pix-banner--information');
   });
 
@@ -101,7 +101,7 @@ module('Integration | Component | Pix Banner', function(hooks) {
     `);
 
     // then
-    assert.equal(this.element.querySelector('a').textContent.trim(), 'Explorer');
+    assert.contains('Explorer');
     assert.equal(this.element.querySelector('a').getAttribute('href'), 'www.test.fr/');
   });
 
@@ -117,6 +117,6 @@ module('Integration | Component | Pix Banner', function(hooks) {
     `);
 
     // then
-    assert.equal(this.element.querySelector('a').textContent.trim(), 'Explorer');
+    assert.contains('Explorer');
   });
 });

--- a/tests/integration/components/pix-block-test.js
+++ b/tests/integration/components/pix-block-test.js
@@ -18,7 +18,7 @@ module('Integration | Component | pix-block', function(hooks) {
     const blockElement = this.element.querySelector(BLOCK_SELECTOR);
 
     // then
-    assert.equal(blockElement.textContent.trim(), 'Je suis un beau bloc avec une ombre légere');
+    assert.contains('Je suis un beau bloc avec une ombre légere');
     assert.equal(blockElement.className, 'pix-block pix-block--shadow-light');
   });
 
@@ -35,7 +35,7 @@ module('Integration | Component | pix-block', function(hooks) {
     const blockElement = this.element.querySelector(BLOCK_SELECTOR);
 
     // then
-    assert.equal(blockElement.textContent.trim(), 'Je suis trop d4rk');
+    assert.contains('Je suis trop d4rk');
     assert.equal(blockElement.className, 'pix-block pix-block--shadow-heavy');
   });
 
@@ -52,7 +52,7 @@ module('Integration | Component | pix-block', function(hooks) {
     const blockElement = this.element.querySelector(BLOCK_SELECTOR);
 
     // then
-    assert.equal(blockElement.textContent.trim(), 'Joli bloc quand même');
+    assert.contains('Joli bloc quand même');
     assert.equal(blockElement.className, 'pix-block pix-block--shadow-light');
   });
 });

--- a/tests/integration/components/pix-button-test.js
+++ b/tests/integration/components/pix-button-test.js
@@ -19,7 +19,7 @@ module('Integration | Component | button', function(hooks) {
 
     // then
     const componentElement = this.element.querySelector(COMPONENT_SELECTOR);
-    assert.equal(componentElement.textContent.trim(), 'Mon bouton');
+    assert.contains('Mon bouton');
     assert.equal(componentElement.type, 'button');
   });
 

--- a/tests/integration/components/pix-button-upload-test.js
+++ b/tests/integration/components/pix-button-upload-test.js
@@ -6,8 +6,6 @@ import { hbs } from 'ember-cli-htmlbars';
 module('Integration | Component | button-upload', function(hooks) {
   setupRenderingTest(hooks);
 
-  const COMPONENT_SELECTOR = '.pix-button';
-
   test('it renders the default PixButtonUpload', async function(assert) {
     // when
     await render(hbs`
@@ -15,10 +13,9 @@ module('Integration | Component | button-upload', function(hooks) {
         content
       </PixButtonUpload>
     `);
-    const componentElement = this.element.querySelector(COMPONENT_SELECTOR);
 
     // then
-    assert.equal(componentElement.textContent.trim(), 'content');
+    assert.contains('content');
   });
 
 });

--- a/tests/integration/components/pix-collapsible-test.js
+++ b/tests/integration/components/pix-collapsible-test.js
@@ -8,7 +8,6 @@ module('Integration | Component | collapsible', function(hooks) {
   setupRenderingTest(hooks);
 
   const COLLAPSIBLE_TITLE_SELECTOR = '.pix-collapsible__title';
-  const COLLAPSIBLE_CONTENT_SELECTOR = '.pix-collapsible__content';
 
   test('it show only PixCollapsible title by default', async function(assert) {
     // when
@@ -19,8 +18,7 @@ module('Integration | Component | collapsible', function(hooks) {
     `);
 
     // then
-    const componentElement = this.element.querySelector(COLLAPSIBLE_TITLE_SELECTOR);
-    assert.equal(componentElement.textContent.trim(), 'Titre de mon élément déroulable');
+    assert.contains('Titre de mon élément déroulable');
   });
 
   test('it shows content on click on PixCollapsible title', async function(assert) {
@@ -33,8 +31,8 @@ module('Integration | Component | collapsible', function(hooks) {
     await click(COLLAPSIBLE_TITLE_SELECTOR);
 
     // then
-    assert.dom(COLLAPSIBLE_TITLE_SELECTOR).hasText('Titre de mon élément déroulable');
-    assert.dom(COLLAPSIBLE_CONTENT_SELECTOR).hasText('Contenu de mon élément');
+    assert.contains('Titre de mon élément déroulable');
+    assert.contains('Contenu de mon élément');
   });
 
   test('it should not show PixCollapsible if title is not provided', async function(assert) {

--- a/tests/integration/components/pix-filter-banner-test.js
+++ b/tests/integration/components/pix-filter-banner-test.js
@@ -8,8 +8,6 @@ import sinon from 'sinon';
 module('Integration | Component | filter-banner', function(hooks) {
   setupRenderingTest(hooks);
 
-  const COMPONENT_SELECTOR = '.pix-filter-banner';
-
   test('it renders the default PixFilterBanner', async function(assert) {
     // when
     await render(hbs`
@@ -17,10 +15,9 @@ module('Integration | Component | filter-banner', function(hooks) {
         content
       </PixFilterBanner>
     `);
-    const componentElement = this.element.querySelector(COMPONENT_SELECTOR);
 
     // then
-    assert.equal(componentElement.textContent.trim(), 'content');
+    assert.contains('content');
   });
 
   test('it renders the PixFilterBanner with title', async function(assert) {
@@ -30,10 +27,9 @@ module('Integration | Component | filter-banner', function(hooks) {
         content
       </PixFilterBanner>
     `);
-    const componentElement = this.element.querySelector('.pix-filter-banner__title');
 
     // then
-    assert.equal(componentElement.textContent.trim(), 'Titre de la bannière');
+    assert.contains('Titre de la bannière');
   });
 
   test('it renders the PixFilterBanner with details', async function(assert) {
@@ -43,10 +39,9 @@ module('Integration | Component | filter-banner', function(hooks) {
         content
       </PixFilterBanner>
     `);
-    const componentElement = this.element.querySelector('.pix-filter-banner__details');
 
     // then
-    assert.equal(componentElement.textContent.trim(), '5 participants filtrés');
+    assert.contains('5 participants filtrés');
   });
 
   test('it renders the PixFilterBanner with a clearFiltersLabel button', async function(assert) {
@@ -57,13 +52,12 @@ module('Integration | Component | filter-banner', function(hooks) {
     // when
     await render(hbs`
       <PixFilterBanner @clearFiltersLabel={{clearFiltersLabel}} @onClearFilters={{onClearFilters}}>
-       content
+        content
       </PixFilterBanner>
     `);
     
     // then
-    const button = this.element.querySelector('button');
-    assert.equal(button.textContent.trim(), this.clearFiltersLabel);
+    assert.contains(this.clearFiltersLabel);
   });
 
   test('it should trigger onClearFilters when button clicked', async function(assert) {

--- a/tests/integration/components/pix-input-password-test.js
+++ b/tests/integration/components/pix-input-password-test.js
@@ -8,72 +8,68 @@ module('Integration | Component | pix-input-password', function(hooks) {
   setupRenderingTest(hooks);
 
   const INPUT_SELECTOR = '.pix-input-password input[type=password]';
-  const LABEL_SELECTOR = '.pix-input__label';
   const INFORMATION_SELECTOR = '.pix-input__information';
-  const ERROR_SELECTOR = '.pix-input__error-message';
   const BUTTON_SELECTOR = '.pix-input-password__button';
 
   test('it should throw an error if there is no id', async function(assert) {
-    // given
+    // given & when
     const componentParams = { id: '   ' };
     const component = createGlimmerComponent('component:pix-input-password', componentParams);
 
-    // when & then
+    // then
     const expectedError = new Error('ERROR in PixInput component, @id param is not provided');
     assert.throws(function() { component.id }, expectedError);
   });
 
   test('it should be possible to have an input label', async function(assert) {
-    // given
+    // given & when
     await render(hbs`<PixInputPassword @label="Mot de passe" @id="password" />`);
 
-    // when & then
-    const selectorElement = this.element.querySelector(LABEL_SELECTOR);
-    assert.equal(selectorElement.innerHTML, 'Mot de passe');
+    // then
+    assert.contains('Mot de passe');
   });
 
   test('it should be possible to add extra information to input', async function(assert) {
-    // given
+    // given & when
     await render(hbs`<PixInputPassword @label="Mot de passe" @id="password" @information="une brève information" />`);
 
-    // when & then
+    // then
     const selectorElement = this.element.querySelector(INFORMATION_SELECTOR);
     assert.equal(selectorElement.innerHTML, 'une brève information');
   });
 
   test('it should be possible to associate an error message to input', async function(assert) {
-    // given
+    // given & when
     await render(hbs`<PixInputPassword @label="Mot de passe" @id="password" @errorMessage="Un message d'erreur." />`);
 
-    // when & then
-    const selectorElement = this.element.querySelector(ERROR_SELECTOR);
-    assert.equal(selectorElement.innerHTML, 'Un message d\'erreur.');
+    // then
+    assert.contains('Un message d\'erreur.');
   });
 
   test('it should be possible to add more params to input', async function(assert) {
-    // given
+    // given & when
     await render(hbs`<PixInputPassword @label="Mot de passe" @id="password" autocomplete="off" />`);
 
-    // when & then
+    // then
     const selectorElement = this.element.querySelector(INPUT_SELECTOR);
     assert.equal(selectorElement.autocomplete, 'off');
   });
 
   test('it renders PixInputPassword with password visibility button', async function(assert) {
-    // given
+    // given & when
     await render(hbs`<PixInputPassword @label="Mot de passe" @id="password" />`);
 
-    // when & then
+    // then
     const passwordVisibilityButton = this.element.querySelector(BUTTON_SELECTOR);
     assert.dom(passwordVisibilityButton).exists();
   });
 
   test('it should throw an error if PixInputPassword has neither a label nor an ariaLabel param', async function(assert) {
-    // given
+    // given & when
     const componentParams = { label: null, ariaLabel: null };
     const component = createGlimmerComponent('component:pix-input-password', componentParams);
 
-    // when & then
+    // then
     const expectedError = new Error('ERROR in PixInputPassword component, you must provide @label or @ariaLabel params');
     assert.throws(function() { component.label }, expectedError);
     assert.throws(function() { component.ariaLabel }, expectedError);

--- a/tests/integration/components/pix-input-test.js
+++ b/tests/integration/components/pix-input-test.js
@@ -8,9 +8,6 @@ module('Integration | Component | input', function(hooks) {
   setupRenderingTest(hooks);
 
   const INPUT_SELECTOR = '.pix-input input';
-  const LABEL_SELECTOR = '.pix-input__label';
-  const INFORMATION_SELECTOR = '.pix-input__information';
-  const ERROR_SELECTOR = '.pix-input__error-message';
 
   test('it renders the default PixInput', async function(assert) {
     // when
@@ -18,68 +15,64 @@ module('Integration | Component | input', function(hooks) {
     await fillIn(INPUT_SELECTOR, 'Jeanne');
 
     // then
-    const selectorElement = this.element.querySelector(INPUT_SELECTOR);
-    assert.equal(selectorElement.value, 'Jeanne');
+    assert.contains('Jeanne');
   });
 
   test('it should throw an error if there is no id', async function(assert) {
-    // given
+    // given & when
     const componentParams = { id: '   ' };
     const component = createGlimmerComponent('component:pix-input', componentParams);
 
-    // when & then
+    // then
     const expectedError = new Error('ERROR in PixInput component, @id param is not provided');
     assert.throws(function() { component.id }, expectedError);
   });
 
   test('it should be possible to give a label to input', async function(assert) {
-    // given
+    // given & when
     await render(hbs`<PixInput @label="Prénom" @id="firstName" />`);
 
-    // when & then
-    const selectorElement = this.element.querySelector(LABEL_SELECTOR);
-    assert.equal(selectorElement.innerHTML, 'Prénom');
+    // then
+    assert.contains('Prénom');
   });
 
   test('it should be possible to give an extra information to input', async function(assert) {
-    // given
+    // given & when
     await render(hbs`<PixInput @id="firstName" @label="Prénom" @information="a small information" />`);
 
-    // when & then
-    const selectorElement = this.element.querySelector(INFORMATION_SELECTOR);
-    assert.equal(selectorElement.innerHTML, 'a small information');
+    // then
+    assert.contains('a small information');
   });
 
   test('it should be possible to give an error message to input', async function(assert) {
-    // given
+    // given & when
     await render(hbs`<PixInput @id="firstName" @errorMessage="Seul les caractères alphanumériques sont autorisés" />`);
 
-    // when & then
-    const selectorElement = this.element.querySelector(ERROR_SELECTOR);
-    assert.equal(selectorElement.innerHTML, 'Seul les caractères alphanumériques sont autorisés');
+    // then
+    assert.contains('Seul les caractères alphanumériques sont autorisés');
   });
 
   test('it should be possible to give an icon to input', async function(assert) {
-    // given
+    // given & when
     await render(hbs`<PixInput @id="firstName" @icon="times" />`);
 
-    // when & then
+    // then
     assert.dom('.pix-input__icon').exists();
   });
 
   test('it should be possible to put an icon to the left of input', async function(assert) {
-    // given
+    // given & when
     await render(hbs`<PixInput @id="firstName" @icon="times" @isIconLeft={{true}} />`);
 
-    // when & then
+    // then
     assert.dom('.pix-input__icon.pix-input__icon--left').exists();
   });
 
   test('it should be possible to give more params to input', async function(assert) {
-    // given
+    // given & when
     await render(hbs`<PixInput @label="Prénom" @id="firstName" value='Jeanne' />`);
 
-    // when & then
+    // then
     const selectorElement = this.element.querySelector(INPUT_SELECTOR);
     assert.equal(selectorElement.value, 'Jeanne');
   });

--- a/tests/integration/components/pix-message-test.js
+++ b/tests/integration/components/pix-message-test.js
@@ -7,76 +7,76 @@ module('Integration | Component | pix-message', function(hooks) {
   setupRenderingTest(hooks);
 
   test('it renders the given content', async function(assert) {
-    // given
+    // given & when
     await render(hbs`<PixMessage>Message text</PixMessage>`);
 
-    // when & then
-    assert.equal(this.element.textContent.trim(), 'Message text');
+    // then
+    assert.contains('Message text');
   });
 
   test('it renders with the given type', async function(assert) {
-    // given
+    // given & when
     await render(hbs`<PixMessage @type="info" />`);
 
-    // when & then
+    // then
     const pixMessageElement = this.element.querySelector('.pix-message');
     assert.equal(pixMessageElement.classList.toString(), 'pix-message pix-message--info');
   });
 
   test('it renders with attributes override', async function(assert) {
-    // given
+    // given & when
     await render(hbs`<PixMessage aria-label="world" />`);
 
-    // when & then
+    // then
     const pixMessageElement = this.element.querySelector('.pix-message');
     assert.equal(pixMessageElement.getAttribute('aria-label'), 'world');
   });
 
   test('it renders with an icon', async function(assert) {
-    // given
+    // given & when
     await render(hbs`<PixMessage @withIcon="true" />`);
 
-    // when & then
+    // then
     const icon = this.element.querySelector('.pix-message svg');
     assert.dom('.pix-message svg').exists();
     assert.equal(icon.getAttribute('data-icon'), 'info-circle');
   });
 
   test('it renders with a warning icon for warning type', async function(assert) {
-    // given
+    // given & when
     await render(hbs`<PixMessage @type="warning" @withIcon="true" />`);
 
-    // when & then
+    // then
     const icon = this.element.querySelector('.pix-message svg');
     assert.dom('.pix-message svg').exists();
     assert.equal(icon.getAttribute('data-icon'), 'exclamation-circle');
   });
 
   test('it renders with a success icon for success type', async function(assert) {
-    // given
+    // given & when
     await render(hbs`<PixMessage @type="success" @withIcon="true" />`);
 
-    // when & then
+    // then
     const icon = this.element.querySelector('.pix-message svg');
     assert.dom('.pix-message svg').exists();
     assert.equal(icon.getAttribute('data-icon'), 'check-circle');
   });
 
   test('it renders with a alert icon for error type', async function(assert) {
-    // given
+    // given & when
     await render(hbs`<PixMessage @type="error" @withIcon="true" />`);
 
-    // when & then
+    // then
     const icon = this.element.querySelector('.pix-message svg');
     assert.dom('.pix-message svg').exists();
     assert.equal(icon.getAttribute('data-icon'), 'exclamation-triangle');
   });
 
   test('it renders with a alert icon for alert type', async function(assert) {
-    // given
+    // given & when
     await render(hbs`<PixMessage @type="alert" @withIcon="true" />`);
 
-    // when & then
+    // then
     const icon = this.element.querySelector('.pix-message svg');
     assert.dom('.pix-message svg').exists();
     assert.equal(icon.getAttribute('data-icon'), 'exclamation-triangle');

--- a/tests/integration/components/pix-multi-select-test.js
+++ b/tests/integration/components/pix-multi-select-test.js
@@ -36,12 +36,10 @@ module('Integration | Component | multi-select', function (hooks) {
         {{option.label}}
       </PixMultiSelect>
     `);
-
-    const buttonElement = this.element.querySelector('.pix-multi-select-header');
-    const listElement = this.element.querySelectorAll('li');
-
+    
     // then
-    assert.equal(buttonElement.textContent.trim(), this.title);
+    const listElement = this.element.querySelectorAll('li');
+    assert.contains('MultiSelectTest');
     assert.equal(listElement.length, 3);
   });
 
@@ -71,12 +69,11 @@ module('Integration | Component | multi-select', function (hooks) {
 
     
     // then
-    const buttonElement = this.element.querySelector('.pix-multi-select-header');
     const listElement = this.element.querySelectorAll('li');
-    assert.equal(buttonElement.textContent.trim(), this.title);
+    assert.contains('MultiSelectTest');
 
     assert.equal(listElement.length, 1);
-    assert.equal(listElement.item(0).textContent.trim(), 'no result');
+    assert.contains('no result');
   });
 
   test('it renders the PixMultiSelect with default checked', async function (assert) {
@@ -217,6 +214,7 @@ module('Integration | Component | multi-select', function (hooks) {
       this.isSearchable = true;
       this.placeholder = 'Placeholder test';
 
+      // when
       await render(hbs`
         <PixMultiSelect
           @isSearchable={{isSearchable}}
@@ -231,13 +229,10 @@ module('Integration | Component | multi-select', function (hooks) {
         </PixMultiSelect>
       `);
 
-      // when
-      const labelElement = this.element.querySelector('.pix-multi-select-header');
+      // then
       const inputElement = this.element.querySelector('.pix-multi-select-header__search-input');
       const listElement = this.element.querySelectorAll('li');
-
-      // then
-      assert.equal(labelElement.textContent.trim(), this.title);
+      assert.contains('MultiSelectTest');
       assert.equal(inputElement.placeholder, this.placeholder);
       assert.equal(listElement.length, 3);
     });
@@ -270,12 +265,10 @@ module('Integration | Component | multi-select', function (hooks) {
       // when
       await fillIn('input', 'tomate');
 
-      // when
-      const listElement = this.element.querySelectorAll('.pix-multi-select-list__item');
-
       // then
+      const listElement = this.element.querySelectorAll('.pix-multi-select-list__item');
       assert.equal(listElement.length, 1);
-      assert.equal(listElement.item(0).textContent.trim(), 'Tomate');
+      assert.contains('Tomate');
     });
 
     test('it should renders no result given case sensitive', async function (assert) {
@@ -311,7 +304,7 @@ module('Integration | Component | multi-select', function (hooks) {
       // then
       const listElement = this.element.querySelectorAll('.pix-multi-select-list__item');
       assert.equal(listElement.length, 1);
-      assert.equal(listElement.item(0).textContent.trim(), 'no result');
+      assert.contains('no result');
     });
 
     test('it should display list PixMultiSelect on focus', async function (assert) {

--- a/tests/integration/components/pix-progress-gauge-test.js
+++ b/tests/integration/components/pix-progress-gauge-test.js
@@ -6,54 +6,51 @@ import { hbs } from 'ember-cli-htmlbars';
 module('Integration | Component | progress-gauge', function(hooks) {
   setupRenderingTest(hooks);
 
+  const MARKER_SELECTOR = '.progress-gauge__marker';
+  const PROGRESS_GAUGE_SELECTOR = '.progress-gauge';
+
   module('Attributes @value', function() {
     test('it renders the progress gauge with correct width', async function(assert) {
-      // when
+      // given & when
       await render(hbs`<PixProgressGauge @value="50"/>`);
   
-      const componentElement = this.element.querySelector('.progress-gauge__marker');
-  
       // then
+      const componentElement = this.element.querySelector(MARKER_SELECTOR);
       assert.equal(componentElement.style.width, '50%');
     });
   
     test('it renders the progress tooltip with correct information', async function(assert) {
-      // when
+      // given & when
       await render(hbs`<PixProgressGauge @value="50" @tooltipText="50%"/>`);
   
-      const componentElement = this.element.querySelector('.progress-gauge__tooltip');
-  
       // then
-      assert.equal(componentElement.textContent.trim(), '50%');
+      assert.contains('50%');
     });
 
     test('it should not renders the progress tooltip if no tooltipText', async function(assert) {
-      // when
+      // given & when
       await render(hbs`<PixProgressGauge @value="50" />`);
   
-      const componentElement = this.element.querySelector('.progress-gauge__tooltip');
-  
       // then
+      const componentElement = this.element.querySelector('.progress-gauge__tooltip');
       assert.notOk(componentElement);
     });
   
     test('it renders the progress gauge with correct width never exceed 100%', async function(assert) {
-      // when
+      // given & when
       await render(hbs`<PixProgressGauge @value="110"/>`);
-  
-      const markerComponent = this.element.querySelector('.progress-gauge__marker');
-  
+      
       // then
+      const markerComponent = this.element.querySelector(MARKER_SELECTOR);
       assert.equal(markerComponent.style.width, '100%');
     });
 
     test('it renders the progress gauge with correct width never under 0%', async function(assert) {
-      // when
+      // given & when
       await render(hbs`<PixProgressGauge @value="-1"/>`);
-  
-      const markerComponent = this.element.querySelector('.progress-gauge__marker');
-  
+      
       // then
+      const markerComponent = this.element.querySelector(MARKER_SELECTOR);
       assert.equal(markerComponent.style.width, '0%');
     });  
   });
@@ -61,109 +58,101 @@ module('Integration | Component | progress-gauge', function(hooks) {
 
   module('Attributes @isArrowLeft', function() {
     test('it renders the progress gauge with default tootlip', async function(assert) {
-      // when
+      // given & when
       await render(hbs`<PixProgressGauge @value="50" />`);
   
-      const componentElement = this.element.querySelector('.progress-gauge');
-  
       // then
+      const componentElement = this.element.querySelector(PROGRESS_GAUGE_SELECTOR);
       assert.equal(componentElement.classList.contains('progress-gauge--tooltip-left'), false);
     });
     
     test('it renders the progress gauge with tootlip left class', async function(assert) {
-      // when
+      // given & when
       await render(hbs`
         <PixProgressGauge
           @value="50"
           @isArrowLeft="true"/>
       `);
-  
-      const componentElement = this.element.querySelector('.progress-gauge');
-  
+      
       // then
+      const componentElement = this.element.querySelector(PROGRESS_GAUGE_SELECTOR);
       assert.equal(componentElement.classList.contains('progress-gauge--tooltip-left'), true);
     });
   });
 
   module('Attributes @color', function() {
     test('it renders the progress gauge by default with yellow class', async function(assert) {
-      // when
+      // given & when
       await render(hbs`<PixProgressGauge @value="50" />`);
 
-      const componentElement = this.element.querySelector('.progress-gauge');
-
       // then
+      const componentElement = this.element.querySelector(PROGRESS_GAUGE_SELECTOR);
       assert.equal(componentElement.classList.contains('progress-gauge--yellow'), true);
     });
 
     test('it renders the progress gauge with yellow class when color not exists', async function(assert) {
-      // when
+      // given & when
       await render(hbs`
         <PixProgressGauge
           @value="50"
           @color="vert-lychen" />
       `);
-
-      const componentElement = this.element.querySelector('.progress-gauge');
-
+      
       // then
+      const componentElement = this.element.querySelector(PROGRESS_GAUGE_SELECTOR);
       assert.equal(componentElement.classList.contains('progress-gauge--yellow'), true);
     });
  
     test('it renders the progress gauge with yellow class', async function(assert) {
-      // when
+      // given & when
       await render(hbs`
         <PixProgressGauge
           @value="50"
           @color="yellow"/>
       `);
 
-      const componentElement = this.element.querySelector('.progress-gauge');
-
       // then
+      const componentElement = this.element.querySelector(PROGRESS_GAUGE_SELECTOR);
       assert.equal(componentElement.classList.contains('progress-gauge--yellow'), true);
     });
     
     test('it renders the progress gauge with white class', async function(assert) {
-      // when
+      // given & when
       await render(hbs`
         <PixProgressGauge
           @value="50"
           @color="white"/>
       `);
-
-      const componentElement = this.element.querySelector('.progress-gauge');
-
+      
       // then
+      const componentElement = this.element.querySelector(PROGRESS_GAUGE_SELECTOR);
       assert.equal(componentElement.classList.contains('progress-gauge--white'), true);
     });
   });
 
   module('Attibutes @subtitle', function () {
     test('it does not render the progress gauge sub-title', async function(assert) {
-      // when
+      // given & when
       await render(hbs`
         <PixProgressGauge
           @value="50" />
       `);
   
-      const componentElement = this.element.querySelector('.progress-gauge__sub-title');
-  
       // then
+      const componentElement = this.element.querySelector('.progress-gauge__sub-title');
       assert.equal(!!componentElement, false);
     });
   
     test('it renders the progress gauge sub-title', async function(assert) {
-      // when
+      // given & when
       await render(hbs`
         <PixProgressGauge
           @value="50"
           @subtitle="toto"/>
       `);
-  
-      const componentElement = this.element.querySelector('.progress-gauge__sub-title');
-  
+      
       // then
+      const componentElement = this.element.querySelector('.progress-gauge__sub-title');
       assert.equal(componentElement.textContent.trim(), 'toto');
     });
   });

--- a/tests/integration/components/pix-radio-button-test.js
+++ b/tests/integration/components/pix-radio-button-test.js
@@ -6,7 +6,6 @@ import { hbs } from 'ember-cli-htmlbars';
 module('Integration | Component | pix-radio-button', function(hooks) {
   setupRenderingTest(hooks);
 
-  const LABEL_SELECTOR = '.pix-radio-button';
   const INPUT_SELECTOR = '.pix-radio-button input';
 
   test('it renders the default PixRadioButton', async function(assert) {
@@ -14,10 +13,8 @@ module('Integration | Component | pix-radio-button', function(hooks) {
     await render(hbs`<PixRadioButton @label="Abricot" />`);
 
     // then
-    const componentLabelElement = this.element.querySelector(LABEL_SELECTOR);
     const componentInputElement = this.element.querySelector(INPUT_SELECTOR);
-
-    assert.equal(componentLabelElement.textContent.trim(), 'Abricot');
+    assert.contains('Abricot');
     assert.equal(componentInputElement.type, 'radio');
   });
 

--- a/tests/integration/components/pix-return-to-test.js
+++ b/tests/integration/components/pix-return-to-test.js
@@ -13,9 +13,9 @@ module('Integration | Component | pix-return-to', function(hooks) {
     await render(hbs`<PixReturnTo @route='home'>Home</PixReturnTo> `);
     
     // then
-    const PixReturnToElement = this.element.querySelector(RETURN_TO_SELECTOR);
-    assert.equal(PixReturnToElement.textContent.trim(), 'Home');
-    assert.ok(PixReturnToElement.classList.toString().includes('pix-return-to pix-return-to--black'));
+    const pixReturnToElement = this.element.querySelector(RETURN_TO_SELECTOR);
+    assert.contains('Home');
+    assert.ok(pixReturnToElement.classList.toString().includes('pix-return-to pix-return-to--black'));
   });
 
   test('it renders with the given shade', async function(assert) {
@@ -23,8 +23,8 @@ module('Integration | Component | pix-return-to', function(hooks) {
     await render(hbs`<PixReturnTo @route='home' @shade="white" />`);
 
     // then
-    const PixReturnToElement = this.element.querySelector(RETURN_TO_SELECTOR);
-    assert.ok(PixReturnToElement.classList.toString().includes('pix-return-to pix-return-to--white'));
+    const pixReturnToElement = this.element.querySelector(RETURN_TO_SELECTOR);
+    assert.ok(pixReturnToElement.classList.toString().includes('pix-return-to pix-return-to--white'));
   });
 
   test('it renders without text', async function(assert) {
@@ -32,7 +32,7 @@ module('Integration | Component | pix-return-to', function(hooks) {
     await render(hbs`<PixReturnTo @route='home' />`);
 
     // then
-    const PixReturnToElement = this.element.querySelector(RETURN_TO_SELECTOR);
-    assert.equal(PixReturnToElement.textContent.trim(), '');
+    const pixReturnToElement = this.element.querySelector(RETURN_TO_SELECTOR);
+    assert.equal(pixReturnToElement.textContent.trim(), '');
   });
 });

--- a/tests/integration/components/pix-tag-test.js
+++ b/tests/integration/components/pix-tag-test.js
@@ -9,7 +9,7 @@ module('Integration | Component | pix-tag', function(hooks) {
   test('it renders the given content', async function(assert) {
     await render(hbs`<PixTag>tag text</PixTag>`);
 
-    assert.equal(this.element.textContent.trim(), 'tag text');
+    assert.contains('tag text');
   });
 
   test('it renders with the given color class', async function(assert) {

--- a/tests/integration/components/pix-textarea-test.js
+++ b/tests/integration/components/pix-textarea-test.js
@@ -8,9 +8,6 @@ module('Integration | Component | textarea', function(hooks) {
   setupRenderingTest(hooks);
 
   const TEXTAREA_SELECTOR = '.pix-textarea textarea';
-  const CHAR_COUNT_SELECTOR = '.pix-textarea p';
-  const LABEL_SELECTOR = '.pix-textarea__label';
-  const ERROR_SELECTOR = '.pix-textarea__error-message';
 
   test('it renders PixTextarea with correct id and content', async function(assert) {
     // given 
@@ -22,7 +19,7 @@ module('Integration | Component | textarea', function(hooks) {
 
     // then
     const textarea = this.element.querySelector(TEXTAREA_SELECTOR);
-    assert.equal(textarea.value.trim(), newContent);
+    assert.contains('Bonjour Pix !');
     assert.equal(textarea.id, 7);
   });
 
@@ -41,7 +38,7 @@ module('Integration | Component | textarea', function(hooks) {
     // then
     const textarea = this.element.querySelector(TEXTAREA_SELECTOR);
     assert.equal(textarea.maxLength, maxlength);
-    assert.dom(CHAR_COUNT_SELECTOR).hasText('11 / 20');
+    assert.contains('11 / 20');
   });
 
   test('it should be possible to add required attributes to PixTextarea', async function(assert) {
@@ -59,7 +56,7 @@ module('Integration | Component | textarea', function(hooks) {
 
 
   test('it should be possible to give a label', async function(assert) {
-    // given
+    // given & when
     await render(hbs`
       <PixTextarea
         @id="pix-select-with-label"
@@ -67,23 +64,22 @@ module('Integration | Component | textarea', function(hooks) {
       />
     `);
 
-    // when & then
-    const selectorElement = this.element.querySelector(LABEL_SELECTOR);
-    assert.equal(selectorElement.innerHTML, 'Décrivez votre problème');
+    // then
+    assert.contains('Décrivez votre problème');
   });
 
   test('it should throw an error if no id is provided when there is a label', async function(assert) {
-    // given
+    // given & when
     const componentParams = { id: '   ', label: 'Décrivez votre problème' };
     const component = createGlimmerComponent('component:pix-textarea', componentParams);
 
-    // when & then
+    // then
     const expectedError = new Error('ERROR in PixTextarea component, @id param is necessary when giving @label');
     assert.throws(function() { component.label }, expectedError);
   });
 
   test('it should be possible to show an error message', async function(assert) {
-    // given
+    // given & when
     await render(hbs`
       <PixTextarea
         @id="pix-textarea-with-error"
@@ -91,9 +87,8 @@ module('Integration | Component | textarea', function(hooks) {
       />
     `);
 
-    // when & then
-    const selectorElement = this.element.querySelector(ERROR_SELECTOR);
-    assert.equal(selectorElement.innerHTML, 'Veuillez remplir ce champ.');
+    // then
+    assert.contains('Veuillez remplir ce champ.');
   })
 
 });

--- a/tests/integration/components/pix-tooltip-test.js
+++ b/tests/integration/components/pix-tooltip-test.js
@@ -7,7 +7,7 @@ module('Integration | Component | pix-tooltip', function(hooks) {
   setupRenderingTest(hooks);
 
   const TOOLTIP_SELECTOR = '.pix-tooltip span';
-  const text = 'Un text à afficher au survol du contenu de la tooltip';
+  const text = 'Un texte à afficher au survol du contenu de la tooltip';
 
   test('it renders the tooltip text', async function(assert) {
     // given
@@ -19,10 +19,9 @@ module('Integration | Component | pix-tooltip', function(hooks) {
         template block text
       </PixTooltip>
     `);
-    const tooltipContentElement = this.element.querySelector(TOOLTIP_SELECTOR);
 
     // then
-    assert.equal(tooltipContentElement.innerHTML.trim(), text);
+    assert.contains(text);
   });
 
   test('it renders only the inner data if there is no tooltip text', async function(assert) {
@@ -32,10 +31,10 @@ module('Integration | Component | pix-tooltip', function(hooks) {
         template block text
       </PixTooltip>
     `);
-    const tooltipContentElement = this.element.querySelector(TOOLTIP_SELECTOR);
 
     // then
-    assert.equal(this.element.textContent.trim(), 'template block text');
+    const tooltipContentElement = this.element.querySelector(TOOLTIP_SELECTOR);
+    assert.contains('template block text');
     assert.notOk(tooltipContentElement);
   });
 
@@ -62,9 +61,9 @@ module('Integration | Component | pix-tooltip', function(hooks) {
         await render(hbs`
           <PixTooltip @position={{this.position}} @text={{this.text}}></PixTooltip>
         `);
-        const tooltipContentElement = this.element.querySelector(TOOLTIP_SELECTOR);
 
         // then
+        const tooltipContentElement = this.element.querySelector(TOOLTIP_SELECTOR);
         assert.ok(tooltipContentElement.classList.toString().includes(TOOLTIP_POSITION_SELECTOR+position));
       });
     });
@@ -83,10 +82,10 @@ module('Integration | Component | pix-tooltip', function(hooks) {
         <PixTooltip @text={{this.text}}>
         </PixTooltip>
       `);
-      const tooltipContentElement = this.element.querySelector(TOOLTIP_SELECTOR);
-      const tooltipContentClasses = tooltipContentElement.classList.toString().trim();
 
       // then
+      const tooltipContentElement = this.element.querySelector(TOOLTIP_SELECTOR);
+      const tooltipContentClasses = tooltipContentElement.classList.toString().trim();
       assert.equal(tooltipContentClasses.includes(LIGHT_CLASS), false);
     });
 
@@ -99,9 +98,9 @@ module('Integration | Component | pix-tooltip', function(hooks) {
         <PixTooltip @isLight={{true}} @text={{this.text}}>
         </PixTooltip>
       `);
-      const tooltipContentElement = this.element.querySelector(TOOLTIP_SELECTOR);
 
       // then
+      const tooltipContentElement = this.element.querySelector(TOOLTIP_SELECTOR);
       assert.ok(tooltipContentElement.classList.toString().includes(LIGHT_CLASS));
     });
   });
@@ -135,9 +134,9 @@ module('Integration | Component | pix-tooltip', function(hooks) {
         <PixTooltip @isInline={{true}} @text={{this.text}}>
         </PixTooltip>
       `);
-      const tooltipContentElement = this.element.querySelector(TOOLTIP_SELECTOR);
 
       // then
+      const tooltipContentElement = this.element.querySelector(TOOLTIP_SELECTOR);
       assert.ok(tooltipContentElement.classList.toString().includes(INLINE_CLASS));
     });
   });
@@ -155,10 +154,10 @@ module('Integration | Component | pix-tooltip', function(hooks) {
         <PixTooltip @text={{this.text}}>
         </PixTooltip>
       `);
-      const tooltipContentElement = this.element.querySelector(TOOLTIP_SELECTOR);
-      const tooltipContentClasses = tooltipContentElement.classList.toString().trim();
 
       // then
+      const tooltipContentElement = this.element.querySelector(TOOLTIP_SELECTOR);
+      const tooltipContentClasses = tooltipContentElement.classList.toString().trim();
       assert.equal(tooltipContentClasses.includes(WIDE_CLASS), false);
     });
 
@@ -171,44 +170,43 @@ module('Integration | Component | pix-tooltip', function(hooks) {
         <PixTooltip @isWide={{true}} @text={{this.text}}>
         </PixTooltip>
       `);
-      const tooltipContentElement = this.element.querySelector(TOOLTIP_SELECTOR);
 
       // then
+      const tooltipContentElement = this.element.querySelector(TOOLTIP_SELECTOR);
       assert.ok(tooltipContentElement.classList.toString().includes(WIDE_CLASS));
     });
   });
 
   module('tooltip unescape html', function() {
-    const htmlText = '<b>Tooltip</b>'
 
     test('it renders escaped html', async function(assert) {
       // given
+      const htmlText = '<b>Tooltip</b>';
       this.set('text', htmlText);
 
       // when
       await render(hbs`
         <PixTooltip @text={{this.text}} @unescapeHtml={{false}}></PixTooltip>
       `);
-      const tooltipContentElement = this.element.querySelector(TOOLTIP_SELECTOR);
 
       // then
+      const tooltipContentElement = this.element.querySelector(TOOLTIP_SELECTOR);
       const displayedText = decodeURI(tooltipContentElement.innerHTML.trim());
       assert.equal(displayedText, "&lt;b&gt;Tooltip&lt;/b&gt;");
     });
 
     test('it renders unescaped html', async function(assert) {
       // given
+      const htmlText = '<b>Tooltip</b>';
       this.set('text', htmlText);
 
       // when
       await render(hbs`
         <PixTooltip @text={{this.text}} @unescapeHtml={{true}}></PixTooltip>
       `);
-      const tooltipContentElement = this.element.querySelector(TOOLTIP_SELECTOR);
 
       // then
-      const displayedText = decodeURI(tooltipContentElement.innerHTML.trim());
-      assert.equal(displayedText, "<b>Tooltip</b>");
+      assert.contains("Tooltip");
     });
   });
 });

--- a/tests/test-helper.js
+++ b/tests/test-helper.js
@@ -2,7 +2,11 @@ import Application from 'dummy/app';
 import config from 'dummy/config/environment';
 import { setApplication } from '@ember/test-helpers';
 import { start } from 'ember-qunit';
+import QUnit from 'qunit';
+import { contains } from './helpers/contains';
 
 setApplication(Application.create(config.APP));
 
 start();
+
+QUnit.assert.contains = contains;


### PR DESCRIPTION
## :unicorn: Description du composant
Chez Pix on essaie de suivre les bonnes pratiques de tests front, notamment s'appuyant sur les pratiques de "Testing Library".

> The more your tests resemble the way your software is used, the more confidence they can give you.
https://testing-library.com/docs/guiding-principles

En suivant donc ce principe, cette PR ajoute l'helper `contains` à Qunit (notre librairie de test).
Ce dernier permet de vérifier si le rendu contient la chaîne de texte passée en paramètre.

Par exemple, on préféra désormais écrire : 
```
assert.contains('Bonjour les amis!');
```
Ce qui revient à demander : `Est-ce que "Bonjour les amis!" s'affiche à l'écran ?`. 

Plutôt que : 
```
assert.equal(this.element.querySelector('h1'), 'Bonjour les amis!');
```
Qui reviendrait à demander : `Est-ce que l'élément HTML h1 contient "Bonjour les amis!" ?`