### PR TITLE
[TECH] Ajout du helper notContains (PIX-3470)

### DIFF
--- a/tests/helpers/contains.js
+++ b/tests/helpers/contains.js
@@ -29,3 +29,18 @@ export function contains(text) {
 
   this.pushResult({ result, message });
 }
+
+export function notContains(text) {
+  const elements = _isTextInElement(getRootElement(), text);
+  const result = elements.length === 0;
+
+  let message = `Element with "${ text }" found`;
+  if (result) {
+    message = `There is no elements with "${ text }"`;
+  }
+
+  this.pushResult({
+    result,
+    message,
+  });
+}


### PR DESCRIPTION
## :unicorn: Description du composant
Première partie : ajout du helper contains https://github.com/1024pix/pix-ui/pull/142 
Voir aussi : 
- ajout du helper FillInByLabel https://github.com/1024pix/pix-ui/pull/144
- ajout du helper clickByLabel https://github.com/1024pix/pix-ui/pull/146

Chez Pix on essaie de suivre les bonnes pratiques de tests front, notamment s'appuyant sur les pratiques de "Testing Library".

> The more your tests resemble the way your software is used, the more confidence they can give you.
https://testing-library.com/docs/guiding-principles

En suivant donc ce principe, cette PR ajoute l'helper `notContains` à Qunit (notre librairie de test).
Ce dernier permet de vérifier si le rendu ne contient pas la chaîne de texte passée en paramètre.

Par exemple, on préféra désormais écrire : 
```
assert.notContains('Bonjour les amis!');
```
Ce qui revient à demander : `Est-ce que "Bonjour les amis!" ne s'affiche pas à l'écran ?`. 