### PR TITLE
[TECH] Ajout du helper fillInByLabel (PIX-3470)

### DIFF
--- a/addon/components/pix-input-code.hbs
+++ b/addon/components/pix-input-code.hbs
@@ -5,7 +5,7 @@
       ...attributes
       id="code-input-{{i}}"
       type="{{this.inputType}}"
-      aria-label="{{this.ariaLabel}}"
+      aria-label="{{this.ariaLabel}} n°{{i}}"
       class="pix-input-code__input"
       min="1"
       max="9"

--- a/tests/helpers/fill-in-by-label.js
+++ b/tests/helpers/fill-in-by-label.js
@@ -1,0 +1,36 @@
+import { fillIn, findAll, find } from '@ember/test-helpers';
+
+export function fillInByLabel(labelText, value) {
+  const control = _findControlForLabel(labelText);
+
+  return fillIn(control, value);
+}
+
+function _findControlForLabel(labelText) {
+  const label = _findLabel(labelText);
+  if (label && label.control) return label.control;
+
+  const control = _findControl(labelText);
+  if (control) return control;
+
+  if (label && !label.control) {
+    throw new Error(`Found label "${labelText}" but no associated form control.`);
+  }
+  throw new Error(`Cannot find form control labelled "${labelText}".`);
+}
+
+function _findLabel(labelText) {
+  return findAll('label').find((label) => label.innerText.includes(labelText));
+}
+
+function _findControl(labelText) {
+  const selectors = [];
+
+  for (const tag of ['input', 'textarea', 'select']) {
+    for (const attr of ['aria-label', 'title']) {
+      selectors.push(`${tag}[${attr}="${labelText}"]`);
+    }
+  }
+
+  return find(selectors.join(','));
+}

--- a/tests/integration/components/pix-input-code-test.js
+++ b/tests/integration/components/pix-input-code-test.js
@@ -1,9 +1,10 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import sinon from 'sinon';
-import { render, focus, fillIn, triggerKeyEvent, triggerEvent } from '@ember/test-helpers';
+import { render, focus, triggerKeyEvent, triggerEvent } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import createGlimmerComponent from "../../helpers/create-glimmer-component";
+import { fillInByLabel } from '../../helpers/fill-in-by-label';
 
 module('Integration | Component | pix-input-code', function (hooks) {
   setupRenderingTest(hooks);
@@ -35,10 +36,10 @@ module('Integration | Component | pix-input-code', function (hooks) {
 
   test('it should focus on next input after inputting value', async function (assert) {
     // given
-    await render(hbs`<PixInputCode @ariaLabel="label" />`);
+    await render(hbs`<PixInputCode @ariaLabel="Mon super input code" />`);
 
     // when
-    await fillIn(`${INPUT_SELECTOR}-1`, '1');
+    await fillInByLabel('Mon super input code n°1', '1');
 
     // then
     assert.dom(`${INPUT_SELECTOR}-1`).hasClass('filled');
@@ -101,7 +102,7 @@ module('Integration | Component | pix-input-code', function (hooks) {
     await render(hbs`<PixInputCode @ariaLabel="label" />`);
 
     // when
-    await fillIn(`${INPUT_SELECTOR}-4`, '12345');
+    await fillInByLabel('label n°4', '12345');
 
     // then
     assert.dom(`${INPUT_SELECTOR}-5`).isFocused();
@@ -114,7 +115,7 @@ module('Integration | Component | pix-input-code', function (hooks) {
     await render(hbs`<PixInputCode @ariaLabel="label" />`);
 
     // when
-    await fillIn(`${INPUT_SELECTOR}-4`, 'a');
+    await fillInByLabel('label n°4', 'a');
 
     // then
     assert.dom(`${INPUT_SELECTOR}-4`).isFocused();
@@ -127,7 +128,7 @@ module('Integration | Component | pix-input-code', function (hooks) {
     await render(hbs`<PixInputCode @ariaLabel="label" @inputType="text" />`);
 
     // when
-    await fillIn(`${INPUT_SELECTOR}-4`, 'abcdf');
+    await fillInByLabel('label n°4', 'abcdf');
 
     // then
     assert.dom(`${INPUT_SELECTOR}-5`).isFocused();
@@ -153,12 +154,12 @@ module('Integration | Component | pix-input-code', function (hooks) {
     await render(hbs`<PixInputCode @ariaLabel="label" @onAllInputsFilled={{this.onAllInputsFilled}} />`);
 
     // when
-    await fillIn(`${INPUT_SELECTOR}-1`, '3');
-    await fillIn(`${INPUT_SELECTOR}-2`, '5');
-    await fillIn(`${INPUT_SELECTOR}-3`, '7');
-    await fillIn(`${INPUT_SELECTOR}-4`, '2');
-    await fillIn(`${INPUT_SELECTOR}-5`, '4');
-    await fillIn(`${INPUT_SELECTOR}-6`, '6');
+    await fillInByLabel('label n°1', '3');
+    await fillInByLabel('label n°2', '5');
+    await fillInByLabel('label n°3', '7');
+    await fillInByLabel('label n°4', '2');
+    await fillInByLabel('label n°5', '4');
+    await fillInByLabel('label n°6', '6');
 
     // then
     assert.ok(this.onAllInputsFilled.calledOnce, 'the callback should be called once');
@@ -171,11 +172,11 @@ module('Integration | Component | pix-input-code', function (hooks) {
     await render(hbs`<PixInputCode @ariaLabel="label" @onAllInputsFilled={{this.onAllInputsFilled}} />`);
 
     // when
-    await fillIn(`${INPUT_SELECTOR}-1`, '3');
-    await fillIn(`${INPUT_SELECTOR}-2`, '5');
-    await fillIn(`${INPUT_SELECTOR}-3`, '7');
-    await fillIn(`${INPUT_SELECTOR}-5`, '4');
-    await fillIn(`${INPUT_SELECTOR}-6`, '6');
+    await fillInByLabel('label n°1', '3');
+    await fillInByLabel('label n°2', '5');
+    await fillInByLabel('label n°3', '7');
+    await fillInByLabel('label n°5', '4');
+    await fillInByLabel('label n°6', '6');
 
     // then
     assert.notOk(this.onAllInputsFilled.calledOnce);
@@ -187,12 +188,12 @@ module('Integration | Component | pix-input-code', function (hooks) {
     await render(hbs`<PixInputCode @ariaLabel="label" @onAllInputsFilled={{this.onAllInputsFilled}} />`);
 
     // when
-    await fillIn(`${INPUT_SELECTOR}-1`, '3');
-    await fillIn(`${INPUT_SELECTOR}-2`, '5');
-    await fillIn(`${INPUT_SELECTOR}-3`, '7');
-    await fillIn(`${INPUT_SELECTOR}-5`, '4');
-    await fillIn(`${INPUT_SELECTOR}-6`, '6');
-    await fillIn(`${INPUT_SELECTOR}-4`, '2');
+    await fillInByLabel('label n°1', '3');
+    await fillInByLabel('label n°2', '5');
+    await fillInByLabel('label n°3', '7');
+    await fillInByLabel('label n°5', '4');
+    await fillInByLabel('label n°6', '6');
+    await fillInByLabel('label n°4', '2');
 
     // then
     assert.ok(this.onAllInputsFilled.calledOnce, 'the callback should be called once');

--- a/tests/integration/components/pix-input-test.js
+++ b/tests/integration/components/pix-input-test.js
@@ -1,8 +1,9 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import { render, fillIn } from '@ember/test-helpers';
+import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import createGlimmerComponent from '../../helpers/create-glimmer-component';
+import { fillInByLabel } from '../../helpers/fill-in-by-label';
 
 module('Integration | Component | input', function(hooks) {
   setupRenderingTest(hooks);
@@ -11,8 +12,8 @@ module('Integration | Component | input', function(hooks) {
 
   test('it renders the default PixInput', async function(assert) {
     // when
-    await render(hbs`<PixInput @id="firstName" />`);
-    await fillIn(INPUT_SELECTOR, 'Jeanne');
+    await render(hbs`<PixInput @id="first-name" @label="Prénom" />`);
+    await fillInByLabel('Prénom', 'Jeanne');
 
     // then
     assert.contains('Jeanne');

--- a/tests/integration/components/pix-multi-select-test.js
+++ b/tests/integration/components/pix-multi-select-test.js
@@ -1,9 +1,10 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import { render, fillIn, focus, blur } from '@ember/test-helpers';
+import { render, focus, blur } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import createGlimmerComponent from '../../helpers/create-glimmer-component';
 import sinon from 'sinon';
+import { fillInByLabel } from '../../helpers/fill-in-by-label';
 import { clickByLabel } from '../../helpers/click-by-label';
 
 module('Integration | Component | multi-select', function (hooks) {
@@ -265,13 +266,15 @@ module('Integration | Component | multi-select', function (hooks) {
           @id={{id}}
           @label="label"
           @emptyMessage={{emptyMessage}}
-          @options={{options}} as |option|>
+          @label="Mon multi select"
+          @options={{options}} as |option|
+        >
           {{option.label}}
         </PixMultiSelect>
       `);
 
       // when
-      await fillIn('input', 'tomate');
+      await fillInByLabel('Mon multi select', 'tomate');
 
       // then
       const listElement = this.element.querySelectorAll('.pix-multi-select-list__item');
@@ -301,13 +304,15 @@ module('Integration | Component | multi-select', function (hooks) {
           @placeholder={{placeholder}}
           @id={{id}}
           @emptyMessage={{emptyMessage}}
-          @options={{options}} as |option|>
+          @label="Mon multi select"
+          @options={{options}} as |option|
+        >
           {{option.label}}
         </PixMultiSelect>
       `);
 
       // when
-      await fillIn('input', 'tomate');
+      await fillInByLabel('Mon multi select', 'tomate');
 
       // then
       const listElement = this.element.querySelectorAll('.pix-multi-select-list__item');
@@ -481,15 +486,17 @@ module('Integration | Component | multi-select', function (hooks) {
           @placeholder={{placeholder}}
           @id={{id}}
           @emptyMessage={{emptyMessage}}
-          @options={{options}} as |option|>
+          @label="Mon multi select"
+          @options={{options}} as |option|
+        >
           {{option.label}}
         </PixMultiSelect>
       `);
     
       // when
-      await fillIn('input', 'Oi')
+      await fillInByLabel('Mon multi select', 'Oi');
       await clickByLabel('Oignon');
-      await fillIn('input', 'o')
+      await fillInByLabel('Mon multi select', 'o');
 
       // then
       const listElement = this.element.querySelectorAll('.pix-multi-select-list__item');
@@ -518,15 +525,17 @@ module('Integration | Component | multi-select', function (hooks) {
           @placeholder={{placeholder}}
           @id={{id}}
           @emptyMessage={{emptyMessage}}
-          @options={{options}} as |option|>
+          @label="Mon multi select"
+          @options={{options}} as |option|
+        >
           {{option.label}}
         </PixMultiSelect>
       `);
     
       // when
-      await fillIn('input', 'Oi')
+      await fillInByLabel('Mon multi select', 'Oi')
       await clickByLabel('Oignon');
-      await fillIn('input', '')
+      await fillInByLabel('Mon multi select', '')
     
       // then
       const listElement = this.element.querySelectorAll('.pix-multi-select-list__item');
@@ -598,18 +607,20 @@ module('Integration | Component | multi-select', function (hooks) {
           @placeholder={{placeholder}}
           @id={{id}}
           @emptyMessage={{emptyMessage}}
-          @options={{options}} as |option|>
+          @label="Mon multi select"
+          @options={{options}} as |option|
+        >
           {{option.label}}
         </PixMultiSelect>
       `);
     
       // when
-      await fillIn('input', 'Oi')
+      await fillInByLabel('Mon multi select', 'Oi')
       await clickByLabel('Oignon');
       
       await blur('input');
 
-      await fillIn('input', '');
+      await fillInByLabel('Mon multi select', '');
     
       // then
       const listElement = this.element.querySelectorAll('.pix-multi-select-list__item');

--- a/tests/integration/components/pix-select-test.js
+++ b/tests/integration/components/pix-select-test.js
@@ -1,9 +1,10 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import { render, fillIn } from '@ember/test-helpers';
+import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import sinon from 'sinon';
 import createGlimmerComponent from '../../helpers/create-glimmer-component';
+import { fillInByLabel } from '../../helpers/fill-in-by-label';
 
 module('Integration | Component | select', function (hooks) {
   setupRenderingTest(hooks);
@@ -84,13 +85,15 @@ module('Integration | Component | select', function (hooks) {
   
     await render(hbs`
       <PixSelect
+        @id="an-id"
         @options={{options}}
         @onChange={{onChange}}
+        @label="Mon select"
       />
     `);
 
     // when
-    await fillIn('select', '2')
+    await fillInByLabel('Mon select', '2')
 
     // then
     assert.ok(this.onChange.calledOnce, "the callback should be called once");
@@ -134,8 +137,13 @@ module('Integration | Component | select', function (hooks) {
         this.isSearchable = true;
   
         // when
-        await render(hbs`<PixSelect @options={{options}} @isSearchable={{isSearchable}} />`);
-        await fillIn(SEARCHABLE_SELECT_SELECTOR, 'tomate');
+        await render(hbs`<PixSelect
+          @id="an-id"
+          @options={{options}}
+          @isSearchable={{isSearchable}}
+          @label="Mon select"
+        />`);
+        await fillInByLabel('Mon select', 'tomate');
   
         // then
         assert.dom('.pix-select--is-valid').doesNotExist();
@@ -153,8 +161,10 @@ module('Integration | Component | select', function (hooks) {
             @options={{options}}
             @isSearchable={{isSearchable}}
             @isValidationActive={{isValidationActive}}
+            @id="select-id"
+            @label="Mon select"
           />`);
-        await fillIn(SEARCHABLE_SELECT_SELECTOR, 'tomate');
+        await fillInByLabel('Mon select', 'tomate');
   
         // then
         assert.dom('.pix-select--is-valid').exists();

--- a/tests/integration/components/pix-textarea-test.js
+++ b/tests/integration/components/pix-textarea-test.js
@@ -1,8 +1,9 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import { render, fillIn } from '@ember/test-helpers';
+import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import createGlimmerComponent from '../../helpers/create-glimmer-component';
+import { fillInByLabel } from '../../helpers/fill-in-by-label';
 
 module('Integration | Component | textarea', function(hooks) {
   setupRenderingTest(hooks);
@@ -14,8 +15,8 @@ module('Integration | Component | textarea', function(hooks) {
     const newContent = 'Bonjour Pix !';
 
     // when
-    await render(hbs`<PixTextarea @id=7 @value="old value" />`);
-    await fillIn(TEXTAREA_SELECTOR, newContent);
+    await render(hbs`<PixTextarea @id=7 @value="old value" @label="label" />`);
+    await fillInByLabel('label', newContent);
 
     // then
     const textarea = this.element.querySelector(TEXTAREA_SELECTOR);
@@ -32,8 +33,14 @@ module('Integration | Component | textarea', function(hooks) {
     this.set('maxlength', maxlength);
 
     // when
-    await render(hbs`<PixTextarea @value={{value}} @maxlength={{maxlength}} />`);
-    await fillIn(TEXTAREA_SELECTOR, 'Hello Pix !');
+    await render(hbs`
+      <PixTextarea
+        @value={{value}}
+        @maxlength={{maxlength}}
+        @id="textarea-id"
+        @label="label"
+      />`);
+    await fillInByLabel('label', 'Hello Pix !');
 
     // then
     const textarea = this.element.querySelector(TEXTAREA_SELECTOR);


### PR DESCRIPTION
## :unicorn: Description
Première partie : ajout du helper contains https://github.com/1024pix/pix-ui/pull/142 
Voir aussi : 
- ajout du helper notContains https://github.com/1024pix/pix-ui/pull/143
- ajout du helper clickByLabel https://github.com/1024pix/pix-ui/pull/146

Chez Pix on essaie de suivre les bonnes pratiques de tests front, notamment s'appuyant sur les pratiques de "Testing Library".

> The more your tests resemble the way your software is used, the more confidence they can give you.
https://testing-library.com/docs/guiding-principles

En suivant donc ce principe, cette PR ajoute l'helper `fillInByLabel`.
Ce dernier permet de remplir un champ à partir de son label.

Par exemple, on préféra désormais écrire : 
```
await fillInByLabel('Nom', 'Toto');
```
Ce qui revient à : `Remplis le champ Nom par "Toto"`. 

Plutôt que : 
```
await fillIn('#last-name', 'Toto');
```
Qui reviendrait à : `Remplis le champ d'identifiant "last-name" par "Toto"`.