### PR TITLE
[BUGFIX] Correction de l'id requis quand le label est renseigné

### DIFF
--- a/addon/components/pix-select.js
+++ b/addon/components/pix-select.js
@@ -16,7 +16,7 @@ export default class PixSelect extends Component {
   
   get label() {
     const labelIsDefined = this.args.label && this.args.label.trim();
-    const idIsNotDefined = this.args.id && !this.args.id.trim();
+    const idIsNotDefined = !(this.args.id && this.args.id.trim());
 
     if (labelIsDefined && idIsNotDefined) {
       throw new Error('ERROR in PixSelect component, @id param is necessary when giving @label');

--- a/addon/components/pix-select.js
+++ b/addon/components/pix-select.js
@@ -15,8 +15,8 @@ export default class PixSelect extends Component {
   }
   
   get label() {
-    const labelIsDefined = this.args.label && this.args.label.trim();
-    const idIsNotDefined = !(this.args.id && this.args.id.trim());
+    const labelIsDefined = this.args.label?.trim();
+    const idIsNotDefined = !(this.args.id?.trim());
 
     if (labelIsDefined && idIsNotDefined) {
       throw new Error('ERROR in PixSelect component, @id param is necessary when giving @label');

--- a/addon/components/pix-textarea.js
+++ b/addon/components/pix-textarea.js
@@ -9,7 +9,7 @@ export default class PixTextarea extends Component {
 
   get label() {
     const labelIsDefined = this.args.label && this.args.label.trim();
-    const idIsNotDefined = this.args.id && !this.args.id.trim();
+    const idIsNotDefined = !(this.args.id && this.args.id.trim());
 
     if (labelIsDefined && idIsNotDefined) {
       throw new Error('ERROR in PixTextarea component, @id param is necessary when giving @label');

--- a/addon/components/pix-textarea.js
+++ b/addon/components/pix-textarea.js
@@ -8,8 +8,8 @@ export default class PixTextarea extends Component {
   }
 
   get label() {
-    const labelIsDefined = this.args.label && this.args.label.trim();
-    const idIsNotDefined = !(this.args.id && this.args.id.trim());
+    const labelIsDefined = this.args.label?.trim();
+    const idIsNotDefined = !(this.args.id?.trim());
 
     if (labelIsDefined && idIsNotDefined) {
       throw new Error('ERROR in PixTextarea component, @id param is necessary when giving @label');

--- a/tests/unit/components/pix-select-test.js
+++ b/tests/unit/components/pix-select-test.js
@@ -8,7 +8,7 @@ module('Unit | Component | pix-select', function(hooks) {
 
   module('#label', function(){
 
-    test('it should return label if id is defined', function(assert){
+    test('it should return the label if id is defined', function(assert){
       // given
       const componentParams = { id: 'Textearea id', label: 'Select label' };
       const component = createGlimmerComponent('component:pix-select', componentParams);

--- a/tests/unit/components/pix-select-test.js
+++ b/tests/unit/components/pix-select-test.js
@@ -1,0 +1,36 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+import createGlimmerComponent from '../../helpers/create-glimmer-component';
+
+
+module('Unit | Component | pix-select', function(hooks) {
+  setupTest(hooks);
+
+  module('#label', function(){
+
+    test('it should return label if id is defined', function(assert){
+      // given
+      const componentParams = { id: 'Textearea id', label: 'Select label' };
+      const component = createGlimmerComponent('component:pix-select', componentParams);
+
+      // when
+      const result = component.label;
+
+      // then
+      assert.equal(result, 'Select label');
+    })
+
+    test('it should throw an error if id is undefined', function(assert){
+      // given
+      const componentParams = { label: 'Select label' };
+      const component = createGlimmerComponent('component:pix-select', componentParams);
+
+      // when & then
+      const expectedError = new Error('ERROR in PixSelect component, @id param is necessary when giving @label');
+      assert.throws(
+        function() { component.label },
+        expectedError
+      );
+    })
+  })
+});

--- a/tests/unit/components/pix-textarea-test.js
+++ b/tests/unit/components/pix-textarea-test.js
@@ -1,0 +1,36 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+import createGlimmerComponent from '../../helpers/create-glimmer-component';
+
+
+module('Unit | Component | pix-textarea', function(hooks) {
+  setupTest(hooks);
+
+  module('#label', function(){
+
+    test('it should return label if id is defined', function(assert){
+      // given
+      const componentParams = { id: 'Textearea id', label: 'Textarea label' };
+      const component = createGlimmerComponent('component:pix-textarea', componentParams);
+
+      // when
+      const result = component.label;
+
+      // then
+      assert.equal(result, 'Textarea label');
+    })
+
+    test('it should throw an error if id is undefined', function(assert){
+      // given
+      const componentParams = { label: 'Textarea label' };
+      const component = createGlimmerComponent('component:pix-textarea', componentParams);
+
+      // when & then
+      const expectedError = new Error('ERROR in PixTextarea component, @id param is necessary when giving @label');
+      assert.throws(
+        function() { component.label },
+        expectedError
+      );
+    })
+  })
+});


### PR DESCRIPTION
## :unicorn: Description du bug
Pour le `PixTextarea` et `PixSelect` lorsqu'on renseigne le label il est nécessaire de fournir aussi l'id (afin que le label soit rattaché à son élément de formulaire).
Cependant l'erreur qui était sensée être jetée lorsque l'id n'est pas renseigné ne fonctionnait pas.