### PR TITLE
[TECH] Ajout du helper clickByLabel (PIX-3470)

### DIFF
--- a/addon/components/pix-collapsible.hbs
+++ b/addon/components/pix-collapsible.hbs
@@ -1,4 +1,4 @@
-<div class='pix-collapsible {{if this.isUnCollapsed 'pix-collapsible--uncollapsed'}}' ...attributes>
+<div class='pix-collapsible {{if this.isUnCollapsed 'pix-collapsible--uncollapsed'}}'>
 
   <button
     type="button"
@@ -6,6 +6,7 @@
     class='pix-collapsible__title {{if this.isUnCollapsed 'pix-collapsible__title--uncollapsed'}}'
     aria-controls={{this.contentId}}
     aria-expanded={{if this.isUnCollapsed 'true' 'false'}}
+    ...attributes
   >
     <span>
       {{#if @titleIcon}}

--- a/tests/helpers/click-by-label.js
+++ b/tests/helpers/click-by-label.js
@@ -1,0 +1,35 @@
+import { click, findAll } from '@ember/test-helpers';
+
+export function clickByLabel(labelText) {
+  const clickableElement = _findClickableElementForLabel(labelText);
+
+  if (!clickableElement) {
+    throw new Error(`Cannot find clickable element labelled "${labelText}".`);
+  }
+
+  return click(clickableElement);
+}
+
+function _findClickableElementForLabel(labelText) {
+  const clickableSelectors = ['button', 'a[href]', '[role="button"]', 'input[type="radio"]', 'input[type="checkbox"]', 'label[for]'];
+  return findAll(clickableSelectors.join(',')).find(_matchesLabel(labelText));
+}
+
+function _matchesLabel(labelText) {
+  return (element) => _matchesInnerText(element, labelText) ||
+                      _matchesTitle(element, labelText) ||
+                      _matchesAriaLabel(element, labelText);
+}
+
+function _matchesInnerText(element, labelText) {
+  return element.textContent.match(labelText);
+}
+
+function _matchesTitle(element, labelText) {
+  return element.title && element.title.match(labelText);
+}
+
+function _matchesAriaLabel(element, labelText) {
+  const ariaLabel = element.getAttribute('aria-label');
+  return ariaLabel && ariaLabel.match(labelText);
+}

--- a/tests/helpers/click-by-label.js
+++ b/tests/helpers/click-by-label.js
@@ -26,7 +26,7 @@ function _matchesInnerText(element, labelText) {
 }
 
 function _matchesTitle(element, labelText) {
-  return element.title && element.title.match(labelText);
+  return element.title?.match(labelText);
 }
 
 function _matchesAriaLabel(element, labelText) {

--- a/tests/helpers/click-by-label.js
+++ b/tests/helpers/click-by-label.js
@@ -31,5 +31,5 @@ function _matchesTitle(element, labelText) {
 
 function _matchesAriaLabel(element, labelText) {
   const ariaLabel = element.getAttribute('aria-label');
-  return ariaLabel && ariaLabel.match(labelText);
+  return ariaLabel?.match(labelText);
 }

--- a/tests/integration/components/pix-button-test.js
+++ b/tests/integration/components/pix-button-test.js
@@ -1,8 +1,9 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import { click, render } from '@ember/test-helpers';
+import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import sinon from 'sinon';
+import { clickByLabel } from '../../helpers/click-by-label';
 
 module('Integration | Component | button', function(hooks) {
   setupRenderingTest(hooks);
@@ -46,13 +47,15 @@ module('Integration | Component | button', function(hooks) {
     //when
     await render(hbs`
       <PixButton
-      @isDisabled={{true}}
-      @triggerAction={{this.triggerAction}}>
+        @isDisabled={{true}}
+        @triggerAction={{this.triggerAction}}
+        aria-label="button label"
+      >
         Mon bouton
       </PixButton>
     `);
 
-    await click('button');
+    await clickByLabel('button label');
 
     // then
     const componentElement = this.element.querySelector(COMPONENT_SELECTOR);
@@ -69,10 +72,10 @@ module('Integration | Component | button', function(hooks) {
 
     //when
     await render(hbs`
-      <PixButton @triggerAction={{this.triggerAction}} />
+      <PixButton @triggerAction={{this.triggerAction}} aria-label="button label" />
     `);
 
-    await click('button');
+    await clickByLabel('button label');
 
     // then
     const componentElement = this.element.querySelector(COMPONENT_SELECTOR);
@@ -85,11 +88,11 @@ module('Integration | Component | button', function(hooks) {
     test('if clicked, it should do nothing', async function(assert) {
       // given
       await render(hbs`
-      <PixButton @type="submit" />
+      <PixButton @type="submit" aria-label="button label"  />
       `);
 
       //  when
-      await click('button');
+      await clickByLabel('button label');
 
       // then
       const componentElement = this.element.querySelector(COMPONENT_SELECTOR);
@@ -149,8 +152,8 @@ module('Integration | Component | button', function(hooks) {
       });
 
       // when
-      await render(hbs`<PixButton @triggerAction={{this.triggerAction}} />`);
-      await click('button');
+      await render(hbs`<PixButton @triggerAction={{this.triggerAction}} aria-label="button label"  />`);
+      await clickByLabel('button label');
 
       // then
       const loadingComponent = this.element.querySelector('.loader');

--- a/tests/integration/components/pix-collapsible-test.js
+++ b/tests/integration/components/pix-collapsible-test.js
@@ -1,13 +1,12 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import { render, click } from '@ember/test-helpers';
+import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import createGlimmerComponent from '../../helpers/create-glimmer-component';
+import { clickByLabel } from '../../helpers/click-by-label';
 
 module('Integration | Component | collapsible', function(hooks) {
   setupRenderingTest(hooks);
-
-  const COLLAPSIBLE_TITLE_SELECTOR = '.pix-collapsible__title';
 
   test('it show only PixCollapsible title by default', async function(assert) {
     // when
@@ -24,11 +23,14 @@ module('Integration | Component | collapsible', function(hooks) {
   test('it shows content on click on PixCollapsible title', async function(assert) {
     // when
     await render(hbs`
-      <PixCollapsible @title="Titre de mon élément déroulable">
+      <PixCollapsible
+        @title="Titre de mon élément déroulable"
+        aria-label="collapsible label"
+      >
         <p>Contenu de mon élément</p>
       </PixCollapsible>
     `);
-    await click(COLLAPSIBLE_TITLE_SELECTOR);
+    await clickByLabel('collapsible label');
 
     // then
     assert.contains('Titre de mon élément déroulable');

--- a/tests/integration/components/pix-filter-banner-test.js
+++ b/tests/integration/components/pix-filter-banner-test.js
@@ -1,8 +1,9 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import { click, render } from '@ember/test-helpers';
+import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import sinon from 'sinon';
+import { clickByLabel } from '../../helpers/click-by-label';
 
 
 module('Integration | Component | filter-banner', function(hooks) {
@@ -67,11 +68,14 @@ module('Integration | Component | filter-banner', function(hooks) {
     
     //when
     await render(hbs`
-      <PixFilterBanner @clearFiltersLabel={{clearFiltersLabel}} @onClearFilters={{onClearFilters}}>
+      <PixFilterBanner
+        @clearFiltersLabel={{clearFiltersLabel}}
+        @onClearFilters={{onClearFilters}}
+      >
         content
       </PixFilterBanner>
     `);
-    await click('button');
+    await clickByLabel('some label');
     
     // then
     assert.ok(this.onClearFilters.calledOnce, 'the callback should be called once');

--- a/tests/integration/components/pix-icon-button-test.js
+++ b/tests/integration/components/pix-icon-button-test.js
@@ -1,8 +1,9 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import { click, render } from '@ember/test-helpers';
+import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import createGlimmerComponent from "../../helpers/create-glimmer-component";
+import { clickByLabel } from '../../helpers/click-by-label';
 
 module('Integration | Component | icon-button', function(hooks) {
   setupRenderingTest(hooks);
@@ -42,7 +43,7 @@ module('Integration | Component | icon-button', function(hooks) {
     await render(hbs`
       <PixIconButton @triggerAction={{this.triggerAction}} @ariaLabel="action du bouton" />
     `);
-    await click('button');
+    await clickByLabel('action du bouton');
 
     // then
     assert.equal(this.count, 2);
@@ -56,7 +57,7 @@ module('Integration | Component | icon-button', function(hooks) {
     await render(hbs`
       <PixIconButton @triggerAction={{this.triggerAction}} disabled={{true}} @ariaLabel="L'action du bouton" />
     `);
-    await click('button');
+    await clickByLabel('action du bouton');
 
     // then
     const componentElement = this.element.querySelector(COMPONENT_SELECTOR);

--- a/tests/integration/components/pix-multi-select-test.js
+++ b/tests/integration/components/pix-multi-select-test.js
@@ -1,9 +1,10 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import { render, click, fillIn, focus, blur } from '@ember/test-helpers';
+import { render, fillIn, focus, blur } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import createGlimmerComponent from '../../helpers/create-glimmer-component';
 import sinon from 'sinon';
+import { clickByLabel } from '../../helpers/click-by-label';
 
 module('Integration | Component | multi-select', function (hooks) {
   setupRenderingTest(hooks);
@@ -59,13 +60,15 @@ module('Integration | Component | multi-select', function (hooks) {
         @onSelect={{onSelect}}
         @title={{title}}
         @id={{id}}
+        @label="label"
         @emptyMessage={{emptyMessage}}
-        @options={{options}} as |option|>
+        @options={{options}} as |option|
+      >
         {{option.label}}
       </PixMultiSelect>
     `);
 
-    await click('button');
+    await clickByLabel('label');
 
     
     // then
@@ -92,6 +95,7 @@ module('Integration | Component | multi-select', function (hooks) {
         @title={{title}}
         @id={{id}}
         @selected={{selected}}
+        @label="label"
         @emptyMessage={{emptyMessage}}
         @options={{options}} as |option|
       >
@@ -99,7 +103,7 @@ module('Integration | Component | multi-select', function (hooks) {
       </PixMultiSelect>
     `);
 
-    await click('button');
+    await clickByLabel('label');
     
     // then
     const checkboxElement = this.element.querySelectorAll('input[type=checkbox]');
@@ -124,6 +128,7 @@ module('Integration | Component | multi-select', function (hooks) {
         @title={{title}}
         @id={{id}}
         @selected={{selected}}
+        @label="label"
         @emptyMessage={{emptyMessage}}
         @options={{options}} as |option|>
         {{option.label}}
@@ -132,7 +137,7 @@ module('Integration | Component | multi-select', function (hooks) {
 
     // when
     this.set('selected', []);
-    await click('button');
+    await clickByLabel('label');
     
     // then
     const checkboxElement = this.element.querySelectorAll('input[type=checkbox]');
@@ -155,6 +160,7 @@ module('Integration | Component | multi-select', function (hooks) {
       @onSelect={{onSelect}}
       @title={{title}}
       @id={{id}}
+      @label="label"
       @emptyMessage={{emptyMessage}}
       @options={{options}} as |option|>
       {{option.label}}
@@ -162,11 +168,11 @@ module('Integration | Component | multi-select', function (hooks) {
   `);
 
     // when
-    await click('button');
-    const firstCheckbox = this.element.querySelectorAll('input[type=checkbox]').item(0);
-    await click(firstCheckbox);
-
+    await clickByLabel('label');
+    await clickByLabel('Salade');
+    
     // then
+    const firstCheckbox = this.element.querySelectorAll('input[type=checkbox]').item(0);
     assert.equal(firstCheckbox.checked, true);
     assert.ok(this.onSelect.calledOnce, 'the callback should be called once');
     assert.ok(this.onSelect.calledWith, ['1']);
@@ -187,6 +193,7 @@ module('Integration | Component | multi-select', function (hooks) {
         @onSelect={{onSelect}}
         @title={{title}}
         @id={{id}}
+        @label="label"
         @emptyMessage={{emptyMessage}}
         @options={{options}} as |option|>
         {{option.label}}
@@ -194,9 +201,8 @@ module('Integration | Component | multi-select', function (hooks) {
     `);
 
     // when
-    await click('button');
-    const firstCheckbox = this.element.querySelectorAll('input[type=checkbox]').item(0);
-    await click(firstCheckbox);
+    await clickByLabel('label');
+    await clickByLabel('Salade');
 
     // then
     assert.ok(this.onSelect.calledWith, ['2']);
@@ -223,6 +229,7 @@ module('Integration | Component | multi-select', function (hooks) {
           @title={{title}}
           @placeholder={{placeholder}}
           @id={{id}}
+          @label="label"
           @emptyMessage={{emptyMessage}}
           @options={{options}} as |option|>
           {{option.label}}
@@ -256,6 +263,7 @@ module('Integration | Component | multi-select', function (hooks) {
           @title={{title}}
           @placeholder={{placeholder}}
           @id={{id}}
+          @label="label"
           @emptyMessage={{emptyMessage}}
           @options={{options}} as |option|>
           {{option.label}}
@@ -433,6 +441,7 @@ module('Integration | Component | multi-select', function (hooks) {
           @onSelect={{onSelect}}
           @title={{title}}
           @placeholder={{placeholder}}
+          @label="label"
           @id={{id}}
           @emptyMessage={{emptyMessage}}
           @options={{options}} as |option|>
@@ -441,9 +450,8 @@ module('Integration | Component | multi-select', function (hooks) {
       `);
     
       // when
-      await click('input[type=text]')
-      const thirdCheckbox = this.element.querySelectorAll('input[type=checkbox]').item(2);
-      await click(thirdCheckbox);
+      await clickByLabel('label')
+      await clickByLabel(DEFAULT_OPTIONS[1].label);
 
       // then
       const listElement = this.element.querySelectorAll('.pix-multi-select-list__item');
@@ -480,8 +488,7 @@ module('Integration | Component | multi-select', function (hooks) {
     
       // when
       await fillIn('input', 'Oi')
-      const checkbox = this.element.querySelectorAll('input[type=checkbox]').item(0);
-      await click(checkbox);
+      await clickByLabel('Oignon');
       await fillIn('input', 'o')
 
       // then
@@ -518,8 +525,7 @@ module('Integration | Component | multi-select', function (hooks) {
     
       // when
       await fillIn('input', 'Oi')
-      const checkbox = this.element.querySelectorAll('input[type=checkbox]').item(0);
-      await click(checkbox);
+      await clickByLabel('Oignon');
       await fillIn('input', '')
     
       // then
@@ -549,6 +555,7 @@ module('Integration | Component | multi-select', function (hooks) {
           @title={{title}}
           @placeholder={{placeholder}}
           @id={{id}}
+          @label="label"
           @emptyMessage={{emptyMessage}}
           @showOptionsOnInput={{true}}
           @options={{options}} as |option|>
@@ -557,13 +564,12 @@ module('Integration | Component | multi-select', function (hooks) {
       `);
     
       // when
-      await click('input[type=text]')
+      await clickByLabel('label')
       
       const listElement = this.element.querySelectorAll('.pix-multi-select-list__item');
       assert.equal(listElement.item(0).textContent.trim(), 'Tomate');
 
-      const checkbox = this.element.querySelectorAll('input[type=checkbox]').item(2);
-      await click(checkbox);
+      await clickByLabel('Oignon');
     
       // then
       const listElement2 = this.element.querySelectorAll('.pix-multi-select-list__item');
@@ -599,8 +605,7 @@ module('Integration | Component | multi-select', function (hooks) {
     
       // when
       await fillIn('input', 'Oi')
-      const checkbox = this.element.querySelectorAll('input[type=checkbox]').item(0);
-      await click(checkbox);
+      await clickByLabel('Oignon');
       
       await blur('input');
 


### PR DESCRIPTION
## :unicorn: Description
Première partie : ajout du helper contains https://github.com/1024pix/pix-ui/pull/142 
Voir aussi : 
- ajout du helper notContains https://github.com/1024pix/pix-ui/pull/143
- ajout du helper fillInByLabel https://github.com/1024pix/pix-ui/pull/144

Chez Pix on essaie de suivre les bonnes pratiques de tests front, notamment s'appuyant sur les pratiques de "Testing Library".

> The more your tests resemble the way your software is used, the more confidence they can give you.
https://testing-library.com/docs/guiding-principles

En suivant donc ce principe, cette PR ajoute l'helper `clickByLabel`.
Ce dernier permet de remplir un champ à partir de son label.

Par exemple, on préféra désormais écrire : 
```
await clickByLabel('Suivant');
```
Ce qui revient à : `Clique sur l'élément "Suivant"`. 

Plutôt que : 
```
await click('button');
```
Qui reviendrait à : `Clique sur l'élément HTML button`.