### PR TITLE
[BUGFIX] Ajout de l'évènement onChange afin de supprimer le message d'erreur lorsque l'utilisateur modifie sa saisie [BREAKING_CHANGES] (PIX-3476)

### DIFF
--- a/addon/components/pix-input-password.hbs
+++ b/addon/components/pix-input-password.hbs
@@ -11,11 +11,12 @@
         <span class="pix-input-password__prefix">{{@prefix}}</span>
       {{/if}}
 
-      <Input
+      <input
         id={{this.id}}
-        @type={{if this.isPasswordVisible 'text' 'password'}}
-        @value={{@value}}
+        type={{if this.isPasswordVisible 'text' 'password'}}
+        value={{@value}}
         aria-label={{this.ariaLabel}}
+        {{on 'change' this.onChange}}
         ...attributes
       />
 

--- a/addon/components/pix-input-password.js
+++ b/addon/components/pix-input-password.js
@@ -26,4 +26,10 @@ export default class PixInputPassword extends PixInput {
   togglePasswordVisibility() {
     this.isPasswordVisible = !this.isPasswordVisible;
   }
+
+  @action
+  onChange() {
+    if(typeof this.args.onChange === 'function')
+      this.args.onChange();
+  }
 }

--- a/addon/components/pix-input.hbs
+++ b/addon/components/pix-input.hbs
@@ -10,6 +10,7 @@
     id={{this.id}}
     class={{this.className}}
     @value={{@value}}
+    {{on 'change' this.onChange}}
     ...attributes />
 
   {{#if @errorMessage}}

--- a/addon/components/pix-input.js
+++ b/addon/components/pix-input.js
@@ -1,5 +1,6 @@
 import Component from '@glimmer/component';
 
+import { action } from '@ember/object';
 export default class PixInput extends Component {
   text = 'pix-input';
 
@@ -16,5 +17,11 @@ export default class PixInput extends Component {
     this.args.icon && classNames.push('pix-input__input--icon');
     this.args.isIconLeft && classNames.push('pix-input__input--icon-left');
     return classNames.join(' ');
+  }
+
+  @action
+  onChange() {
+    if(typeof this.args.onChange === 'function')
+      this.args.onChange();
   }
 }

--- a/app/stories/pix-input-password.stories.mdx
+++ b/app/stories/pix-input-password.stories.mdx
@@ -23,10 +23,7 @@ Si vous utilisez le `PixInputPassword` sans label alors il faut renseigner le pa
 > Si vous renseignez les paramètres label et ariaLabel ensemble, ariaLabel sera nullifié.
 
 ```html
-<PixInputPassword
-    @ariaLabel={{ariaLabel}}
-    @id={{id}}
-/>
+<PixInputPassword @ariaLabel='{{ariaLabel}}' @id='{{id}}' />
 ```
 
 ## Default
@@ -57,15 +54,16 @@ Si vous utilisez le `PixInputPassword` sans label alors il faut renseigner le pa
 
 ```html
 <PixInputPassword
-    @id={{id}}
-    @label={{label}}
-    @information={{information}}
-    @value={{value}}
-    @errorMessage={{errorMessage}}
-    @prefix={{prefix}}
+  @id='{{id}}'
+  @label='{{label}}'
+  @information='{{information}}'
+  @value='{{value}}'
+  @errorMessage='{{errorMessage}}'
+  @prefix='{{prefix}}'
+  @onChange='{{onChange}}'
 />
 ```
 
 ## Arguments
 
-<ArgsTable story="Default" />
+<ArgsTable story='Default' />

--- a/app/stories/pix-input.stories.mdx
+++ b/app/stories/pix-input.stories.mdx
@@ -48,7 +48,8 @@ Le PixInput permet de créer un champ de texte.
   @information='Complément du label'
   @errorMessage="Un message d'erreur"
   @icon="eye"
-  @isIconLeft={{false}} />
+  @isIconLeft={{false}}
+  @onChange={{onChange}} />
 ```
 
 ## Arguments

--- a/tests/integration/components/pix-input-password-test.js
+++ b/tests/integration/components/pix-input-password-test.js
@@ -1,8 +1,11 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { render } from '@ember/test-helpers';
+
+import fillInByLabel from '../../helpers/fill-in-by-label';
 import { hbs } from 'ember-cli-htmlbars';
 import createGlimmerComponent from "../../helpers/create-glimmer-component";
+import sinon from 'sinon';
 
 module('Integration | Component | pix-input-password', function(hooks) {
   setupRenderingTest(hooks);
@@ -90,5 +93,19 @@ module('Integration | Component | pix-input-password', function(hooks) {
     // then
     const selectorElement = this.element.querySelector(INPUT_SELECTOR);
     assert.equal(selectorElement.value, 'pix123');
+  });
+
+  module('Attributes @onChange', function() {
+    test('it calls onChange event while typing', async function(assert) {
+      // given
+      this.onChange = sinon.spy();
+      // when
+      await render(hbs`<PixInputPassword @label="Mot de passe" @id="password" @onChange={{this.onChange}}/>`);
+  
+      await fillInByLabel('Mot de passe', 'Jeanne');
+  
+      // then
+      assert.ok(this.onChange.called);
+    });
   });
 });

--- a/tests/integration/components/pix-input-test.js
+++ b/tests/integration/components/pix-input-test.js
@@ -4,6 +4,7 @@ import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import createGlimmerComponent from '../../helpers/create-glimmer-component';
 import fillInByLabel from '../../helpers/fill-in-by-label';
+import sinon from 'sinon';
 
 module('Integration | Component | input', function(hooks) {
   setupRenderingTest(hooks);
@@ -94,5 +95,19 @@ module('Integration | Component | input', function(hooks) {
     // then
     const selectorElement = this.element.querySelector(INPUT_SELECTOR);
     assert.equal(selectorElement.autocomplete, 'on');
+  });
+
+  module('Attributes @onChange', function() {
+    test('it calls onChange event while typing', async function(assert) {
+      // given
+      this.onChange = sinon.spy();
+      // when
+      await render(hbs`<PixInput @label="Prénom" @id="firstName" @onChange={{this.onChange}}/>`);
+  
+      await fillInByLabel('Prénom', 'Jeanne');
+  
+      // then
+      assert.ok(this.onChange.called);
+    });
   });
 });


### PR DESCRIPTION
## 💥 BREAKING_CHANGES
Le changement de l'`Input` ember à l'`input` natif ne permet plus de traquer les `value`.
Il est désormais nécessaire de déclarer un évènement `onChange` et de répercuter les changements de valeurs à votre variable via cet évènement.

## :unicorn: Description du composant
Lorsque l'utilisateur modifié une entrée saisie comme en erreur, celle-ci restait en erreur jusqu'à la nouvelle vérification.

Nous voulons que le message disparaisse quand l'utilisateur modifie sa saisie afin de ne pas être induit en erreur (penser que sa modification est toujours en erreur par exemple)

## :rainbow: Remarques
J'ai modifier PixInputPassWord qui était `Input` ember en `input` natif. ça me semble correct

## :100: Pour tester
> _Lien vers Zeroheight (modèle) et Storybook (rendu final)._
