### PR TITLE
[FEATURE] Permettre de tracker les values des PixInput et PixInputPassword

### DIFF
--- a/addon/components/pix-input-password.hbs
+++ b/addon/components/pix-input-password.hbs
@@ -10,6 +10,7 @@
       <Input
         id={{this.id}}
         @type={{if this.isPasswordVisible 'text' 'password'}}
+        @value={{@value}}
         aria-label={{this.ariaLabel}}
         ...attributes
       />

--- a/addon/components/pix-input.hbs
+++ b/addon/components/pix-input.hbs
@@ -6,9 +6,10 @@
     <label for={{this.id}} class="pix-input__information">{{@information}}</label>
   {{/if}}
 
-  <input
+  <Input
     id={{this.id}}
     class={{this.className}}
+    @value={{@value}}
     ...attributes />
 
   {{#if @errorMessage}}

--- a/addon/components/pix-input.js
+++ b/addon/components/pix-input.js
@@ -4,7 +4,7 @@ export default class PixInput extends Component {
   text = 'pix-input';
 
   get id() {
-    if (!this.args.id || !this.args.id.trim()) {
+    if (!this.args.id || !this.args.id.toString().trim()) {
       throw new Error('ERROR in PixInput component, @id param is not provided');
     }
     return this.args.id;

--- a/addon/stories/pix-input-password.stories.js
+++ b/addon/stories/pix-input-password.stories.js
@@ -42,16 +42,22 @@ export const argTypes = {
     type: { name: 'string', required: true },
     defaultValue: null,
   },
+  value: {
+    name: 'value',
+    description: 'Valeur de l\'input',
+    type: { name: 'string', required: false },
+    defaultValue: null,
+  },
   label: {
     name: 'label',
-    description: 'Label de l\'input',
-    type: { name: 'string', required: false },
+    description: 'Label de l\'input. Requis si ariaLabel n\'est pas définit.',
+    type: { name: 'string', required: true },
     defaultValue: null,
   },
   ariaLabel: {
     name: 'ariaLabel',
-    description: 'l\'action du bouton, pour l\'accessibilité',
-    type: { name: 'string', required: false },
+    description: 'L\'action du bouton, pour l\'accessibilité. Requis si label n\'est pas définit.',
+    type: { name: 'string', required: true },
     defaultValue: null,
   },
   information: {

--- a/addon/stories/pix-input-password.stories.mdx
+++ b/addon/stories/pix-input-password.stories.mdx
@@ -54,6 +54,7 @@ Si vous utilisez le `PixInputPassword` sans label alors il faut renseigner le pa
     @id={{id}}
     @label={{label}}
     @information={{information}}
+    @value={{value}}
     @errorMessage={{errorMessage}}
 />
 ```

--- a/addon/stories/pix-input.stories.js
+++ b/addon/stories/pix-input.stories.js
@@ -50,6 +50,12 @@ export const argTypes = {
     type: { name: 'string', required: true },
     defaultValue: null,
   },
+  value: {
+    name: 'value',
+    description: 'Valeur de l\'input',
+    type: { name: 'string', required: false },
+    defaultValue: null,
+  },
   label: {
     name: 'label',
     description: 'Le label de l\'input',

--- a/tests/integration/components/pix-input-password-test.js
+++ b/tests/integration/components/pix-input-password-test.js
@@ -74,4 +74,13 @@ module('Integration | Component | pix-input-password', function(hooks) {
     assert.throws(function() { component.label }, expectedError);
     assert.throws(function() { component.ariaLabel }, expectedError);
   });
+
+  test('it should be possible to track value of input', async function(assert) {
+    // given && when
+    await render(hbs`<PixInputPassword @id="password" @label="Mot de passe" @value="pix123" />`);
+
+    // then
+    const selectorElement = this.element.querySelector(INPUT_SELECTOR);
+    assert.equal(selectorElement.value, 'pix123');
+  });
 });

--- a/tests/integration/components/pix-input-test.js
+++ b/tests/integration/components/pix-input-test.js
@@ -78,12 +78,21 @@ module('Integration | Component | input', function(hooks) {
     assert.dom('.pix-input__icon.pix-input__icon--left').exists();
   });
 
-  test('it should be possible to give more params to input', async function(assert) {
+  test('it should be possible to track value from input', async function(assert) {
     // given & when
-    await render(hbs`<PixInput @label="Prénom" @id="firstName" value='Jeanne' />`);
+    await render(hbs`<PixInput @label="Prénom" @id="firstName" @value='Jeanne' />`);
 
     // then
     const selectorElement = this.element.querySelector(INPUT_SELECTOR);
     assert.equal(selectorElement.value, 'Jeanne');
+  });
+
+  test('it should be possible to give more params to input', async function(assert) {
+    // given & when
+    await render(hbs`<PixInput @label="Prénom" @id="firstName" autocomplete="on" />`);
+
+    // then
+    const selectorElement = this.element.querySelector(INPUT_SELECTOR);
+    assert.equal(selectorElement.autocomplete, 'on');
   });
 });

--- a/tests/integration/components/pix-input-test.js
+++ b/tests/integration/components/pix-input-test.js
@@ -29,6 +29,15 @@ module('Integration | Component | input', function(hooks) {
     assert.throws(function() { component.id }, expectedError);
   });
 
+  test('it should be possible to give a number as id', async function(assert) {
+    // given & when
+    await render(hbs`<PixInput @id={{123}} />`);
+
+    // then
+    const selectorElement = this.element.querySelector(INPUT_SELECTOR);
+    assert.equal(selectorElement.id, '123');
+  });
+
   test('it should be possible to give a label to input', async function(assert) {
     // given & when
     await render(hbs`<PixInput @label="Prénom" @id="firstName" />`);


### PR DESCRIPTION
## :unicorn: Description
Lors de l'utilisation de PixInput ou PixInputPassword, il n'est pas possible de traquer correctement leur valeur.
En effet, pour que cela soit possible il faut avoir un `<Input>` d'ember et il faut lui passer la valeur par paramètre `@value=`.
