### PR TITLE
[TECH] Mettre à jour la version de l'auto merge et donner les permissions nécessaires au github token

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -9,8 +9,9 @@ on:
       - completed
 
 permissions:
-  contents: read
-  pull-requests: write
+  checks: read
+  contents: write
+  actions: write
 
 jobs:
   automerge:

--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: automerge
-        uses: "pascalgn/automerge-action@v0.8.3"
+        uses: "pascalgn/automerge-action@v0.14.3"
         env:
           GITHUB_TOKEN: "${{ github.token }}"
           MERGE_LABELS: ":rocket: Ready to Merge"


### PR DESCRIPTION
## :unicorn: Description 
Depuis la PR https://github.com/1024pix/pix-ui/pull/140  l'auto merge ne fonctionne plus.

En fait les permissions du github token ne sont pas suffisantes.
Après plusieurs essais sur un repo de test les permissions minimale pour que le github token marche sont : 

- checks: read (pour lire les checks de la PR)
- contents: write (pour push sur le repo)
- actions: write (pour pouvoir lancer / arrêter une github action)

Pour plus d'info voir : 
- https://github.blog/changelog/2021-04-20-github-actions-control-permissions-for-github_token/
- https://docs.github.com/en/rest/reference/permissions-required-for-github-apps 
