### PR TITLE
[BUGFIX] Mettre à jour le PixInputCode [BREAKING_CHANGES] 

### DIFF
--- a/addon/components/pix-input-code.hbs
+++ b/addon/components/pix-input-code.hbs
@@ -1,6 +1,6 @@
 {{!-- template-lint-disable no-down-event-binding --}}
 <div class='pix-input-code'>
-  {{#each this.numIterations as |i|}}
+  {{#each this.numbersForIterations as |i|}}
     <input
       ...attributes
       id="code-input-{{i}}"

--- a/addon/components/pix-input-code.hbs
+++ b/addon/components/pix-input-code.hbs
@@ -1,14 +1,14 @@
 {{!-- template-lint-disable no-down-event-binding --}}
 <div class='pix-input-code'>
-  <p id='pix-input-code__details-of-use'>{{this.detailsOfUse}}</p>
+  <p id='pix-input-code__details-of-use'>{{this.explanationOfUse}}</p>
   <fieldset aria-describedby='pix-input-code__details-of-use'>
     <legend>{{this.legend}}</legend>
-    {{#each this.numbersForIterations as |i|}}
+    {{#each this.numberOfIterations as |i|}}
       <input
         ...attributes
         id="code-input-{{i}}"
         type="{{this.inputType}}"
-        aria-label="{{this.ariaLabel}} n°{{i}}"
+        aria-label="{{this.ariaLabel}} {{i}}"
         class="pix-input-code__input"
         min="1"
         max="9"

--- a/addon/components/pix-input-code.hbs
+++ b/addon/components/pix-input-code.hbs
@@ -1,6 +1,7 @@
 {{!-- template-lint-disable no-down-event-binding --}}
 <div class='pix-input-code'>
-  <fieldset>
+  <p id='pix-input-code__details-of-use'>{{this.detailsOfUse}}</p>
+  <fieldset aria-describedby='pix-input-code__details-of-use'>
     <legend>{{this.legend}}</legend>
     {{#each this.numbersForIterations as |i|}}
       <input

--- a/addon/components/pix-input-code.hbs
+++ b/addon/components/pix-input-code.hbs
@@ -1,20 +1,23 @@
 {{!-- template-lint-disable no-down-event-binding --}}
 <div class='pix-input-code'>
-  {{#each this.numbersForIterations as |i|}}
-    <input
-      ...attributes
-      id="code-input-{{i}}"
-      type="{{this.inputType}}"
-      aria-label="{{this.ariaLabel}} n°{{i}}"
-      class="pix-input-code__input"
-      min="1"
-      max="9"
-      autocomplete="off"
-      placeholder="{{this.placeholder}}"
-      {{on "keydown" this.handleArrowUpOrDown}}
-      {{on "keyup" (fn this.handleKeyUp i)}}
-      {{on "input" (fn this.handleCodeInput i)}}
-      {{on "paste" (fn this.handlePaste i)}}
-    />
-  {{/each}}
+  <fieldset>
+    <legend>{{this.legend}}</legend>
+    {{#each this.numbersForIterations as |i|}}
+      <input
+        ...attributes
+        id="code-input-{{i}}"
+        type="{{this.inputType}}"
+        aria-label="{{this.ariaLabel}} n°{{i}}"
+        class="pix-input-code__input"
+        min="1"
+        max="9"
+        autocomplete="off"
+        placeholder="{{this.placeholder}}"
+        {{on "keydown" this.handleArrowUpOrDown}}
+        {{on "keyup" (fn this.handleKeyUp i)}}
+        {{on "input" (fn this.handleCodeInput i)}}
+        {{on "paste" (fn this.handlePaste i)}}
+      />
+    {{/each}}
+  </fieldset>
 </div>

--- a/addon/components/pix-input-code.js
+++ b/addon/components/pix-input-code.js
@@ -2,6 +2,9 @@ import Component from '@glimmer/component';
 import { action } from '@ember/object';
 
 const ERROR_MESSAGE = 'ERROR in PixInputCode component, you must provide an @ariaLabel and an @legend';
+const DETAILS_OF_DEPLACEMENT_MESSAGE = "Pour se déplacer de champ en champ vous pouvez utiliser la tabulation ou bien les flèches gauche et droite de votre clavier.";
+const DETAILS_OF_FILL_FOR_INPUT_NUMBER_MESSAGE = "Pour remplir un champ vous pouvez utiliser des chiffres de 1 à 9 ou bien les flèches haut et bas de votre clavier pour incrémenter de 1 la valeur du champ.";
+const DETAILS_OF_FILL_FOR_INPUT_TEXT_MESSAGE = "Pour remplir un champ vous pouvez utiliser les caractères alphanumériques de votre clavier.";
 
 export default class PixInputCode extends Component {
   moveFocus = true;
@@ -16,6 +19,15 @@ export default class PixInputCode extends Component {
       throw new Error(ERROR_MESSAGE);
     }
     return this.args.ariaLabel;
+  }
+
+  get detailsOfUse() {
+    const defaultDetailsOfFill = this.inputType === 'number'
+      ? DETAILS_OF_FILL_FOR_INPUT_NUMBER_MESSAGE
+      : DETAILS_OF_FILL_FOR_INPUT_TEXT_MESSAGE;
+    const defaultDetailsOfUseMessage = DETAILS_OF_DEPLACEMENT_MESSAGE + ' ' + defaultDetailsOfFill;
+
+    return this.args.detailsOfUse ? this.args.detailsOfUse : defaultDetailsOfUseMessage;
   }
 
   get legend() {

--- a/addon/components/pix-input-code.js
+++ b/addon/components/pix-input-code.js
@@ -1,7 +1,7 @@
 import Component from '@glimmer/component';
 import { action } from '@ember/object';
 
-const ERROR_MESSAGE = 'ERROR in PixInputCode component, you must provide an @ariaLabel';
+const ERROR_MESSAGE = 'ERROR in PixInputCode component, you must provide an @ariaLabel and an @legend';
 
 export default class PixInputCode extends Component {
   moveFocus = true;
@@ -16,6 +16,13 @@ export default class PixInputCode extends Component {
       throw new Error(ERROR_MESSAGE);
     }
     return this.args.ariaLabel;
+  }
+
+  get legend() {
+    if (!this.args.legend) {
+      throw new Error(ERROR_MESSAGE);
+    }
+    return this.args.legend;
   }
 
   get inputType() {

--- a/addon/components/pix-input-code.js
+++ b/addon/components/pix-input-code.js
@@ -1,16 +1,16 @@
 import Component from '@glimmer/component';
 import { action } from '@ember/object';
 
-const ERROR_MESSAGE = 'ERROR in PixInputCode component, you must provide an @ariaLabel and an @legend';
-const DETAILS_OF_DEPLACEMENT_MESSAGE = "Pour se déplacer de champ en champ vous pouvez utiliser la tabulation ou bien les flèches gauche et droite de votre clavier.";
-const DETAILS_OF_FILL_FOR_INPUT_NUMBER_MESSAGE = "Pour remplir un champ vous pouvez utiliser des chiffres de 1 à 9 ou bien les flèches haut et bas de votre clavier pour incrémenter de 1 la valeur du champ.";
-const DETAILS_OF_FILL_FOR_INPUT_TEXT_MESSAGE = "Pour remplir un champ vous pouvez utiliser les caractères alphanumériques de votre clavier.";
+const ERROR_MESSAGE = 'ERROR in PixInputCode component, you must provide an @ariaLabel and a @legend';
+const NAVIGATION_EXPLANATION = "Pour se déplacer de champ en champ vous pouvez utiliser la tabulation ou bien les flèches gauche et droite de votre clavier.";
+const NUMBER_INPUT_EXPLANATION = "Pour remplir un champ vous pouvez utiliser des chiffres de 1 à 9 ou bien les flèches haut et bas de votre clavier pour incrémenter de 1 la valeur du champ.";
+const TEXT_INPUT_EXPLANATION = "Pour remplir un champ vous pouvez utiliser les caractères alphanumériques de votre clavier.";
 
 export default class PixInputCode extends Component {
   moveFocus = true;
   numInputs = this.args.numInputs || 6;
 
-  get numbersForIterations() {
+  get numberOfIterations() {
     return Array.from({ length: this.numInputs }, (_, i) => i + 1);
   }
 
@@ -21,13 +21,13 @@ export default class PixInputCode extends Component {
     return this.args.ariaLabel;
   }
 
-  get detailsOfUse() {
-    const defaultDetailsOfFill = this.inputType === 'number'
-      ? DETAILS_OF_FILL_FOR_INPUT_NUMBER_MESSAGE
-      : DETAILS_OF_FILL_FOR_INPUT_TEXT_MESSAGE;
-    const defaultDetailsOfUseMessage = DETAILS_OF_DEPLACEMENT_MESSAGE + ' ' + defaultDetailsOfFill;
+  get explanationOfUse() {
+    const defaultFillingExplanation = this.inputType === 'number'
+      ? NUMBER_INPUT_EXPLANATION
+      : TEXT_INPUT_EXPLANATION;
+    const defaultExplanationOfUseMessage = NAVIGATION_EXPLANATION + ' ' + defaultFillingExplanation;
 
-    return this.args.detailsOfUse ? this.args.detailsOfUse : defaultDetailsOfUseMessage;
+    return this.args.explanationOfUse ? this.args.explanationOfUse : defaultExplanationOfUseMessage;
   }
 
   get legend() {
@@ -108,7 +108,7 @@ export default class PixInputCode extends Component {
     event.stopPropagation();
 
     const pastedText = (event.clipboardData || window.clipboardData).getData('text');
-    const pastedTextWithOnlyValidCharacters = _removeNotAllowedCharaters(pastedText);
+    const pastedTextWithOnlyValidCharacters = _extractValidCharacters(pastedText);
 
     pastedTextWithOnlyValidCharacters.forEach(char => {
       const input = document.getElementById(`code-input-${index}`);
@@ -124,7 +124,7 @@ export default class PixInputCode extends Component {
   }
 }
 
-function _removeNotAllowedCharaters(pastedText) {
+function _extractValidCharacters(pastedText) {
   const alphanumericCharacters = /^[a-zA-Z0-9_]*$/;
   return [...pastedText].filter((char) => alphanumericCharacters.test(char));
 }

--- a/addon/components/pix-input-code.js
+++ b/addon/components/pix-input-code.js
@@ -7,7 +7,7 @@ export default class PixInputCode extends Component {
   moveFocus = true;
   numInputs = this.args.numInputs || 6;
 
-  get numIterations() {
+  get numbersForIterations() {
     return Array.from({ length: this.numInputs }, (_, i) => i + 1);
   }
 
@@ -26,7 +26,7 @@ export default class PixInputCode extends Component {
     return this.inputType === 'number' ? '0' : null;
   }
 
-  focusElem(index) {
+  focusElement(index) {
     const nextElem = document.getElementById(`code-input-${index}`);
     nextElem && nextElem.focus();
   }
@@ -45,7 +45,7 @@ export default class PixInputCode extends Component {
     const code = [];
     for(let i = 1; i <= this.numInputs; i++) {
       const elem = document.getElementById(`code-input-${i}`);
-     elem.value.length > 0 && code.push(elem.value);
+      elem.value.length > 0 && code.push(elem.value);
     }
     if (code.length === this.numInputs) {
       this.args.onAllInputsFilled(code.join(''));
@@ -58,7 +58,7 @@ export default class PixInputCode extends Component {
     this.validateInput(elem);
     if (elem.value.length > 0) {
       elem.classList.add("filled");
-      this.moveFocus && this.focusElem(index + 1);
+      this.moveFocus && this.focusElement(index + 1);
       this.triggerAction();
     } else {
       elem.classList.remove("filled");
@@ -73,7 +73,7 @@ export default class PixInputCode extends Component {
       ArrowRight: index + 1
     }
     const newIndex = eventMap[event.code || event.key];
-    this.focusElem(newIndex);
+    this.focusElement(newIndex);
   }
 
   @action
@@ -91,12 +91,12 @@ export default class PixInputCode extends Component {
     [...pastedText].forEach(char => {
       const elem = document.getElementById(`code-input-${index}`);
       if (elem) {
-        this.focusElem(index);
+        this.focusElement(index);
         elem.value = char;
         index++;
       }
     });
-    this.focusElem(index);
+    this.focusElement(index);
     this.triggerAction();
   }
 }

--- a/addon/components/pix-input-code.js
+++ b/addon/components/pix-input-code.js
@@ -99,10 +99,11 @@ export default class PixInputCode extends Component {
     const pastedTextWithOnlyValidCharacters = _removeNotAllowedCharaters(pastedText);
 
     pastedTextWithOnlyValidCharacters.forEach(char => {
-      const elem = document.getElementById(`code-input-${index}`);
-      if (elem) {
+      const input = document.getElementById(`code-input-${index}`);
+      if (input) {
         this.focusElement(index);
-        elem.value = char;
+        input.value = char;
+        input.classList.add("filled");
         index++;
       }
     });

--- a/addon/components/pix-input-code.js
+++ b/addon/components/pix-input-code.js
@@ -87,8 +87,11 @@ export default class PixInputCode extends Component {
   handlePaste(index, event) {
     event.preventDefault();
     event.stopPropagation();
+
     const pastedText = (event.clipboardData || window.clipboardData).getData('text');
-    [...pastedText].forEach(char => {
+    const pastedTextWithOnlyValidCharacters = _removeNotAllowedCharaters(pastedText);
+
+    pastedTextWithOnlyValidCharacters.forEach(char => {
       const elem = document.getElementById(`code-input-${index}`);
       if (elem) {
         this.focusElement(index);
@@ -99,4 +102,9 @@ export default class PixInputCode extends Component {
     this.focusElement(index);
     this.triggerAction();
   }
+}
+
+function _removeNotAllowedCharaters(pastedText) {
+  const alphanumericCharacters = /^[a-zA-Z0-9_]*$/;
+  return [...pastedText].filter((char) => alphanumericCharacters.test(char));
 }

--- a/addon/stories/pix-input-code.stories.js
+++ b/addon/stories/pix-input-code.stories.js
@@ -8,6 +8,7 @@ export const Template = (args) => {
         @legend={{legend}}
         @inputType={{inputType}}
         @numInputs={{numInputs}}
+        @detailsOfUse={{detailsOfUse}}
       />
     `,
     context: args,
@@ -28,8 +29,17 @@ export const argTypes = {
   },
   legend: {
     name: 'legend',
-    description: "La description du composant. Indiquer ce à quoi correspond votre PixInputCode.",
+    description: "La description du composant. Ce champ n'est pas visible. Indiquer ce à quoi correspond votre PixInputCode.",
     type: { name: 'string', required: true },
+  },
+  detailsOfUse: {
+    name: 'detailsOfUse',
+    description: "Explications du fonctionnement des champs du PixInputCode. Ce champ n'est pas visible. Le texte par défaut est uniquement en Français. Veillez à donc le surchager avec vos traductions. Par ailleurs, le texte par défaut change selon le type du champ du PixInputCode",
+    type: { name: 'string', required: false },
+    table: {
+      type: { summary: 'string' },
+      defaultValue: { summary: 'Pour se déplacer de champ en champ vous pouvez utiliser la tabulation ou bien les flèches gauche et droite de votre clavier. Pour remplir un champ vous pouvez utiliser des chiffres de 1 à 9 ou bien les flèches haut et bas de votre clavier pour incrémenter de 1 la valeur du champ.' },
+    }
   },
   inputType: {
     name: 'inputType',

--- a/addon/stories/pix-input-code.stories.js
+++ b/addon/stories/pix-input-code.stories.js
@@ -5,6 +5,7 @@ export const Template = (args) => {
     template: hbs`
       <PixInputCode
         @ariaLabel={{ariaLabel}}
+        @legend={{legend}}
         @inputType={{inputType}}
         @numInputs={{numInputs}}
       />
@@ -15,13 +16,19 @@ export const Template = (args) => {
 
 export const Default = Template.bind({});
 Default.args = {
-  ariaLabel: "Code de validation d'adresse e-mail",
+  ariaLabel: "Chiffre",
+  legend: "Code de validation d'adresse e-mail"
 }
 
 export const argTypes = {
-  'ariaLabel': {
+  ariaLabel: {
     name: 'ariaLabel',
-    description: "L'aria-label de chaque champ",
+    description: "L'aria-label de chaque case. L'aria-label est automatiquement complété à la fin par n°<numéro>. Avec <numéro> correspondant à la position du champ dans le PixInputCode.",
+    type: { name: 'string', required: true },
+  },
+  legend: {
+    name: 'legend',
+    description: "La description du composant. Indiquer ce à quoi correspond votre PixInputCode.",
     type: { name: 'string', required: true },
   },
   inputType: {
@@ -44,7 +51,7 @@ export const argTypes = {
   },
   onAllInputsFilled: {
     name: 'onAllInputsFilled',
-    description: 'fonction appeler une fois que tous les champs ont été rempli avec le code en parametre',
+    description: 'fonction appelée (avec le code en paramètre) une fois tous les champs remplis',
     type: { required: false },
     control: { disable: true },
   },

--- a/addon/stories/pix-input-code.stories.js
+++ b/addon/stories/pix-input-code.stories.js
@@ -8,7 +8,7 @@ export const Template = (args) => {
         @legend={{legend}}
         @inputType={{inputType}}
         @numInputs={{numInputs}}
-        @detailsOfUse={{detailsOfUse}}
+        @explanationOfUse={{explanationOfUse}}
       />
     `,
     context: args,
@@ -17,14 +17,14 @@ export const Template = (args) => {
 
 export const Default = Template.bind({});
 Default.args = {
-  ariaLabel: "Chiffre",
+  ariaLabel: "Champ",
   legend: "Code de validation d'adresse e-mail"
 }
 
 export const argTypes = {
   ariaLabel: {
     name: 'ariaLabel',
-    description: "L'aria-label de chaque case. L'aria-label est automatiquement complété à la fin par n°<numéro>. Avec <numéro> correspondant à la position du champ dans le PixInputCode.",
+    description: "L'aria-label de chaque champ. L'aria-label est automatiquement complété à la fin par ` <numero>`, où `<numero>` correspond à la position du champ dans le PixInputCode.",
     type: { name: 'string', required: true },
   },
   legend: {
@@ -32,9 +32,9 @@ export const argTypes = {
     description: "La description du composant. Ce champ n'est pas visible. Indiquer ce à quoi correspond votre PixInputCode.",
     type: { name: 'string', required: true },
   },
-  detailsOfUse: {
-    name: 'detailsOfUse',
-    description: "Explications du fonctionnement des champs du PixInputCode. Ce champ n'est pas visible. Le texte par défaut est uniquement en Français. Veillez à donc le surchager avec vos traductions. Par ailleurs, le texte par défaut change selon le type du champ du PixInputCode",
+  explanationOfUse: {
+    name: 'explanationOfUse',
+    description: "Explication du fonctionnement des champs du PixInputCode. Ce champ n'est pas visible. Le texte par défaut est uniquement en Français. Veillez à donc le surchager avec vos traductions. Par ailleurs, le texte par défaut change selon le type du champ du PixInputCode",
     type: { name: 'string', required: false },
     table: {
       type: { summary: 'string' },
@@ -61,7 +61,7 @@ export const argTypes = {
   },
   onAllInputsFilled: {
     name: 'onAllInputsFilled',
-    description: 'fonction appelée (avec le code en paramètre) une fois tous les champs remplis',
+    description: 'Fonction appelée (avec le code en paramètre) une fois tous les champs remplis',
     type: { required: false },
     control: { disable: true },
   },

--- a/addon/stories/pix-input-code.stories.mdx
+++ b/addon/stories/pix-input-code.stories.mdx
@@ -20,6 +20,8 @@ Par défaut il y a 6 champs mais le nombre est modifiable avec `numInputs`.
 
 Le composant peut être numérique ou alphanumérique précisé avec la propriété `inputType`, par défaut il est numérique.
 
+> ⚠️ N'oubliez pas de renseigner vous même la variable `@explanationOfUse` afin de garantir la gestion de traduction sur le composant PixInputCode.
+
 ## Default
 
 <Canvas>
@@ -30,9 +32,9 @@ Le composant peut être numérique ou alphanumérique précisé avec la proprié
 
 ```html
 <PixInputCode
-    @ariaLabel="Chiffre"
+    @ariaLabel="Champ"
     @legend="Code correspondant au code de vérification envoyé par email"
-    @detailsOfUse="Détails d'utilisation du PixInputCode"
+    @explanationOfUse="Détails d'utilisation du PixInputCode"
     @numInputs={{6}}
     @inputType="number"
     @onAllInputsFilled={{(code) => {}}}

--- a/addon/stories/pix-input-code.stories.mdx
+++ b/addon/stories/pix-input-code.stories.mdx
@@ -30,7 +30,8 @@ Le composant peut être numérique ou alphanumérique précisé avec la proprié
 
 ```html
 <PixInputCode
-    @ariaLabel="My aria-label"
+    @ariaLabel="Chiffre"
+    @legend="Code correspondant au code de vérification envoyé par email"
     @numInputs={{6}}
     @inputType="number"
     @onAllInputsFilled={{(code) => {}}}

--- a/addon/stories/pix-input-code.stories.mdx
+++ b/addon/stories/pix-input-code.stories.mdx
@@ -32,6 +32,7 @@ Le composant peut être numérique ou alphanumérique précisé avec la proprié
 <PixInputCode
     @ariaLabel="Chiffre"
     @legend="Code correspondant au code de vérification envoyé par email"
+    @detailsOfUse="Détails d'utilisation du PixInputCode"
     @numInputs={{6}}
     @inputType="number"
     @onAllInputsFilled={{(code) => {}}}

--- a/addon/styles/_pix-input-code.scss
+++ b/addon/styles/_pix-input-code.scss
@@ -38,6 +38,8 @@
     text-align: center;
     outline: none;
 
+    @include hoverFormElement();
+
     &:not(:first-child) {
       margin-left: 4px;
     }

--- a/addon/styles/_pix-input-code.scss
+++ b/addon/styles/_pix-input-code.scss
@@ -18,6 +18,10 @@
     display: none;
   }
 
+  #pix-input-code__details-of-use {
+    display: none;
+  }
+
   input:nth-of-type(3n+4) {
     margin-left: 12px;
   }

--- a/addon/styles/_pix-input-code.scss
+++ b/addon/styles/_pix-input-code.scss
@@ -26,14 +26,17 @@
     margin-left: 12px;
   }
 
-  &__input {
+  input.pix-input-code__input {
     display: inline-block;
     box-sizing: border-box;
     height: 44px;
     width: 38px;
     padding: 10px 12px 8px;
     background-color: $grey-10;
-    border: 1px solid $grey-50;
+    border: 1.4px solid $grey-50;
+    font-family: $font-roboto;
+    font-size: 1.25rem;
+    color: $grey-90;
     border-radius: 4px;
     text-align: center;
     outline: none;
@@ -49,7 +52,7 @@
     }
 
     &:hover {
-      border-color: $grey-45;
+      border-color: $grey-70;
     }
 
     &:active,

--- a/addon/styles/_pix-input-code.scss
+++ b/addon/styles/_pix-input-code.scss
@@ -14,6 +14,14 @@
     }
   }
 
+  fieldset legend {
+    display: none;
+  }
+
+  input:nth-of-type(3n+4) {
+    margin-left: 12px;
+  }
+
   &__input {
     display: inline-block;
     box-sizing: border-box;
@@ -28,10 +36,6 @@
 
     &:not(:first-child) {
       margin-left: 4px;
-    }
-
-    &:nth-child(3n+4) {
-      margin-left: 12px;
     }
 
     &::placeholder {

--- a/addon/styles/_pix-input-code.scss
+++ b/addon/styles/_pix-input-code.scss
@@ -29,7 +29,7 @@
     width: 38px;
     padding: 10px 12px 8px;
     background-color: $grey-10;
-    border: 1px solid $grey-15;
+    border: 1px solid $grey-50;
     border-radius: 4px;
     text-align: center;
     outline: none;
@@ -39,7 +39,7 @@
     }
 
     &::placeholder {
-      color: $grey-22;
+      color: $grey-50;
     }
 
     &:hover {

--- a/tests/integration/components/pix-input-code-test.js
+++ b/tests/integration/components/pix-input-code-test.js
@@ -31,6 +31,18 @@ module('Integration | Component | pix-input-code', function (hooks) {
     assert.contains('Ce code est le code de vérification d\'email');
   });
 
+  test('it should explain how PixInputCode can be eddited', async function(assert) {
+    // given & when
+    await render(hbs`<PixInputCode
+      @legend="Ce code est le code de vérification d'email"
+      @ariaLabel="Champ"
+      @detailsOfUse="Vous pouvez utiliser les flèches pour naviguer de champ en champ"
+    />`);
+
+    // then
+    assert.contains('Vous pouvez utiliser les flèches pour naviguer de champ en champ');
+  });
+
   test('it should throw an error if PixInputCode does not have an ariaLabel', async function (assert) {
     // given
     const componentParams = { ariaLabel: null, legend: 'super legende' };

--- a/tests/integration/components/pix-input-code-test.js
+++ b/tests/integration/components/pix-input-code-test.js
@@ -34,182 +34,195 @@ module('Integration | Component | pix-input-code', function (hooks) {
     }, expectedError);
   });
 
-  test('it should focus on next input after inputting value', async function (assert) {
-    // given
-    await render(hbs`<PixInputCode @ariaLabel="Mon super input code" />`);
+  module('when adding characters', function () {
 
-    // when
-    await fillInByLabel('Mon super input code n°1', '1');
+    test('it should focus on next input after inputting value', async function (assert) {
+      // given
+      await render(hbs`<PixInputCode @ariaLabel="Mon super input code" />`);
 
-    // then
-    assert.dom(`${INPUT_SELECTOR}-1`).hasClass('filled');
-    assert.dom(`${INPUT_SELECTOR}-2`).isFocused();
+      // when
+      await fillInByLabel('Mon super input code n°1', '1');
+
+      // then
+      assert.dom(`${INPUT_SELECTOR}-1`).hasClass('filled');
+      assert.dom(`${INPUT_SELECTOR}-2`).isFocused();
+    });
+
+    test('it should truncate input to 1 digit', async function (assert) {
+      // given
+      await render(hbs`<PixInputCode @ariaLabel="label" />`);
+
+      // when
+      await fillInByLabel('label n°4', '12345');
+
+      // then
+      assert.dom(`${INPUT_SELECTOR}-5`).isFocused();
+      assert.dom(`${INPUT_SELECTOR}-5`).isFocused();
+      assert.dom(`${INPUT_SELECTOR}-4`).hasValue('1');
+    });
+
+    test('it should not allow characters when type is number', async function (assert) {
+      // given
+      await render(hbs`<PixInputCode @ariaLabel="label" />`);
+
+      // when
+      await fillInByLabel('label n°4', 'a');
+
+      // then
+      assert.dom(`${INPUT_SELECTOR}-4`).isFocused();
+      assert.dom(`${INPUT_SELECTOR}-4`).doesNotHaveClass('filled');
+      assert.dom(`${INPUT_SELECTOR}-4`).hasValue('');
+    });
+
+    test('it should truncate input to 1 character', async function (assert) {
+      // given
+      await render(hbs`<PixInputCode @ariaLabel="label" @inputType="text" />`);
+
+      // when
+      await fillInByLabel('label n°4', 'abcdf');
+
+      // then
+      assert.dom(`${INPUT_SELECTOR}-5`).isFocused();
+      assert.dom(`${INPUT_SELECTOR}-4`).hasValue('a');
+    });
+
+    test('it should trigger function with entered code when all inputs are filled', async function (assert) {
+      // given
+      this.set('onAllInputsFilled', sinon.spy());
+      await render(hbs`<PixInputCode @ariaLabel="label" @onAllInputsFilled={{this.onAllInputsFilled}} />`);
+
+      // when
+      await fillInByLabel('label n°1', '3');
+      await fillInByLabel('label n°2', '5');
+      await fillInByLabel('label n°3', '7');
+      await fillInByLabel('label n°4', '2');
+      await fillInByLabel('label n°5', '4');
+      await fillInByLabel('label n°6', '6');
+
+      // then
+      assert.ok(this.onAllInputsFilled.calledOnce, 'the callback should be called once');
+      assert.ok(this.onAllInputsFilled.calledWith, ['357246']);
+    });
+
+    test('it should not trigger function with entered code when all inputs not filled', async function (assert) {
+      // given
+      this.set('onAllInputsFilled', sinon.spy());
+      await render(hbs`<PixInputCode @ariaLabel="label" @onAllInputsFilled={{this.onAllInputsFilled}} />`);
+
+      // when
+      await fillInByLabel('label n°1', '3');
+      await fillInByLabel('label n°2', '5');
+      await fillInByLabel('label n°3', '7');
+      await fillInByLabel('label n°5', '4');
+      await fillInByLabel('label n°6', '6');
+
+      // then
+      assert.notOk(this.onAllInputsFilled.calledOnce);
+    });
+
+    test('it should trigger function with entered code even if last entered value is not the last input', async function (assert) {
+      // given
+      this.set('onAllInputsFilled', sinon.spy());
+      await render(hbs`<PixInputCode @ariaLabel="label" @onAllInputsFilled={{this.onAllInputsFilled}} />`);
+
+      // when
+      await fillInByLabel('label n°1', '3');
+      await fillInByLabel('label n°2', '5');
+      await fillInByLabel('label n°3', '7');
+      await fillInByLabel('label n°5', '4');
+      await fillInByLabel('label n°6', '6');
+      await fillInByLabel('label n°4', '2');
+
+      // then
+      assert.ok(this.onAllInputsFilled.calledOnce, 'the callback should be called once');
+      assert.ok(this.onAllInputsFilled.calledWith, ['357246']);
+    });
+
   });
 
-  test('it should focus on previous input after Backspace', async function (assert) {
-    // given
-    await render(hbs`<PixInputCode @ariaLabel="label" />`);
+  module('when deleting characters', function () {
 
-    // when
-    await focus(`${INPUT_SELECTOR}-4`);
-    await triggerKeyEvent(`${INPUT_SELECTOR}-4`, 'keyup', 'Backspace');
+    test('it should focus on previous input after Backspace', async function (assert) {
+      // given
+      await render(hbs`<PixInputCode @ariaLabel="label" />`);
 
-    // then
-    assert.dom(`${INPUT_SELECTOR}-3`).isFocused();
-  });
+      // when
+      await focus(`${INPUT_SELECTOR}-4`);
+      await triggerKeyEvent(`${INPUT_SELECTOR}-4`, 'keyup', 'Backspace');
 
-  test('it should focus on previous input after ArrowLeft', async function (assert) {
-    // given
-    await render(hbs`<PixInputCode @ariaLabel="label" />`);
-
-    // when
-    await focus(`${INPUT_SELECTOR}-4`);
-    await triggerKeyEvent(`${INPUT_SELECTOR}-4`, 'keyup', 'ArrowLeft');
-
-    // then
-    assert.dom(`${INPUT_SELECTOR}-3`).isFocused();
-  });
-
-  test('it should focus on next input after ArrowRight', async function (assert) {
-    // given
-    await render(hbs`<PixInputCode @ariaLabel="label" />`);
-
-    // when
-    await focus(`${INPUT_SELECTOR}-4`);
-    await triggerKeyEvent(`${INPUT_SELECTOR}-4`, 'keyup', 'ArrowRight');
-
-    // then
-    assert.dom(`${INPUT_SELECTOR}-5`).isFocused();
-  });
-
-  test('it should not focus on next input after ArrowUp or ArrowDown', async function (assert) {
-    // given
-    await render(hbs`<PixInputCode @ariaLabel="label" />`);
-
-    // when
-    await focus(`${INPUT_SELECTOR}-4`);
-    await triggerKeyEvent(`${INPUT_SELECTOR}-4`, 'keydown', 'ArrowUp');
-    await triggerKeyEvent(`${INPUT_SELECTOR}-4`, 'keydown', 'ArrowUp');
-    await triggerKeyEvent(`${INPUT_SELECTOR}-4`, 'keydown', 'ArrowUp');
-    await triggerKeyEvent(`${INPUT_SELECTOR}-4`, 'keydown', 'ArrowDown');
-
-    // then
-    assert.dom(`${INPUT_SELECTOR}-4`).isFocused();
-  });
-
-  test('it should truncate input to 1 digit', async function (assert) {
-    // given
-    await render(hbs`<PixInputCode @ariaLabel="label" />`);
-
-    // when
-    await fillInByLabel('label n°4', '12345');
-
-    // then
-    assert.dom(`${INPUT_SELECTOR}-5`).isFocused();
-    assert.dom(`${INPUT_SELECTOR}-5`).isFocused();
-    assert.dom(`${INPUT_SELECTOR}-4`).hasValue('1');
-  });
-
-  test('it should not allow characters when type is number', async function (assert) {
-    // given
-    await render(hbs`<PixInputCode @ariaLabel="label" />`);
-
-    // when
-    await fillInByLabel('label n°4', 'a');
-
-    // then
-    assert.dom(`${INPUT_SELECTOR}-4`).isFocused();
-    assert.dom(`${INPUT_SELECTOR}-4`).doesNotHaveClass('filled');
-    assert.dom(`${INPUT_SELECTOR}-4`).hasValue('');
-  });
-
-  test('it should truncate input to 1 character', async function (assert) {
-    // given
-    await render(hbs`<PixInputCode @ariaLabel="label" @inputType="text" />`);
-
-    // when
-    await fillInByLabel('label n°4', 'abcdf');
-
-    // then
-    assert.dom(`${INPUT_SELECTOR}-5`).isFocused();
-    assert.dom(`${INPUT_SELECTOR}-4`).hasValue('a');
-  });
-
-  test('it should support paste filling all inputs', async function (assert) {
-    // given
-    await render(hbs`<PixInputCode @ariaLabel="label" />`);
-
-    // when
-    await triggerEvent(`${INPUT_SELECTOR}-1`, 'paste', { clipboardData: { getData: () => '123456' } });
-
-    // then
-    [1, 2, 3, 4, 5, 6].forEach(index => {
-      assert.dom(`${INPUT_SELECTOR}-${index}`).hasValue(`${index}`);
+      // then
+      assert.dom(`${INPUT_SELECTOR}-3`).isFocused();
     });
   });
 
-  test('it should trigger function with entered code when all inputs are filled', async function (assert) {
-    // given
-    this.set('onAllInputsFilled', sinon.spy());
-    await render(hbs`<PixInputCode @ariaLabel="label" @onAllInputsFilled={{this.onAllInputsFilled}} />`);
+  module('when changing focus', function () {
 
-    // when
-    await fillInByLabel('label n°1', '3');
-    await fillInByLabel('label n°2', '5');
-    await fillInByLabel('label n°3', '7');
-    await fillInByLabel('label n°4', '2');
-    await fillInByLabel('label n°5', '4');
-    await fillInByLabel('label n°6', '6');
+    test('it should focus on previous input after ArrowLeft', async function (assert) {
+      // given
+      await render(hbs`<PixInputCode @ariaLabel="label" />`);
 
-    // then
-    assert.ok(this.onAllInputsFilled.calledOnce, 'the callback should be called once');
-    assert.ok(this.onAllInputsFilled.calledWith, ['357246']);
+      // when
+      await focus(`${INPUT_SELECTOR}-4`);
+      await triggerKeyEvent(`${INPUT_SELECTOR}-4`, 'keyup', 'ArrowLeft');
+
+      // then
+      assert.dom(`${INPUT_SELECTOR}-3`).isFocused();
+    });
+
+    test('it should focus on next input after ArrowRight', async function (assert) {
+      // given
+      await render(hbs`<PixInputCode @ariaLabel="label" />`);
+
+      // when
+      await focus(`${INPUT_SELECTOR}-4`);
+      await triggerKeyEvent(`${INPUT_SELECTOR}-4`, 'keyup', 'ArrowRight');
+
+      // then
+      assert.dom(`${INPUT_SELECTOR}-5`).isFocused();
+    });
+
+    test('it should not focus on next input after ArrowUp or ArrowDown', async function (assert) {
+      // given
+      await render(hbs`<PixInputCode @ariaLabel="label" />`);
+
+      // when
+      await focus(`${INPUT_SELECTOR}-4`);
+      await triggerKeyEvent(`${INPUT_SELECTOR}-4`, 'keydown', 'ArrowUp');
+      await triggerKeyEvent(`${INPUT_SELECTOR}-4`, 'keydown', 'ArrowUp');
+      await triggerKeyEvent(`${INPUT_SELECTOR}-4`, 'keydown', 'ArrowUp');
+      await triggerKeyEvent(`${INPUT_SELECTOR}-4`, 'keydown', 'ArrowDown');
+
+      // then
+      assert.dom(`${INPUT_SELECTOR}-4`).isFocused();
+    });
   });
 
-  test('it should not trigger function with entered code when all inputs not filled', async function (assert) {
-    // given
-    this.set('onAllInputsFilled', sinon.spy());
-    await render(hbs`<PixInputCode @ariaLabel="label" @onAllInputsFilled={{this.onAllInputsFilled}} />`);
+  module('when filling inputs by copy paste', function () {
 
-    // when
-    await fillInByLabel('label n°1', '3');
-    await fillInByLabel('label n°2', '5');
-    await fillInByLabel('label n°3', '7');
-    await fillInByLabel('label n°5', '4');
-    await fillInByLabel('label n°6', '6');
+    test('it should support paste filling all inputs', async function (assert) {
+      // given
+      await render(hbs`<PixInputCode @ariaLabel="label" />`);
 
-    // then
-    assert.notOk(this.onAllInputsFilled.calledOnce);
-  });
+      // when
+      await triggerEvent(`${INPUT_SELECTOR}-1`, 'paste', { clipboardData: { getData: () => '123456' } });
 
-  test('it should trigger function with entered code even if last entered value is not the last input', async function (assert) {
-    // given
-    this.set('onAllInputsFilled', sinon.spy());
-    await render(hbs`<PixInputCode @ariaLabel="label" @onAllInputsFilled={{this.onAllInputsFilled}} />`);
+      // then
+      [1, 2, 3, 4, 5, 6].forEach(index => {
+        assert.dom(`${INPUT_SELECTOR}-${index}`).hasValue(`${index}`);
+      });
+    });
 
-    // when
-    await fillInByLabel('label n°1', '3');
-    await fillInByLabel('label n°2', '5');
-    await fillInByLabel('label n°3', '7');
-    await fillInByLabel('label n°5', '4');
-    await fillInByLabel('label n°6', '6');
-    await fillInByLabel('label n°4', '2');
-
-    // then
-    assert.ok(this.onAllInputsFilled.calledOnce, 'the callback should be called once');
-    assert.ok(this.onAllInputsFilled.calledWith, ['357246']);
-  });
-
-  test('it should trigger function with entered code after paste', async function (assert) {
-    // given
-    this.set('onAllInputsFilled', sinon.spy());
-    await render(hbs`<PixInputCode @ariaLabel="label" @onAllInputsFilled={{this.onAllInputsFilled}} />`);
-
-    // when
-    await triggerEvent(`${INPUT_SELECTOR}-1`, 'paste', { clipboardData: { getData: () => '‎ 357246' } });
-
-    // then
-    assert.ok(this.onAllInputsFilled.calledOnce, 'the callback should be called once');
-    assert.ok(this.onAllInputsFilled.calledWith, ['357246']);
+    test('it should trigger function with entered code after paste', async function (assert) {
+      // given
+      this.set('onAllInputsFilled', sinon.spy());
+      await render(hbs`<PixInputCode @ariaLabel="label" @onAllInputsFilled={{this.onAllInputsFilled}} />`);
+  
+      // when
+      await triggerEvent(`${INPUT_SELECTOR}-1`, 'paste', { clipboardData: { getData: () => '‎ 357246' } });
+  
+      // then
+      assert.ok(this.onAllInputsFilled.calledOnce, 'the callback should be called once');
+      assert.ok(this.onAllInputsFilled.calledWith, ['357246']);
+    });
   });
 });

--- a/tests/integration/components/pix-input-code-test.js
+++ b/tests/integration/components/pix-input-code-test.js
@@ -206,7 +206,7 @@ module('Integration | Component | pix-input-code', function (hooks) {
     await render(hbs`<PixInputCode @ariaLabel="label" @onAllInputsFilled={{this.onAllInputsFilled}} />`);
 
     // when
-    await triggerEvent(`${INPUT_SELECTOR}-1`, 'paste', { clipboardData: { getData: () => '357246' } });
+    await triggerEvent(`${INPUT_SELECTOR}-1`, 'paste', { clipboardData: { getData: () => '‎ 357246' } });
 
     // then
     assert.ok(this.onAllInputsFilled.calledOnce, 'the callback should be called once');

--- a/tests/integration/components/pix-input-code-test.js
+++ b/tests/integration/components/pix-input-code-test.js
@@ -14,7 +14,7 @@ module('Integration | Component | pix-input-code', function (hooks) {
 
   test('it renders the default PixInputCode with 6 inputs', async function (assert) {
     // given & when
-    await render(hbs`<PixInputCode @ariaLabel="label" />`);
+    await render(hbs`<PixInputCode @legend="Nom du PixInputCode" @ariaLabel="Champ" />`);
 
     // then
     assert.dom(COMPONENT_SELECTOR).exists();
@@ -22,15 +22,36 @@ module('Integration | Component | pix-input-code', function (hooks) {
     assert.equal(inputElementsFound.length, 6);
   });
 
+  test('it should have a fieldset with a legend for accessibility', async function(assert) {
+    // given & when
+    await render(hbs`<PixInputCode @legend="Ce code est le code de vérification d'email" @ariaLabel="Champ" />`);
+
+    // then
+    assert.dom('fieldset').exists();
+    assert.contains('Ce code est le code de vérification d\'email');
+  });
+
   test('it should throw an error if PixInputCode does not have an ariaLabel', async function (assert) {
     // given
-    const componentParams = { ariaLabel: null };
+    const componentParams = { ariaLabel: null, legend: 'super legende' };
     const component = createGlimmerComponent('component:pix-input-code', componentParams);
 
     // when & then
-    const expectedError = new Error('ERROR in PixInputCode component, you must provide an @ariaLabel');
+    const expectedError = new Error('ERROR in PixInputCode component, you must provide an @ariaLabel and an @legend');
     assert.throws(function () {
       component.ariaLabel
+    }, expectedError);
+  });
+
+  test('it should throw an error if PixInputCode does not have a legend', async function (assert) {
+    // given
+    const componentParams = { ariaLabel: 'Champ', legend: null };
+    const component = createGlimmerComponent('component:pix-input-code', componentParams);
+
+    // when & then
+    const expectedError = new Error('ERROR in PixInputCode component, you must provide an @ariaLabel and an @legend');
+    assert.throws(function () {
+      component.legend
     }, expectedError);
   });
 
@@ -38,7 +59,7 @@ module('Integration | Component | pix-input-code', function (hooks) {
 
     test('it should focus on next input after inputting value', async function (assert) {
       // given
-      await render(hbs`<PixInputCode @ariaLabel="Mon super input code" />`);
+      await render(hbs`<PixInputCode @legend="Nom du PixInputCode" @ariaLabel="Mon super input code" />`);
 
       // when
       await fillInByLabel('Mon super input code n°1', '1');
@@ -50,7 +71,7 @@ module('Integration | Component | pix-input-code', function (hooks) {
 
     test('it should truncate input to 1 digit', async function (assert) {
       // given
-      await render(hbs`<PixInputCode @ariaLabel="label" />`);
+      await render(hbs`<PixInputCode @legend="Nom du PixInputCode" @ariaLabel="label" />`);
 
       // when
       await fillInByLabel('label n°4', '12345');
@@ -63,7 +84,7 @@ module('Integration | Component | pix-input-code', function (hooks) {
 
     test('it should not allow characters when type is number', async function (assert) {
       // given
-      await render(hbs`<PixInputCode @ariaLabel="label" />`);
+      await render(hbs`<PixInputCode @legend="Nom du PixInputCode" @ariaLabel="label" />`);
 
       // when
       await fillInByLabel('label n°4', 'a');
@@ -76,7 +97,7 @@ module('Integration | Component | pix-input-code', function (hooks) {
 
     test('it should truncate input to 1 character', async function (assert) {
       // given
-      await render(hbs`<PixInputCode @ariaLabel="label" @inputType="text" />`);
+      await render(hbs`<PixInputCode @legend="Nom du PixInputCode" @ariaLabel="label" @inputType="text" />`);
 
       // when
       await fillInByLabel('label n°4', 'abcdf');
@@ -89,7 +110,7 @@ module('Integration | Component | pix-input-code', function (hooks) {
     test('it should trigger function with entered code when all inputs are filled', async function (assert) {
       // given
       this.set('onAllInputsFilled', sinon.spy());
-      await render(hbs`<PixInputCode @ariaLabel="label" @onAllInputsFilled={{this.onAllInputsFilled}} />`);
+      await render(hbs`<PixInputCode @legend="Nom du PixInputCode" @ariaLabel="label" @onAllInputsFilled={{this.onAllInputsFilled}} />`);
 
       // when
       await fillInByLabel('label n°1', '3');
@@ -107,7 +128,7 @@ module('Integration | Component | pix-input-code', function (hooks) {
     test('it should not trigger function with entered code when all inputs not filled', async function (assert) {
       // given
       this.set('onAllInputsFilled', sinon.spy());
-      await render(hbs`<PixInputCode @ariaLabel="label" @onAllInputsFilled={{this.onAllInputsFilled}} />`);
+      await render(hbs`<PixInputCode @legend="Nom du PixInputCode" @ariaLabel="label" @onAllInputsFilled={{this.onAllInputsFilled}} />`);
 
       // when
       await fillInByLabel('label n°1', '3');
@@ -123,7 +144,7 @@ module('Integration | Component | pix-input-code', function (hooks) {
     test('it should trigger function with entered code even if last entered value is not the last input', async function (assert) {
       // given
       this.set('onAllInputsFilled', sinon.spy());
-      await render(hbs`<PixInputCode @ariaLabel="label" @onAllInputsFilled={{this.onAllInputsFilled}} />`);
+      await render(hbs`<PixInputCode @legend="Nom du PixInputCode" @ariaLabel="label" @onAllInputsFilled={{this.onAllInputsFilled}} />`);
 
       // when
       await fillInByLabel('label n°1', '3');
@@ -144,7 +165,7 @@ module('Integration | Component | pix-input-code', function (hooks) {
 
     test('it should focus on previous input after Backspace', async function (assert) {
       // given
-      await render(hbs`<PixInputCode @ariaLabel="label" />`);
+      await render(hbs`<PixInputCode @legend="Nom du PixInputCode" @ariaLabel="label" />`);
 
       // when
       await focus(`${INPUT_SELECTOR}-4`);
@@ -159,7 +180,7 @@ module('Integration | Component | pix-input-code', function (hooks) {
 
     test('it should focus on previous input after ArrowLeft', async function (assert) {
       // given
-      await render(hbs`<PixInputCode @ariaLabel="label" />`);
+      await render(hbs`<PixInputCode @legend="Nom du PixInputCode" @ariaLabel="label" />`);
 
       // when
       await focus(`${INPUT_SELECTOR}-4`);
@@ -171,7 +192,7 @@ module('Integration | Component | pix-input-code', function (hooks) {
 
     test('it should focus on next input after ArrowRight', async function (assert) {
       // given
-      await render(hbs`<PixInputCode @ariaLabel="label" />`);
+      await render(hbs`<PixInputCode @legend="Nom du PixInputCode" @ariaLabel="label" />`);
 
       // when
       await focus(`${INPUT_SELECTOR}-4`);
@@ -183,7 +204,7 @@ module('Integration | Component | pix-input-code', function (hooks) {
 
     test('it should not focus on next input after ArrowUp or ArrowDown', async function (assert) {
       // given
-      await render(hbs`<PixInputCode @ariaLabel="label" />`);
+      await render(hbs`<PixInputCode @legend="Nom du PixInputCode" @ariaLabel="label" />`);
 
       // when
       await focus(`${INPUT_SELECTOR}-4`);
@@ -201,7 +222,7 @@ module('Integration | Component | pix-input-code', function (hooks) {
 
     test('it should support paste filling all inputs', async function (assert) {
       // given
-      await render(hbs`<PixInputCode @ariaLabel="label" />`);
+      await render(hbs`<PixInputCode @legend="Nom du PixInputCode" @ariaLabel="label" />`);
 
       // when
       await triggerEvent(`${INPUT_SELECTOR}-1`, 'paste', { clipboardData: { getData: () => '123456' } });
@@ -215,7 +236,7 @@ module('Integration | Component | pix-input-code', function (hooks) {
     test('it should trigger function with entered code after paste', async function (assert) {
       // given
       this.set('onAllInputsFilled', sinon.spy());
-      await render(hbs`<PixInputCode @ariaLabel="label" @onAllInputsFilled={{this.onAllInputsFilled}} />`);
+      await render(hbs`<PixInputCode @legend="Nom du PixInputCode" @ariaLabel="label" @onAllInputsFilled={{this.onAllInputsFilled}} />`);
   
       // when
       await triggerEvent(`${INPUT_SELECTOR}-1`, 'paste', { clipboardData: { getData: () => '‎ 357246' } });

--- a/tests/integration/components/pix-input-code-test.js
+++ b/tests/integration/components/pix-input-code-test.js
@@ -36,7 +36,7 @@ module('Integration | Component | pix-input-code', function (hooks) {
     await render(hbs`<PixInputCode
       @legend="Ce code est le code de vérification d'email"
       @ariaLabel="Champ"
-      @detailsOfUse="Vous pouvez utiliser les flèches pour naviguer de champ en champ"
+      @explanationOfUse="Vous pouvez utiliser les flèches pour naviguer de champ en champ"
     />`);
 
     // then
@@ -49,7 +49,7 @@ module('Integration | Component | pix-input-code', function (hooks) {
     const component = createGlimmerComponent('component:pix-input-code', componentParams);
 
     // when & then
-    const expectedError = new Error('ERROR in PixInputCode component, you must provide an @ariaLabel and an @legend');
+    const expectedError = new Error('ERROR in PixInputCode component, you must provide an @ariaLabel and a @legend');
     assert.throws(function () {
       component.ariaLabel
     }, expectedError);
@@ -61,7 +61,7 @@ module('Integration | Component | pix-input-code', function (hooks) {
     const component = createGlimmerComponent('component:pix-input-code', componentParams);
 
     // when & then
-    const expectedError = new Error('ERROR in PixInputCode component, you must provide an @ariaLabel and an @legend');
+    const expectedError = new Error('ERROR in PixInputCode component, you must provide an @ariaLabel and a @legend');
     assert.throws(function () {
       component.legend
     }, expectedError);
@@ -71,10 +71,10 @@ module('Integration | Component | pix-input-code', function (hooks) {
 
     test('it should focus on next input after inputting value', async function (assert) {
       // given
-      await render(hbs`<PixInputCode @legend="Nom du PixInputCode" @ariaLabel="Mon super input code" />`);
+      await render(hbs`<PixInputCode @legend="Nom du PixInputCode" @ariaLabel="Champ" />`);
 
       // when
-      await fillInByLabel('Mon super input code n°1', '1');
+      await fillInByLabel('Champ 1', '1');
 
       // then
       assert.dom(`${INPUT_SELECTOR}-1`).hasClass('filled');
@@ -86,7 +86,7 @@ module('Integration | Component | pix-input-code', function (hooks) {
       await render(hbs`<PixInputCode @legend="Nom du PixInputCode" @ariaLabel="label" />`);
 
       // when
-      await fillInByLabel('label n°4', '12345');
+      await fillInByLabel('label 4', '12345');
 
       // then
       assert.dom(`${INPUT_SELECTOR}-5`).isFocused();
@@ -99,7 +99,7 @@ module('Integration | Component | pix-input-code', function (hooks) {
       await render(hbs`<PixInputCode @legend="Nom du PixInputCode" @ariaLabel="label" />`);
 
       // when
-      await fillInByLabel('label n°4', 'a');
+      await fillInByLabel('label 4', 'a');
 
       // then
       assert.dom(`${INPUT_SELECTOR}-4`).isFocused();
@@ -112,7 +112,7 @@ module('Integration | Component | pix-input-code', function (hooks) {
       await render(hbs`<PixInputCode @legend="Nom du PixInputCode" @ariaLabel="label" @inputType="text" />`);
 
       // when
-      await fillInByLabel('label n°4', 'abcdf');
+      await fillInByLabel('label 4', 'abcdf');
 
       // then
       assert.dom(`${INPUT_SELECTOR}-5`).isFocused();
@@ -125,12 +125,12 @@ module('Integration | Component | pix-input-code', function (hooks) {
       await render(hbs`<PixInputCode @legend="Nom du PixInputCode" @ariaLabel="label" @onAllInputsFilled={{this.onAllInputsFilled}} />`);
 
       // when
-      await fillInByLabel('label n°1', '3');
-      await fillInByLabel('label n°2', '5');
-      await fillInByLabel('label n°3', '7');
-      await fillInByLabel('label n°4', '2');
-      await fillInByLabel('label n°5', '4');
-      await fillInByLabel('label n°6', '6');
+      await fillInByLabel('label 1', '3');
+      await fillInByLabel('label 2', '5');
+      await fillInByLabel('label 3', '7');
+      await fillInByLabel('label 4', '2');
+      await fillInByLabel('label 5', '4');
+      await fillInByLabel('label 6', '6');
 
       // then
       assert.ok(this.onAllInputsFilled.calledOnce, 'the callback should be called once');
@@ -143,11 +143,11 @@ module('Integration | Component | pix-input-code', function (hooks) {
       await render(hbs`<PixInputCode @legend="Nom du PixInputCode" @ariaLabel="label" @onAllInputsFilled={{this.onAllInputsFilled}} />`);
 
       // when
-      await fillInByLabel('label n°1', '3');
-      await fillInByLabel('label n°2', '5');
-      await fillInByLabel('label n°3', '7');
-      await fillInByLabel('label n°5', '4');
-      await fillInByLabel('label n°6', '6');
+      await fillInByLabel('label 1', '3');
+      await fillInByLabel('label 2', '5');
+      await fillInByLabel('label 3', '7');
+      await fillInByLabel('label 5', '4');
+      await fillInByLabel('label 6', '6');
 
       // then
       assert.notOk(this.onAllInputsFilled.calledOnce);
@@ -159,12 +159,12 @@ module('Integration | Component | pix-input-code', function (hooks) {
       await render(hbs`<PixInputCode @legend="Nom du PixInputCode" @ariaLabel="label" @onAllInputsFilled={{this.onAllInputsFilled}} />`);
 
       // when
-      await fillInByLabel('label n°1', '3');
-      await fillInByLabel('label n°2', '5');
-      await fillInByLabel('label n°3', '7');
-      await fillInByLabel('label n°5', '4');
-      await fillInByLabel('label n°6', '6');
-      await fillInByLabel('label n°4', '2');
+      await fillInByLabel('label 1', '3');
+      await fillInByLabel('label 2', '5');
+      await fillInByLabel('label 3', '7');
+      await fillInByLabel('label 5', '4');
+      await fillInByLabel('label 6', '6');
+      await fillInByLabel('label 4', '2');
 
       // then
       assert.ok(this.onAllInputsFilled.calledOnce, 'the callback should be called once');


### PR DESCRIPTION
## :unicorn: Description
Lors de l'utilisation du PixInputCode plusieurs soucis ont été relevés : 

- le composant n'est pas accessible 
- le copier / coller ne change pas la couleur du fond de l'input (comme c'est le cas lorsqu'on remplis champ par champ)
- le copier / coller sous firefox est décallé 
<img width="273" alt="image" src="https://user-images.githubusercontent.com/38167520/136061459-d670d85d-9cce-4077-8dc7-544f335b9931.png">


## ✉️   Au sujet du copier / coller
Il y a 2 type de copier coller sous firefox qui ne fonctionnent pas comme attendus : 
- le copier coller après sélection de la droite vers gauche (et pas l'inverse attention) 
- le copier coller après sélection via double clic sur la chaine de caractère

En fait, lors de ces 2 types de copier coller, des espaces "non classiques" sont inclus dans le presse papier, ce qui décale le code.

Pour palier ce décalage il suffit de filtrer le contenu du presse papier pour n'en tirer que les caractères alphanumériques.

## 🌈  Compte rendu d'accessibilité par Tanaguru
1- Suivre le mode de groupement de champs indiqué dans le traitement de l’épreuve du code binaire
L'épreuve du code binaire = réunir les 3 input dans un élément `<fieldset>` ou `<div role='group'>` + une légende (« code correspondant à x ») + donner un <label> à chaque champ (« chiffre 1 », « chiffre 2 »…)
Exemples : 
https://www.w3.org/WAI/tutorials/forms/grouping/#radio-buttons
 https://www.w3.org/WAI/tutorials/forms/grouping/#associating-related-controls-with-wai-ari 

2- Ajouter une précision sur l’utilisation du champ (`<p id='precision-d-utilisation'>` + `aria-describedby='precision-d-utilisation'` sur le champ) afin d’informer l’utilisateur des 2 modes de fonctionnement du champ (saisie + touche flèche gauche/droite) pour pallier le problème de support des boutons rotatifs entre chrome + nvda)

3- Contraste des cases KO

## 💥 BREAKING CHANGES 
Le paramètre `@legend` devient obligatoire.
