### PR TITLE
[BUGFIX] Améliorer l'ordre des explications d'accessibilité du PixInputCode 

### DIFF
--- a/addon/components/pix-input-code.hbs
+++ b/addon/components/pix-input-code.hbs
@@ -1,8 +1,8 @@
 {{!-- template-lint-disable no-down-event-binding --}}
 <div class='pix-input-code'>
-  <p id='pix-input-code__details-of-use'>{{this.explanationOfUse}}</p>
   <fieldset aria-describedby='pix-input-code__details-of-use'>
     <legend>{{this.legend}}</legend>
+    <p id='pix-input-code__details-of-use'>{{this.explanationOfUse}}</p>
     {{#each this.numberOfIterations as |i|}}
       <input
         ...attributes


### PR DESCRIPTION
## :unicorn: Description du composant
Voir : https://1024pix.slack.com/archives/C025GM3PZFB/p1633602243000400 

Pour améliorer les explications d'accessibilité du composant PixInputCode il faudrait expliquer les détails d'utilisation après la légende du champ.