### PR TITLE
[BUGFIX] Les options du select n'apparaissent pas complètement (PIX-3608).

### DIFF
--- a/addon/stories/form.stories.js
+++ b/addon/stories/form.stories.js
@@ -29,6 +29,7 @@ export const form = (args) => {
         @isSearchable={{true}}
         @isValidationActive={{true}}
         placeholder='Fraises, Mangues...'
+        style='width:100%'
       />
       <br>
 

--- a/addon/styles/_pix-select.scss
+++ b/addon/styles/_pix-select.scss
@@ -12,7 +12,6 @@
     font-family: $font-roboto;
     font-size: 0.875rem;
     height: 36px;
-    width: 100%;
 
     @include hoverFormElement();
     @include focusFormElement();
@@ -39,7 +38,7 @@
     &.pix-select--big {
       height: 44px;
     }
-  
+
     // Remove arrow for Chrome
     &::-webkit-calendar-picker-indicator {
       display: none;
@@ -67,5 +66,5 @@
 
   .pix-select__label ~ .pix-select__icon {
     top: calc(50% + 6px);
-  } 
+  }
 }


### PR DESCRIPTION
## :unicorn: Description du composant
On ne vois pas le label complet des options du select

## :rainbow: Remarques
Supprimer le width:100%

## :100: Pour tester
Quand il y a des options avec de long label on voit tout le label
