### PR TITLE
[FEATURE] Ajouter le chargement asynchrone des options sur PixMultiSelect

### DIFF
--- a/addon/components/pix-multi-select.hbs
+++ b/addon/components/pix-multi-select.hbs
@@ -14,7 +14,7 @@
         id={{@id}}
         type="text"
         name={{@id}}
-        placeholder={{@placeholder}}
+        placeholder={{this.placeholder}}
         autocomplete="off"
         {{on "input" this.updateSearch}}
         {{on "focus" this.focusDropdown}}
@@ -50,8 +50,10 @@
           </label>
         </li>
       {{/each}}
+    {{else if this.isLoadingOptions}}
+      <li class="pix-multi-select-list__item pix-multi-select-list__item--no-result">{{@loadingMessage}}</li>
     {{else}}
-        <li class="pix-multi-select-list__item pix-multi-select-list__item--no-result">{{@emptyMessage}}</li>
+      <li class="pix-multi-select-list__item pix-multi-select-list__item--no-result">{{@emptyMessage}}</li>
     {{/if}}
   </ul>
 </div>

--- a/addon/components/pix-multi-select.js
+++ b/addon/components/pix-multi-select.js
@@ -18,11 +18,24 @@ export default class PixMultiSelect extends Component {
   @tracked isExpanded = false;  
   @tracked searchData;
 
-  @tracked options = [...this.args.options || []];
+  @tracked options = [];
+  @tracked isLoadingOptions = false;
 
   constructor(...args) {
     super(...args)
-    this._setDisplayedOptions(this.args.selected, true);
+    const { onLoadOptions, selected } = this.args;
+  
+    if (onLoadOptions) {
+      this.isLoadingOptions = true;
+      onLoadOptions().then((options = []) => {
+        this.options = options;
+        this._setDisplayedOptions(selected, true);
+        this.isLoadingOptions = false;
+      });
+    } else {
+      this.options = [...this.args.options || []];
+      this._setDisplayedOptions(selected, true);
+    }
   }
 
   get label() {
@@ -44,6 +57,21 @@ export default class PixMultiSelect extends Component {
       return this.options.filter(({ label }) => this._search(label));
     }
     return this.options;
+  }
+
+  get placeholder() {
+    const { selected, placeholder } = this.args;
+    if (selected?.length > 0) {
+      const selectedOptionLabels = this.options
+        .filter(({ value, label }) => {
+          const hasOption = selected.includes(value);
+          return hasOption && Boolean(label)
+        })
+        .map(({ label }) => label)
+        .join(', ');
+      return selectedOptionLabels;
+    }
+    return placeholder;
   }
 
   _setDisplayedOptions(selected, shouldSort) {

--- a/addon/stories/pix-multi-select.stories.js
+++ b/addon/stories/pix-multi-select.stories.js
@@ -1,10 +1,24 @@
 import { hbs } from 'ember-cli-htmlbars';
 import { action } from '@storybook/addon-actions';
 
+const DEFAULT_OPTIONS = [
+  {label:"ANETH HERBE AROMATIQUE", value: '1'},
+  {label:"ANIS VERT HERBE AROMATIQUE", value: '2'},
+  {label:"BADIANE AROMATE", value: '3'},
+  {label:"BAIES ROSES EPICES", value: '4'},
+  {label:"BASILIC HERBE AROMATIQUE", value: '5'},
+  {label:"BOURRACHE OFFICINALE HERBE AROMATIQUE", value: '6'},
+  {label:"CANNELLE AROMATE", value: '7'},
+  {label:"CAPRE CONDIMENT", value: '8'},
+  {label:"CARDAMOME AROMATE", value: '9'},
+  {label:"CARVI HERBE AROMATIQUE", value: '10'},
+  {label:"CERFEUIL HERBE AROMATIQUE", value: '11'},
+]
+
 export const multiSelectWithChildComponent = (args) => {
   return {
     template: hbs`
-      <h3>⚠️ Pour voir le réel rendu, importez PixMultiSelect dans votre app</h3>
+      <h4>⚠️ La sélection des éléments ne fonctionne pas dans Storybook.</h4>
       <PixMultiSelect
         @title={{titleStars}}
         @id={{id}}
@@ -22,6 +36,7 @@ export const multiSelectWithChildComponent = (args) => {
     context: args,
   };
 };
+
 multiSelectWithChildComponent.args = {
   titleStars: 'Sélectionner le niveau souhaité',
   options: [
@@ -34,7 +49,7 @@ multiSelectWithChildComponent.args = {
 export const multiSelectSearchable = (args) => {
   return {
     template: hbs`
-      <h3>⚠️ Pour voir le réel rendu, importez PixMultiSelect dans votre app</h3>
+      <h4>⚠️ La sélection des éléments ne fonctionne pas dans Storybook.</h4>
       <PixMultiSelect
         style="width:350px"
         @id={{id}}
@@ -48,6 +63,32 @@ export const multiSelectSearchable = (args) => {
         @size={{size}}
         @selected={{selected}}
         @options={{options}} as |option|
+      >
+        {{option.label}}
+      </PixMultiSelect>
+    `,
+    context: args,
+  };
+};
+
+export const multiSelectAsyncOptions = (args) => {
+  args.onLoadOptions = () => Promise.resolve(DEFAULT_OPTIONS);
+  return {
+    template: hbs`
+      <h4>⚠️ La sélection des éléments ne fonctionne pas dans Storybook.</h4>
+      <PixMultiSelect
+        style="width:350px"
+        @id={{id}}
+        @title={{title}}
+        @placeholder={{placeholder}}
+        @isSearchable={{isSearchable}}
+        @showOptionsOnInput={{showOptionsOnInput}}
+        @strictSearch={{strictSearch}}
+        @onSelect={{doSomething}}
+        @emptyMessage={{emptyMessage}}
+        @size={{size}}
+        @selected={{selected}}
+        @onLoadOptions={{onLoadOptions}} as |option|
       >
         {{option.label}}
       </PixMultiSelect>
@@ -84,6 +125,12 @@ export const argTypes = {
     type: { name: 'string', required: true },
     defaultValue: 'pas de résultat',
   },
+  loadingMessage: {
+    name: 'loadingMessage',
+    description: 'Message qui apparaît dans les options quand celles-ci sont en train d\'être chargées via onLoadOptions',
+    type: { name: 'string', required: false },
+    defaultValue: 'Chargement...',
+  },
   placeholder: {
     name: 'placeholder',
     description: 'Donner une liste d‘exemple pour la recherche utilisateur dans le cas ``isSearchable`` à ``true``',
@@ -94,19 +141,12 @@ export const argTypes = {
     name: 'options',
     description: 'Les options sont représentées par un tableau d‘objet contenant les propriétés ``value`` et ``label``. ``value`` doit être de type ``String`` pour être conforme au traitement des input value.',
     type: { name: 'array', required: true },
-    defaultValue: [
-      {label:"ANETH HERBE AROMATIQUE", value: '1'},
-      {label:"ANIS VERT HERBE AROMATIQUE", value: '2'},
-      {label:"BADIANE AROMATE", value: '3'},
-      {label:"BAIES ROSES EPICES", value: '4'},
-      {label:"BASILIC HERBE AROMATIQUE", value: '5'},
-      {label:"BOURRACHE OFFICINALE HERBE AROMATIQUE", value: '6'},
-      {label:"CANNELLE AROMATE", value: '7'},
-      {label:"CAPRE CONDIMENT", value: '8'},
-      {label:"CARDAMOME AROMATE", value: '9'},
-      {label:"CARVI HERBE AROMATIQUE", value: '10'},
-      {label:"CERFEUIL HERBE AROMATIQUE", value: '11'},
-    ],
+    defaultValue: DEFAULT_OPTIONS,
+  },
+  onLoadOptions: {
+    name: 'onLoadOptions',
+    description: 'Charge de manière asynchrone les options. Doit renvoyer une promesse avec la liste des options. Les options sont représentées par un tableau d‘objet contenant les propriétés ``value`` et ``label``. ``value`` doit être de type ``String`` pour être conforme au traitement des input value.',
+    type: { required: false },
   },
   onSelect: {
     name: 'onSelect',

--- a/addon/stories/pix-multi-select.stories.mdx
+++ b/addon/stories/pix-multi-select.stories.mdx
@@ -25,6 +25,17 @@ L'ajout de ``class`` et d'autres attributs comme ``aria-label`` sont possibles.
   <Story name="Searchable" story={stories.multiSelectSearchable} height={330}/>
 </Canvas>
 
+## With async options
+
+Via la propriété `onLoadOptions`, le composant peut charger lui-même les options de manière asynchrone.
+Le callback `onLoadOptions` est une promesse renvoyant la liste des options. (eg. `[{ label: 'A', value: '1' }]`).
+
+Il est possible de donner un message via `loadingMessage` à afficher à la place des options pendant que celles-ci soient chargées.
+
+<Canvas>
+  <Story name="With async options" story={stories.multiSelectAsyncOptions} height={330}/>
+</Canvas>
+
 ## Usage
 
 ```html

--- a/tests/integration/components/pix-multi-select-test.js
+++ b/tests/integration/components/pix-multi-select-test.js
@@ -114,6 +114,37 @@ module('Integration | Component | multi-select', function (hooks) {
     assert.equal(checkboxElement.item(2).checked, false);
   });
 
+  test('it should display selected labels when the multiselect is searchable', async function (assert) {
+    // given
+    this.options = DEFAULT_OPTIONS;
+    this.onSelect = (selected) => this.set('selected', selected);
+    this.selected = ['2', '3'];
+    this.emptyMessage = 'no result';
+    this.title = 'MultiSelectTest';
+    this.id = 'id-MultiSelectTest';
+
+    // when
+    await render(hbs`
+      <PixMultiSelect
+        @onSelect={{onSelect}}
+        @title={{title}}
+        @id={{id}}
+        @selected={{selected}}
+        @label="label"
+        @emptyMessage={{emptyMessage}}
+        @placeholder="Yo"
+        @isSearchable={{true}}
+        @options={{options}} as |option|
+      >
+        {{option.label}}
+      </PixMultiSelect>
+    `);
+    
+    // then
+    const inputElement = this.element.querySelector('.pix-multi-select-header__search-input');
+    assert.equal(inputElement.placeholder, 'Tomate, Oignon');
+  });
+
   test('it should updates selected items when @selected is changed', async function (assert) {
     // given
     this.options = DEFAULT_OPTIONS;
@@ -658,5 +689,33 @@ module('Integration | Component | multi-select', function (hooks) {
     // when & then
     const expectedError = new Error('ERROR in PixMultiSelect component, @id param is necessary when giving @label');
     assert.throws(function() { component.label }, expectedError);
+  });
+
+  test('it should asynchronously load options', async function (assert) {
+    // given
+    this.onLoadOptions = () => Promise.resolve(DEFAULT_OPTIONS)
+    this.selected = [];
+    this.onSelect = (selected) => this.set('selected', selected);
+    this.emptyMessage = 'no result';
+    this.title = 'MultiSelectTest';
+    this.id = 'id-MultiSelectTest';
+
+    // when
+    await render(hbs`
+      <PixMultiSelect
+        @selected={{selected}}
+        @onSelect={{onSelect}}
+        @title={{title}}
+        @id={{id}}
+        @emptyMessage={{emptyMessage}}
+        @onLoadOptions={{onLoadOptions}} as |option|>
+        {{option.label}}
+      </PixMultiSelect>
+    `);
+    
+    // then
+    const listElement = this.element.querySelectorAll('li');
+    assert.contains('MultiSelectTest');
+    assert.equal(listElement.length, 3);
   });
 });


### PR DESCRIPTION
## :unicorn: Problème

Le composant Multi-Select permet de définir les options via l'argument `@options`. Mais une fois le composant monté les options ne sont pas mises à jour. Or parfois on souhaite récupérer les options de façon asynchrone via un appel dédié et que ces options soient valuées au sein du composant.

## :unicorn: Solution

Ajouter un callback `onLoadOptions` en argument du Multi-select qui chargera les options en asynchrone. Un autre argument, `loadingMessage`, permet d'afficher un message de chargement (à la place des options) pendant que l'appel est effectué.

**Exemple**
```js
load() {
  // ici on aura tendance a faire un appel serveur
  return Promise.resolve([{ label: "A", value: 1 }]);
}
```
```hbs
<PixMultiSelect
   @onLoadOptions={{this.load}}
   @loadingMessage="Chargement..."
   ...
/>
```

**L'ajout de cette feature est rétro-compatible**. Elle n'impacte pas l'utilisation actuelle de `@options`.
Désormais 2 possibilités pour charger les options:
- `@options`: Permet d'indiquer directement les options du MultiSelect.
- `@onLoadOptions`: Permet de charger les options de façon asynchrone.

## :rainbow: Remarques

Nous en avons profiter pour ajouter une petite feature. Quand le composant est recherchable, les label des éléments sélectionnés sont indiqué dans le placeholder afin de mettre en évidence ce qui a été sélectionné.

**PS:** 

## :100: Pour tester

Voir la story dédiée dans Storybook et observé que le composant a bien chargé les options.
