### PR TITLE
[TECH] Enlever les règles bloquantes et non utiles du reset CSS [BREAKING_CHANGES]

### DIFF
--- a/addon/styles/_form.scss
+++ b/addon/styles/_form.scss
@@ -41,7 +41,6 @@
 }
 
 @mixin input() {
-  line-height: 0;
   font-family: $font-roboto;
   font-size: 0.875rem;
   font-weight: 400;

--- a/addon/styles/_pix-block.scss
+++ b/addon/styles/_pix-block.scss
@@ -1,6 +1,5 @@
 .pix-block {
   position: relative;
-  box-sizing: border-box;
   width: 100%;
   max-width: 980px;
   padding: 14px 24px;

--- a/addon/styles/_pix-collapsible.scss
+++ b/addon/styles/_pix-collapsible.scss
@@ -12,7 +12,6 @@
   background-color: $white;
 
   &__title {
-    box-sizing: border-box;
     padding: 14px 10px 14px 16px;
     min-width: 100%;
     cursor: pointer;

--- a/addon/styles/_pix-filter-banner.scss
+++ b/addon/styles/_pix-filter-banner.scss
@@ -6,7 +6,6 @@
   flex-direction: row;
   justify-content: space-between;
   align-items: center;
-  box-sizing: border-box;
   width: 100%;
 
   background-color: $white;

--- a/addon/styles/_pix-input-code.scss
+++ b/addon/styles/_pix-input-code.scss
@@ -28,7 +28,6 @@
 
   input.pix-input-code__input {
     display: inline-block;
-    box-sizing: border-box;
     height: 44px;
     width: 38px;
     padding: 10px 12px 8px;

--- a/addon/styles/_pix-input-password.scss
+++ b/addon/styles/_pix-input-password.scss
@@ -9,7 +9,6 @@
     display: flex;
     box-sizing: border-box;
     align-items: center;
-    line-height: 0;
     border: 1px solid $grey-40;
     border-radius: $spacing-xxs;
     padding: 1px 0 1px 1px;

--- a/addon/styles/_pix-input-password.scss
+++ b/addon/styles/_pix-input-password.scss
@@ -7,7 +7,6 @@
 
   &__container {
     display: flex;
-    box-sizing: border-box;
     align-items: center;
     border: 1px solid $grey-40;
     border-radius: $spacing-xxs;
@@ -62,7 +61,7 @@
     border-radius: 50%;
     font-size: 0.6rem;
     padding: 2px;
-    width: 14px;
-    height: 14px;
+    width: 18px;
+    height: 18px;
   }
 }

--- a/addon/styles/_pix-input.scss
+++ b/addon/styles/_pix-input.scss
@@ -18,9 +18,12 @@
 
   svg.pix-input__icon {
     position: absolute;
-    bottom: 10px;
+    bottom: 9px;
     right: 6px;
     color: $grey-25;
+    font-size: 1.125rem;
+    width: 18px;
+    height: 18px;
 
     &--left {
       left: 6px;
@@ -29,7 +32,7 @@
 
   svg ~ svg.pix-input__icon {
     right: calc(6px + 12px + 2px);
-    padding-right: 6px;
+    margin-right: 8px;
   }
 
   svg.pix-input__error-icon {
@@ -41,8 +44,8 @@
     border-radius: 50%;
     font-size: 0.6rem;
     padding: 2px;
-    width: 12px;
-    height: 12px;
+    width: 18px;
+    height: 18px;
   }
 
   &__error-message {
@@ -54,7 +57,6 @@
   input {
     display: flex;
     height: 36px;
-    box-sizing: border-box;
     flex-direction: column;
     justify-content: center;
     border: 1px solid $grey-40;

--- a/addon/styles/_pix-multi-select.scss
+++ b/addon/styles/_pix-multi-select.scss
@@ -23,7 +23,6 @@
   background-color: $white;
   border-radius: 4px;
   outline: none;
-  box-sizing: border-box;
   font-size: 0.875rem;
   cursor: pointer;
   color: $grey-90;

--- a/addon/styles/_pix-select.scss
+++ b/addon/styles/_pix-select.scss
@@ -6,7 +6,6 @@
   @mixin pixSelect {
     appearance: none;
     border: 1px $grey-40 solid;
-    box-sizing: border-box;
     border-radius: 4px;
     color: $grey-90;
     font-family: $font-roboto;

--- a/addon/styles/_pix-tag.scss
+++ b/addon/styles/_pix-tag.scss
@@ -2,7 +2,6 @@
   @import 'reset-css';
 
   display: inline-block;
-  box-sizing: border-box;
   text-align: center;
   vertical-align: baseline;
   white-space: nowrap;

--- a/addon/styles/_pix-textarea.scss
+++ b/addon/styles/_pix-textarea.scss
@@ -2,7 +2,6 @@
   @import 'reset-css';
 
   textarea {
-    box-sizing: border-box;
     width: 100%;
     border: 1px solid $grey-40;
     border-style: solid;

--- a/addon/styles/_reset-css.scss
+++ b/addon/styles/_reset-css.scss
@@ -29,12 +29,6 @@ caption, th, td
 	font-weight: normal;
 }
 
-input, textarea, select
-{
-	font-size: 110%;
-	line-height: 1.1;
-}
-
 abbr, acronym
 {
 	border-bottom: .1em dotted;

--- a/addon/styles/addon.scss
+++ b/addon/styles/addon.scss
@@ -34,3 +34,7 @@ html {
 body {
   font-family: $font-roboto;
 }
+
+* {
+  box-sizing: border-box;
+}


### PR DESCRIPTION
## 🎃 Description du problème
Lors de la PR https://github.com/1024pix/pix/pull/3591 nous avons observé un soucis en RA que nous n'avions pas en local : l'icone du PixInputCode était décalée en RA mais se positionnait correctement en local.


<img width="630" alt="image" src="https://user-images.githubusercontent.com/38167520/137758872-6f4d1cc8-ba81-4d2d-a6b9-b9adb3d1f494.png">

Après comparaison du CSS de la RA et en local il y avait une différence dans la `font-size` de la balise `input`. 
En effet, en local elle était de `0.875rem` tandis qu'en RA elle valait `100%`. Et cela causait bien le décalage visuel de l'icon "eye".
Cette différence est due au fait que : (pour les calculs voir https://i.stack.imgur.com/DESkB.png)
- la spécificité CSS de la règle `font-size: 100%` en RA est de : 0-1-0 (une classe)  + 0-0-1 (une balise input) = 0-1-1
(`.pix-input-password input`)
- la spécificité CSS de la règle `font-size: 0.875rem` en local est de : 0-1-0 (une classe) + 0-0-1  (une balise input) = 0-1-1
(`.pix-input-password__container input`)

Donc le niveau de spécificité est le même. Quand le niveau de spécificité est le même c'est l'ordre dans lequel sont lue les valeurs qui est important : c'est la dernière déclaration qui prend le dessus.

Là où, en local, on build l'application en mode dev, en RA elle est buildé en mode production. Cela a donc dû influencer sur l'ordre de concaténation des fichiers CSS, et donc des déclarations. Ainsi la déclaration `font-size: 100%` est passée après la `font-size: 0.875rem` sur la RA (et l'inverse en local).

# 🦇  Remarque
Nous avons profité de cette PR pour appliquer un deuxième correctif : celui des `box-sizing`. Nous avons appliqué `box-sizing: border-box` à tous les éléments Pix-UI. [BREAKING_CHANGE]
Suppression d'un morceau de reset CSS.  [BREAKING_CHANGE]

# 🕸️ Proposition de solution
Comme nous ne nous servons jamais de la règle (et je ne pense pas que ça soit souhaitable si nous suivons le design system)

```
input, textarea, select
{
	font-size: 110%;
	line-height: 1.1;
}
```

du reset-css , je propose carrément de l'enlever. 