### PR TITLE
[FEATURE] Afficher un préfixe optionnel dans le composant PixInputPassword.

### DIFF
--- a/addon/components/pix-input-password.hbs
+++ b/addon/components/pix-input-password.hbs
@@ -5,7 +5,11 @@
   {{#if @information}}
     <label for={{this.id}} class="pix-input__information">{{@information}}</label>
   {{/if}}
-    <div class="pix-input-password__container {{if @errorMessage " pix-input-password__error-container"}}">
+    <div class="pix-input-password__container {{if @errorMessage "pix-input-password__error-container"}} {{if @prefix "pix-input-password__with-prefix"}}">
+
+      {{#if @prefix}}
+        <span class="pix-input-password__prefix">{{@prefix}}</span>
+      {{/if}}
 
       <Input
         id={{this.id}}

--- a/addon/stories/pix-input-password.stories.js
+++ b/addon/stories/pix-input-password.stories.js
@@ -9,6 +9,7 @@ export const Template = (args) => {
         @label={{label}}
         @information={{information}}
         @errorMessage={{errorMessage}}
+        @prefix={{prefix}}
       />
     `,
     context: args,
@@ -33,6 +34,13 @@ withErrorMessage.args = {
   id: 'password',
   label: 'Mot de passe',
   errorMessage: 'Un message d\'erreur.',
+}
+
+export const withPrefix = Template.bind({});
+withPrefix.args = {
+  id: 'password',
+  label: 'Mot de passe',
+  prefix: 'C -',
 }
 
 export const argTypes = {
@@ -69,6 +77,12 @@ export const argTypes = {
   errorMessage: {
     name: 'errorMessage',
     description: 'Affiche le message d\'erreur donné et encadre en rouge le champ',
+    type: { name: 'string', required: false },
+    defaultValue: null,
+  },
+  prefix: {
+    name: 'prefix',
+    description: 'Affiche un préfixe avant la zone de saisie du champ',
     type: { name: 'string', required: false },
     defaultValue: null,
   },

--- a/addon/stories/pix-input-password.stories.mdx
+++ b/addon/stories/pix-input-password.stories.mdx
@@ -47,6 +47,12 @@ Si vous utilisez le `PixInputPassword` sans label alors il faut renseigner le pa
   <Story story={stories.withErrorMessage} height={130} />
 </Canvas>
 
+## With prefix
+
+<Canvas>
+  <Story story={stories.withPrefix} height={100} />
+</Canvas>
+
 ## Usage
 
 ```html
@@ -56,6 +62,7 @@ Si vous utilisez le `PixInputPassword` sans label alors il faut renseigner le pa
     @information={{information}}
     @value={{value}}
     @errorMessage={{errorMessage}}
+    @prefix={{prefix}}
 />
 ```
 

--- a/addon/styles/_pix-input-password.scss
+++ b/addon/styles/_pix-input-password.scss
@@ -30,6 +30,16 @@
     }
   }
 
+  &__with-prefix {
+    input {
+      padding-left: 0;
+    }
+  }
+
+  &__prefix {
+    padding: 0 4px 0 8px;
+  }
+
   &__button {
     &:hover,
     &:active,

--- a/tests/integration/components/pix-input-password-test.js
+++ b/tests/integration/components/pix-input-password-test.js
@@ -46,6 +46,14 @@ module('Integration | Component | pix-input-password', function(hooks) {
     assert.contains('Un message d\'erreur.');
   });
 
+  test('it should display an input prefix if necessary', async function(assert) {
+    // given & when
+    await render(hbs`<PixInputPassword @label="Mot de passe" @id="password" @prefix="A prefix" />`);
+
+    // then
+    assert.contains('A prefix');
+  });
+
   test('it should be possible to add more params to input', async function(assert) {
     // given & when
     await render(hbs`<PixInputPassword @label="Mot de passe" @id="password" autocomplete="off" />`);


### PR DESCRIPTION
## :unicorn: Évolution du composant

Dans le cadre de la [création de l'espace surveillant,](https://github.com/1024pix/pix/pull/3623) l'utilisateur est amené à entrer plusieurs codes différents selon les circonstances. Pour éviter toute confusion, nous avons décidé de préfixer le nouveau "mot de passe de session" par un préfixe : tous les codes commenceront par "C-".

Nous avons besoin que le composant PixInputPassword affiche ce préfixe dans ce contexte pour indiquer clairement à l'utilisateur qu'elle est le rendu final.

## :rainbow: Remarques
Le paramètre est optionnel

## :100: Pour tester
Vérifier que la CI passe