### PR TITLE
[TECH] Ajout d'une permission d'écriture pour l'auto merge

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -27,3 +27,4 @@ jobs:
           UPDATE_LABELS: ":rocket: Ready to Merge"
           UPDATE_METHOD: "rebase"
           MERGE_FORKS: "false"
+          LOG: "TRACE"

--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -12,6 +12,7 @@ permissions:
   checks: read
   contents: write
   actions: write
+  pull-requests: write
 
 jobs:
   automerge:


### PR DESCRIPTION
## :jack_o_lantern: Problème

Il semble que l'auto-merge soit bloqué une fois que la PR a été mise à jour par rapport à dev automatiquement.
Voir la PR : https://github.com/1024pix/pix-ui/pull/158 . Le label auto-merge a été rajouté, la PR a été mise à jour automatiquement mais elle n'a pas été mergée.

[Le log ](https://github.com/1024pix/pix-ui/runs/3950848872?check_suite_focus=true) indique `Current PR status: mergeable_state: blocked`

```bash
Run pascalgn/automerge-action@v0.14.3
2021-10-20T11:26:31.898Z INFO  Event name: pull_request
2021-10-20T11:26:32.232Z INFO  Updating PR #158 [DOC] Suivre le déploiement de la release.
2021-10-20T11:26:32.925Z INFO  doc-add-release-logs HEAD: b831a3477051855a889a35350f637122a275258d
2021-10-20T11:26:32.931Z INFO  Rebasing onto dev 254dc026b2312f22c5e02a3ee84bec64cf0870b4
2021-10-20T11:26:32.974Z INFO  Already up to date: doc-add-release-logs -> dev 254dc026b2312f22c5e02a3ee84bec64cf0870b4
2021-10-20T11:26:33.003Z INFO  Merging PR #158 [DOC] Suivre le déploiement de la release.
2021-10-20T11:26:33.004Z INFO  Current PR status: mergeable_state: blocked
2021-10-20T11:26:33.004Z INFO  Retrying after 5000 ms ... (1/6)
```
## :bat: Solution
Il manque très certainement une permission au github token pour lire l'état de la PR et relancer l'auto-merge.

La doc github est assez sommaire sur le sujet mais au vu des descriptions des requêtes possible de github, je pense qu'il manque la permission `write` sur les `pull-requests`. 
```
PUT /repos/:owner/:repo/pulls/:pull_number/merge (:write)
```
[Liste des permissions](https://docs.github.com/en/rest/reference/permissions-required-for-github-apps#permission-on-pull-requests)

Ajout du mode debug où cas où le problème n'est pas résolu

## :spider_web: Remarques
Le message d'erreur est analysé dans ce [dans ce thread](https://githubmemory.com/repo/pascalgn/automerge-action/issues/129), mais ne s'applique pas ici (automerge n'est pas marqué dans les required checks)

Ce qui est curieux, c'est que ces permissions ne sont pas listées dans la doc [comme étant obligatoires](https://github.com/marketplace/actions/merge-pull-requests-automerge-action#usage)

## :ghost: Pour tester
Merger après un rebase à effectuer

