### PR TITLE
[TECH] Restaurer la version initiale de automerge.

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: automerge
-        uses: "pascalgn/automerge-action@v0.14.3"
+        uses: "pascalgn/automerge-action@v0.8.3"
         env:
           GITHUB_TOKEN: "${{ github.token }}"
           MERGE_LABELS: ":rocket: Ready to Merge"


### PR DESCRIPTION
Suite de https://github.com/1024pix/pix-ui/pull/159
On downgrade pour voir si c'est lié au totken ou à la version de la github action
