### PR TITLE
[INFRA] Release npm @1024pix/pix-ui automatisée

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -1,0 +1,23 @@
+# This workflow will run tests using node and then publish a package to GitHub Packages when a release is created
+# For more information see: https://help.github.com/actions/language-and-framework-guides/publishing-nodejs-packages
+
+name: Node.js Package
+
+on:
+  push:
+    tags:
+      - '*'
+
+jobs:
+  publish-npm:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: '16'
+          check-latest: true
+          registry-url: https://registry.npmjs.org/
+      - run: npm publish --access public
+        env:
+          NODE_AUTH_TOKEN: ${{secrets.NPM_PUBLISH_ACCESS_TOKEN}}

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Pix-UI c'est l'implémentation des principes du design system de Pix. Cela se ma
 ## Installation de l'addon Pix-UI <a id="Addon"></a>
 
 Pour utiliser les composants sur une application Ember externe, il faut installer l'addon ember Pix-UI avec la commande : 
-- `npm install git://github.com/1024pix/pix-ui.git#<tag_souhaité>`
+- `npm install @1024pix/pix-ui@<tag_souhaité>`
 
 ##### Quel tag choisir ?
 

--- a/app/components/pix-background-header.js
+++ b/app/components/pix-background-header.js
@@ -1,1 +1,1 @@
-export { default } from 'pix-ui/components/pix-background-header';
+export { default } from '@1024pix/pix-ui/components/pix-background-header';

--- a/app/components/pix-banner.js
+++ b/app/components/pix-banner.js
@@ -1,1 +1,1 @@
-export { default } from 'pix-ui/components/pix-banner';
+export { default } from '@1024pix/pix-ui/components/pix-banner';

--- a/app/components/pix-block.js
+++ b/app/components/pix-block.js
@@ -1,1 +1,1 @@
-export { default } from 'pix-ui/components/pix-block';
+export { default } from '@1024pix/pix-ui/components/pix-block';

--- a/app/components/pix-button-link.js
+++ b/app/components/pix-button-link.js
@@ -1,1 +1,1 @@
-export { default } from 'pix-ui/components/pix-button-link';
+export { default } from '@1024pix/pix-ui/components/pix-button-link';

--- a/app/components/pix-button-upload.js
+++ b/app/components/pix-button-upload.js
@@ -1,1 +1,1 @@
-export { default } from 'pix-ui/components/pix-button-upload';
+export { default } from '@1024pix/pix-ui/components/pix-button-upload';

--- a/app/components/pix-button.js
+++ b/app/components/pix-button.js
@@ -1,1 +1,1 @@
-export { default } from 'pix-ui/components/pix-button';
+export { default } from '@1024pix/pix-ui/components/pix-button';

--- a/app/components/pix-collapsible.js
+++ b/app/components/pix-collapsible.js
@@ -1,1 +1,1 @@
-export { default } from 'pix-ui/components/pix-collapsible';
+export { default } from '@1024pix/pix-ui/components/pix-collapsible';

--- a/app/components/pix-filter-banner.js
+++ b/app/components/pix-filter-banner.js
@@ -1,1 +1,1 @@
-export { default } from 'pix-ui/components/pix-filter-banner';
+export { default } from '@1024pix/pix-ui/components/pix-filter-banner';

--- a/app/components/pix-icon-button.js
+++ b/app/components/pix-icon-button.js
@@ -1,1 +1,1 @@
-export { default } from 'pix-ui/components/pix-icon-button';
+export { default } from '@1024pix/pix-ui/components/pix-icon-button';

--- a/app/components/pix-input-code.js
+++ b/app/components/pix-input-code.js
@@ -1,1 +1,1 @@
-export { default } from 'pix-ui/components/pix-input-code';
+export { default } from '@1024pix/pix-ui/components/pix-input-code';

--- a/app/components/pix-input-password.js
+++ b/app/components/pix-input-password.js
@@ -1,1 +1,1 @@
-export { default } from 'pix-ui/components/pix-input-password';
+export { default } from '@1024pix/pix-ui/components/pix-input-password';

--- a/app/components/pix-input.js
+++ b/app/components/pix-input.js
@@ -1,1 +1,1 @@
-export { default } from 'pix-ui/components/pix-input';
+export { default } from '@1024pix/pix-ui/components/pix-input';

--- a/app/components/pix-message.js
+++ b/app/components/pix-message.js
@@ -1,1 +1,1 @@
-export { default } from 'pix-ui/components/pix-message';
+export { default } from '@1024pix/pix-ui/components/pix-message';

--- a/app/components/pix-multi-select.js
+++ b/app/components/pix-multi-select.js
@@ -1,1 +1,1 @@
-export { default } from 'pix-ui/components/pix-multi-select';
+export { default } from '@1024pix/pix-ui/components/pix-multi-select';

--- a/app/components/pix-progress-gauge.js
+++ b/app/components/pix-progress-gauge.js
@@ -1,1 +1,1 @@
-export { default } from 'pix-ui/components/pix-progress-gauge';
+export { default } from '@1024pix/pix-ui/components/pix-progress-gauge';

--- a/app/components/pix-radio-button.js
+++ b/app/components/pix-radio-button.js
@@ -1,1 +1,1 @@
-export { default } from 'pix-ui/components/pix-radio-button';
+export { default } from '@1024pix/pix-ui/components/pix-radio-button';

--- a/app/components/pix-return-to.js
+++ b/app/components/pix-return-to.js
@@ -1,1 +1,1 @@
-export { default } from 'pix-ui/components/pix-return-to';
+export { default } from '@1024pix/pix-ui/components/pix-return-to';

--- a/app/components/pix-select.js
+++ b/app/components/pix-select.js
@@ -1,1 +1,1 @@
-export { default } from 'pix-ui/components/pix-select';
+export { default } from '@1024pix/pix-ui/components/pix-select';

--- a/app/components/pix-stars.js
+++ b/app/components/pix-stars.js
@@ -1,1 +1,1 @@
-export { default } from 'pix-ui/components/pix-stars';
+export { default } from '@1024pix/pix-ui/components/pix-stars';

--- a/app/components/pix-tag.js
+++ b/app/components/pix-tag.js
@@ -1,1 +1,1 @@
-export { default } from 'pix-ui/components/pix-tag';
+export { default } from '@1024pix/pix-ui/components/pix-tag';

--- a/app/components/pix-textarea.js
+++ b/app/components/pix-textarea.js
@@ -1,1 +1,1 @@
-export { default } from 'pix-ui/components/pix-textarea';
+export { default } from '@1024pix/pix-ui/components/pix-textarea';

--- a/app/components/pix-tooltip.js
+++ b/app/components/pix-tooltip.js
@@ -1,1 +1,1 @@
-export { default } from 'pix-ui/components/pix-tooltip';
+export { default } from '@1024pix/pix-ui/components/pix-tooltip';

--- a/blueprints/pix-component/files/app/components/pix-__name__.js
+++ b/blueprints/pix-component/files/app/components/pix-__name__.js
@@ -1,1 +1,1 @@
-export { default } from 'pix-ui/components/pix-<%= dasherizedModuleName %>';
+export { default } from '@1024pix/pix-ui/components/pix-<%= dasherizedModuleName %>';

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "pix-ui",
+  "name": "@1024pix/pix-ui",
   "version": "10.0.2",
   "lockfileVersion": 1,
   "requires": true,

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "pix-ui",
+  "name": "@1024pix/pix-ui",
   "version": "10.0.2",
   "description": "Addon pour l'UI des applications Pix",
   "keywords": [
@@ -15,7 +15,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/1024pix/pix-ui.git"
+    "url": "git+ssh://git@github.com/1024pix/pix-ui.git"
   },
   "directories": {
     "doc": "doc",
@@ -98,6 +98,11 @@
     "qunit-dom": "^1.6.0",
     "sass": "^1.37.5"
   },
+  "bugs": {
+    "url": "https://github.com/1024pix/pix-ui/issues"
+  },
+  "homepage": "https://github.com/1024pix/pix-ui#readme",
+  "main": "index.js",
   "ember-addon": {
     "configPath": "tests/dummy/config"
   },


### PR DESCRIPTION
## :unicorn: Problème
Aujourd'hui, nous devons importer pix-ui avec son URL git (ex : `git://github.com/1024pix/pix-ui.git#v9.1.0`). J'ai un doute que les mise à jour npm peuvent se faire de manière standard avec `npm upgrade`.

## :robot: Solution
Proposer le package npm `pix-ui` dans l'orga `@1024pix` : `npm install @1024pix/pix-ui`.

## :rainbow: Remarques
RAS

## :100: Pour tester
Pas de test à proprement parler, voir l'historique de [ember-testing-library](https://github.com/1024pix/ember-testing-library) pour plus d'infos :) 
