### PR TITLE
[FIXBUG] Problème de sélection des statuts sur Firefox (PIX-3636)

### DIFF
--- a/addon/components/pix-select.hbs
+++ b/addon/components/pix-select.hbs
@@ -36,9 +36,17 @@
         {{/if}}
       {{/if}}
       {{#each @options as |opt|}}
-        <option value={{opt.value}} defaultSelected={{eq @selectedOption opt.value}}>
-          {{opt.label}}
-        </option>
+        {{#if (eq @selectedOption opt.value)}}
+          {{!-- https://github.com/emberjs/ember.js/issues/15484
+                ember-prop-modifier let us fix a bug about selected attribute in FireFox --}}
+          <option value={{opt.value}} {{prop selected="true"}}>
+            {{opt.label}}
+          </option>
+        {{else}}
+          <option value={{opt.value}}>
+            {{opt.label}}
+          </option>
+        {{/if}}
       {{/each}}
     </select>
     <FaIcon class='pix-select__icon' @icon="chevron-down" />

--- a/addon/components/pix-select.js
+++ b/addon/components/pix-select.js
@@ -13,7 +13,7 @@ export default class PixSelect extends Component {
       this.datalistId = 'pix-select-list-' + guidFor(this);
     }
   }
-  
+
   get label() {
     const labelIsDefined = this.args.label?.trim();
     const idIsNotDefined = !(this.args.id?.trim());

--- a/package-lock.json
+++ b/package-lock.json
@@ -13660,6 +13660,15 @@
         }
       }
     },
+    "ember-prop-modifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/ember-prop-modifier/-/ember-prop-modifier-1.0.1.tgz",
+      "integrity": "sha512-IbWHOY1MtEFwA5oMC+54CiTh0TuhMDIE6Z+QyX9pYvIOpr+BJsDphujPw9697Dt/0EK3PE41ZWllI8G4Butd/w==",
+      "requires": {
+        "ember-cli-babel": "^7.1.2",
+        "ember-modifier": "^2.1.1"
+      }
+    },
     "ember-qunit": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/ember-qunit/-/ember-qunit-4.6.0.tgz",

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "ember-cli-sass": "^10.0.1",
     "ember-cli-string-utils": "^1.1.0",
     "ember-click-outside": "^2.0.0",
+    "ember-prop-modifier": "^1.0.1",
     "ember-truth-helpers": "^3.0.0"
   },
   "devDependencies": {

--- a/tests/integration/components/pix-select-test.js
+++ b/tests/integration/components/pix-select-test.js
@@ -33,6 +33,7 @@ module('Integration | Component | select', function (hooks) {
 
     // then
     const options = this.element.querySelectorAll('option');
+
     assert.equal(options.length, 3);
     assert.equal(options.item(0).value, '1');
     assert.equal(options.item(0).text, 'Salade');
@@ -75,7 +76,9 @@ module('Integration | Component | select', function (hooks) {
 
     // then
     const options = this.element.querySelectorAll('option');
-    assert.equal(options.item(1).defaultSelected, true);
+    assert.equal(options.item(1).selected, true);
+    assert.equal(options.item(0).selected, false);
+    assert.equal(options.item(2).selected, false);
   });
 
   test('it should trigger onChange function when an item is selected', async function (assert) {


### PR DESCRIPTION
## :unicorn: Description du composant
Sur firefox, quand on sélectionne un statut, la requête est bien faite avec le bon filtre mais la valeur de l'option du drop down ne correspond pas au filtre.

## :rainbow: Remarques
Afficher la bonne valeur de l'option.

## :100: Pour tester
Brancher cette version de pix-ui à pix orga en local et vérifier que l'option affichée correspond bien au filtre sélectionné.
