### PR TITLE
[BUGFIX] Empêcher PixSelect de déborder de l'élément parent

### DIFF
--- a/addon/styles/_pix-select.scss
+++ b/addon/styles/_pix-select.scss
@@ -11,6 +11,8 @@
     font-family: $font-roboto;
     font-size: 0.875rem;
     height: 36px;
+    max-width: 100%;
+    text-overflow: ellipsis;
 
     @include hoverFormElement();
     @include focusFormElement();

--- a/app/stories/pix-select.stories.js
+++ b/app/stories/pix-select.stories.js
@@ -32,6 +32,7 @@ Default.args = {
     { value: '9', label: 'Avocat' },
     { value: '10', label: 'Fraises' },
     { value: '11', label: 'Kaki' },
+    { value: '12', label: 'Asiminier trilobé oblong vert (à ne pas confondre avec la papaye)' },
   ],
   onChange: action('onChange'),
 }


### PR DESCRIPTION
## :unicorn: Problème

Lorsque PixSelect a des option avec des libellés très longues dans un élément parent avec une taille limitée, il va déborder de l'élément parent, pour un résultat visuel disgracieux, comme dans cet exemple tiré de Pix Certif :

![Capture d’écran 2021-11-03 à 10 36 51](https://user-images.githubusercontent.com/5627688/140037486-37d3e206-7dbc-4ec0-aa8f-40c25d72a343.png)

## 🤖  Solution

Tronquer le texte pour empêcher le débordement du champ si le libellé est plus long que le parent :

![Capture d’écran 2021-11-03 à 09 54 48](https://user-images.githubusercontent.com/5627688/140038332-db3657b6-ae24-48ec-90d3-d712f0b704c5.png)

## :rainbow: Remarques

Le libellé entier reste lisible lorsqu'on ouvre le PixSelect pour afficher toutes les options.

![Capture d’écran 2021-11-03 à 09 54 54](https://user-images.githubusercontent.com/5627688/140038554-05612318-475f-4d5b-a9d9-cbe19424e9e7.png)

## :100: Pour tester

1. Se rendre [sur la page du composant](https://ui-pr166.review.pix.fr/?path=/docs/form-select--default)
2. Ajouter une taille fixe et une bordure à l'élément parent (`ember-view`) à l'aide des dev tools du navigateur (ex: `width: 250px; border: 1px solid red;`)
3. Constater que le texte est tronqué et que le PixSelect ne dépasse pas la bordure

![Capture d’écran 2021-11-03 à 10 52 49](https://user-images.githubusercontent.com/5627688/140039765-95fa4d10-da86-4b13-9a78-ecc3fcc2a230.png)
