### PR TITLE
[DOC] Améliorer l'information sur l'accessibilité dans la doc de PixTooltip

### DIFF
--- a/app/stories/pix-tooltip.stories.mdx
+++ b/app/stories/pix-tooltip.stories.mdx
@@ -37,7 +37,9 @@ Si vous utilisez un élément `<div>` ou `<span>`, il faut ajouter `tabindex="0"
 </PixTooltip>
 ```
 
-Les tooltips doivent prendre un `@id` et être référencées par leur élément déclencheur via `aria-describedby`:
+Les tooltips doivent prendre un `@id` et être référencées par leur élément déclencheur 
+
+- soit via `aria-describedby` si l'élément possèdent déjà un label, car le tooltip agit alors comme une description supplémentaire.
 
 ```html
 <PixTooltip @id="tooltip-1">
@@ -50,6 +52,15 @@ Les tooltips doivent prendre un `@id` et être référencées par leur élément
   </:tooltip>
 </PixTooltip>
 ```
+
+- soit via `aria-labelledby` si l'élément ne possède pas de label et que le tooltip fait office de libellé.
+
+```html
+<PixTooltip @id="tooltip-2" @text="Cette information apparaît uniquement au survol de l'icone">
+  <span class="icon icon-info" aria-labelledby="tooltip-2"></span>
+</PixTooltip>
+```
+
 
 ## Default
 


### PR DESCRIPTION
## :unicorn: Problème

La documentation de PixTooltip recommande d'utiliser l'attribut `aria-describedby` pour lier l'info-bulle à l'élément qu'elle décrit, ce qui est valide pour ajouter une information supplémentaire. Mais `PixTooltip` est souvent utilisé comme un label, pour des éléments qui n'en ont pas, et il faut dans ce cas utiliser l'attribut `aria-labelledby`.

## :robot: Solution

Ajouter l'attribut à la documentation avec un exemple.

## :rainbow: Remarques

*RAS*

## :100: Pour tester

- https://ui-pr171.review.pix.fr/?path=/docs/basics-tooltip--default