### PR TITLE
[TECH] Faire en sorte que le message d'erreur soit situé à l'intérieur de l'élément qui le compose [BREAKING_CHANGES] (PIX-3829)

### DIFF
--- a/addon/components/pix-input-password.hbs
+++ b/addon/components/pix-input-password.hbs
@@ -32,10 +32,12 @@
       @size="small"
     />
 
+    {{#if @errorMessage}}
+      <FaIcon @icon="times" class="pix-input-password__error-icon" />
+    {{/if}}
   </div>
 
   {{#if @errorMessage}}
-    <FaIcon @icon="times" class="pix-input-password__error-icon" />
     <label for={{this.id}} class="pix-input__error-message">{{@errorMessage}}</label>
   {{/if}}
 </div>

--- a/addon/components/pix-input.hbs
+++ b/addon/components/pix-input.hbs
@@ -6,21 +6,25 @@
     <label for={{this.id}} class="pix-input__information">{{@information}}</label>
   {{/if}}
 
-  <Input
-    id={{this.id}}
-    class={{this.className}}
-    @value={{@value}}
-    {{on "change" this.onChange}}
-    ...attributes
-  />
+  <div class="pix-input__container">
+    <input
+      id={{this.id}}
+      class={{this.className}}
+      value={{@value}}
+      {{on "change" this.onChange}}
+      ...attributes
+    />
+
+    {{#if @errorMessage}}
+      <FaIcon @icon="times" class="pix-input__error-icon" />
+    {{/if}}
+
+    {{#if @icon}}
+      <FaIcon @icon={{@icon}} class="pix-input__icon {{if @isIconLeft "pix-input__icon--left"}}" />
+    {{/if}}
+  </div>
 
   {{#if @errorMessage}}
-    <FaIcon @icon="times" class="pix-input__error-icon" />
     <label for={{this.id}} class="pix-input__error-message">{{@errorMessage}}</label>
   {{/if}}
-
-  {{#if @icon}}
-    <FaIcon @icon={{@icon}} class="pix-input__icon {{if @isIconLeft "pix-input__icon--left"}}" />
-  {{/if}}
-
 </div>

--- a/addon/styles/_form.scss
+++ b/addon/styles/_form.scss
@@ -29,7 +29,6 @@
 }
 
 @mixin errorMessage() {
-  position: absolute;
   font-family: $font-roboto;
   font-size: 0.75rem;
   color: $red;

--- a/addon/styles/_pix-input-password.scss
+++ b/addon/styles/_pix-input-password.scss
@@ -6,6 +6,7 @@
   position: relative;
 
   &__container {
+    position: relative;
     display: flex;
     align-items: center;
     border: 1px solid $grey-40;

--- a/addon/styles/_pix-input.scss
+++ b/addon/styles/_pix-input.scss
@@ -16,6 +16,10 @@
     margin-bottom: 4px;
   }
 
+  &__container {
+    position: relative;
+  }
+
   svg.pix-input__icon {
     position: absolute;
     bottom: 9px;


### PR DESCRIPTION
## 💥 BREAKING_CHANGES

Le changement de l'Input ember à l'input natif ne permet plus de traquer les value.
Il est désormais nécessaire de déclarer un évènement onChange et de répercuter les changements de valeurs à votre variable via cet évènement.
A CHANGER :
- enlever @value de votre composant et rajouter un {{on "change" votreFonctionOnChange}}
- si vous souhaitez que votre champ soit autocompletable par le navigateur n'oubliez pas de rajouter un `{{on "input" updateMaValeur}}` pour mettre à jour la valeur de votre variable pour le submit + un `{{on "focusout" valideMonChamp}}`
- enlever le @type pour mettre juste `type`
- vérifier le style et l'adapter à votre contexte. L'ajout de la `div class="pix-input__container"` rétrécie la largeur de l'input , il sera peut être nécessaire de rajouter `.votre-classe { width: 100%;}`
<img width="442" alt="image" src="https://user-images.githubusercontent.com/38167520/151210041-8de5f017-8326-4a7b-b765-824fb39443b5.png">

Pour la montée de version, voici un exemple des changements à faire : https://github.com/1024pix/pix/pull/3979 


## :unicorn: Description du composant
En voulant utiliser les composants dans Pix Admin sur un formulaire, je me suis rendu compte que les messages d'erreurs étaient en dehors du scope du composant

Ce qui nous aurait obligé à gérer des marges (potentiellement différentes en fonction de la longueurs du message d'erreur) dans les applications.

J'ai fait en sorte que les messages d'erreurs soit à l'intérieur du composant afin que l'affichage ne chevauche pas un autre élement ( ce qui était le cas avec le `position:absolute`)
## :rainbow: Remarques
Ça me paraissait normal que tout soit dans le composant. Si il y a un aspect que je n'aurai pas vu je suis preneur :)

## :100: Pour tester
> _Lien vers Zeroheight (modèle) et Storybook (rendu final)._
