### PR TITLE
[FEATURE] Ajout des groupes d'options pour le select (Pix-3755).

### DIFF
--- a/addon/components/pix-option.hbs
+++ b/addon/components/pix-option.hbs
@@ -1,0 +1,11 @@
+{{#if @selected}}
+  {{! https://github.com/emberjs/ember.js/issues/15484
+      ember-prop-modifier let us fix a bug about selected attribute in FireFox }}
+  <option value={{@option.value}} {{prop selected="true"}}>
+    {{@option.label}}
+  </option>
+{{else}}
+  <option value={{@option.value}}>
+    {{@option.label}}
+  </option>
+{{/if}}

--- a/addon/components/pix-select-grouped-options.hbs
+++ b/addon/components/pix-select-grouped-options.hbs
@@ -1,0 +1,58 @@
+<div class="pix-select-group" {{on-click-outside this.hideOptions capture=true}}>
+
+  <label for={{@id}} class="pix-select-group__label">{{@label}}</label>
+
+  <span class="pix-select-group__search">
+    {{#if @isSearchable}}
+      <input
+        role="searchbox"
+        id={{@id}}
+        {{on "input" this.onSearch}}
+        {{on "click" this.displayOptions}}
+        value={{this.inputValue}}
+        ...attributes
+      />
+    {{else}}
+      <input
+        id={{@id}}
+        {{on "click" this.displayOptions}}
+        value={{this.selectedOption.label}}
+        ...attributes
+        autocomplete="off"
+        readonly
+      />
+    {{/if}}
+
+    <FaIcon
+      class="pix-select-group__icon pix-select-group__icon--searchable"
+      @icon="chevron-down"
+    />
+  </span>
+  {{! in order to let the focus on the input when the user click on a category }}
+  {{! we added a handler on mousedown to prevent the li element to steal the focus }}
+  {{! template-lint-disable no-down-event-binding }}
+  <ul
+    class="option-list {{if this.optionsHidden "option-list--hidden"}}"
+    role="listbox"
+    {{on "mousedown" this.avoidTakingFocus}}
+  >
+    {{! template-lint-enable no-down-event-binding }}
+    {{#each this.optionsByCategory as |category|}}
+      <li role="group">
+        <span class="option-list__category-title">{{category.label}}</span>
+        <ul>
+          {{#each category.options as |opt|}}
+            <li
+              class="option-list__option"
+              role="option"
+              optionValue={{opt.value}}
+              {{on "click" this.onClick}}
+            >
+              {{opt.label}}
+            </li>
+          {{/each}}
+        </ul>
+      </li>
+    {{/each}}
+  </ul>
+</div>

--- a/addon/components/pix-select-grouped-options.js
+++ b/addon/components/pix-select-grouped-options.js
@@ -1,0 +1,98 @@
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+import { action } from '@ember/object';
+
+export default class PixSelectGroupedOptions extends Component {
+  @tracked matchingOptions;
+  @tracked optionsHidden = true;
+  @tracked selectedOption = {};
+  @tracked searchedText;
+
+  constructor() {
+    super(...arguments);
+    this.matchingOptions = this.args.options;
+  }
+
+  get optionsByCategory() {
+    const categoryNames = _uniqValues(this.matchingOptions, 'category');
+    const { categories } = this.args;
+
+    return categoryNames
+      .sort((name1, name2) => name1.localeCompare(name2))
+      .map((categoryName) => {
+        return {
+          ...categories.find(({ name }) => name === categoryName),
+          options: this.matchingOptions.filter((option) => option.category === categoryName),
+        };
+      });
+  }
+
+  get inputValue() {
+    if (this.searchedText === null) {
+      return this.selectedOption.label;
+    }
+    return this.searchedText;
+  }
+
+  @action
+  displayOptions() {
+    this.searchedText = '';
+    this.optionsHidden = false;
+  }
+
+  @action
+  onClick(e) {
+    const { onChange, options } = this.args;
+
+    const value = e.target.getAttribute('optionValue');
+    this.selectedOption = _selectOptions(options, value);
+    this.hideOptions();
+    onChange(this.selectedOption.value);
+  }
+
+  @action
+  hideOptions() {
+    this.optionsHidden = true;
+    this.searchedText = null;
+    this.matchingOptions = this.args.options;
+  }
+
+  @action
+  avoidTakingFocus(e) {
+    if (event.target.getAttribute('role') !== 'option') {
+      e.preventDefault();
+    }
+  }
+
+  @action
+  onSearch(event) {
+    this.searchedText = event.target.value;
+    this.matchingOptions = this.filterOptions(this.args.options, this.searchedText);
+  }
+
+  filterOptions(options, text) {
+    const regex = new RegExp(text, 'i');
+    return options.filter(({ label }) => {
+      return regex.test(label);
+    });
+  }
+}
+
+function _uniqValues(values, key) {
+  const allValues = values.map((value) => value[key]);
+  const uniqValues = [];
+
+  allValues.forEach((value) => {
+    if (!uniqValues.includes(value)) {
+      uniqValues.push(value);
+    }
+  });
+
+  return uniqValues;
+}
+
+function _selectOptions(options, value) {
+  return options.find((option) => {
+    return option.value === value;
+  });
+}

--- a/addon/components/pix-select.hbs
+++ b/addon/components/pix-select.hbs
@@ -36,17 +36,7 @@
         {{/if}}
       {{/if}}
       {{#each @options as |opt|}}
-        {{#if (eq @selectedOption opt.value)}}
-          {{! https://github.com/emberjs/ember.js/issues/15484
-                ember-prop-modifier let us fix a bug about selected attribute in FireFox }}
-          <option value={{opt.value}} {{prop selected="true"}}>
-            {{opt.label}}
-          </option>
-        {{else}}
-          <option value={{opt.value}}>
-            {{opt.label}}
-          </option>
-        {{/if}}
+        <PixOption @option={{opt}} @selected={{eq @selectedOption opt.value}} />
       {{/each}}
     </select>
     <FaIcon class="pix-select__icon" @icon="chevron-down" />

--- a/addon/styles/_pix-select-grouped-options.scss
+++ b/addon/styles/_pix-select-grouped-options.scss
@@ -1,0 +1,113 @@
+.pix-select-group {
+  @import 'reset-css';
+
+  position: relative;
+
+  @mixin pixSelectGroup {
+    appearance: none;
+    border: 1px $grey-40 solid;
+    border-radius: 4px;
+    color: $grey-90;
+    font-family: $font-roboto;
+    font-size: 0.875rem;
+    height: 36px;
+    width: 100%;
+    text-overflow: ellipsis;
+
+    @include hoverFormElement();
+    @include focusFormElement();
+    @include focusWithinFormElement();
+  }
+
+  &__search {
+    position: relative;
+  }
+
+  select {
+    @include pixSelectGroup;
+    padding: 0 32px 0 16px;
+
+    &::-ms-expand {
+      display: none;
+    }
+  }
+
+  input {
+    @include pixSelectGroup;
+    padding: 0 8px 0 16px;
+
+    &.pix-select--big {
+      height: 44px;
+    }
+
+    // Remove arrow for Chrome
+    &::-webkit-calendar-picker-indicator {
+      display: none;
+    }
+
+    &:focus {
+      border-radius: 4px 4px 0px 0px;
+    }
+
+    &:read-only {
+      cursor: default;
+    }
+  }
+
+  &__icon {
+    font-size: 11px;
+    color: $grey-30;
+    right: 10px;
+    top: calc(50% + 6px);
+    padding: 0 0 2px;
+    position: absolute;
+    pointer-events: none;
+
+    &--searchable {
+      top: calc(50% - 3px);
+    }
+  }
+
+  &__label {
+    @include label();
+  }
+
+  .pix-select__label ~ .pix-select__icon {
+    top: calc(50% + 6px);
+  }
+
+}
+
+.option-list {
+  position: absolute;
+  width: max-content;
+  list-style: none;
+  color: $white;
+  background-color: $grey-70;
+  border-radius: 0px 0px 4px 4px;
+  width: 100%;
+
+  li {
+    line-height: 36px;
+    cursor: default;
+
+    &.option-list__option {
+      padding: 0 16px;
+      cursor: pointer;
+
+      &:hover {
+        background-color: $blue-hover;
+      }
+    }
+
+    &.option-list__category-title {
+      padding: 0 8px;
+      font-weight: bold;
+    }
+
+  }
+
+  &--hidden {
+    display: none;
+  }
+}

--- a/addon/styles/addon.scss
+++ b/addon/styles/addon.scss
@@ -26,6 +26,7 @@
 @import 'pix-input-password';
 @import 'pix-radio-button';
 @import 'pix-input-code';
+@import 'pix-select-grouped-options';
 
 html {
   font-size: 16px;

--- a/app/components/pix-option.js
+++ b/app/components/pix-option.js
@@ -1,0 +1,1 @@
+export { default } from '@1024pix/pix-ui/components/pix-option';

--- a/app/components/pix-select-grouped-options.js
+++ b/app/components/pix-select-grouped-options.js
@@ -1,0 +1,1 @@
+export { default } from '@1024pix/pix-ui/components/pix-select-grouped-options';

--- a/app/stories/pix-select-grouped-options.stories.js
+++ b/app/stories/pix-select-grouped-options.stories.js
@@ -1,0 +1,101 @@
+import { hbs } from 'ember-cli-htmlbars';
+import { action } from '@storybook/addon-actions';
+
+const Template = (args) => ({
+  template: hbs`
+      <div style="width: 300px">
+        <PixSelectGroupedOptions
+          @id={{id}}
+          @options={{options}}
+          @onChange={{onChange}}
+          @selectedOption={{selectedOption}}
+          @isSearchable={{isSearchable}}
+          @label={{label}}
+          @categories={{categories}}
+        />
+      </div>
+    `,
+  context: args,
+});
+
+export const Default = Template.bind({});
+Default.args = {
+  id: 'pix-select-with-label',
+  label: 'Films',
+  categories: [
+    { name: 'action', label: 'Action' },
+    { name: 'animation', label: 'Animation' },
+    { name: 'horreur', label: 'Horreur' },
+  ],
+  options: [
+    { value: '1', label: 'Die Hard', category: 'action' },
+    { value: '2', label: 'Inception', category: 'action' },
+    { value: '3', label: 'Terminator', category: 'action' },
+    { value: '4', label: 'Princess Mononoké', category: 'animation' },
+    { value: '5', label: 'Le Roi Lion', category: 'animation' },
+    { value: '6', label: 'Spider-Man: New Generation', category: 'animation' },
+    { value: '7', label: 'Alien', category: 'horreur' },
+    { value: '8', label: 'The thing', category: 'horreur' },
+    { value: '9', label: 'Shining', category: 'horreur' },
+  ],
+  onChange: action('onChange'),
+};
+
+export const searchable = Template.bind({});
+searchable.args = {
+  ...Default.args,
+  id: 'pix-select-search',
+  label: 'Films',
+  isSearchable: true,
+  placeholder: 'Fraises, Mangues...',
+};
+
+export const argTypes = {
+  options: {
+    name: 'options',
+    description:
+      'Les options sont représentées par un tableau d‘objet contenant les propriétés ``value`` et ``label``. ``value`` doit être de type ``String`` pour être que le champ puisse être cherchable',
+    type: { name: 'object', required: true },
+  },
+  onChange: {
+    name: 'onChange',
+    description: 'Fonction à appeler si une option est sélectionnée',
+    type: { required: true },
+    control: { disable: true },
+  },
+  selectedOption: {
+    name: 'selectedOption',
+    description: 'Option sélectionnée',
+    options: ['1', '2', '3', '4', '5', '6', '7', '8', '9', '10'],
+    control: { type: 'select' },
+    type: { name: 'string', required: false },
+    table: {
+      type: { summary: 'string' },
+      defaultValue: { summary: null },
+    },
+  },
+  isSearchable: {
+    name: 'isSearchable',
+    description: 'Rend le champ cherchable',
+    control: { type: 'boolean' },
+    type: { name: 'boolean', required: false },
+    table: {
+      type: { summary: 'boolean' },
+      defaultValue: { summary: false },
+    },
+  },
+  label: {
+    name: 'label',
+    description: 'Donne un label au champ, le paramètre @id devient obligatoire avec ce paramètre.',
+    type: { name: 'string', required: true },
+    table: {
+      type: { summary: 'string' },
+      defaultValue: { summary: null },
+    },
+  },
+  categories: {
+    name: 'categories',
+    description: '',
+    type: { name: 'object', required: false },
+  },
+};

--- a/app/stories/pix-select-grouped-options.stories.mdx
+++ b/app/stories/pix-select-grouped-options.stories.mdx
@@ -1,0 +1,49 @@
+import { Meta, Story, Canvas, ArgsTable } from '@storybook/addon-docs/blocks';
+import centered from '@storybook/addon-centered/ember';
+import * as stories from './pix-select-grouped-options.stories.js';
+
+<Meta
+  title='Form/Select Grouped Options'
+  component='PixSelectGroupedOptions'
+  decorators={[centered]}
+  argTypes={stories.argTypes}
+/>
+
+# Pix Select Grouped Options
+
+Affiche un champ Select avec la liste des options fournies, les options sont groupées par catégories et triés
+par ordre alphabétique.
+
+> **⚠️** __N'oubliez pas de rajouter un id et un label rattaché à l'input pour le rendre accessible !
+A défaut d'avoir un label, vous pouvez rajouter l'attribut `aria-label` à l'input.__
+
+> Pour aider l'utilisateur avec le PixSelectGroupedOptions cherchable, rajoutez un placeholder cohérent !
+
+## Default
+
+<Canvas>
+  <Story name="Default" story={stories.Default} height={500} />
+</Canvas>
+
+## Searchable
+
+<Canvas>
+  <Story name="Searchable" story={stories.searchable} height={500} />
+</Canvas>
+
+## Usage
+
+```html
+<PixSelectGroupedOptions
+  @options={{options}}
+  @onChange={{onChange}}
+  @selectedOption="1"
+  @label={{label}}
+  @isSearchable={{false}}
+  @categories={{categories}}
+/>
+```
+
+## Arguments
+
+<ArgsTable story="Grouped options" />

--- a/tests/helpers/query-by-label.js
+++ b/tests/helpers/query-by-label.js
@@ -31,6 +31,7 @@ function _findElementWithLabel(labelText) {
     'button',
     'a[href]',
     '[role="button"]',
+    '[role="option"]',
     'input',
     'textarea',
     'select',

--- a/tests/integration/components/pix-select-grouped-options-test.js
+++ b/tests/integration/components/pix-select-grouped-options-test.js
@@ -1,0 +1,209 @@
+import { module, test } from 'qunit';
+import sinon from 'sinon';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+import fillInByLabel from '../../helpers/fill-in-by-label';
+import clickByLabel from '../../helpers/click-by-label';
+import queryByLabel from '../../helpers/query-by-label';
+
+module('Integration | Component | PixSelectGroupedOptions', function (hooks) {
+  setupRenderingTest(hooks);
+
+  module('when the select is not searchable', function () {
+    test('it returns the selected value', async function (assert) {
+      this.label = 'label';
+      this.options = [
+        { value: '1', label: 'Die Hard', category: 'action' },
+        { value: '2', label: 'Alien', category: 'horreur' },
+      ];
+      this.categories = [
+        { name: 'action', label: 'Action' },
+        { name: 'horreur', label: 'Horreur' },
+      ];
+      this.onChange = sinon.stub();
+
+      await render(hbs`
+        <PixSelectGroupedOptions
+            @id={{'select'}}
+            @label={{this.label}}
+            @options={{this.options}}
+            @categories={{this.categories}}
+            @onChange={{this.onChange}}
+            @isSearchable={{false}}
+          >
+        </PixSelectGroupedOptions>
+      `);
+      await clickByLabel(this.label);
+      await clickByLabel('Alien');
+
+      sinon.assert.calledWith(this.onChange, '2');
+      assert.ok(true);
+    });
+  });
+
+  module('when the select is searchable', function () {
+    test('it returns the selected value', async function (assert) {
+      this.label = 'label';
+      this.options = [
+        { value: '1', label: 'Die Hard', category: 'action' },
+        { value: '2', label: 'Alien', category: 'horreur' },
+      ];
+      this.categories = [
+        { name: 'action', label: 'Action' },
+        { name: 'horreur', label: 'Horreur' },
+      ];
+      this.onChange = sinon.stub();
+
+      await render(hbs`
+        <PixSelectGroupedOptions
+            @id={{'select'}}
+            @label={{this.label}}
+            @options={{this.options}}
+            @categories={{this.categories}}
+            @onChange={{this.onChange}}
+            @isSearchable={{true}}
+          >
+        </PixSelectGroupedOptions>
+      `);
+      await clickByLabel(this.label);
+      await clickByLabel('Alien');
+
+      sinon.assert.calledWith(this.onChange, '2');
+      assert.ok(true);
+    });
+
+    test('it displays the selected value', async function (assert) {
+      this.label = 'label';
+      this.options = [
+        { value: '1', label: 'Die Hard', category: 'action' },
+        { value: '2', label: 'Inception', category: 'action' },
+        { value: '3', label: 'Alien', category: 'horreur' },
+      ];
+      this.categories = [
+        { name: 'action', label: 'Action' },
+        { name: 'horreur', label: 'Horreur' },
+      ];
+      this.onChange = sinon.stub();
+
+      await render(hbs`
+      <PixSelectGroupedOptions
+          @id={{'select'}}
+          @label={{this.label}}
+          @options={{this.options}}
+          @categories={{this.categories}}
+          @onChange={{this.onChange}}
+          @isSearchable={{true}}
+        >
+      </PixSelectGroupedOptions>
+    `);
+
+      await clickByLabel(this.label);
+      await clickByLabel('Inception');
+      const input = await queryByLabel(this.label);
+
+      assert.equal(input.value, 'Inception');
+    });
+
+    module('when the the user search an option', function () {
+      test('it display matching value', async function (assert) {
+        this.label = 'label';
+        this.options = [
+          { value: '1', label: 'Die Hard', category: 'action' },
+          { value: '2', label: 'Inception', category: 'action' },
+          { value: '3', label: 'AlieN', category: 'horreur' },
+        ];
+        this.categories = [
+          { name: 'action', label: 'Action' },
+          { name: 'horreur', label: 'Horreur' },
+        ];
+        this.onChange = sinon.stub();
+
+        await render(hbs`
+        <PixSelectGroupedOptions
+            @id={{'select'}}
+            @label={{this.label}}
+            @options={{this.options}}
+            @categories={{this.categories}}
+            @onChange={{this.onChange}}
+            @isSearchable={{true}}
+          >
+        </PixSelectGroupedOptions>
+      `);
+        await fillInByLabel(this.label, 'n');
+        const dieHardOption = await queryByLabel('Die Hard');
+
+        assert.contains('Inception');
+        assert.contains('AlieN');
+        assert.notOk(dieHardOption);
+      });
+
+      test('it display the searched value', async function (assert) {
+        this.label = 'label';
+        this.options = [
+          { value: '1', label: 'Die Hard', category: 'action' },
+          { value: '2', label: 'Inception', category: 'action' },
+          { value: '3', label: 'AlieN', category: 'horreur' },
+        ];
+        this.categories = [
+          { name: 'action', label: 'Action' },
+          { name: 'horreur', label: 'Horreur' },
+        ];
+        this.onChange = sinon.stub();
+
+        await render(hbs`
+        <PixSelectGroupedOptions
+            @id={{'select'}}
+            @label={{this.label}}
+            @options={{this.options}}
+            @categories={{this.categories}}
+            @onChange={{this.onChange}}
+            @isSearchable={{true}}
+          >
+        </PixSelectGroupedOptions>
+      `);
+        await fillInByLabel(this.label, 'lie');
+
+        assert.contains('lie');
+      });
+
+      test('it clear the searched value when the user stop searching an option', async function (assert) {
+        this.label = 'label';
+        this.options = [
+          { value: '1', label: 'Die Hard', category: 'action' },
+          { value: '2', label: 'Inception', category: 'action' },
+          { value: '3', label: 'Alien', category: 'horreur' },
+        ];
+        this.categories = [
+          { name: 'action', label: 'Action' },
+          { name: 'horreur', label: 'Horreur' },
+        ];
+        this.onChange = sinon.stub();
+
+        await render(hbs`
+          <div>
+            <label for='otherInput'>Other</label>
+            <input id='otherInput' />
+            <PixSelectGroupedOptions
+                @id={{'select'}}
+                @label={{this.label}}
+                @options={{this.options}}
+                @categories={{this.categories}}
+                @onChange={{this.onChange}}
+                @isSearchable={{true}}
+              >
+            </PixSelectGroupedOptions>
+          </div>
+        `);
+
+        await fillInByLabel(this.label, 'cep');
+        await fillInByLabel('Other', 'Je fais autre chose');
+        await clickByLabel(this.label);
+
+        const input = await queryByLabel(this.label);
+
+        assert.equal(input.value, '');
+      });
+    });
+  });
+});


### PR DESCRIPTION
## :unicorn: Description du composant
Ajout d'un composant select avec des groupes d'options qui permet la recherche d'option

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
Il y a un nouveau composant select avec les groupes.
On peut sélectionner une option
On peut chercher une option
Lors de la recherche on affiche uniquement les options qui match la recherche