### PR TITLE
[FEATURE] Création du composant Tag sélectionnable  dans Pix UI (PIX-3757)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,4 @@
 !.idea/runConfigurations/*.xml
 *.iml
 *.code-workspace
+.history

--- a/addon/components/pix-selectable-tag.hbs
+++ b/addon/components/pix-selectable-tag.hbs
@@ -1,0 +1,10 @@
+<div class="pix-selectable-tag {{if this.isChecked " pix-selectable-tag--checked"}}">
+  <input
+    type="checkbox"
+    id={{@id}}
+    onChange={{this.toggleIsChecked}}
+    checked={{this.isChecked}}
+    ...attributes
+  />
+  <label for={{@id}}>{{@label}}</label>
+</div>

--- a/addon/components/pix-selectable-tag.js
+++ b/addon/components/pix-selectable-tag.js
@@ -1,0 +1,13 @@
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+import { action } from '@ember/object';
+
+export default class PixSelectableTag extends Component {
+  @tracked isChecked = this.args.checked;
+
+  @action
+  toggleIsChecked() {
+    this.isChecked = !this.isChecked;
+    return this.args.onChange(this.isChecked);
+  }
+}

--- a/addon/styles/_pix-selectable-tag.scss
+++ b/addon/styles/_pix-selectable-tag.scss
@@ -1,0 +1,86 @@
+$checkmark-width: 0.625rem;
+$checkmark-width-with-space: $checkmark-width + 0.438rem;
+@mixin checkmarkColor($borderColor) {
+  
+  input[type="checkbox"]:checked + label::before {
+    position: absolute;
+    top: 6px;
+    left: 8px;
+    width: $checkmark-width;
+    height: 0.3125rem;
+    border: 2px solid;
+    border-color: $borderColor;
+    border-top: none;
+    border-right: none;
+    transform: rotate(-45deg);
+    content: "";
+  }
+}
+
+.pix-selectable-tag {
+  @import 'reset-css';
+  display: inline-block;
+  text-align: center;
+  position: relative;
+  padding: 3px calc(8px + #{$checkmark-width-with-space} / 2);
+  letter-spacing: 0.009rem;
+  border-radius: 0.75rem;
+  border: $grey-30 solid 1px;
+  color: $grey-60;
+  background-color: $white;
+  font-family: $font-roboto;
+  font-size: 0.8125rem;
+  font-weight: $font-normal;
+  cursor: pointer;
+
+  input {
+    position: absolute;
+    opacity: 0;
+    cursor: pointer;
+  }
+
+  label {
+    cursor: pointer;
+  }
+
+  &:hover {
+    background-color: $grey-22;
+    border: $grey-25 solid 1px;
+    color: $grey-70;
+  }
+  
+  &--checked {
+    @include checkmarkColor($grey-70);
+    border: $grey-22 solid 1px;
+    background-color: $grey-20;
+    color: $grey-70;
+    padding: 3px 8px;
+
+    &:hover {
+      @include checkmarkColor($grey-70);
+      background-color: $grey-22;
+      border: $grey-25 solid 1px;
+      color: $grey-70;
+    }
+
+    & label {
+      padding-left: $checkmark-width-with-space;
+    }
+  }
+
+  &:focus-within {
+    @include checkmarkColor($white);
+    background-color: $blue-zodiac;
+    color: $white;
+    box-shadow: 0 0 0 1px $blue-zodiac;
+    border-color: $white;
+    outline: none;
+
+    &:hover {
+      @include checkmarkColor($grey-70);
+      color: $grey-70;
+      background-color: $grey-22;
+      border: $grey-25 solid 1px;
+    }
+  }
+}

--- a/addon/styles/addon.scss
+++ b/addon/styles/addon.scss
@@ -26,6 +26,7 @@
 @import 'pix-input-password';
 @import 'pix-radio-button';
 @import 'pix-input-code';
+@import 'pix-selectable-tag';
 
 html {
   font-size: 16px;

--- a/app/components/pix-selectable-tag.js
+++ b/app/components/pix-selectable-tag.js
@@ -1,0 +1,1 @@
+export { default } from '@1024pix/pix-ui/components/pix-selectable-tag';

--- a/app/stories/pix-selectable-tag.stories.js
+++ b/app/stories/pix-selectable-tag.stories.js
@@ -1,0 +1,91 @@
+import { hbs } from 'ember-cli-htmlbars';
+
+export const selectableTagDefault = (args) => {
+  return {
+    template: hbs`
+      <PixSelectableTag  
+        @label="non sélectionné"
+        @id="123"
+        @onChange={{onChange}}
+        @checked={{false}}
+      />
+    `,
+    context: args,
+  };
+};
+
+export const selectableTagSelected = (args) => {
+  return {
+    template: hbs`
+      <PixSelectableTag  
+        @label="Sélectionné"
+        @id="456"
+        @onChange={{onChange}}
+        @checked={{true}}
+      />
+    `,
+    context: args,
+  };
+};
+
+export const selectableTagMultiple = (args) => {
+  return {
+    template: hbs`
+      <div style="display:flex;justify-content:space-around;width:400px;height:100%;padding:10px">
+        <PixSelectableTag
+          @label="Lorem ipsum"
+          @id="1"
+          @onChange={{onChange}}
+          @checked={{false}}
+        />
+        <PixSelectableTag
+          @label="Lorem ipsum"
+          @id="2"
+          @onChange={{onChange}}
+          @checked={{false}}
+        />
+        <PixSelectableTag
+          @label="Lorem ipsum"
+          @id="3"
+          @onChange={{onChange}}
+          @checked={{false}}
+        />
+      </div>
+    `,
+    context: args,
+  };
+};
+
+export const argTypes = {
+  label: {
+    name: 'label',
+    description: 'Le label du tag sélectionnable',
+    type: { name: 'string', required: true },
+    table: {
+      type: { summary: 'string' },
+    },
+  },
+  id: {
+    name: 'id',
+    description: "L'id du tag sélectionnable",
+    type: { name: 'string', required: true },
+    table: {
+      type: { summary: 'string' },
+    },
+  },
+  onChange: {
+    name: 'onChange',
+    description: 'Fonction à appeler si le tag est sélectionné',
+    type: { required: true },
+    control: { disable: true },
+  },
+  checked: {
+    name: 'checked',
+    description: 'Indiquez si le tag doit être coché',
+    type: { name: 'boolean', required: true },
+    table: {
+      type: { summary: 'boolean' },
+      defaultValue: { summary: false },
+    },
+  },
+};

--- a/app/stories/pix-selectable-tag.stories.mdx
+++ b/app/stories/pix-selectable-tag.stories.mdx
@@ -1,0 +1,55 @@
+import { Meta, Story, Canvas, ArgsTable } from '@storybook/addon-docs/blocks';
+import centered from '@storybook/addon-centered/ember';
+
+import * as stories from './pix-selectable-tag.stories.js';
+
+<Meta
+  title='basics/Tag/Selectable Tag'
+  component='PixSelectableTag'
+  decorators={[centered]}
+  argTypes={stories.argTypes}
+/>
+
+# Pix Selectable Tag
+
+Un tag permettant de sélectionner ou non la valeur.
+
+##  Default
+
+<Canvas>
+  <Story name='Selectable Tag default' story={stories.selectableTagDefault} height={60} />
+</Canvas>
+
+##  Selected
+
+<Canvas>
+  <Story name='Selectable Tag checked' story={stories.selectableTagSelected} height={60} />
+</Canvas>
+
+## Multiple tags
+<Canvas>
+  <Story name='Selectable Tag multiple' story={stories.selectableTagMultiple} height={60} />
+</Canvas>
+
+## Usage
+
+```html
+Par défaut :
+<PixSelectableTag>
+  @label={{label}}
+  @id={{id}}
+  @onChange={{onChange}}
+</PixSelectableTag>
+
+Tag Sélectionné :
+<PixSelectableTag>
+  @label={{label}}
+  @id={{id}}
+  @onChange={{onChange}}
+  @checked={{true}}
+</PixSelectableTag>
+```
+
+## Arguments
+
+<ArgsTable story="Selectable Tag default" />

--- a/tests/integration/components/pix-selectable-tag-test.js
+++ b/tests/integration/components/pix-selectable-tag-test.js
@@ -1,0 +1,43 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+
+module('Integration | Component | selectable-tag', function (hooks) {
+  setupRenderingTest(hooks);
+
+  test('it renders PixSelectableTag component with label attribute', async function (assert) {
+    // when
+    await render(hbs`
+      <PixSelectableTag @label="test PixSelectableTag">
+        content
+      </PixSelectableTag>
+    `);
+
+    // then
+    assert.contains('test PixSelectableTag');
+  });
+
+  test('it renders PixSelectableTag component with id attribute', async function (assert) {
+    // when
+    await render(hbs`
+      <PixSelectableTag @label="test PixSelectableTag" @id="testId" >
+        content
+      </PixSelectableTag>
+    `);
+
+    // then
+    assert.dom('#testId').exists();
+  });
+  test('it renders PixSelectableTag component with checked attribute', async function (assert) {
+    // when
+    await render(hbs`
+      <PixSelectableTag @label="test PixSelectableTag" @id="testId" @checked=true>
+        content
+      </PixSelectableTag>
+    `);
+
+    // then
+    assert.dom('#testId').isChecked();
+  });
+});


### PR DESCRIPTION
## :unicorn: Description du composant
Une création de campagne comprend le choix du profil cible, cependant il peut y avoir jusqu'au 70 profils cibles  (PC) dans la drop down. On va donc rajouter des catégories pour améliorer le filtre et le choix. En conséquence , le composant flag/tag à été créé afin de pouvoir sélectionner des catégories des profiles cibles et puis les filtrer dans la page de création de campagne


## :rainbow: Remarques
le composant a deux états , Sélectionné et pas sélectionné, la couleur change en fonction de l’état. Bleu pour sélectionner et gris pour pas sélectionner. par défaut le composant est pas sélectionné. 

## :100: Pour tester
- Allez sur storybook
- sélectionnez le composant check box
- constatez qu'il existe en deux états 
- cliquez sur le checkbox et constater qu'il change d'état on click ainsi que la couleur.