### PR TITLE
[TECH] Mise à jour du template de pull request pour faire apparaître plus clairement les BREAKING_CHANGES

### DIFF
--- a/docs/pull_request_template.md
+++ b/docs/pull_request_template.md
@@ -1,3 +1,6 @@
+## :boom: BREAKING_CHANGES
+> _Décrivez ici les changements cassant (voir la doc associée)[https://github.com/1024pix/pix-ui/blob/dev/docs/breaking-changes.stories.mdx], s'il n'y en a pas indiquez le aussi.
+
 ## :christmas_tree: Problème
 > _Décrivez ici le besoin ou l'intention couvert par cette Pull Request._
 

--- a/docs/pull_request_template.md
+++ b/docs/pull_request_template.md
@@ -1,8 +1,11 @@
-## :unicorn: Description du composant
+## :christmas_tree: Problème
 > _Décrivez ici le besoin ou l'intention couvert par cette Pull Request._
 
-## :rainbow: Remarques
+## :gift: Solution
+> _Ajoutez à cet endroit, si nécessaire, des détails concernant la solution technique retenue et mise en oeuvre, des difficultés ou problèmes rencontrés._
+
+## :star2: Remarques
 > _Des infos supplémentaires, trucs et astuces ?_
 
-## :100: Pour tester
-> _Lien vers Zeroheight (modèle) et Storybook (rendu final)._
+## :santa: Pour tester
+> _Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc._


### PR DESCRIPTION
## :boom: BREAKING_CHANGES
Aucun.

## :christmas_tree: Problème
Lors de l'utilisation de Pix-UI nous avons constaté qu'il était difficile de comprendre / d'accéder aux changements cassants d'une montée de version majeure.

## :gift: Solution
Mettre par défaut une section BREAKING_CHANGES dans chaques PR 

## :star2: Remarques
Le lien dans la description dépend de la PR https://github.com/1024pix/pix-ui/pull/178 pour fonctionner.
On en profite pour mettre un thème de Noël sur Pix-UI aussi ❄️ 

## :santa: Pour tester
Faites des PRs !
