### PR TITLE
[TECH] Ajouter la possibilité d'utiliser des composants Ember à l'intérieur de la tooltip (Pix-3925)

### DIFF
--- a/addon/components/pix-tooltip-deprecated.hbs
+++ b/addon/components/pix-tooltip-deprecated.hbs
@@ -1,0 +1,18 @@
+<span class="pix-tooltip" ...attributes>
+
+  {{yield}}
+
+  {{#if @text}}
+    <span
+      id={{@id}}
+      role="tooltip"
+      class="pix-tooltip__content pix-tooltip__content--{{this.position}}
+        {{if @isInline "pix-tooltip__content--inline"}}
+        {{if @isLight "pix-tooltip__content--light"}}
+        {{if @isWide "pix-tooltip__content--wide"}}"
+    >
+      {{this.text}}
+    </span>
+  {{/if}}
+
+</span>

--- a/addon/components/pix-tooltip-deprecated.js
+++ b/addon/components/pix-tooltip-deprecated.js
@@ -1,0 +1,26 @@
+import Component from '@glimmer/component';
+import { htmlSafe } from '@ember/template';
+
+export default class PixTooltipDeprecated extends Component {
+  get position() {
+    const correctsPosition = [
+      'top',
+      'right',
+      'bottom',
+      'bottom-left',
+      'bottom-right',
+      'left',
+      'top-left',
+      'top-right',
+    ];
+    return correctsPosition.includes(this.args.position) ? this.args.position : 'top';
+  }
+
+  get text() {
+    if (this.args.unescapeHtml) {
+      return htmlSafe(this.args.text);
+    } else {
+      return this.args.text;
+    }
+  }
+}

--- a/addon/components/pix-tooltip.hbs
+++ b/addon/components/pix-tooltip.hbs
@@ -1,8 +1,9 @@
 <span class="pix-tooltip" ...attributes>
+  {{#if (has-block "triggerElement")}}
+    {{yield to="triggerElement"}}
+  {{/if}}
 
-  {{yield}}
-
-  {{#if @text}}
+  {{#if (has-block "tooltip")}}
     <span
       id={{@id}}
       role="tooltip"
@@ -11,8 +12,7 @@
         {{if @isLight "pix-tooltip__content--light"}}
         {{if @isWide "pix-tooltip__content--wide"}}"
     >
-      {{this.text}}
+      {{yield to="tooltip"}}
     </span>
   {{/if}}
-
 </span>

--- a/addon/components/pix-tooltip.js
+++ b/addon/components/pix-tooltip.js
@@ -1,5 +1,4 @@
 import Component from '@glimmer/component';
-import { htmlSafe } from '@ember/template';
 
 export default class PixTooltip extends Component {
   get position() {
@@ -14,13 +13,5 @@ export default class PixTooltip extends Component {
       'top-right',
     ];
     return correctsPosition.includes(this.args.position) ? this.args.position : 'top';
-  }
-
-  get text() {
-    if (this.args.unescapeHtml) {
-      return htmlSafe(this.args.text);
-    } else {
-      return this.args.text;
-    }
   }
 }

--- a/app/components/pix-tooltip-deprecated.js
+++ b/app/components/pix-tooltip-deprecated.js
@@ -1,0 +1,1 @@
+export { default } from '@1024pix/pix-ui/components/pix-tooltip-deprecated';

--- a/app/stories/pix-tooltip-deprecated.stories.js
+++ b/app/stories/pix-tooltip-deprecated.stories.js
@@ -1,0 +1,136 @@
+import { hbs } from 'ember-cli-htmlbars';
+
+const Template = (args) => {
+  return {
+    template: hbs`
+      <PixTooltipDeprecated
+        @id="tooltip-1"
+        @text={{this.text}}
+        @position={{this.position}}
+        @isLight={{this.isLight}}
+        @isInline={{this.isInline}}
+        @isWide={{this.isWide}}
+        @unescapeHtml={{this.unescapeHtml}}
+      >
+        <PixButton aria-describedby="tooltip-1">
+          {{this.label}}
+        </PixButton>
+      </PixTooltipDeprecated>
+    `,
+    context: args,
+  };
+};
+
+export const Default = Template.bind({});
+Default.args = {
+  text: 'Hello World',
+  label: 'À survoler pour voir la tooltip',
+};
+
+export const isLight = Template.bind({});
+isLight.args = {
+  ...Default.args,
+  isLight: true,
+};
+
+export const isWide = Template.bind({});
+isWide.args = {
+  ...Default.args,
+  text: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Ut egestas molestie mauris vel viverra.',
+  isWide: true,
+};
+
+export const isInline = Template.bind({});
+isInline.args = {
+  ...Default.args,
+  text: 'Je suis une trèèèèèèèès longue information',
+  isInline: true,
+};
+
+export const left = Template.bind({});
+left.args = {
+  ...Default.args,
+  label: 'Mon infobulle apparaît à gauche',
+  position: 'left',
+  isInline: true,
+};
+
+export const right = Template.bind({});
+right.args = {
+  ...Default.args,
+  label: 'Mon infobulle apparaît à droite',
+  position: 'right',
+  isInline: true,
+};
+
+export const bottom = Template.bind({});
+bottom.args = {
+  ...Default.args,
+  label: 'Mon infobulle apparaît en bas',
+  position: 'bottom',
+};
+
+export const unescapeHtml = Template.bind({});
+unescapeHtml.args = {
+  ...Default.args,
+  text: 'Hello <b style="color: red;">W</b>orld',
+  label: "J'affiche du html",
+  unescapeHtml: true,
+};
+
+export const argTypes = {
+  id: {
+    name: 'id',
+    description: 'Identifiant permettant de référencer le déclencheur via aria-describedby',
+    type: { name: 'string', required: true },
+  },
+  text: {
+    name: 'text',
+    defaultValue: 'Tooltiptop',
+    description: 'Texte à afficher',
+    type: { name: 'string', required: false },
+  },
+  position: {
+    name: 'position',
+    description: 'Position de la tooltip',
+    type: { name: 'string', required: false },
+    table: { defaultValue: { summary: 'top' } },
+    control: {
+      type: 'select',
+      options: [
+        'top',
+        'top-left',
+        'top-right',
+        'right',
+        'bottom',
+        'bottom-left',
+        'bottom-right',
+        'left',
+      ],
+    },
+  },
+  isLight: {
+    name: 'isLight',
+    description: 'Affichage en mode clair',
+    type: { name: 'boolean', required: false },
+    table: { defaultValue: { summary: false } },
+  },
+  isInline: {
+    name: 'isInline',
+    description: 'Affichage en une seule ligne',
+    type: { name: 'boolean', required: false },
+    table: { defaultValue: { summary: false } },
+  },
+  isWide: {
+    name: 'isWide',
+    description: 'Affichage large',
+    type: { name: 'boolean', required: false },
+    table: { defaultValue: { summary: false } },
+  },
+  unescapeHtml: {
+    name: 'unescapeHtml',
+    description: "Évite d'échapper les caractères HTML",
+    type: { name: 'boolean', required: false },
+    table: { defaultValue: { summary: false } },
+  },
+};

--- a/app/stories/pix-tooltip-deprecated.stories.mdx
+++ b/app/stories/pix-tooltip-deprecated.stories.mdx
@@ -1,0 +1,143 @@
+import { Meta, Story, Canvas, ArgsTable } from '@storybook/addon-docs/blocks';
+import centered from '@storybook/addon-centered/ember';
+import * as stories from './pix-tooltip-deprecated.stories.js';
+
+<Meta
+  title='Basics/TooltipDeprecated (3.24 Compliant)'
+  component='PixTooltipDeprecated'
+  decorators={[centered]}
+  argTypes={stories.argTypes}
+/>
+
+# Pix Tooltip
+
+Une infobulle qui s'affiche au survol d'un élément.
+
+Ce composant est utilisé comme wrapper, c'est à dire qu'il encadre l'élément sur lequel on souhaite ajouter une infobulle.
+
+> ⚠️ A noter que le wrapper PixTooltipDeprecated est en `display: flex;`, il s'adaptera donc à la taille de ses enfants. Ainsi si votre élément ne s'affiche plus comme avant après l'ajout de la PixTooltipDeprecated, veillez à rajouter les dimensions voulues à l'enfant.
+
+> ⚠️ L'infobulle ne s'affichera pas si le texte est vide.
+
+## Accessibilité
+
+Les tooltips doivent être appliquées de préférences sur des éléments nativement focusable comme `<button>` ou `<input>`.
+
+Si vous utilisez un élément `<div>` ou `<span>`, il faut ajouter `tabindex="0"` pour qu'il prenne le focus.
+
+```html
+<PixTooltipDeprecated @text="My tooltip">
+  <span tabindex="0">Mon span</span>
+</PixTooltipDeprecated>
+```
+
+Les tooltips doivent prendre un `@id` et être référencées par leur élément déclencheur via `aria-describedby`:
+
+```html
+<PixTooltipDeprecated @id="tooltip-1" @text="My tooltip">
+  <PixButton aria-describedby="tooltip-1">Mon bouton</PixButton>
+</PixTooltipDeprecated>
+```
+
+## Default
+
+Infobulle en position `top`, fond sombre (par défaut).
+
+<Canvas>
+  <Story name="Default" story={stories.Default} height={200} />
+</Canvas>
+
+## Is Light
+
+Infobulle en mode clair.
+
+> ⚠️ le tooltip "light" est à utiliser de préférence sur fond coloré ! Mais ce n'est pas obligatoire.
+
+<Canvas>
+  <Story name="Is Light" story={stories.isLight} height={200} />
+</Canvas>
+
+## Position
+
+Différentes positions de l'infobulle.
+Existe aussi `top-left`, `top-right`, `bottom-left` et `bottom-right`.
+
+<Canvas isColumn>
+  <Story name="Left" story={stories.left} height={100} />
+  <Story name="Right" story={stories.right} height={100} />
+  <Story name="Bottom" story={stories.bottom} height={150} />
+</Canvas>
+
+## Is Wide
+
+Infobulle en plus large.
+
+<Canvas>
+  <Story name="Is Wide" story={stories.isWide} height={200} />
+</Canvas>
+
+## Is Inline
+
+Infobulle dont le contenu reste sur une ligne.
+
+<Canvas>
+  <Story name="Is Inline" story={stories.isInline} height={200} />
+</Canvas>
+
+## unescape HTML
+
+N'échappe pas l'HTML (Affiche du HTML formaté)
+
+<Canvas>
+    <Story name="unescape HTML" story={stories.unescapeHtml} height={200} />
+</Canvas>
+
+## Usage
+
+```html
+<PixTooltipDeprecated
+  @text='Hey'
+>
+  <button>Tooltip par défaut</button>
+</PixTooltipDeprecated>
+
+<PixTooltipDeprecated
+  @text='Hey'
+  @isLight={{true}}
+>
+  <button>Tooltip en mode clair</button>
+</PixTooltipDeprecated>
+
+<PixTooltipDeprecated
+  @text='Hey'
+  @isLight={{true}}
+>
+  <button>Tooltip sur une ligne</button>
+</PixTooltipDeprecated>
+
+<PixTooltipDeprecated
+  @text='Hey'
+  @position='bottom'
+  @isLight={{true}}
+  >
+  <button>Tooltip apparaissant en bas</button>
+</PixTooltipDeprecated>
+
+<PixTooltipDeprecated
+  @text='Hey'
+  @isWide={{true}}
+  >
+  <button>Tooltip en mode large</button>
+</PixTooltipDeprecated>
+
+<PixTooltipDeprecated
+  @text='Super <b style="color: green">i</b>n<b style="color: green">f</b>o'
+  @unescapeHtml={{true}}
+  >
+  <button>Html tooltip</button>
+</PixTooltipDeprecated>
+```
+
+## Arguments
+
+<ArgsTable story="Default" />

--- a/app/stories/pix-tooltip.stories.js
+++ b/app/stories/pix-tooltip.stories.js
@@ -4,17 +4,41 @@ const Template = (args) => {
   return {
     template: hbs`
       <PixTooltip
-        @id="tooltip-1"
-        @text={{this.text}}
+        @id={{this.id}}
         @position={{this.position}}
         @isLight={{this.isLight}}
         @isInline={{this.isInline}}
-        @isWide={{this.isWide}}
-        @unescapeHtml={{this.unescapeHtml}}
-      >
-        <PixButton aria-describedby="tooltip-1">
-          {{this.label}}
-        </PixButton>
+        @isWide={{this.isWide}}>
+        <:triggerElement>
+          <PixButton aria-describedby={{this.id}}>
+            {{this.label}}
+          </PixButton>
+        </:triggerElement>
+
+        <:tooltip>
+          {{this.text}}
+        </:tooltip>
+      </PixTooltip>
+    `,
+    context: args,
+  };
+};
+
+const TemplateWithHTMLElement = (args) => {
+  return {
+    template: hbs`
+      <PixTooltip
+        @id={{this.id}}
+        @isInline=true>
+        <:triggerElement>
+          <PixButton aria-describedby={{this.id}}>
+            {{this.label}}
+          </PixButton>
+        </:triggerElement>
+
+        <:tooltip>
+          <FaIcon @icon="external-link-alt" /> <strong>HTML/Ember</strong>
+        </:tooltip>
       </PixTooltip>
     `,
     context: args,
@@ -30,12 +54,14 @@ Default.args = {
 export const isLight = Template.bind({});
 isLight.args = {
   ...Default.args,
+  id: 'tooltip-light',
   isLight: true,
 };
 
 export const isWide = Template.bind({});
 isWide.args = {
   ...Default.args,
+  id: 'tooltip-wide',
   text: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Ut egestas molestie mauris vel viverra.',
   isWide: true,
 };
@@ -43,6 +69,7 @@ isWide.args = {
 export const isInline = Template.bind({});
 isInline.args = {
   ...Default.args,
+  id: 'tooltip-large',
   text: 'Je suis une trèèèèèèèès longue information',
   isInline: true,
 };
@@ -50,6 +77,7 @@ isInline.args = {
 export const left = Template.bind({});
 left.args = {
   ...Default.args,
+  id: 'tooltip-left',
   label: 'Mon infobulle apparaît à gauche',
   position: 'left',
   isInline: true,
@@ -58,6 +86,7 @@ left.args = {
 export const right = Template.bind({});
 right.args = {
   ...Default.args,
+  id: 'tooltip-right',
   label: 'Mon infobulle apparaît à droite',
   position: 'right',
   isInline: true,
@@ -66,16 +95,14 @@ right.args = {
 export const bottom = Template.bind({});
 bottom.args = {
   ...Default.args,
+  id: 'tooltip-bottom',
   label: 'Mon infobulle apparaît en bas',
   position: 'bottom',
 };
 
-export const unescapeHtml = Template.bind({});
-unescapeHtml.args = {
-  ...Default.args,
-  text: 'Hello <b style="color: red;">W</b>orld',
-  label: "J'affiche du html",
-  unescapeHtml: true,
+export const WithHTML = TemplateWithHTMLElement.bind({});
+WithHTML.args = {
+  label: 'À survoler pour voir la tooltip',
 };
 
 export const argTypes = {
@@ -124,12 +151,6 @@ export const argTypes = {
   isWide: {
     name: 'isWide',
     description: 'Affichage large',
-    type: { name: 'boolean', required: false },
-    table: { defaultValue: { summary: false } },
-  },
-  unescapeHtml: {
-    name: 'unescapeHtml',
-    description: "Évite d'échapper les caractères HTML",
     type: { name: 'boolean', required: false },
     table: { defaultValue: { summary: false } },
   },

--- a/app/stories/pix-tooltip.stories.mdx
+++ b/app/stories/pix-tooltip.stories.mdx
@@ -13,7 +13,7 @@ import * as stories from './pix-tooltip.stories.js';
 
 Une infobulle qui s'affiche au survol d'un élément.
 
-Ce composant est utilisé comme wrapper, c'est à dire qu'il encadre l'élément sur lequel on souhaite ajouter une infobulle.
+Ce composant est utilisé comme wrapper, c'est à dire qu'il encadre l'élément sur lequel on souhaite ajouter une infobulle. L'utilisation de `Named Block` permet d'utiliser des composants HTML facilement dans la tooltip.
 
 > ⚠️ A noter que le wrapper PixTooltip est en `display: flex;`, il s'adaptera donc à la taille de ses enfants. Ainsi si votre élément ne s'affiche plus comme avant après l'ajout de la PixTooltip, veillez à rajouter les dimensions voulues à l'enfant.
 
@@ -26,16 +26,28 @@ Les tooltips doivent être appliquées de préférences sur des éléments nativ
 Si vous utilisez un élément `<div>` ou `<span>`, il faut ajouter `tabindex="0"` pour qu'il prenne le focus.
 
 ```html
-<PixTooltip @text="My tooltip">
-  <span tabindex="0">Mon span</span>
+<PixTooltip>
+  <:triggerElement>
+    <span tabindex="0">Mon span</span>
+  </:triggerElement>
+
+  <:tooltip>
+    My tooltip
+  </:tooltip>
 </PixTooltip>
 ```
 
 Les tooltips doivent prendre un `@id` et être référencées par leur élément déclencheur via `aria-describedby`:
 
 ```html
-<PixTooltip @id="tooltip-1" @text="My tooltip">
-  <PixButton aria-describedby="tooltip-1">Mon bouton</PixButton>
+<PixTooltip @id="tooltip-1">
+  <:triggerElement>
+    <PixButton aria-describedby="tooltip-1">Mon bouton</PixButton>
+  </:triggerElement>
+
+  <:tooltip>
+    My tooltip
+  </:tooltip>
 </PixTooltip>
 ```
 
@@ -84,57 +96,74 @@ Infobulle dont le contenu reste sur une ligne.
   <Story name="Is Inline" story={stories.isInline} height={200} />
 </Canvas>
 
-## unescape HTML
 
-N'échappe pas l'HTML (Affiche du HTML formaté)
+## With HTML
+
+Infobulle contenant des éléments HTML
 
 <Canvas>
-    <Story name="unescape HTML" story={stories.unescapeHtml} height={200} />
+  <Story name="WithHTML" story={stories.WithHTML} height={200} />
 </Canvas>
 
 ## Usage
 
 ```html
-<PixTooltip
-  @text='Hey'
->
-  <button>Tooltip par défaut</button>
+<PixTooltip>
+  <:triggerElement>
+    <button>Tooltip par défaut</button>
+  </:triggerElement>
+  <:tooltip>
+    <FaIcon @icon="external-link-alt" /> Avec des <strong>éléments</strong> HTML/Ember
+  </:tooltip>
 </PixTooltip>
 
 <PixTooltip
-  @text='Hey'
   @isLight={{true}}
 >
-  <button>Tooltip en mode clair</button>
+  <:triggerElement>
+    <button>Tooltip en mode clair</button>
+  </:triggerElement>
+
+  <:tooltip>
+    Hey
+  </:tooltip>
 </PixTooltip>
 
 <PixTooltip
-  @text='Hey'
   @isLight={{true}}
 >
-  <button>Tooltip sur une ligne</button>
+  <:triggerElement>
+    <button>Tooltip sur une ligne</button>
+  </:triggerElement>
+
+  <:tooltip>
+    Hey
+  </:tooltip>
 </PixTooltip>
 
 <PixTooltip
-  @text='Hey'
   @position='bottom'
   @isLight={{true}}
   >
-  <button>Tooltip apparaissant en bas</button>
+  <:triggerElement>
+    <button>Tooltip apparaissant en bas</button>
+  </:triggerElement>
+
+  <:tooltip>
+    Hey
+  </:tooltip>
 </PixTooltip>
 
 <PixTooltip
-  @text='Hey'
   @isWide={{true}}
   >
-  <button>Tooltip en mode large</button>
-</PixTooltip>
+  <:triggerElement>
+    <button>Tooltip en mode large</button>
+  </:triggerElement>
 
-<PixTooltip
-  @text='Super <b style="color: green">i</b>n<b style="color: green">f</b>o'
-  @unescapeHtml={{true}}
-  >
-  <button>Html tooltip</button>
+  <:tooltip>
+    Hey
+  </:tooltip>
 </PixTooltip>
 ```
 

--- a/tests/integration/components/pix-tooltip-test.js
+++ b/tests/integration/components/pix-tooltip-test.js
@@ -15,8 +15,14 @@ module('Integration | Component | pix-tooltip', function (hooks) {
 
     // when
     await render(hbs`
-      <PixTooltip @text={{this.text}}>
-        template block text
+      <PixTooltip>
+        <:triggerElement>
+          template block text
+        </:triggerElement>
+
+        <:tooltip>
+          {{this.text}}
+        </:tooltip>
       </PixTooltip>
     `);
 
@@ -28,7 +34,9 @@ module('Integration | Component | pix-tooltip', function (hooks) {
     // when
     await render(hbs`
       <PixTooltip>
-        template block text
+        <:triggerElement>
+          template block text
+        </:triggerElement>
       </PixTooltip>
     `);
 
@@ -58,7 +66,11 @@ module('Integration | Component | pix-tooltip', function (hooks) {
 
         // when
         await render(hbs`
-          <PixTooltip @position={{this.position}} @text={{this.text}}></PixTooltip>
+          <PixTooltip @position={{this.position}}>
+            <:tooltip>
+              {{this.text}}
+            </:tooltip>
+          </PixTooltip>
         `);
 
         // then
@@ -79,7 +91,10 @@ module('Integration | Component | pix-tooltip', function (hooks) {
 
       // when
       await render(hbs`
-        <PixTooltip @text={{this.text}}>
+        <PixTooltip>
+          <:tooltip>
+            {{this.text}}
+          </:tooltip>
         </PixTooltip>
       `);
 
@@ -95,7 +110,10 @@ module('Integration | Component | pix-tooltip', function (hooks) {
 
       // when
       await render(hbs`
-        <PixTooltip @isLight={{true}} @text={{this.text}}>
+        <PixTooltip @isLight={{true}}>
+          <:tooltip>
+            {{this.text}}
+          </:tooltip>
         </PixTooltip>
       `);
 
@@ -114,7 +132,10 @@ module('Integration | Component | pix-tooltip', function (hooks) {
 
       // when
       await render(hbs`
-        <PixTooltip @text={{this.text}}>
+        <PixTooltip>
+          <:tooltip>
+            {{this.text}}
+          </:tooltip>
         </PixTooltip>
       `);
       const tooltipContentElement = this.element.querySelector(TOOLTIP_SELECTOR);
@@ -130,7 +151,10 @@ module('Integration | Component | pix-tooltip', function (hooks) {
 
       // when
       await render(hbs`
-        <PixTooltip @isInline={{true}} @text={{this.text}}>
+        <PixTooltip @isInline={{true}}>
+          <:tooltip>
+           {{this.text}}
+          </:tooltip>
         </PixTooltip>
       `);
 
@@ -149,7 +173,10 @@ module('Integration | Component | pix-tooltip', function (hooks) {
 
       // when
       await render(hbs`
-        <PixTooltip @text={{this.text}}>
+        <PixTooltip>
+          <:tooltip>
+            {{this.text}}
+          </:tooltip>
         </PixTooltip>
       `);
 
@@ -165,45 +192,16 @@ module('Integration | Component | pix-tooltip', function (hooks) {
 
       // when
       await render(hbs`
-        <PixTooltip @isWide={{true}} @text={{this.text}}>
+        <PixTooltip @isWide={{true}}>
+          <:tooltip>
+            {{this.text}}
+          </:tooltip>
         </PixTooltip>
       `);
 
       // then
       const tooltipContentElement = this.element.querySelector(TOOLTIP_SELECTOR);
       assert.ok(tooltipContentElement.classList.toString().includes(WIDE_CLASS));
-    });
-  });
-
-  module('tooltip unescape html', function () {
-    test('it renders escaped html', async function (assert) {
-      // given
-      const htmlText = '<b>Tooltip</b>';
-      this.set('text', htmlText);
-
-      // when
-      await render(hbs`
-        <PixTooltip @text={{this.text}} @unescapeHtml={{false}}></PixTooltip>
-      `);
-
-      // then
-      const tooltipContentElement = this.element.querySelector(TOOLTIP_SELECTOR);
-      const displayedText = decodeURI(tooltipContentElement.innerHTML.trim());
-      assert.equal(displayedText, '&lt;b&gt;Tooltip&lt;/b&gt;');
-    });
-
-    test('it renders unescaped html', async function (assert) {
-      // given
-      const htmlText = '<b>Tooltip</b>';
-      this.set('text', htmlText);
-
-      // when
-      await render(hbs`
-        <PixTooltip @text={{this.text}} @unescapeHtml={{true}}></PixTooltip>
-      `);
-
-      // then
-      assert.contains('Tooltip');
     });
   });
 });


### PR DESCRIPTION
## :unicorn: Description du composant
Nous avons besoin de pouvoir insérer un template complexe dans la tooltip incluant des composants Ember

Nous sommes partie sur l'ajout de plusieurs `named block` afin de pouvoir faire cela

## :rainbow: Remarques
Breaking Changes Majeur : il faudra changer de version une fois mergé

## :100: Pour tester
> _Lien vers Zeroheight (modèle) et Storybook (rendu final)._
