### PR TITLE
[BUGFIX] Corriger les explications d'utilisations du PixInputCode

### DIFF
--- a/addon/components/pix-input-code.hbs
+++ b/addon/components/pix-input-code.hbs
@@ -1,8 +1,8 @@
 {{! template-lint-disable no-down-event-binding }}
 <div class="pix-input-code">
   <fieldset aria-describedby="pix-input-code__details-of-use">
-    <legend>{{this.legend}}</legend>
     <p id="pix-input-code__details-of-use">{{this.explanationOfUse}}</p>
+    <legend>{{this.legend}}</legend>
     {{#each this.numberOfIterations as |i|}}
       <input
         ...attributes


### PR DESCRIPTION
## :unicorn: Description
Suite au retour de Tanaguru sur le composant pixInputCode, nous avons ajouté une balise <p> masqué qui est lu par les lecteurs d'écran, elle permet d'expliquer les détails d'utilisation de ce composant.

La balise est mal positionné dans le composant, elle doit être placé entre la balise legend et fieldset.

