### PR TITLE
[TECH] Rendre responsive la PixFilterBanner

### DIFF
--- a/addon/components/pix-filter-banner.hbs
+++ b/addon/components/pix-filter-banner.hbs
@@ -3,9 +3,7 @@
     {{#if this.displayTitle}}
       <p class="pix-filter-banner__title">{{@title}}</p>
     {{/if}}
-    <div class="pix-filter-banner__content">
-      {{yield}}
-    </div>
+    {{yield}}
   </div>
   <div class="pix-filter-banner__container-right">
     {{#if this.displayDetails}}

--- a/addon/styles/_pix-filter-banner.scss
+++ b/addon/styles/_pix-filter-banner.scss
@@ -3,9 +3,8 @@
 
   position: relative;
   display: flex;
-  flex-direction: row;
-  justify-content: space-between;
-  align-items: center;
+  flex-direction: column;
+  gap: 6px;
   width: 100%;
 
   background-color: $white;
@@ -15,53 +14,34 @@
 
   &__container-left {
     display: flex;
-    align-items: center;
-    height: 36px;
+    flex-direction: column;
+    gap: 12px;
+    
+    > * > * {
+      width: 100%;
+    }
   }
 
   &__container-right {
     display: flex;
-    align-items: center;
-    justify-content: flex-end;
-    height: 36px;
+    flex-direction: column;
   }
 
   &__title {
     color: $grey-60;
     font-family: $font-roboto;
     font-size: 0.875rem;
-    padding-right: 24px;
     margin: 0;
   }
 
-  &__content {
-    display: flex;
-
-    > * {
-      margin-right: 16px;
-    }
-
-    > *:last-child {
-      margin-right: 0;
-    }
-  }
-
-  &__details {
+  p.pix-filter-banner__details {
     color: $grey-60;
     font-family: $font-roboto;
     font-weight: $font-medium;
-    padding-left: 16px;
     font-size: 0.875rem;
-    margin: 0;
-    margin-right: 16px;
-    height: 18px;
-    padding-top: 4px;
-    text-align: center;
-  }
-
-  &__button-container {
-    border-left: 1px solid $grey-15;
-    padding-left: 16px;
+    margin-top: 10px;
+    padding-top: 10px;
+    border-top: 1px solid $grey-15;
   }
 
   &__button {
@@ -71,4 +51,54 @@
 
 .pix-filter-banner-button__icon {
   padding-right: 4px;
+}
+
+@include device-is('tablet') {
+  .pix-filter-banner {
+    flex-direction: row;
+    justify-content: space-between;
+    align-items: center;
+
+    &__container-left {
+      flex-direction: row;
+      height: 36px;
+      align-items: center;
+    }
+
+    &__container-right {
+      flex-direction: row;
+      height: 36px;
+      align-items: center;
+      justify-content: flex-end;
+    }
+
+    &__content {
+      > * {
+        margin-right: 16px;
+      }
+
+      > *:last-child {
+        margin-right: 0;
+      }
+    }
+
+    &__title {
+      padding-right: 24px;
+      margin: 0;
+    }
+
+    p.pix-filter-banner__details {
+      margin: 0;
+      margin-right: 16px;
+      padding-left: 16px;
+      padding-top: 4px;
+      text-align: center;
+      border: none;
+    }
+
+    &__button-container {
+      border-left: 1px solid $grey-15;
+      padding-left: 16px;
+    }
+  }
 }


### PR DESCRIPTION
## :boom: BREAKING_CHANGES
RAS

## :christmas_tree: Problème
La PixFilterBanner est utilisé sur PixOrga, cependant comme le besoin d'utilisation de PixOrga sur mobile n'est pas fort, cette dernière n'a pas été pensée mobile-first et n'est donc pas responsive.

## :gift: Solution
Evoluer le design de la PixFilterBanner pour la rendre responsive (sur mobile) et appliquer la méthodologie mobile-first.

## :star2: Remarques
> Mobile First Approach refers to the practice of designing and/or developing an online experience for mobile before designing for desktop web or any other device. Taking a Mobile First approach aims to reverse the workflow of designing for desktop and scaling down the design for mobile afterwards.  

Il y a de nombreux avantages à penser mobile-first lors du développement d'un composant, notamment : 
- simplifier l'implémentation responsive d'un composant
- écologique et accessibilité friendly
- contenu plus pertinent / concis
- plus rapide / performant etc.

## :santa: Pour tester
Aller sur storybook, afficher la PixFilterBanner, vérifier que sur toutes les dimensions d'écran elle s'affiche correctement.
