### PR TITLE
[BREAKING_CHANGE] Améliorer l'interface du composant PixMultiSelect

### DIFF
--- a/addon/components/pix-multi-select.hbs
+++ b/addon/components/pix-multi-select.hbs
@@ -5,7 +5,6 @@
     {{/if}}
 
     <span class="pix-multi-select-header">
-      <span class="pix-multi-select-header__title">{{@title}}</span>
       <FaIcon @icon="search" class="pix-multi-select-header__search-icon" />
 
       <input

--- a/addon/components/pix-multi-select.hbs
+++ b/addon/components/pix-multi-select.hbs
@@ -1,12 +1,10 @@
 <div class="pix-multi-select" ...attributes {{on-click-outside this.hideDropDown capture=true}}>
-
-  {{#if this.label}}
-    <label for={{@id}} class="pix-multi-select__label">{{this.label}}</label>
-  {{/if}}
-
   {{#if @isSearchable}}
-    <label class="pix-multi-select-header">
+    {{#if this.label}}
+      <label for={{@id}} class="pix-multi-select__label">{{this.label}}</label>
+    {{/if}}
 
+    <span class="pix-multi-select-header">
       <span class="pix-multi-select-header__title">{{@title}}</span>
       <FaIcon @icon="search" class="pix-multi-select-header__search-icon" />
 
@@ -20,8 +18,7 @@
         {{on "focus" this.focusDropdown}}
         class="pix-multi-select-header__search-input"
       />
-
-    </label>
+    </span>
   {{else}}
     <button
       id={{@id}}
@@ -29,7 +26,7 @@
       class="pix-multi-select-header {{if this.isBig "pix-multi-select-header--big"}}"
       {{on "click" this.toggleDropDown}}
     >
-      {{@title}}
+      {{@label}}
       <FaIcon
         class="pix-multi-select-header__dropdown-icon
           {{if this.isExpanded ' pix-multi-select-header__dropdown-icon--expand'}}"

--- a/addon/components/pix-multi-select.hbs
+++ b/addon/components/pix-multi-select.hbs
@@ -5,7 +5,7 @@
   {{/if}}
 
   {{#if @isSearchable}}
-    <label class="pix-multi-select-header {{if this.isBig 'pix-multi-select-header--big'}}">
+    <label class="pix-multi-select-header">
 
       <span class="pix-multi-select-header__title">{{@title}}</span>
       <FaIcon @icon="search" class="pix-multi-select-header__search-icon" />
@@ -26,7 +26,7 @@
     <button
       id={{@id}}
       type="button"
-      class="pix-multi-select-header {{if this.isBig 'pix-multi-select-header--big'}}"
+      class="pix-multi-select-header {{if this.isBig "pix-multi-select-header--big"}}"
       {{on "click" this.toggleDropDown}}
     >
       {{@title}}

--- a/addon/components/pix-multi-select.hbs
+++ b/addon/components/pix-multi-select.hbs
@@ -7,10 +7,13 @@
     <span class="pix-multi-select-header">
       <FaIcon @icon="search" class="pix-multi-select-header__search-icon" />
 
+      {{! template-lint-disable require-input-label }}
+      {{! https://github.com/ember-template-lint/ember-template-lint/issues/2141 }}
       <input
         id={{@id}}
         type="text"
         name={{@id}}
+        aria-label={{@ariaLabel}}
         placeholder={{this.placeholder}}
         autocomplete="off"
         {{on "input" this.updateSearch}}
@@ -22,7 +25,8 @@
     <button
       id={{@id}}
       type="button"
-      class="pix-multi-select-header {{if this.isBig "pix-multi-select-header--big"}}"
+      class="pix-multi-select-header {{if this.isBig 'pix-multi-select-header--big'}}"
+      aria-label={{@ariaLabel}}
       {{on "click" this.toggleDropDown}}
     >
       {{@label}}

--- a/addon/components/pix-multi-select.js
+++ b/addon/components/pix-multi-select.js
@@ -28,6 +28,12 @@ export default class PixMultiSelect extends Component {
     super(...args);
     const { onLoadOptions, selected } = this.args;
 
+    if (this.args.size) {
+      throw new Error(
+        'ERROR in PixMultiSelect component: @size argument has been removed and must not be used anymore.'
+      );
+    }
+
     if (onLoadOptions) {
       this.isLoadingOptions = true;
       onLoadOptions().then((options = []) => {
@@ -51,10 +57,6 @@ export default class PixMultiSelect extends Component {
       );
     }
     return this.args.label || null;
-  }
-
-  get isBig() {
-    return this.args.size === 'big';
   }
 
   get results() {

--- a/addon/components/pix-multi-select.js
+++ b/addon/components/pix-multi-select.js
@@ -28,6 +28,12 @@ export default class PixMultiSelect extends Component {
     super(...args);
     const { onLoadOptions, selected } = this.args;
 
+    if (this.args.title) {
+      throw new Error(
+        'ERROR in PixMultiSelect component: @title argument has been removed and must not be used anymore. Use @label to display a visible label or aria-label for accessibility.'
+      );
+    }
+
     if (this.args.size) {
       throw new Error(
         'ERROR in PixMultiSelect component: @size argument has been removed and must not be used anymore.'

--- a/addon/styles/_pix-multi-select.scss
+++ b/addon/styles/_pix-multi-select.scss
@@ -78,7 +78,7 @@
 
   &--hidden {
     display: none;
-  }  
+  }
 
   &::-webkit-scrollbar {
     width: 11px;
@@ -103,22 +103,22 @@
     list-style: none;
     font-size: 0.9rem;
 
-    @include hoverFormElement();  
+    @include hoverFormElement();
 
     &--no-result {
       text-align: center;
       padding: 12px 0;
     }
-  
+
     &:last-of-type {
       border-bottom: none;
     }
   }
-  
+
   &__checkbox {
     position: absolute;
     opacity: 0;
-  
+
     & + label {
       position: relative;
       display: flex;
@@ -126,7 +126,7 @@
       padding: 11px 16px;
       cursor: pointer;
     }
-  
+
     & + label:before {
       content: '';
       margin-right: 12px;
@@ -138,12 +138,12 @@
       background: $white;
       border: 1px solid $grey-20;
     }
-        
+
     &:checked + label:before {
       background: $blue;
       border-color: $blue;
     }
-      
+
     &:checked + label:after {
       position: absolute;
       top: calc(50% - 5px);
@@ -162,7 +162,7 @@
       & + label {
         padding: 11px 36px;
       }
-      
+
       &:checked + label:after {
         left: 41px;
       }

--- a/addon/styles/_pix-multi-select.scss
+++ b/addon/styles/_pix-multi-select.scss
@@ -34,13 +34,6 @@
     color: $grey-30;
   }
 
-  &__title {
-    position: absolute;
-    opacity: 0;
-    width: 0;
-    height: 0;
-  }
-
   input.pix-multi-select-header__search-input {
     height: inherit;
     width: 100%;

--- a/addon/styles/_pix-multi-select.scss
+++ b/addon/styles/_pix-multi-select.scss
@@ -30,10 +30,6 @@
   @include hoverFormElement();
   @include focusWithinFormElement();
 
-  &--big {
-    height: 44px;
-  }
-
   &__search-icon {
     color: $grey-30;
   }

--- a/app/stories/pix-multi-select.stories.js
+++ b/app/stories/pix-multi-select.stories.js
@@ -101,12 +101,6 @@ export const argTypes = {
     type: { name: 'string', required: true },
     defaultValue: 'aromate',
   },
-  title: {
-    name: 'title',
-    description: 'Donne un titre à sa liste de choix multiple.',
-    type: { name: 'string', required: true },
-    defaultValue: 'Rechercher un condiment',
-  },
   label: {
     name: 'label',
     description: 'Donne un label au champ, le paramètre @id devient obligatoire avec ce paramètre.',

--- a/app/stories/pix-multi-select.stories.js
+++ b/app/stories/pix-multi-select.stories.js
@@ -24,6 +24,7 @@ export const multiSelectWithChildComponent = (args) => {
         @onSelect={{onSelect}}
         @emptyMessage={{emptyMessage}}
         @label={{label}}
+        @ariaLabel={{ariaLabel}}
         @options={{options}} as |star|
       >
         <PixStars
@@ -52,7 +53,8 @@ export const multiSelectSearchable = (args) => {
       <PixMultiSelect
         style="width:350px"
         @id={{id}}
-        @label="Sélectionner une herbe aromatique"
+        @label={{label}}
+        @ariaLabel={{ariaLabel}}
         @placeholder={{placeholder}}
         @isSearchable={{isSearchable}}
         @showOptionsOnInput={{showOptionsOnInput}}
@@ -78,6 +80,7 @@ export const multiSelectAsyncOptions = (args) => {
         style="width:350px"
         @id={{id}}
         @label={{label}}
+        @ariaLabel={{ariaLabel}}
         @placeholder={{placeholder}}
         @isSearchable={{isSearchable}}
         @showOptionsOnInput={{showOptionsOnInput}}
@@ -104,6 +107,15 @@ export const argTypes = {
   label: {
     name: 'label',
     description: 'Donne un label au champ, le paramètre @id devient obligatoire avec ce paramètre.',
+    type: { name: 'string', required: false },
+    table: {
+      type: { summary: 'string' },
+      defaultValue: { summary: null },
+    },
+  },
+  ariaLabel: {
+    name: 'ariaLabel',
+    description: 'Permet de donner un label accessible au champ (attribut aria-label).',
     type: { name: 'string', required: false },
     table: {
       type: { summary: 'string' },

--- a/app/stories/pix-multi-select.stories.js
+++ b/app/stories/pix-multi-select.stories.js
@@ -60,7 +60,6 @@ export const multiSelectSearchable = (args) => {
         @strictSearch={{strictSearch}}
         @onSelect={{doSomething}}
         @emptyMessage={{emptyMessage}}
-        @size={{size}}
         @selected={{selected}}
         @options={{options}} as |option|
       >
@@ -86,7 +85,6 @@ export const multiSelectAsyncOptions = (args) => {
         @strictSearch={{strictSearch}}
         @onSelect={{doSomething}}
         @emptyMessage={{emptyMessage}}
-        @size={{size}}
         @selected={{selected}}
         @onLoadOptions={{onLoadOptions}} as |option|
       >
@@ -184,16 +182,5 @@ export const argTypes = {
       'Permet de rendre sensible à la casse et au diacritiques lorsque ``isSearchable`` à ``true``',
     type: { name: 'boolean', required: false },
     defaultValue: false,
-  },
-  size: {
-    name: 'size',
-    description:
-      '⚠️ **Propriété dépréciée** ⚠️ , désormais tous les éléments de formulaires feront 36px de hauteur.',
-    options: ['big', 'small'],
-    type: { name: 'string', required: false },
-    table: {
-      type: { summary: 'string' },
-      defaultValue: { summary: 'small' },
-    },
   },
 };

--- a/app/stories/pix-multi-select.stories.js
+++ b/app/stories/pix-multi-select.stories.js
@@ -20,7 +20,6 @@ export const multiSelectWithChildComponent = (args) => {
     template: hbs`
       <h4>⚠️ La sélection des éléments ne fonctionne pas dans Storybook.</h4>
       <PixMultiSelect
-        @title={{titleStars}}
         @id={{id}}
         @onSelect={{onSelect}}
         @emptyMessage={{emptyMessage}}
@@ -38,7 +37,7 @@ export const multiSelectWithChildComponent = (args) => {
 };
 
 multiSelectWithChildComponent.args = {
-  titleStars: 'Sélectionner le niveau souhaité',
+  label: 'Sélectionner le niveau souhaité',
   options: [
     { value: '1', total: 3 },
     { value: '2', total: 3 },
@@ -53,7 +52,7 @@ export const multiSelectSearchable = (args) => {
       <PixMultiSelect
         style="width:350px"
         @id={{id}}
-        @title={{title}}
+        @label="Sélectionner une herbe aromatique"
         @placeholder={{placeholder}}
         @isSearchable={{isSearchable}}
         @showOptionsOnInput={{showOptionsOnInput}}
@@ -78,7 +77,7 @@ export const multiSelectAsyncOptions = (args) => {
       <PixMultiSelect
         style="width:350px"
         @id={{id}}
-        @title={{title}}
+        @label={{label}}
         @placeholder={{placeholder}}
         @isSearchable={{isSearchable}}
         @showOptionsOnInput={{showOptionsOnInput}}

--- a/app/stories/pix-multi-select.stories.mdx
+++ b/app/stories/pix-multi-select.stories.mdx
@@ -41,6 +41,7 @@ Il est possible de donner un message via `loadingMessage` à afficher à la plac
 ```html
 <PixMultiSelect
   @label={{label}}
+  @ariaLabel={{ariaLabel}}
   @emptyMessage={{emptyMessage}}
   @id={{id}}
   @onSelect={{doSomething}}

--- a/app/stories/pix-multi-select.stories.mdx
+++ b/app/stories/pix-multi-select.stories.mdx
@@ -40,7 +40,7 @@ Il est possible de donner un message via `loadingMessage` à afficher à la plac
 
 ```html
 <PixMultiSelect
-  @title={{title}}
+  @label={{label}}
   @emptyMessage={{emptyMessage}}
   @id={{id}}
   @onSelect={{doSomething}}

--- a/tests/helpers/contains.js
+++ b/tests/helpers/contains.js
@@ -2,7 +2,7 @@ import { getRootElement } from '@ember/test-helpers';
 
 function _isTextInElement(element, text) {
   const isTextFoundInElement =
-    element.textContent?.trim().includes(text) || element.value?.trim().includes(text);
+    element.textContent?.trim().includes(text) || element.value?.toString().trim().includes(text);
 
   if (isTextFoundInElement) {
     return true;

--- a/tests/integration/components/pix-multi-select-test.js
+++ b/tests/integration/components/pix-multi-select-test.js
@@ -702,4 +702,20 @@ module('Integration | Component | multi-select', function (hooks) {
     );
     assert.throws(renderComponent, expectedError);
   });
+
+  test('it should throw an error if removed argument title is used', async function (assert) {
+    // given
+    const componentParams = { title: 'MultiSelect', options: DEFAULT_OPTIONS };
+
+    // when
+    const renderComponent = function () {
+      createGlimmerComponent('component:pix-multi-select', componentParams);
+    };
+
+    // then
+    const expectedError = new Error(
+      'ERROR in PixMultiSelect component: @title argument has been removed and must not be used anymore. Use @label to display a visible label or aria-label for accessibility.'
+    );
+    assert.throws(renderComponent, expectedError);
+  });
 });

--- a/tests/integration/components/pix-multi-select-test.js
+++ b/tests/integration/components/pix-multi-select-test.js
@@ -15,7 +15,6 @@ module('Integration | Component | multi-select', function (hooks) {
     { value: '2', label: 'Tomate' },
     { value: '3', label: 'Oignon' },
   ];
-  const LABEL_SELECTOR = '.pix-multi-select__label';
 
   test('it renders PixMultiSelect with list', async function (assert) {
     // given
@@ -23,15 +22,16 @@ module('Integration | Component | multi-select', function (hooks) {
     this.selected = [];
     this.onSelect = (selected) => this.set('selected', selected);
     this.emptyMessage = 'no result';
-    this.title = 'MultiSelectTest';
+    this.label = 'MultiSelectTest';
     this.id = 'id-MultiSelectTest';
 
     // when
     await render(hbs`
       <PixMultiSelect
+        @selected={{selected}}
         @selected={{this.selected}}
         @onSelect={{this.onSelect}}
-        @title={{this.title}}
+        @label={{this.label}}
         @id={{this.id}}
         @emptyMessage={{this.emptyMessage}}
         @options={{this.options}} as |option|>
@@ -51,7 +51,7 @@ module('Integration | Component | multi-select', function (hooks) {
     this.selected = [];
     this.onSelect = (selected) => this.set('selected', selected);
     this.emptyMessage = 'no result';
-    this.title = 'MultiSelectTest';
+    this.label = 'MultiSelectTest';
     this.id = 'id-MultiSelectTest';
 
     // when
@@ -59,17 +59,15 @@ module('Integration | Component | multi-select', function (hooks) {
       <PixMultiSelect
         @selected={{this.selected}}
         @onSelect={{this.onSelect}}
-        @title={{this.title}}
+        @label={{this.label}}
         @id={{this.id}}
-        @label="label"
         @emptyMessage={{this.emptyMessage}}
         @options={{this.options}} as |option|
       >
         {{option.label}}
       </PixMultiSelect>
     `);
-
-    await clickByLabel('label');
+    await clickByLabel('MultiSelectTest');
 
     // then
     const listElement = this.element.querySelectorAll('li');
@@ -85,17 +83,16 @@ module('Integration | Component | multi-select', function (hooks) {
     this.onSelect = (selected) => this.set('selected', selected);
     this.selected = ['2'];
     this.emptyMessage = 'no result';
-    this.title = 'MultiSelectTest';
+    this.label = 'MultiSelectTest';
     this.id = 'id-MultiSelectTest';
 
     // when
     await render(hbs`
       <PixMultiSelect
         @onSelect={{this.onSelect}}
-        @title={{this.title}}
+        @label={{this.label}}
         @id={{this.id}}
         @selected={{this.selected}}
-        @label="label"
         @emptyMessage={{this.emptyMessage}}
         @options={{this.options}} as |option|
       >
@@ -103,7 +100,7 @@ module('Integration | Component | multi-select', function (hooks) {
       </PixMultiSelect>
     `);
 
-    await clickByLabel('label');
+    await clickByLabel('MultiSelectTest');
 
     // then
     const checkboxElement = this.element.querySelectorAll('input[type=checkbox]');
@@ -119,14 +116,14 @@ module('Integration | Component | multi-select', function (hooks) {
     this.onSelect = (selected) => this.set('selected', selected);
     this.selected = ['2', '3'];
     this.emptyMessage = 'no result';
-    this.title = 'MultiSelectTest';
+    this.label = 'MultiSelectTest';
     this.id = 'id-MultiSelectTest';
 
     // when
     await render(hbs`
       <PixMultiSelect
         @onSelect={{this.onSelect}}
-        @title={{this.title}}
+        @label={{this.label}}
         @id={{this.id}}
         @selected={{this.selected}}
         @label="label"
@@ -150,16 +147,15 @@ module('Integration | Component | multi-select', function (hooks) {
     this.selected = ['2'];
     this.onSelect = (selected) => this.set('selected', selected);
     this.emptyMessage = 'no result';
-    this.title = 'MultiSelectTest';
+    this.label = 'MultiSelectTest';
     this.id = 'id-MultiSelectTest';
 
     await render(hbs`
       <PixMultiSelect
         @onSelect={{this.onSelect}}
-        @title={{this.title}}
+        @label={{this.label}}
         @id={{this.id}}
         @selected={{this.selected}}
-        @label="label"
         @emptyMessage={{this.emptyMessage}}
         @options={{this.options}} as |option|>
         {{option.label}}
@@ -168,7 +164,7 @@ module('Integration | Component | multi-select', function (hooks) {
 
     // when
     this.set('selected', []);
-    await clickByLabel('label');
+    await clickByLabel('MultiSelectTest');
 
     // then
     const checkboxElement = this.element.querySelectorAll('input[type=checkbox]');
@@ -181,7 +177,7 @@ module('Integration | Component | multi-select', function (hooks) {
     // given
     this.options = DEFAULT_OPTIONS;
 
-    this.title = 'MultiSelectTest';
+    this.label = 'MultiSelectTest';
     this.emptyMessage = 'no result';
     this.id = 'id-MultiSelectTest';
     this.onSelect = sinon.spy();
@@ -189,9 +185,8 @@ module('Integration | Component | multi-select', function (hooks) {
     await render(hbs`
     <PixMultiSelect
       @onSelect={{this.onSelect}}
-      @title={{this.title}}
+      @label={{this.label}}
       @id={{this.id}}
-      @label="label"
       @emptyMessage={{this.emptyMessage}}
       @options={{this.options}} as |option|>
       {{option.label}}
@@ -199,7 +194,7 @@ module('Integration | Component | multi-select', function (hooks) {
   `);
 
     // when
-    await clickByLabel('label');
+    await clickByLabel('MultiSelectTest');
     await clickByLabel('Salade');
 
     // then
@@ -213,7 +208,7 @@ module('Integration | Component | multi-select', function (hooks) {
     // given
     this.options = DEFAULT_OPTIONS;
 
-    this.title = 'MultiSelectTest';
+    this.label = 'MultiSelectTest';
     this.emptyMessage = 'no result';
     this.selected = ['1', '2'];
     this.id = 'id-MultiSelectTest';
@@ -222,9 +217,8 @@ module('Integration | Component | multi-select', function (hooks) {
     await render(hbs`
       <PixMultiSelect
         @onSelect={{this.onSelect}}
-        @title={{this.title}}
+        @label={{this.label}}
         @id={{this.id}}
-        @label="label"
         @emptyMessage={{this.emptyMessage}}
         @options={{this.options}} as |option|>
         {{option.label}}
@@ -232,7 +226,7 @@ module('Integration | Component | multi-select', function (hooks) {
     `);
 
     // when
-    await clickByLabel('label');
+    await clickByLabel('MultiSelectTest');
     await clickByLabel('Salade');
 
     // then
@@ -246,7 +240,7 @@ module('Integration | Component | multi-select', function (hooks) {
       this.selected = [];
       this.onSelect = (selected) => this.set('selected', selected);
       this.emptyMessage = 'no result';
-      this.title = 'MultiSelectTest';
+      this.label = 'MultiSelectTest';
       this.id = 'id-MultiSelectTest';
       this.isSearchable = true;
       this.placeholder = 'Placeholder test';
@@ -257,10 +251,9 @@ module('Integration | Component | multi-select', function (hooks) {
           @isSearchable={{this.isSearchable}}
           @selected={{this.selected}}
           @onSelect={{this.onSelect}}
-          @title={{this.title}}
+          @label={{this.label}}
           @placeholder={{this.placeholder}}
           @id={{this.id}}
-          @label="label"
           @emptyMessage={{this.emptyMessage}}
           @options={{this.options}} as |option|>
           {{option.label}}
@@ -281,7 +274,6 @@ module('Integration | Component | multi-select', function (hooks) {
       this.selected = [];
       this.onSelect = (selected) => this.set('selected', selected);
       this.emptyMessage = 'no result';
-      this.title = 'MultiSelectTest';
       this.id = 'id-MultiSelectTest';
       this.isSearchable = true;
       this.placeholder = 'Placeholder test';
@@ -291,10 +283,8 @@ module('Integration | Component | multi-select', function (hooks) {
           @isSearchable={{this.isSearchable}}
           @selected={{this.selected}}
           @onSelect={{this.onSelect}}
-          @title={{this.title}}
           @placeholder={{this.placeholder}}
           @id={{this.id}}
-          @label="label"
           @emptyMessage={{this.emptyMessage}}
           @label="Mon multi select"
           @options={{this.options}} as |option|
@@ -318,7 +308,7 @@ module('Integration | Component | multi-select', function (hooks) {
       this.selected = [];
       this.onSelect = (selected) => this.set('selected', selected);
       this.emptyMessage = 'no result';
-      this.title = 'MultiSelectTest';
+      this.label = 'MultiSelectTest';
       this.id = 'id-MultiSelectTest';
       this.isSearchable = true;
       this.strictSearch = true;
@@ -330,7 +320,7 @@ module('Integration | Component | multi-select', function (hooks) {
           @strictSearch={{this.strictSearch}}
           @selected={{this.selected}}
           @onSelect={{this.onSelect}}
-          @title={{this.title}}
+          @label={{this.label}}
           @placeholder={{this.placeholder}}
           @id={{this.id}}
           @emptyMessage={{this.emptyMessage}}
@@ -356,7 +346,7 @@ module('Integration | Component | multi-select', function (hooks) {
       this.selected = [];
       this.onSelect = (selected) => this.set('selected', selected);
       this.emptyMessage = 'no result';
-      this.title = 'MultiSelectTest';
+      this.label = 'MultiSelectTest';
       this.id = 'id-MultiSelectTest';
       this.isSearchable = true;
       this.showOptionsOnInput = true;
@@ -368,7 +358,7 @@ module('Integration | Component | multi-select', function (hooks) {
           @showOptionsOnInput={{this.showOptionsOnInput}}
           @selected={{this.selected}}
           @onSelect={{this.onSelect}}
-          @title={{this.title}}
+          @label={{this.label}}
           @placeholder={{this.placeholder}}
           @id={{this.id}}
           @emptyMessage={{this.emptyMessage}}
@@ -391,7 +381,7 @@ module('Integration | Component | multi-select', function (hooks) {
       this.selected = [];
       this.onSelect = (selected) => this.set('selected', selected);
       this.emptyMessage = 'no result';
-      this.title = 'MultiSelectTest';
+      this.label = 'MultiSelectTest';
       this.id = 'id-MultiSelectTest';
       this.isSearchable = true;
       this.showOptionsOnInput = false;
@@ -403,7 +393,7 @@ module('Integration | Component | multi-select', function (hooks) {
           @showOptionsOnInput={{this.showOptionsOnInput}}
           @selected={{this.selected}}
           @onSelect={{this.onSelect}}
-          @title={{this.title}}
+          @label={{this.label}}
           @placeholder={{this.placeholder}}
           @id={{this.id}}
           @emptyMessage={{this.emptyMessage}}
@@ -426,7 +416,7 @@ module('Integration | Component | multi-select', function (hooks) {
       this.selected = [];
       this.onSelect = (selected) => this.set('selected', selected);
       this.emptyMessage = 'no result';
-      this.title = 'MultiSelectTest';
+      this.label = 'MultiSelectTest';
       this.id = 'id-MultiSelectTest';
       this.isSearchable = true;
       this.placeholder = 'Placeholder test';
@@ -437,7 +427,7 @@ module('Integration | Component | multi-select', function (hooks) {
           @isSearchable={{this.isSearchable}}
           @selected={{this.selected}}
           @onSelect={{this.onSelect}}
-          @title={{this.title}}
+          @label={{this.label}}
           @placeholder={{this.placeholder}}
           @id={{this.id}}
           @emptyMessage={{this.emptyMessage}}
@@ -464,7 +454,7 @@ module('Integration | Component | multi-select', function (hooks) {
       this.selected = [];
       this.onSelect = (selected) => this.set('selected', selected);
       this.emptyMessage = 'no result';
-      this.title = 'MultiSelectTest';
+      this.label = 'MultiSelectTest';
       this.id = 'id-MultiSelectTest';
       this.isSearchable = true;
       this.placeholder = 'Placeholder test';
@@ -474,9 +464,8 @@ module('Integration | Component | multi-select', function (hooks) {
           @isSearchable={{this.isSearchable}}
           @selected={{this.selected}}
           @onSelect={{this.onSelect}}
-          @title={{this.title}}
+          @label={{this.label}}
           @placeholder={{this.placeholder}}
-          @label="label"
           @id={{this.id}}
           @emptyMessage={{this.emptyMessage}}
           @options={{this.options}} as |option|>
@@ -485,7 +474,7 @@ module('Integration | Component | multi-select', function (hooks) {
       `);
 
       // when
-      await clickByLabel('label');
+      await clickByLabel('MultiSelectTest');
       await clickByLabel(DEFAULT_OPTIONS[1].label);
 
       // then
@@ -502,7 +491,6 @@ module('Integration | Component | multi-select', function (hooks) {
       this.selected = [];
       this.onSelect = (selected) => this.set('selected', selected);
       this.emptyMessage = 'no result';
-      this.title = 'MultiSelectTest';
       this.id = 'id-MultiSelectTest';
       this.isSearchable = true;
       this.placeholder = 'Placeholder test';
@@ -512,7 +500,6 @@ module('Integration | Component | multi-select', function (hooks) {
           @isSearchable={{this.isSearchable}}
           @selected={{this.selected}}
           @onSelect={{this.onSelect}}
-          @title={{this.title}}
           @placeholder={{this.placeholder}}
           @id={{this.id}}
           @emptyMessage={{this.emptyMessage}}
@@ -541,7 +528,7 @@ module('Integration | Component | multi-select', function (hooks) {
       this.selected = [];
       this.onSelect = (selected) => this.set('selected', selected);
       this.emptyMessage = 'no result';
-      this.title = 'MultiSelectTest';
+      this.label = 'MultiSelectTest';
       this.id = 'id-MultiSelectTest';
       this.isSearchable = true;
       this.placeholder = 'Placeholder test';
@@ -551,7 +538,6 @@ module('Integration | Component | multi-select', function (hooks) {
           @isSearchable={{this.isSearchable}}
           @selected={{this.selected}}
           @onSelect={{this.onSelect}}
-          @title={{this.title}}
           @placeholder={{this.placeholder}}
           @id={{this.id}}
           @emptyMessage={{this.emptyMessage}}
@@ -581,7 +567,7 @@ module('Integration | Component | multi-select', function (hooks) {
       this.selected = ['2'];
       this.onSelect = (selected) => this.set('selected', selected);
       this.emptyMessage = 'no result';
-      this.title = 'MultiSelectTest';
+      this.label = 'MultiSelectTest';
       this.id = 'id-MultiSelectTest';
       this.isSearchable = true;
       this.placeholder = 'Placeholder test';
@@ -591,10 +577,9 @@ module('Integration | Component | multi-select', function (hooks) {
           @isSearchable={{this.isSearchable}}
           @selected={{this.selected}}
           @onSelect={{this.onSelect}}
-          @title={{this.title}}
+          @label={{this.label}}
           @placeholder={{this.placeholder}}
           @id={{this.id}}
-          @label="label"
           @emptyMessage={{this.emptyMessage}}
           @showOptionsOnInput={{true}}
           @options={{this.options}} as |option|>
@@ -603,7 +588,7 @@ module('Integration | Component | multi-select', function (hooks) {
       `);
 
       // when
-      await clickByLabel('label');
+      await clickByLabel('MultiSelectTest');
 
       const listElement = this.element.querySelectorAll('.pix-multi-select-list__item');
       assert.equal(listElement.item(0).textContent.trim(), 'Tomate');
@@ -623,7 +608,7 @@ module('Integration | Component | multi-select', function (hooks) {
       this.selected = [];
       this.onSelect = (selected) => this.set('selected', selected);
       this.emptyMessage = 'no result';
-      this.title = 'MultiSelectTest';
+      this.label = 'MultiSelectTest';
       this.id = 'id-MultiSelectTest';
       this.isSearchable = true;
       this.placeholder = 'Placeholder test';
@@ -633,7 +618,6 @@ module('Integration | Component | multi-select', function (hooks) {
           @isSearchable={{this.isSearchable}}
           @selected={{this.selected}}
           @onSelect={{this.onSelect}}
-          @title={{this.title}}
           @placeholder={{this.placeholder}}
           @id={{this.id}}
           @emptyMessage={{this.emptyMessage}}
@@ -661,25 +645,6 @@ module('Integration | Component | multi-select', function (hooks) {
     });
   });
 
-  test('it should be possible to give a label', async function (assert) {
-    // given
-    this.options = DEFAULT_OPTIONS;
-    this.selected = [];
-    this.onSelect = (selected) => this.set('selected', selected);
-    await render(hbs`
-      <PixMultiSelect
-        @id="pix-select-with-label"
-        @label="Votre choix:"
-        @options={{this.options}}
-        @onChange={{this.onSelect}}
-      />
-    `);
-
-    // when & then
-    const selectorElement = this.element.querySelector(LABEL_SELECTOR);
-    assert.equal(selectorElement.innerHTML, 'Votre choix:');
-  });
-
   test('it should throw an error if no id is provided when there is a label', async function (assert) {
     // given
     const componentParams = { id: '   ', label: 'Votre choix: ', options: DEFAULT_OPTIONS };
@@ -700,7 +665,7 @@ module('Integration | Component | multi-select', function (hooks) {
     this.selected = [];
     this.onSelect = (selected) => this.set('selected', selected);
     this.emptyMessage = 'no result';
-    this.title = 'MultiSelectTest';
+    this.label = 'MultiSelectTest';
     this.id = 'id-MultiSelectTest';
 
     // when
@@ -708,7 +673,7 @@ module('Integration | Component | multi-select', function (hooks) {
       <PixMultiSelect
         @selected={{this.selected}}
         @onSelect={{this.onSelect}}
-        @title={{this.title}}
+        @label={{this.label}}
         @id={{this.id}}
         @emptyMessage={{this.emptyMessage}}
         @onLoadOptions={{this.onLoadOptions}} as |option|>

--- a/tests/integration/components/pix-multi-select-test.js
+++ b/tests/integration/components/pix-multi-select-test.js
@@ -23,6 +23,7 @@ module('Integration | Component | multi-select', function (hooks) {
     this.onSelect = (selected) => this.set('selected', selected);
     this.emptyMessage = 'no result';
     this.label = 'MultiSelectTest';
+    this.ariaLabel = 'This label is for accessibility';
     this.id = 'id-MultiSelectTest';
 
     // when
@@ -32,6 +33,7 @@ module('Integration | Component | multi-select', function (hooks) {
         @selected={{this.selected}}
         @onSelect={{this.onSelect}}
         @label={{this.label}}
+        @ariaLabel={{ariaLabel}}
         @id={{this.id}}
         @emptyMessage={{this.emptyMessage}}
         @options={{this.options}} as |option|>
@@ -43,6 +45,7 @@ module('Integration | Component | multi-select', function (hooks) {
     const listElement = this.element.querySelectorAll('li');
     assert.contains('MultiSelectTest');
     assert.equal(listElement.length, 3);
+    assert.dom('button[aria-label="This label is for accessibility"]').exists();
   });
 
   test('it renders the PixMultiSelect with empty message', async function (assert) {
@@ -241,6 +244,7 @@ module('Integration | Component | multi-select', function (hooks) {
       this.onSelect = (selected) => this.set('selected', selected);
       this.emptyMessage = 'no result';
       this.label = 'MultiSelectTest';
+      this.ariaLabel = 'This label is for accessibility';
       this.id = 'id-MultiSelectTest';
       this.isSearchable = true;
       this.placeholder = 'Placeholder test';
@@ -252,6 +256,7 @@ module('Integration | Component | multi-select', function (hooks) {
           @selected={{this.selected}}
           @onSelect={{this.onSelect}}
           @label={{this.label}}
+          @ariaLabel={{ariaLabel}}
           @placeholder={{this.placeholder}}
           @id={{this.id}}
           @emptyMessage={{this.emptyMessage}}
@@ -266,6 +271,7 @@ module('Integration | Component | multi-select', function (hooks) {
       assert.contains('MultiSelectTest');
       assert.equal(inputElement.placeholder, this.placeholder);
       assert.equal(listElement.length, 3);
+      assert.dom('input[aria-label="This label is for accessibility"]').exists();
     });
 
     test('it should renders filtered given case insensitive', async function (assert) {

--- a/tests/integration/components/pix-multi-select-test.js
+++ b/tests/integration/components/pix-multi-select-test.js
@@ -721,4 +721,20 @@ module('Integration | Component | multi-select', function (hooks) {
     assert.contains('MultiSelectTest');
     assert.equal(listElement.length, 3);
   });
+
+  test('it should throw an error if removed argument size is used', async function (assert) {
+    // given
+    const componentParams = { size: 'big', options: DEFAULT_OPTIONS };
+
+    // when
+    const renderComponent = function () {
+      createGlimmerComponent('component:pix-multi-select', componentParams);
+    };
+
+    // then
+    const expectedError = new Error(
+      'ERROR in PixMultiSelect component: @size argument has been removed and must not be used anymore.'
+    );
+    assert.throws(renderComponent, expectedError);
+  });
 });


### PR DESCRIPTION
## :boom: BREAKING_CHANGES

- L'argument `@title` du `PixMultiSelect` a été supprimé et ne doit plus être utilisé. Utilisez à la place l'argument `@label` pour un libellé visible et `aria-label` pour un libellé accessible. 
- L'argument `@size` du `PixMultiSelect` a été supprimé (cf. Remarques) et ne doit plus être utilisé. Ce composant a désormais une taille unique (correspondant à l'ancien `small`).

## :christmas_tree: Problème

Il existe une confusion autour des paramètres `@label` et `@title` du `PixMultiSelect` qui font un peu la même chose mais parfois non :

- l'argument `@title` est utilisé comme libellé affiché en mode normal, mais masqué en mode searchable 
- l'argument `@label` ajoute un élément html `label`, ce qui n'a pas de sens en mode normal (car un bouton n'a pas besoin de label) et redondant en mode searchable car le composant est déjà wrappé dans un label
- l'attribut `aria-label` n'est pas pris en compte en mode searchable 

## :gift: Solution

Simplifier l'interface du composant de manière à pouvoir l'utiliser comme suit : 

```hbs
<PixMultiSelect
  @label="Filtrer"
  @ariaLabel="Filtrer la liste des élèves en cochant la ou les classes souhaitées"
  …
>
</PixMultiSelect>
```

c'est-à-dire :

TODO
- [x] supprimer l'argument `@title` et utiliser uniquement l'argument `@label` pour les libellés dans les deux modes
- [x] retirer l'élément `label` qui entoure le composant en mode searchable pour éviter la redondance
- [x] ajouter un argument `@ariaLabel` pour l'accessibilité

## :star2: Remarques

L'argument `@size`, déjà déprécié, a également été supprimé, afin de regrouper dans la même release les breaking changes concernant ce composant.

## :santa: Pour tester

- Installer cette branche de Pix UI dans une app ember Pix `npm install "git://github.com/1024pix/pix-ui#remove-multi-select-title-and-size-arguments" --save-dev`
- Instancier un `PixMultiSelect` avec l'argument `@title` et vérifier qu'une erreur est lancée
- Instancier un `PixMultiSelect` avec l'argument `@size` et vérifier qu'une erreur est lancée
- Instancier un `PixMultiSelect` avec l'argument `@label` et vérifier que le label est visible
- Instancier un `PixMultiSelect` avec l'argument `@ariaLabel` et vérifier que le bouton a un `aria-label` (idéalement avec un lecteur d'écran)
