### PR TITLE
[BUGFIX] Désactiver l'autocomplete sur le composant Pix Select [BREAKING_CHANGES] (PIX-4158)

### DIFF
--- a/addon/components/pix-select.hbs
+++ b/addon/components/pix-select.hbs
@@ -12,6 +12,7 @@
       {{on "input" this.onChange}}
       class="{{if this.isValid "pix-select--is-valid"}} {{if this.isBig "pix-select--big"}}"
       ...attributes
+      autocomplete="off"
     />
 
     <datalist id={{this.datalistId}}>

--- a/tests/integration/components/pix-select-test.js
+++ b/tests/integration/components/pix-select-test.js
@@ -132,6 +132,21 @@ module('Integration | Component | select', function (hooks) {
       assert.equal(options.item(1).label, 'Tomate');
     });
 
+    test('it should keep autocomplete off even if pix select receive the "auto-complete=on" attribute', async function (assert) {
+      // given
+      this.options = DEFAULT_OPTIONS;
+      this.isSearchable = true;
+
+      // when
+      await render(
+        hbs`<PixSelect @options={{options}} @isSearchable={{isSearchable}} autocomplete="on"/>`
+      );
+
+      // then
+      const input = this.element.querySelector(SEARCHABLE_SELECT_SELECTOR);
+      assert.equal(input.autocomplete, 'off');
+    });
+
     module('green validation', function () {
       test('it should not have a green border', async function (assert) {
         // given


### PR DESCRIPTION
## :boom: BREAKING_CHANGES
`autocomplete="off"` est un attribut par défaut de PixSelect isSerachable. L'attribut ne peut être changé.

## :christmas_tree: Problème
Dû fait qu'on autorisait l'autocomplete, quand on filtrait les profiles cibles avec les tags , on pouvait voir des PC qui ne devrait pas apparaître

## :gift: Solution
 Désactiver l'autocomplete sur les tags sélectionnables 

## :star2: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :santa: Pour tester
