### PR TITLE
[BUGFIX] Rendre tout le tag sélectionnable (PIX-4179)

### DIFF
--- a/addon/styles/_pix-selectable-tag.scss
+++ b/addon/styles/_pix-selectable-tag.scss
@@ -37,6 +37,10 @@ $checkmark-width-with-space: $checkmark-width + 0.438rem;
     position: absolute;
     opacity: 0;
     cursor: pointer;
+    width: 100%;
+    height: 100%;
+    left: 0;
+    top: 0;
   }
 
   label {


### PR DESCRIPTION
## :boom: BREAKING_CHANGES
Pas de breaking changes, juste une agrandissement de la zone cliquable.

## :christmas_tree: Problème
Le tag n'était cliquable qu'au niveau du wording.

## :gift: Solution
Faire en sorte de pouvoir cliquer sur tout le tag (même en dehors du wording).

## :star2: Remarques


## :santa: Pour tester
> _Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc._
