### PR TITLE
[BREAKING_CHANGES] Input / InputPassword missing event on onChange (PIX-4243)

### DIFF
--- a/addon/components/pix-input-password.hbs
+++ b/addon/components/pix-input-password.hbs
@@ -20,7 +20,6 @@
       type={{if this.isPasswordVisible "text" "password"}}
       value={{@value}}
       aria-label={{this.ariaLabel}}
-      {{on "change" this.onChange}}
       ...attributes
     />
 

--- a/addon/components/pix-input-password.js
+++ b/addon/components/pix-input-password.js
@@ -26,9 +26,4 @@ export default class PixInputPassword extends PixInput {
   togglePasswordVisibility() {
     this.isPasswordVisible = !this.isPasswordVisible;
   }
-
-  @action
-  onChange() {
-    if (typeof this.args.onChange === 'function') this.args.onChange();
-  }
 }

--- a/addon/components/pix-input.hbs
+++ b/addon/components/pix-input.hbs
@@ -7,13 +7,7 @@
   {{/if}}
 
   <div class="pix-input__container">
-    <input
-      id={{this.id}}
-      class={{this.className}}
-      value={{@value}}
-      {{on "change" this.onChange}}
-      ...attributes
-    />
+    <input id={{this.id}} class={{this.className}} value={{@value}} ...attributes />
 
     {{#if @errorMessage}}
       <FaIcon @icon="times" class="pix-input__error-icon" />

--- a/addon/components/pix-input.js
+++ b/addon/components/pix-input.js
@@ -1,9 +1,6 @@
 import Component from '@glimmer/component';
 
-import { action } from '@ember/object';
 export default class PixInput extends Component {
-  text = 'pix-input';
-
   get id() {
     if (!this.args.id || !this.args.id.toString().trim()) {
       throw new Error('ERROR in PixInput component, @id param is not provided');
@@ -17,10 +14,5 @@ export default class PixInput extends Component {
     this.args.icon && classNames.push('pix-input__input--icon');
     this.args.isIconLeft && classNames.push('pix-input__input--icon-left');
     return classNames.join(' ');
-  }
-
-  @action
-  onChange() {
-    if (typeof this.args.onChange === 'function') this.args.onChange();
   }
 }

--- a/addon/styles/_pix-input.scss
+++ b/addon/styles/_pix-input.scss
@@ -59,10 +59,8 @@
   }
 
   input {
-    display: flex;
+    width: 100%;
     height: 36px;
-    flex-direction: column;
-    justify-content: center;
     border: 1px solid $grey-40;
 
     @include input();

--- a/app/stories/pix-input-password.stories.mdx
+++ b/app/stories/pix-input-password.stories.mdx
@@ -60,7 +60,6 @@ Si vous utilisez le `PixInputPassword` sans label alors il faut renseigner le pa
   @value='{{value}}'
   @errorMessage='{{errorMessage}}'
   @prefix='{{prefix}}'
-  @onChange='{{onChange}}'
 />
 ```
 

--- a/app/stories/pix-input.stories.mdx
+++ b/app/stories/pix-input.stories.mdx
@@ -48,8 +48,7 @@ Le PixInput permet de créer un champ de texte.
   @information='Complément du label'
   @errorMessage="Un message d'erreur"
   @icon="eye"
-  @isIconLeft={{false}}
-  @onChange={{onChange}} />
+  @isIconLeft={{false}} />
 ```
 
 ## Arguments

--- a/tests/integration/components/pix-input-password-test.js
+++ b/tests/integration/components/pix-input-password-test.js
@@ -2,10 +2,8 @@ import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { render } from '@ember/test-helpers';
 
-import fillInByLabel from '../../helpers/fill-in-by-label';
 import { hbs } from 'ember-cli-htmlbars';
 import createGlimmerComponent from '../../helpers/create-glimmer-component';
-import sinon from 'sinon';
 
 module('Integration | Component | pix-input-password', function (hooks) {
   setupRenderingTest(hooks);
@@ -105,21 +103,5 @@ module('Integration | Component | pix-input-password', function (hooks) {
     // then
     const selectorElement = this.element.querySelector(INPUT_SELECTOR);
     assert.equal(selectorElement.value, 'pix123');
-  });
-
-  module('Attributes @onChange', function () {
-    test('it calls onChange event while typing', async function (assert) {
-      // given
-      this.onChange = sinon.spy();
-      // when
-      await render(
-        hbs`<PixInputPassword @label="Mot de passe" @id="password" @onChange={{this.onChange}}/>`
-      );
-
-      await fillInByLabel('Mot de passe', 'Jeanne');
-
-      // then
-      assert.ok(this.onChange.called);
-    });
   });
 });

--- a/tests/integration/components/pix-input-test.js
+++ b/tests/integration/components/pix-input-test.js
@@ -4,7 +4,6 @@ import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import createGlimmerComponent from '../../helpers/create-glimmer-component';
 import fillInByLabel from '../../helpers/fill-in-by-label';
-import sinon from 'sinon';
 
 module('Integration | Component | input', function (hooks) {
   setupRenderingTest(hooks);
@@ -101,19 +100,5 @@ module('Integration | Component | input', function (hooks) {
     // then
     const selectorElement = this.element.querySelector(INPUT_SELECTOR);
     assert.equal(selectorElement.autocomplete, 'on');
-  });
-
-  module('Attributes @onChange', function () {
-    test('it calls onChange event while typing', async function (assert) {
-      // given
-      this.onChange = sinon.spy();
-      // when
-      await render(hbs`<PixInput @label="Prénom" @id="firstName" @onChange={{this.onChange}}/>`);
-
-      await fillInByLabel('Prénom', 'Jeanne');
-
-      // then
-      assert.ok(this.onChange.called);
-    });
   });
 });


### PR DESCRIPTION
## :boom: BREAKING_CHANGES
 L’argument `@onChange` est supprimé, utilisez à la place l’attribut standard `{{on 'change' yourFunction}}`.

## :christmas_tree: Problème
On montant de version Pix-UI sur Pix Orga, je me suis rendu compte que le onChange ne fonctionnait pas (effectivement, on passe par un sous fonction qui ne prend pas l'event onChange en argument

## :gift: Solution
Passer dirrectement par la fonction passée en paramètre.
Correction d'un problème de width sur le pix-input à l'affichage dans Pix Orga

![input_bug](https://user-images.githubusercontent.com/33637571/151153985-f4640436-328c-4ad8-9b60-f33935360021.png)

## :star2: Remarques
Nous supprimons l’argument onChange , il est plus pertinent que ce soit l’application qui décide quel `event `il veut utiliser pour remonter les données

## :santa: Pour tester
