### PR TITLE
[TECH] Améliorer le blueprint pour auto-générer les nouveaux composants.

### DIFF
--- a/blueprints/pix-component/files/app/stories/pix-__name__.stories.js
+++ b/blueprints/pix-component/files/app/stories/pix-__name__.stories.js
@@ -1,14 +1,19 @@
 import { hbs } from 'ember-cli-htmlbars';
 
-export const <%= camelizedModuleName %> = (args) => {
+export const Template = (args) => {
   return {
     template: hbs`
-      <Pix<%= classifiedModuleName %>>
-        TODO
-      </Pix<%= classifiedModuleName %>>
+      <Pix<%= classifiedModuleName %>
+        <!-- TODO -->
+      />
     `,
     context: args,
   };
+};
+
+export const Default = Template.bind({});
+Default.args = {
+  // TODO
 };
 
 // TODO: add component attributes information

--- a/blueprints/pix-component/files/app/stories/pix-__name__.stories.mdx
+++ b/blueprints/pix-component/files/app/stories/pix-__name__.stories.mdx
@@ -15,17 +15,17 @@ import * as stories from './pix-<%= dasherizedModuleName %>.stories.js';
 TODO: insert component description
 
 <Canvas>
-  <Story name='Pix<%= classifiedModuleName %>' story={stories.<%= camelizedModuleName %>} height={60} />
+  <Story name='Default' story={stories.Default} height={60} />
 </Canvas>
 
 ## Usage
 
 ```html
-<Pix<%= classifiedModuleName %>>
-  TODO: add component attributes
-</Pix<%= classifiedModuleName %>>
+<Pix<%= classifiedModuleName %>
+  <!-- TODO -->
+/>
 ```
 
 ## Arguments
 
-<ArgsTable story="Pix<%= classifiedModuleName %>" />
+<ArgsTable story="Default" />

--- a/blueprints/pix-component/files/tests/integration/components/pix-__name__-test.js
+++ b/blueprints/pix-component/files/tests/integration/components/pix-__name__-test.js
@@ -11,9 +11,9 @@ module('Integration | Component | <%= dasherizedModuleName %>', function(hooks) 
   test('it renders the default Pix<%= classifiedModuleName %>', async function(assert) {
     // when
     await render(hbs`
-      <Pix<%= classifiedModuleName %>>
-        content
-      </Pix<%= classifiedModuleName %>>
+      <Pix<%= classifiedModuleName %>
+        <!-- TODO -->
+      />
     `);
     const componentElement = this.element.querySelector(COMPONENT_SELECTOR);
 


### PR DESCRIPTION
## :unicorn: Explication
Amélioration du blueprint pour rendre plus évidents les endroits à modifier

## :100: Pour tester
Lancer la commande `ember g pix-component nomDuComposant` et vérifier les fichiers générés
