### PR TITLE
[FEAT] Permettre à la tooltip de ne pas s'afficher (PIX-4375)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@
 - [#94](https://github.com/1024pix/pix-ui/pull/94) [FEATURE] Ajout du composant PixModal
 
 ### :bug: Bug fix
-- [#186](https://github.com/1024pix/pix-ui/pull/186) [BUGFIX] Désactiver l'autocomplete sur le composant Pix Select (PIX-4158)
+- [#186](https://github.com/1024pix/pix-ui/pull/186) [BREAKING_CHANGES] Désactiver l'autocomplete sur le composant Pix Select (PIX-4158)
 - [#187](https://github.com/1024pix/pix-ui/pull/187) [BUGFIX] Rendre tout le tag sélectionnable (PIX-4179)
 
 ## v11.2.0 (14/01/2022)
@@ -32,7 +32,7 @@
 
 
 ### :building_construction: Tech
-- [#175](https://github.com/1024pix/pix-ui/pull/175) [TECH] Faire en sorte que le message d'erreur soit situé à l'intérieur de l'élément qui le compose (PIX-3829)
+- [#175](https://github.com/1024pix/pix-ui/pull/175) [BREAKING_CHANGES] Faire en sorte que le message d'erreur soit situé à l'intérieur de l'élément qui le compose (PIX-3829)
 
 ## v11.0.1 (08/12/2021)
 
@@ -50,12 +50,12 @@
 - [#177](https://github.com/1024pix/pix-ui/pull/177) [FEATURE] Création du composant Tag sélectionnable  dans Pix UI (PIX-3757)
 
 ### :building_construction: Tech
-- [#180](https://github.com/1024pix/pix-ui/pull/180) [TECH] Ajouter la possibilité d'utiliser des composants Ember à l'intérieur de la tooltip (Pix-3925)
+- [#180](https://github.com/1024pix/pix-ui/pull/180) [BREAKING_CHANGES] Ajouter la possibilité d'utiliser des composants Ember à l'intérieur de la tooltip (Pix-3925)
 - [#179](https://github.com/1024pix/pix-ui/pull/179) [TECH] Mise à jour du template de pull request pour faire apparaître plus clairement les BREAKING_CHANGES
 - [#148](https://github.com/1024pix/pix-ui/pull/148) [TECH] Formatter les fichiers avec prettier (PIX-3469)
 
 ### :bug: Bug fix
-- [#147](https://github.com/1024pix/pix-ui/pull/147) [BUGFIX] Ajout de l'évènement onChange afin de supprimer le message d'erreur lorsque l'utilisateur modifie sa saisie (PIX-3476)
+- [#147](https://github.com/1024pix/pix-ui/pull/147) [BREAKING_CHANGES] Ajout de l'évènement onChange afin de supprimer le message d'erreur lorsque l'utilisateur modifie sa saisie (PIX-3476)
 
 ### :coffee: Various
 - [#178](https://github.com/1024pix/pix-ui/pull/178) [DOC] Améliorer l'information sur les breaking changes dans Pix UI

--- a/addon/components/pix-tooltip.hbs
+++ b/addon/components/pix-tooltip.hbs
@@ -4,15 +4,17 @@
   {{/if}}
 
   {{#if (has-block "tooltip")}}
-    <span
-      id={{@id}}
-      role="tooltip"
-      class="pix-tooltip__content pix-tooltip__content--{{this.position}}
-        {{if @isInline 'pix-tooltip__content--inline'}}
-        {{if @isLight 'pix-tooltip__content--light'}}
-        {{if @isWide 'pix-tooltip__content--wide'}}"
-    >
-      {{yield to="tooltip"}}
-    </span>
+    {{#if this.display}}
+      <span
+        id={{@id}}
+        role="tooltip"
+        class="pix-tooltip__content pix-tooltip__content--{{this.position}}
+          {{if @isInline 'pix-tooltip__content--inline'}}
+          {{if @isLight 'pix-tooltip__content--light'}}
+          {{if @isWide 'pix-tooltip__content--wide'}}"
+      >
+        {{yield to="tooltip"}}
+      </span>
+    {{/if}}
   {{/if}}
 </span>

--- a/addon/components/pix-tooltip.js
+++ b/addon/components/pix-tooltip.js
@@ -14,4 +14,8 @@ export default class PixTooltip extends Component {
     ];
     return correctsPosition.includes(this.args.position) ? this.args.position : 'top';
   }
+
+  get display() {
+    return typeof this.args.hide === 'undefined' || !this.args.hide;
+  }
 }

--- a/app/stories/pix-tooltip.stories.js
+++ b/app/stories/pix-tooltip.stories.js
@@ -8,7 +8,8 @@ const Template = (args) => {
         @position={{this.position}}
         @isLight={{this.isLight}}
         @isInline={{this.isInline}}
-        @isWide={{this.isWide}}>
+        @isWide={{this.isWide}}
+        @hide={{this.hide}}>
         <:triggerElement>
           <PixButton aria-describedby={{this.id}}>
             {{this.label}}
@@ -100,6 +101,13 @@ bottom.args = {
   position: 'bottom',
 };
 
+export const hide = Template.bind({});
+hide.args = {
+  label: 'À survoler pour voir la tooltip',
+  text: "Ne devrait pas s'afficher",
+  hide: true,
+};
+
 export const WithHTML = TemplateWithHTMLElement.bind({});
 WithHTML.args = {
   label: 'À survoler pour voir la tooltip',
@@ -151,6 +159,12 @@ export const argTypes = {
   isWide: {
     name: 'isWide',
     description: 'Affichage large',
+    type: { name: 'boolean', required: false },
+    table: { defaultValue: { summary: false } },
+  },
+  hide: {
+    name: 'hide',
+    description: 'Masquer la tooltip',
     type: { name: 'boolean', required: false },
     table: { defaultValue: { summary: false } },
   },

--- a/app/stories/pix-tooltip.stories.mdx
+++ b/app/stories/pix-tooltip.stories.mdx
@@ -61,6 +61,13 @@ Les tooltips doivent prendre un `@id` et être référencées par leur élément
 </PixTooltip>
 ```
 
+## Hide
+
+Cache la tooltip (par exemple si le contenu est vide).
+
+<Canvas>
+  <Story name="Hide" story={stories.hide} height={200} />
+</Canvas>
 
 ## Default
 
@@ -158,6 +165,18 @@ Infobulle contenant des éléments HTML
   >
   <:triggerElement>
     <button>Tooltip apparaissant en bas</button>
+  </:triggerElement>
+
+  <:tooltip>
+    Hey
+  </:tooltip>
+</PixTooltip>
+
+<PixTooltip
+  @hide={{true}}
+  >
+  <:triggerElement>
+    <button>Tooltip n'apparaissant pas</button>
   </:triggerElement>
 
   <:tooltip>

--- a/tests/integration/components/pix-tooltip-test.js
+++ b/tests/integration/components/pix-tooltip-test.js
@@ -46,6 +46,23 @@ module('Integration | Component | pix-tooltip', function (hooks) {
     assert.notOk(tooltipContentElement);
   });
 
+  test('it renders only the inner data if hide is true', async function (assert) {
+    // when
+    await render(hbs`
+      <PixTooltip @hide={{true}}>
+        <:triggerElement>
+          template block text
+        </:triggerElement>
+        <:tooltip></:tooltip>
+      </PixTooltip>
+    `);
+
+    // then
+    const tooltipContentElement = this.element.querySelector(TOOLTIP_SELECTOR);
+    assert.contains('template block text');
+    assert.notOk(tooltipContentElement);
+  });
+
   module('tooltip position', function () {
     const TOOLTIP_POSITION_SELECTOR = 'pix-tooltip__content--';
 


### PR DESCRIPTION
## :christmas_tree: Problème
La tooltip s'affiche toujours, même si le contenu est vide

## :gift: Solution
Ajouter une option 'hide' pour cacher/desactiver sur demande le tooltip

## :star2: Remarques
Il serait plus simple de cacher la tooltip si le contenu est vide mais ce n'est pas possible avec les _named blocks_ de récupérer le contenu

C'etait possible avant le version 11 de pix-ui ([PR](https://github.com/1024pix/pix-ui/pull/180))

## :santa: Pour tester
Ajouter l'option @hide={{false}} et voir que la tooltip s'affiche. 
Passer à true et constater qu'elle ne s'affiche plus
(dans la "vrai vie", le true/false sera dynamique)

