### PR TITLE
[FEATURE] Permettre de rendre obligatoire le PixDropdown

### DIFF
--- a/addon/components/pix-dropdown.hbs
+++ b/addon/components/pix-dropdown.hbs
@@ -1,7 +1,14 @@
 <div class="pix-dropdown">
+
   {{#if this.label}}
-    <label id={{@id}} class="pix-dropdown__label">{{this.label}}</label>
+    <label id={{@id}} class="pix-dropdown__label">
+      {{#if @requiredLabel}}
+        <abbr title={{@requiredLabel}} class="mandatory-mark" aria-hidden="true">*</abbr>
+      {{/if}}
+      {{this.label}}
+    </label>
   {{/if}}
+
   <div class="pix-dropdown__controller">
     <button
       type="button"
@@ -9,15 +16,16 @@
       aria-label={{if this.isExpanded @collapseLabel @expandLabel}}
       {{on "click" this.toggleDropdown}}
       {{on "keyup" this.navigateThroughOptions}}
+      ...attributes
     >
       <p
         title={{this.placeholder}}
-        class="pix-dropdown__controller--placeholder-text{{unless
-            this.hasSelectedOption
-            ' default'
-          }}"
+        class="pix-dropdown__controller--placeholder-text
+          {{unless this.hasSelectedOption ' default'}}"
+        aria-required={{if this.requiredLabel true false}}
       >{{this.placeholder}}</p>
     </button>
+
     {{#if this.hasSelectedOption}}
       <button
         type="button"
@@ -28,11 +36,13 @@
         <FaIcon @icon="times" />
       </button>
     {{/if}}
+
     <FaIcon
       class="pix-dropdown__controller--chevron"
       @icon={{if this.isExpanded "chevron-up" "chevron-down"}}
     />
   </div>
+
   <div
     role="listbox"
     id={{this.menuId}}
@@ -45,6 +55,7 @@
     {{on "keyup" this.navigateThroughOptions}}
     {{on "scroll" this.incrementPage}}
   >
+
     {{#if @isSearchable}}
       <div class="pix-dropdown__menu--search">
         <FaIcon class="pix-dropdown__menu--search-icon" @icon="search" />
@@ -62,6 +73,7 @@
         />
       </div>
     {{/if}}
+
     {{#each this.options as |opt index|}}
       {{#if (lt index this.showLimit)}}
         <div
@@ -82,4 +94,5 @@
       {{/if}}
     {{/each}}
   </div>
+
 </div>

--- a/addon/components/pix-dropdown.hbs
+++ b/addon/components/pix-dropdown.hbs
@@ -37,10 +37,14 @@
       </button>
     {{/if}}
 
-    <FaIcon
+    <button
+      tabindex="-1"
+      type="button"
       class="pix-dropdown__controller--chevron"
-      @icon={{if this.isExpanded "chevron-up" "chevron-down"}}
-    />
+      {{on "click" this.toggleDropdown}}
+    >
+      <FaIcon @icon={{if this.isExpanded "chevron-up" "chevron-down"}} />
+    </button>
   </div>
 
   <div

--- a/addon/styles/_form.scss
+++ b/addon/styles/_form.scss
@@ -66,3 +66,10 @@
     margin-right: 10px;
   }
 }
+
+abbr.mandatory-mark {
+  cursor: help;
+  color: $pink-alert-dark;
+  text-decoration: none;
+  border: none;
+}

--- a/addon/styles/_pix-dropdown.scss
+++ b/addon/styles/_pix-dropdown.scss
@@ -4,7 +4,6 @@
   position: relative;
 
   button {
-    background: transparent;
     margin: 0;
     text-align: left;
     cursor: pointer;
@@ -27,7 +26,7 @@
       border: 1px solid $grey-40;
       border-radius: $spacing-xxs;
       padding: 0;
-      background: white;
+      background: $white;
 
       &.expanded {
         border-bottom-left-radius: 0;
@@ -50,6 +49,7 @@
     }
 
     &--clear {
+      background: transparent;
       font-size: 1rem;
       color: $grey-50;
       position: absolute;
@@ -66,11 +66,18 @@
     }
 
     &--chevron {
+      background: transparent;
+      border: none;
+      padding: 0;
       position: absolute;
-      z-index: -1;
-      top: 9px;
+      top: 9.5px;
       right: 12px;
       color: $grey-50;
+      font-size: 1rem;
+
+      &:hover {
+        color: $grey-70;
+      }
     }
   }
 

--- a/addon/styles/_reset-css.scss
+++ b/addon/styles/_reset-css.scss
@@ -28,9 +28,3 @@ caption, th, td
 	vertical-align: top;
 	font-weight: normal;
 }
-
-abbr, acronym
-{
-	border-bottom: .1em dotted;
-	cursor: help;
-}

--- a/app/stories/pix-dropdown.stories.js
+++ b/app/stories/pix-dropdown.stories.js
@@ -18,6 +18,7 @@ export const Template = (args) => {
           @expandLabel={{expandLabel}}
           @collapseLabel={{collapseLabel}}
           @pageSize={{pageSize}}
+          @requiredLabel={{requiredLabel}}
         />
       </div>
     `,
@@ -54,6 +55,7 @@ withLabel.args = {
   ...Default.args,
   id: 'dropdown-with-label',
   label: 'Ton fruit préféré: ',
+  requiredLabel: 'Champ requis',
 };
 
 export const searchableDropdown = Template.bind({});
@@ -132,6 +134,15 @@ export const argTypes = {
   label: {
     name: 'label',
     description: 'Label du menu déroulant, le paramètre @id devient obligatoire avec ce paramètre.',
+    type: { name: 'string', required: false },
+    table: {
+      type: { summary: 'string' },
+    },
+  },
+  requiredLabel: {
+    name: 'requiredLabel',
+    description:
+      'Label indiquant que le champ est requis, le paramètre @label devient obligatoire avec ce paramètre.',
     type: { name: 'string', required: false },
     table: {
       type: { summary: 'string' },

--- a/app/stories/pix-dropdown.stories.mdx
+++ b/app/stories/pix-dropdown.stories.mdx
@@ -57,6 +57,7 @@ Les options sont représentées par un tableau d'objet contenant les propriété
   @placeholder="Choisissez une option"
   @searchPlaceholder="Rechercher"
   @label="Mon menu déroulant"
+  @requiredLabel="Requis"
   @clearLabel="Supprimer la sélection"
   @expandLabel="Ouvrir le menu déroulant"
   @collapseLabel="Réduire le menu déroulant"

--- a/tests/integration/components/pix-dropdown-test.js
+++ b/tests/integration/components/pix-dropdown-test.js
@@ -34,6 +34,24 @@ module('Integration | Component | dropdown', function (hooks) {
     assert.dom(screen.queryByLabelText('Supprimer la sélection')).doesNotExist();
   });
 
+  test('it should be possible to make pix dropdown required', async function (assert) {
+    // given & when
+    const screen = await render(hbs`
+      <PixDropdown
+        @id="pix-dropdown"
+        @options={{this.options}}
+        @label="Mon menu déroulant"
+        @clearLabel="Supprimer la sélection"
+        @expandLabel="Ouvrir le menu déroulant"
+        @collapseLabel="Réduire le menu déroulant"
+        @requiredLabel="Champ obligatoire"
+      />
+    `);
+
+    // then
+    assert.dom(screen.getByLabelText('* Mon menu déroulant')).exists();
+  });
+
   module('selection', () => {
     test('it allows to select an option and renders a clear button', async function (assert) {
       // given


### PR DESCRIPTION
## :boom: BREAKING_CHANGES
Une partie du reset CSS a été supprimée, ceci concerne les balises `abbr` et `acronym`. Cependant ces changements n'impactent que les composants Pix-UI et il n'y a aucun composant existant les utilisants ces balises, donc cela ne devrait pas impacter les anciens composants. 

## :christmas_tree: Problème
Il n'est pas possible de rendre le PixDropdown obligatoire.
De plus, ce dernier est transparent par défaut , ce qui créé une différence avec les autres champs de formulaires : 
<img width="539" alt="image" src="https://user-images.githubusercontent.com/38167520/154701050-86d758f5-4ae8-48d3-8195-878139cd083f.png">


## :gift: Solution
Ajouter une option pour labeliser le fait que le champ PixDropdown peut être obligatoire.
Ajouter la couleur de background blanc.

## :star2: Remarques
Etant donné que les balises utilisés pour se composant ne sont pas des balises de formulaire classique le comportement de validation de formulaire par défaut ne fonctionnera pas.
_Exemple : mettre le PixDropdown dans un <form>. Rendre le PixDropdown obligatoire. Ne pas remplir le PixDropdown et soumettre le formulaire. Le formulaire est soumis même si le champ est obligatoire._

## :santa: Pour tester
- Rajouter l'attribut @requiredLabel
- Constater qu'une petite étoile est rajouté au label avec la mention "obligatoire"


- Changer la couleur du fond sur laquelle vous utilisez le PixDropdown
- Constater que le champ a bien un fond blanc

- Vérifier les non régression du comportement du composant
