### PR TITLE
[BUGFIX] Corriger la couleur de la sélection et l'erreur d'accessibilité.

### DIFF
--- a/addon/components/pix-dropdown.hbs
+++ b/addon/components/pix-dropdown.hbs
@@ -30,21 +30,21 @@
       <button
         type="button"
         class="pix-dropdown__controller--clear"
-        {{on "click" this.clearSelection}}
         aria-label={{@clearLabel}}
+        {{on "click" this.clearSelection}}
       >
         <FaIcon @icon="times" />
       </button>
     {{/if}}
 
-    <button
+    <div
+      role="button"
       tabindex="-1"
-      type="button"
       class="pix-dropdown__controller--chevron"
       {{on "click" this.toggleDropdown}}
     >
       <FaIcon @icon={{if this.isExpanded "chevron-up" "chevron-down"}} />
-    </button>
+    </div>
   </div>
 
   <div

--- a/addon/styles/_pix-dropdown.scss
+++ b/addon/styles/_pix-dropdown.scss
@@ -35,6 +35,7 @@
     }
 
     &--placeholder-text {
+      color: $grey-90;
       margin: 0;
       font-size: 0.875rem;
       overflow: hidden;
@@ -70,10 +71,10 @@
       border: none;
       padding: 0;
       position: absolute;
-      top: 9.5px;
+      top: 9px;
       right: 12px;
       color: $grey-50;
-      font-size: 1rem;
+      cursor: pointer;
 
       &:hover {
         color: $grey-70;


### PR DESCRIPTION
## :unicorn: Problème
La couleur du texte quand une sélection est faite n'est pas la bonne et le bouton autour du chevron a des erreurs d'accessibilité

## :robot: Solution
Rajouter un aria-label au bouton et mettre la bonne couleur pour le texte

## :santa: Pour tester
Verifier Wave et la couleur après avoir sélectionné une option
