### PR TITLE
[BUGFIX] Corriger l'alignement dans le header de la Pix Modal.

### DIFF
--- a/addon/styles/_pix-modal.scss
+++ b/addon/styles/_pix-modal.scss
@@ -27,14 +27,13 @@ $button-margin: 16px;
     border-top-left-radius: 4px;
     border-top-right-radius: 4px;
     padding: $modal-padding;
-    position: relative;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
   }
 
   &__close-button {
     flex-shrink: 0;
-    right: $modal-padding;
-    position: absolute;
-    top: $modal-padding;
 
     @include device-is('tablet') {
       height: $tablet-close-button-size;


### PR DESCRIPTION
## :unicorn: Problème
Le bouton close n'est pas aligné avec le titre

## :robot: Solution
Ajuster le css pour bien le centré

## :100: Pour tester
Ouvrir la RA et verifier la modal
