### PR TITLE
[BUGFIX] Aligner la modal dans le centre de la fenêtre.

### DIFF
--- a/addon/styles/_pix-modal.scss
+++ b/addon/styles/_pix-modal.scss
@@ -17,7 +17,7 @@ $button-margin: 16px;
 .pix-modal {
   @import "reset-css";
   box-shadow: 1px 1px 5px rgba(0,0,0,.1);
-  margin: 20vw auto;
+  margin: 20vh auto;
   max-width: 512px;
   width: calc(100% - 24px);
 
@@ -28,12 +28,13 @@ $button-margin: 16px;
     border-top-right-radius: 4px;
     padding: $modal-padding;
     display: flex;
-    align-items: center;
+    align-items: flex-start;
     justify-content: space-between;
   }
 
   &__close-button {
     flex-shrink: 0;
+    margin-top: -4px;
 
     @include device-is('tablet') {
       height: $tablet-close-button-size;


### PR DESCRIPTION
## :unicorn: Problème
La modal n'est pas alignée dans le centre et le bouton close doit rester vers le haut quand le titre s'étale sur plusieurs lignes.

## :robot: Solution
Corriger l'alignement de la modal avec un display flex et changer l'alignement du header en flex-start.

## :100: Pour tester
Verifier le composant pix modal dans la RA