### PR TITLE
[FEATURE] Permettre de rendre Pix Input et Pix Input Password obligatoires (PIX-4138).

### DIFF
--- a/addon/components/pix-input-password.hbs
+++ b/addon/components/pix-input-password.hbs
@@ -1,6 +1,11 @@
 <div class="pix-input-password">
   {{#if this.label}}
-    <label for={{this.id}} class="pix-input__label">{{this.label}}</label>
+    <label for={{this.id}} class="pix-input__label">
+      {{#if @requiredLabel}}
+        <abbr title={{@requiredLabel}} class="mandatory-mark" aria-hidden="true">*</abbr>
+      {{/if}}
+      {{this.label}}
+    </label>
   {{/if}}
   {{#if @information}}
     <label for={{this.id}} class="pix-input__information">{{@information}}</label>
@@ -20,6 +25,8 @@
       type={{if this.isPasswordVisible "text" "password"}}
       value={{@value}}
       aria-label={{this.ariaLabel}}
+      aria-required="{{if @requiredLabel true false}}"
+      required={{if @requiredLabel true false}}
       ...attributes
     />
 

--- a/addon/components/pix-input.hbs
+++ b/addon/components/pix-input.hbs
@@ -1,13 +1,25 @@
 <div class="pix-input">
   {{#if @label}}
-    <label for={{this.id}} class="pix-input__label">{{@label}}</label>
+    <label for={{this.id}} class="pix-input__label">
+      {{#if @requiredLabel}}
+        <abbr title={{@requiredLabel}} class="mandatory-mark" aria-hidden="true">*</abbr>
+      {{/if}}
+      {{@label}}
+    </label>
   {{/if}}
   {{#if @information}}
     <label for={{this.id}} class="pix-input__information">{{@information}}</label>
   {{/if}}
 
   <div class="pix-input__container">
-    <input id={{this.id}} class={{this.className}} value={{@value}} ...attributes />
+    <input
+      id={{this.id}}
+      class={{this.className}}
+      value={{@value}}
+      aria-required="{{if @requiredLabel true false}}"
+      required={{if @requiredLabel true false}}
+      ...attributes
+    />
 
     {{#if @errorMessage}}
       <FaIcon @icon="times" class="pix-input__error-icon" />

--- a/app/stories/form.stories.js
+++ b/app/stories/form.stories.js
@@ -5,7 +5,7 @@ export const form = (args) => {
   return {
     template: hbs`
     <form>
-      <PixInput @id='firstName' @label='Prénom' @errorMessage={{genericErrorMessage}} />
+      <PixInput @id='firstName' @label='Prénom' @errorMessage={{genericErrorMessage}} @requiredLabel='champ obligatoire'/>
       <br>
       <PixInputPassword @id='password' @label='Mot de passe' @errorMessage={{genericErrorMessage}} />
       <br>

--- a/app/stories/pix-input-password.stories.js
+++ b/app/stories/pix-input-password.stories.js
@@ -10,6 +10,7 @@ export const Template = (args) => {
         @information={{information}}
         @errorMessage={{errorMessage}}
         @prefix={{prefix}}
+        @requiredLabel={{requiredLabel}}
       />
     `,
     context: args,
@@ -41,6 +42,13 @@ withPrefix.args = {
   id: 'password',
   label: 'Mot de passe',
   prefix: 'C -',
+};
+
+export const withRequiredLabel = Template.bind({});
+withRequiredLabel.args = {
+  id: 'password',
+  label: 'Mot de passe',
+  requiredLabel: 'Champ obligatoire',
 };
 
 export const argTypes = {
@@ -85,5 +93,14 @@ export const argTypes = {
     description: 'Affiche un préfixe avant la zone de saisie du champ',
     type: { name: 'string', required: false },
     defaultValue: null,
+  },
+  requiredLabel: {
+    name: 'requiredLabel',
+    description:
+      'Label indiquant que le champ est requis, le paramètre @label devient obligatoire avec ce paramètre.',
+    type: { name: 'string', required: false },
+    table: {
+      type: { summary: 'string' },
+    },
   },
 };

--- a/app/stories/pix-input-password.stories.mdx
+++ b/app/stories/pix-input-password.stories.mdx
@@ -41,7 +41,7 @@ Si vous utilisez le `PixInputPassword` sans label alors il faut renseigner le pa
 ## With error message
 
 <Canvas>
-  <Story story={stories.withErrorMessage} height={130} />
+  <Story story={stories.withErrorMessage} height={100} />
 </Canvas>
 
 ## With prefix
@@ -50,16 +50,23 @@ Si vous utilisez le `PixInputPassword` sans label alors il faut renseigner le pa
   <Story story={stories.withPrefix} height={100} />
 </Canvas>
 
+## With required label
+
+<Canvas>
+  <Story story={stories.withRequiredLabel} height={100} />
+</Canvas>
+
 ## Usage
 
 ```html
 <PixInputPassword
-  @id='{{id}}'
-  @label='{{label}}'
-  @information='{{information}}'
-  @value='{{value}}'
-  @errorMessage='{{errorMessage}}'
-  @prefix='{{prefix}}'
+  @id='password'
+  @label='Mot de passe'
+  @information='8 caractères dont une majuscule...'
+  @value='pix123'
+  @errorMessage='Le mot de passe est erroné'
+  @prefix='C-'
+  @requiredLabel='Champ obligatoire'
 />
 ```
 

--- a/app/stories/pix-input.stories.js
+++ b/app/stories/pix-input.stories.js
@@ -10,7 +10,9 @@ export const Template = (args) => {
         @errorMessage={{errorMessage}}
         @icon={{icon}}
         @isIconLeft={{isIconLeft}}
-        placeholder='Jeanne, Pierre ...' />
+        placeholder='Jeanne, Pierre ...'
+        @requiredLabel={{requiredLabel}}
+      />
     `,
     context: args,
   };
@@ -41,6 +43,13 @@ withIcon.args = {
   id: 'firstName',
   label: 'Prénom',
   icon: 'eye',
+};
+
+export const withRequiredLabel = Template.bind({});
+withRequiredLabel.args = {
+  id: 'firstName',
+  label: 'Prénom',
+  requiredLabel: 'Champ obligatoire',
 };
 
 export const argTypes = {
@@ -89,6 +98,15 @@ export const argTypes = {
     table: {
       type: { summary: 'boolean' },
       defaultValue: { summary: 'false' },
+    },
+  },
+  requiredLabel: {
+    name: 'requiredLabel',
+    description:
+      'Label indiquant que le champ est requis, le paramètre @label devient obligatoire avec ce paramètre.',
+    type: { name: 'string', required: false },
+    table: {
+      type: { summary: 'string' },
     },
   },
 };

--- a/app/stories/pix-input.stories.mdx
+++ b/app/stories/pix-input.stories.mdx
@@ -39,6 +39,12 @@ Le PixInput permet de créer un champ de texte.
   <Story story={stories.withIcon} height={130} />
 </Canvas>
 
+## With required label
+
+<Canvas>
+  <Story story={stories.withRequiredLabel} height={130} />
+</Canvas>
+
 ## Usage
 
 ```html
@@ -46,9 +52,11 @@ Le PixInput permet de créer un champ de texte.
   @id='firstName'
   @label='Prénom'
   @information='Complément du label'
-  @errorMessage="Un message d'erreur"
-  @icon="eye"
-  @isIconLeft={{false}} />
+  @errorMessage='Un message d`erreur'
+  @icon='eye'
+  @isIconLeft={{false}}
+  @requiredLabel='Champ obligatoire'
+/>
 ```
 
 ## Arguments

--- a/tests/integration/components/pix-input-password-test.js
+++ b/tests/integration/components/pix-input-password-test.js
@@ -1,6 +1,6 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import { render } from '@ember/test-helpers';
+import { render } from '@1024pix/ember-testing-library';
 
 import { hbs } from 'ember-cli-htmlbars';
 import createGlimmerComponent from '../../helpers/create-glimmer-component';
@@ -103,5 +103,16 @@ module('Integration | Component | pix-input-password', function (hooks) {
     // then
     const selectorElement = this.element.querySelector(INPUT_SELECTOR);
     assert.equal(selectorElement.value, 'pix123');
+  });
+
+  test('it should be possible to make pix input password required', async function (assert) {
+    // given & when
+    const screen = await render(
+      hbs`<PixInputPassword @id="password" @label="Mot de passe" @requiredLabel="Champ obligatoire" />`
+    );
+
+    // then
+    const requiredPasswordInput = screen.getByLabelText('* Mot de passe');
+    assert.dom(requiredPasswordInput).isRequired();
   });
 });

--- a/tests/integration/components/pix-input-test.js
+++ b/tests/integration/components/pix-input-test.js
@@ -1,7 +1,7 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
+import { render } from '@1024pix/ember-testing-library';
 import createGlimmerComponent from '../../helpers/create-glimmer-component';
 import fillInByLabel from '../../helpers/fill-in-by-label';
 
@@ -100,5 +100,16 @@ module('Integration | Component | input', function (hooks) {
     // then
     const selectorElement = this.element.querySelector(INPUT_SELECTOR);
     assert.equal(selectorElement.autocomplete, 'on');
+  });
+
+  test('it should be possible to make pix input required', async function (assert) {
+    // given & when
+    const screen = await render(
+      hbs`<PixInput @label="Prénom" @id="firstName" @requiredLabel="Champ obligatoire" />`
+    );
+
+    // then
+    const requiredInput = screen.getByLabelText('* Prénom');
+    assert.dom(requiredInput).isRequired();
   });
 });


### PR DESCRIPTION
## :boom: BREAKING_CHANGES
Pas de BREAKING_CHANGES ici.

## :christmas_tree: Problème
Aujourd'hui si on a un besoin de mettre nos deux composants, Pix Input et Pix Input Password, en obligatoire, on doit faire une bidouille dans nos apps ( ne pas mettre le label du composant pour mettre un label et un abbr à la main) 

## :gift: Solution
Permettre de rendre les deux composants obligatoire. 
Ici on attend du texte pour le besoin de traduction. (et non un booléen)

## :santa: Pour tester
Aller sur Storybook et voir les deux composants.
Vérifier visuellement le rendu, ouvrir la console et voir que les inputs sont en required et aria-required.
Vérifier le comportement dans la page d'exemple, si vous validez le formulaire, vous êtes renvoyé vers le champ requis