### PR TITLE
[BUGFIX] Augmenter la priorité d'affichage de la modal

### DIFF
--- a/addon/styles/_pix-modal.scss
+++ b/addon/styles/_pix-modal.scss
@@ -6,6 +6,7 @@
   position: fixed;
   right: 0;
   top: 0;
+  z-index: 1000;
 }
 
 $modal-padding: 24px;


### PR DESCRIPTION
## :boom: BREAKING_CHANGES
RAS

## 🦄 Problème
En utilisant PixModal, des éléments de l'application se plaçait au dessus.

## 🤖 Solution
Ajouter un `z-index` pour le placer en plus haute priorité sur l'axe vertical.

## 💯 Pour tester
Verifier dans Storybook que tout est bon 😄 
