### PR TITLE
[FEATURE] Composant de pagination (PIX-4511)

### DIFF
--- a/addon/components/pix-pagination.hbs
+++ b/addon/components/pix-pagination.hbs
@@ -6,7 +6,7 @@
       class="pagination-size__choice"
       @selectedOption={{this.pageSize}}
       @onChange={{this.changePageSize}}
-      @options={{this.pageOptions}}
+      @options={{@pageOptions}}
     />
   </section>
   <section class="pix-pagination__navigation">

--- a/addon/components/pix-pagination.hbs
+++ b/addon/components/pix-pagination.hbs
@@ -1,8 +1,8 @@
 <footer class="pagination-control">
   <section class="page-size">
-    <p class="page-size__label">{{@beforeResultsPerPage}}</p>
+    <p class="page-size__label">{{this.beforeResultsPerPage}}</p>
     <PixSelect
-      aria-label= {{@selectPageSizeLabel}}
+      aria-label={{this.selectPageSizeLabel}}
       class="page-size__choice"
       @selectedOption={{this.pageSize}}
       @onChange={{this.changePageSize}}
@@ -12,14 +12,14 @@
   <section class="page-navigation">
     <p>
       {{#if (eq this.pageCount 1)}}
-        {{@pageResults}}
+        {{this.pageResults}}
       {{else}}
-        {{@pageInfo}}
+        {{this.pageInfo}}
       {{/if}}
     </p>
     <PixIconButton
       @icon="arrow-left"
-      aria-label={{@previousPageLabel}}
+      aria-label={{this.previousPageLabel}}
       @triggerAction={{this.goToPreviousPage}}
       @withBackground={{false}}
       @size="small"
@@ -29,11 +29,11 @@
       class="page-navigation__arrow page-navigation__arrow--previous"
     />
     <p>
-      {{@pageNumber}}
+      {{this.pageNumber}}
     </p>
     <PixIconButton
       @icon="arrow-right"
-      aria-label={{@nextPageLabel}}
+      aria-label={{this.nextPageLabel}}
       @triggerAction={{this.goToNextPage}}
       @withBackground={{false}}
       @size="small"

--- a/addon/components/pix-pagination.hbs
+++ b/addon/components/pix-pagination.hbs
@@ -1,0 +1,46 @@
+<footer class="pagination-control">
+  <section class="page-size">
+    <p class="page-size__label">{{@beforeResultsPerPage}}</p>
+    <PixSelect
+      aria-label= {{@selectPageSizeLabel}}
+      class="page-size__choice"
+      @selectedOption={{this.pageSize}}
+      @onChange={{this.changePageSize}}
+      @options={{this.pageOptions}}
+    />
+  </section>
+  <section class="page-navigation">
+    <p>
+      {{#if (eq this.pageCount 1)}}
+        {{@pageResults}}
+      {{else}}
+        {{@pageInfo}}
+      {{/if}}
+    </p>
+    <PixIconButton
+      @icon="arrow-left"
+      aria-label={{@previousPageLabel}}
+      @triggerAction={{this.goToPreviousPage}}
+      @withBackground={{false}}
+      @size="small"
+      @color="dark-grey"
+      disabled={{this.isPreviousPageDisabled}}
+      aria-disabled="{{this.isPreviousPageDisabled}}"
+      class="page-navigation__arrow page-navigation__arrow--previous"
+    />
+    <p>
+      {{@pageNumber}}
+    </p>
+    <PixIconButton
+      @icon="arrow-right"
+      aria-label={{@nextPageLabel}}
+      @triggerAction={{this.goToNextPage}}
+      @withBackground={{false}}
+      @size="small"
+      @color="dark-grey"
+      disabled={{this.isNextPageDisabled}}
+      aria-disabled="{{this.isNextPageDisabled}}"
+      class="page-navigation__arrow page-navigation__arrow--next"
+    />
+  </section>
+</footer>

--- a/addon/components/pix-pagination.hbs
+++ b/addon/components/pix-pagination.hbs
@@ -17,30 +17,30 @@
         {{this.pageInfo}}
       {{/if}}
     </span>
-    <PixIconButton
-      @icon="arrow-left"
-      aria-label={{this.previousPageLabel}}
-      @triggerAction={{this.goToPreviousPage}}
-      @withBackground={{false}}
-      @size="big"
-      @color="dark-grey"
-      disabled={{this.isPreviousPageDisabled}}
-      aria-disabled="{{this.isPreviousPageDisabled}}"
-      class="arrow arrow--previous"
-    />
-    <span>
-      {{this.pageNumber}}
-    </span>
-    <PixIconButton
-      @icon="arrow-right"
-      aria-label={{this.nextPageLabel}}
-      @triggerAction={{this.goToNextPage}}
-      @withBackground={{false}}
-      @size="big"
-      @color="dark-grey"
-      disabled={{this.isNextPageDisabled}}
-      aria-disabled="{{this.isNextPageDisabled}}"
-      class="arrow arrow--next"
-    />
+    <div class="pix-pagination__navigation-action">
+      <PixIconButton
+        @icon="arrow-left"
+        aria-label={{this.previousPageLabel}}
+        @triggerAction={{this.goToPreviousPage}}
+        @withBackground={{false}}
+        @size="big"
+        @color="dark-grey"
+        disabled={{this.isPreviousPageDisabled}}
+        aria-disabled="{{this.isPreviousPageDisabled}}"
+      />
+      <span>
+        {{this.pageNumber}}
+      </span>
+      <PixIconButton
+        @icon="arrow-right"
+        aria-label={{this.nextPageLabel}}
+        @triggerAction={{this.goToNextPage}}
+        @withBackground={{false}}
+        @size="big"
+        @color="dark-grey"
+        disabled={{this.isNextPageDisabled}}
+        aria-disabled="{{this.isNextPageDisabled}}"
+      />
+    </div>
   </section>
 </footer>

--- a/addon/components/pix-pagination.hbs
+++ b/addon/components/pix-pagination.hbs
@@ -6,7 +6,7 @@
       class="pagination-size__choice"
       @selectedOption={{this.pageSize}}
       @onChange={{this.changePageSize}}
-      @options={{@pageOptions}}
+      @options={{this.pageOptions}}
     />
   </section>
   <section class="pix-pagination__navigation">

--- a/addon/components/pix-pagination.hbs
+++ b/addon/components/pix-pagination.hbs
@@ -1,46 +1,46 @@
-<footer class="pagination-control">
-  <section class="page-size">
-    <p class="page-size__label">{{this.beforeResultsPerPage}}</p>
+<footer class="pix-pagination">
+  <section class="pix-pagination__size">
+    <span class="pagination-size__label">{{this.beforeResultsPerPage}}</span>
     <PixSelect
       aria-label={{this.selectPageSizeLabel}}
-      class="page-size__choice"
+      class="pagination-size__choice"
       @selectedOption={{this.pageSize}}
       @onChange={{this.changePageSize}}
       @options={{this.pageOptions}}
     />
   </section>
-  <section class="page-navigation">
-    <p>
+  <section class="pix-pagination__navigation">
+    <span>
       {{#if (eq this.pageCount 1)}}
         {{this.pageResults}}
       {{else}}
         {{this.pageInfo}}
       {{/if}}
-    </p>
+    </span>
     <PixIconButton
       @icon="arrow-left"
       aria-label={{this.previousPageLabel}}
       @triggerAction={{this.goToPreviousPage}}
       @withBackground={{false}}
-      @size="small"
+      @size="big"
       @color="dark-grey"
       disabled={{this.isPreviousPageDisabled}}
       aria-disabled="{{this.isPreviousPageDisabled}}"
-      class="page-navigation__arrow page-navigation__arrow--previous"
+      class="arrow arrow--previous"
     />
-    <p>
+    <span>
       {{this.pageNumber}}
-    </p>
+    </span>
     <PixIconButton
       @icon="arrow-right"
       aria-label={{this.nextPageLabel}}
       @triggerAction={{this.goToNextPage}}
       @withBackground={{false}}
-      @size="small"
+      @size="big"
       @color="dark-grey"
       disabled={{this.isNextPageDisabled}}
       aria-disabled="{{this.isNextPageDisabled}}"
-      class="page-navigation__arrow page-navigation__arrow--next"
+      class="arrow arrow--next"
     />
   </section>
 </footer>

--- a/addon/components/pix-pagination.js
+++ b/addon/components/pix-pagination.js
@@ -1,11 +1,80 @@
 import { action } from '@ember/object';
 import { inject as service } from '@ember/service';
 import Component from '@glimmer/component';
+import { createIntl } from '@formatjs/intl';
 
 const DEFAULT_PAGE_SIZE = 10;
 
 export default class PixPagination extends Component {
   @service router;
+
+  static messages = {
+    fr: createIntl({
+      locale: 'fr',
+      messages: {
+        beforeResultsPerPage: 'Voir',
+        selectPageSizeLabel: "Nombre d'élément à afficher par page",
+        pageResults:
+          '{total, plural, =0 {0 élément} =1 {1 élément} other {{total, number} éléments}}',
+        pageInfo:
+          '{start, number}-{end, number} sur {total, plural, =0 {0 élément} =1 {1 élément} other {{total, number} éléments}}',
+        previousPageLabel: 'Aller à la page précédente',
+        pageNumber: 'Page {current, number} / {total, number}',
+        nextPageLabel: 'Aller à la page suivante',
+      },
+    }),
+    en: createIntl({
+      locale: 'en',
+      messages: {
+        beforeResultsPerPage: 'See',
+        selectPageSizeLabel: 'Select the number of items by page',
+        pageResults: '{total, plural, =0 {0 items} =1 {1 item} other {{total, number} items}}',
+        pageInfo:
+          '{start, number}-{end, number} of {total, plural, =0 {0 items} =1 {1 item} other {{total, number} items}}',
+        previousPageLabel: 'Go to previous page',
+        pageNumber: 'Page {current, number} / {total, number}',
+        nextPageLabel: 'Go to next page',
+      },
+    }),
+  };
+
+  get beforeResultsPerPage() {
+    return this.formatMessage('beforeResultsPerPage');
+  }
+
+  get previousPageLabel() {
+    return this.formatMessage('previousPageLabel');
+  }
+
+  get nextPageLabel() {
+    return this.formatMessage('nextPageLabel');
+  }
+
+  get pageNumber() {
+    return this.formatMessage('pageNumber', {
+      total: this.pageCount,
+      current: this.currentPage,
+    });
+  }
+  get pageInfo() {
+    return this.formatMessage('pageInfo', {
+      total: this.resultsCount,
+      start: this.firstItemPosition,
+      end: this.lastItemPosition,
+    });
+  }
+
+  get selectPageSizeLabel() {
+    return this.formatMessage('selectPageSizeLabel');
+  }
+
+  get pageResults() {
+    return this.formatMessage('pageResults', { total: this.args.pagination.rowCount });
+  }
+
+  formatMessage(message, values) {
+    return PixPagination.messages[this.args.locale ?? 'fr'].formatMessage({ id: message }, values);
+  }
 
   get currentPage() {
     return this.args.pagination ? this.args.pagination.page : 1;

--- a/addon/components/pix-pagination.js
+++ b/addon/components/pix-pagination.js
@@ -1,7 +1,7 @@
 import { action } from '@ember/object';
 import { inject as service } from '@ember/service';
 import Component from '@glimmer/component';
-import { createIntl } from '@formatjs/intl';
+import { formatMessage } from '../translations';
 
 const DEFAULT_PAGE_OPTIONS = [
   { label: '10', value: 10 },
@@ -11,36 +11,6 @@ const DEFAULT_PAGE_OPTIONS = [
 ];
 export default class PixPagination extends Component {
   @service router;
-
-  static messages = {
-    fr: createIntl({
-      locale: 'fr',
-      messages: {
-        beforeResultsPerPage: 'Voir',
-        selectPageSizeLabel: "Nombre d'élément à afficher par page",
-        pageResults:
-          '{total, plural, =0 {0 élément} =1 {1 élément} other {{total, number} éléments}}',
-        pageInfo:
-          '{start, number}-{end, number} sur {total, plural, =0 {0 élément} =1 {1 élément} other {{total, number} éléments}}',
-        previousPageLabel: 'Aller à la page précédente',
-        pageNumber: 'Page {current, number} / {total, number}',
-        nextPageLabel: 'Aller à la page suivante',
-      },
-    }),
-    en: createIntl({
-      locale: 'en',
-      messages: {
-        beforeResultsPerPage: 'See',
-        selectPageSizeLabel: 'Select the number of items by page',
-        pageResults: '{total, plural, =0 {0 items} =1 {1 item} other {{total, number} items}}',
-        pageInfo:
-          '{start, number}-{end, number} of {total, plural, =0 {0 items} =1 {1 item} other {{total, number} items}}',
-        previousPageLabel: 'Go to previous page',
-        pageNumber: 'Page {current, number} / {total, number}',
-        nextPageLabel: 'Go to next page',
-      },
-    }),
-  };
 
   get beforeResultsPerPage() {
     return this.formatMessage('beforeResultsPerPage');
@@ -81,7 +51,7 @@ export default class PixPagination extends Component {
   }
 
   formatMessage(message, values) {
-    return PixPagination.messages[this.args.locale ?? 'fr'].formatMessage({ id: message }, values);
+    return formatMessage(this.args.locale ?? 'fr', `pagination.${message}`, values);
   }
 
   get currentPage() {

--- a/addon/components/pix-pagination.js
+++ b/addon/components/pix-pagination.js
@@ -3,8 +3,12 @@ import { inject as service } from '@ember/service';
 import Component from '@glimmer/component';
 import { createIntl } from '@formatjs/intl';
 
-const DEFAULT_PAGE_SIZE = 10;
-
+const DEFAULT_PAGE_OPTIONS = [
+  { label: '10', value: 10 },
+  { label: '20', value: 20 },
+  { label: '50', value: 50 },
+  { label: '100', value: 100 },
+];
 export default class PixPagination extends Component {
   @service router;
 
@@ -64,6 +68,10 @@ export default class PixPagination extends Component {
     });
   }
 
+  get pageOptions() {
+    return this.args.pageOptions ? this.args.pageOptions : DEFAULT_PAGE_OPTIONS;
+  }
+
   get selectPageSizeLabel() {
     return this.formatMessage('selectPageSizeLabel');
   }
@@ -87,7 +95,7 @@ export default class PixPagination extends Component {
   }
 
   get pageSize() {
-    return this.args.pagination ? this.args.pagination.pageSize : DEFAULT_PAGE_SIZE;
+    return this.args.pagination ? this.args.pagination.pageSize : this.args.pageOptions[0];
   }
 
   get isNextPageDisabled() {

--- a/addon/components/pix-pagination.js
+++ b/addon/components/pix-pagination.js
@@ -121,15 +121,6 @@ export default class PixPagination extends Component {
     return Math.min(rowCount, this.firstItemPosition + this.pageSize - 1);
   }
 
-  get pageOptions() {
-    return [
-      { label: '10', value: 10 },
-      { label: '20', value: 20 },
-      { label: '50', value: 50 },
-      { label: '100', value: 100 },
-    ];
-  }
-
   @action
   changePageSize(event) {
     this.router.replaceWith({ queryParams: { pageSize: event.target.value, pageNumber: 1 } });

--- a/addon/components/pix-pagination.js
+++ b/addon/components/pix-pagination.js
@@ -5,7 +5,7 @@ import { createIntl } from '@formatjs/intl';
 
 const DEFAULT_PAGE_OPTIONS = [
   { label: '10', value: 10 },
-  { label: '20', value: 20 },
+  { label: '25', value: 25 },
   { label: '50', value: 50 },
   { label: '100', value: 100 },
 ];

--- a/addon/components/pix-pagination.js
+++ b/addon/components/pix-pagination.js
@@ -1,0 +1,78 @@
+import { action } from '@ember/object';
+import { inject as service } from '@ember/service';
+import Component from '@glimmer/component';
+
+const DEFAULT_PAGE_SIZE = 10;
+
+export default class PixPagination extends Component {
+  @service router;
+
+  get currentPage() {
+    return this.args.pagination ? this.args.pagination.page : 1;
+  }
+
+  get pageCount() {
+    if (!this.args.pagination) return 0;
+    if (this.args.pagination.pageCount === 0) return 1;
+    return this.args.pagination.pageCount;
+  }
+
+  get pageSize() {
+    return this.args.pagination ? this.args.pagination.pageSize : DEFAULT_PAGE_SIZE;
+  }
+
+  get isNextPageDisabled() {
+    return this.currentPage === this.pageCount || this.pageCount === 0;
+  }
+
+  get nextPage() {
+    return Math.min(this.currentPage + 1, this.pageCount);
+  }
+
+  get isPreviousPageDisabled() {
+    return this.currentPage === 1 || this.pageCount === 0;
+  }
+
+  get previousPage() {
+    return Math.max(this.currentPage - 1, 1);
+  }
+
+  get resultsCount() {
+    return this.args.pagination ? this.args.pagination.rowCount : 0;
+  }
+
+  get firstItemPosition() {
+    if (!this.args.pagination) return 0;
+    return (this.currentPage - 1) * this.pageSize + 1;
+  }
+
+  get lastItemPosition() {
+    if (!this.args.pagination) return 0;
+    const { rowCount } = this.args.pagination;
+    return Math.min(rowCount, this.firstItemPosition + this.pageSize - 1);
+  }
+
+  get pageOptions() {
+    return [
+      { label: '10', value: 10 },
+      { label: '20', value: 20 },
+      { label: '50', value: 50 },
+      { label: '100', value: 100 },
+    ];
+  }
+
+  @action
+  changePageSize(event) {
+    this.router.replaceWith({ queryParams: { pageSize: event.target.value, pageNumber: 1 } });
+  }
+
+  @action
+  goToNextPage() {
+    this.router.replaceWith({ queryParams: { pageNumber: this.nextPage } });
+  }
+
+  @action
+  goToPreviousPage() {
+    this.router.replaceWith({ queryParams: { pageNumber: this.previousPage } });
+  }
+}

--- a/addon/styles/_pix-pagination.scss
+++ b/addon/styles/_pix-pagination.scss
@@ -1,40 +1,41 @@
-.pagination-control {
+.pix-pagination{
   display: flex;
   justify-content: space-between;
   margin: 16px 0;
   color: $grey-60;
   font-size: 0.875rem;
-}
 
-.page-size {
-  display: flex;
-  align-items: center;
-  padding: 0;
+  &__size {
+    display: flex;
+    align-items: center;
+    padding: 0;
 
-  &__label {
-    margin-right: 16px;
-  }
-}
-
-select.page-size__choice {
-  height: 36px;
-  font-size: 0.8rem;
-  padding-left: 8px;
-  padding-right: 24px;
-}
-
-.page-navigation {
-  display: flex;
-  align-items: center;
-  padding: 0;
-
-  &__arrow {
-    &--previous {
-      margin: 0 8px;
+    .pagination-size__label {
+      margin-right: 16px;
     }
 
-    &--next {
-      margin-left: 8px;
+    select.pagination__choice {
+      height: 36px;
+      font-size: 0.8rem;
+      padding-left: 8px;
+      padding-right: 24px;
+    }
+  }
+
+  &__navigation{
+    display: flex;
+    align-items: center;
+    padding: 0;
+
+    .arrow {
+
+      &--previous {
+        margin: 0 8px;
+      }
+
+      &--next {
+        margin-left: 8px;
+      }
     }
   }
 }

--- a/addon/styles/_pix-pagination.scss
+++ b/addon/styles/_pix-pagination.scss
@@ -1,12 +1,11 @@
 .pix-pagination{
   display: flex;
-  justify-content: space-between;
+  justify-content: end;
   margin: 16px 0;
   color: $grey-60;
   font-size: 0.875rem;
-
   &__size {
-    display: flex;
+    display: none;
     align-items: center;
     padding: 0;
 
@@ -36,6 +35,15 @@
       &--next {
         margin-left: 8px;
       }
+    }
+  }
+}
+
+@include device-is('tablet') {
+  .pix-pagination {
+    justify-content: space-between;
+    &__size{
+      display: flex;
     }
   }
 }

--- a/addon/styles/_pix-pagination.scss
+++ b/addon/styles/_pix-pagination.scss
@@ -1,0 +1,46 @@
+.pix-pagination {
+  @import 'reset-css';
+  width: 400px;
+  height: 200px;
+  background: red;
+}
+.pagination-control {
+  display: flex;
+  justify-content: space-between;
+  margin: 16px 0;
+  color: $grey-60;
+  font-size: 0.875rem;
+}
+
+.page-size {
+  display: flex;
+  align-items: center;
+  padding: 0;
+
+  &__label {
+    margin-right: 16px;
+  }
+}
+
+select.page-size__choice {
+  height: 36px;
+  font-size: 0.8rem;
+  padding-left: 8px;
+  padding-right: 24px;
+}
+
+.page-navigation {
+  display: flex;
+  align-items: center;
+  padding: 0;
+
+  &__arrow {
+    &--previous {
+      margin: 0 8px;
+    }
+
+    &--next {
+      margin-left: 8px;
+    }
+  }
+}

--- a/addon/styles/_pix-pagination.scss
+++ b/addon/styles/_pix-pagination.scss
@@ -1,9 +1,3 @@
-.pix-pagination {
-  @import 'reset-css';
-  width: 400px;
-  height: 200px;
-  background: red;
-}
 .pagination-control {
   display: flex;
   justify-content: space-between;

--- a/addon/styles/_pix-pagination.scss
+++ b/addon/styles/_pix-pagination.scss
@@ -1,6 +1,6 @@
 .pix-pagination{
   display: flex;
-  justify-content: end;
+  justify-content: center;
   margin: 16px 0;
   color: $grey-60;
   font-size: 0.875rem;
@@ -25,16 +25,11 @@
     display: flex;
     align-items: center;
     padding: 0;
-
-    .arrow {
-
-      &--previous {
-        margin: 0 8px;
-      }
-
-      &--next {
-        margin-left: 8px;
-      }
+    gap: 12px;
+    flex-direction: column-reverse;
+    &-action {
+      display: flex;
+      align-items: center;
     }
   }
 }
@@ -44,6 +39,10 @@
     justify-content: space-between;
     &__size{
       display: flex;
+    }
+    &__navigation{
+      gap: initial;
+      flex-direction:initial ;
     }
   }
 }

--- a/addon/styles/addon.scss
+++ b/addon/styles/addon.scss
@@ -29,6 +29,7 @@
 @import 'pix-input-code';
 @import 'pix-selectable-tag';
 @import 'pix-dropdown';
+@import 'pix-pagination';
 
 html {
   font-size: 16px;

--- a/addon/translations/en.js
+++ b/addon/translations/en.js
@@ -1,0 +1,12 @@
+export default {
+  pagination: {
+    beforeResultsPerPage: 'See',
+    selectPageSizeLabel: 'Select the number of items by page',
+    pageResults: '{total, plural, =0 {0 items} =1 {1 item} other {{total, number} items}}',
+    pageInfo:
+      '{start, number}-{end, number} of {total, plural, =0 {0 items} =1 {1 item} other {{total, number} items}}',
+    previousPageLabel: 'Go to previous page',
+    pageNumber: 'Page {current, number} / {total, number}',
+    nextPageLabel: 'Go to next page',
+  },
+};

--- a/addon/translations/fr.js
+++ b/addon/translations/fr.js
@@ -1,0 +1,12 @@
+export default {
+  pagination: {
+    beforeResultsPerPage: 'Voir',
+    selectPageSizeLabel: "Nombre d'élément à afficher par page",
+    pageResults: '{total, plural, =0 {0 élément} =1 {1 élément} other {{total, number} éléments}}',
+    pageInfo:
+      '{start, number}-{end, number} sur {total, plural, =0 {0 élément} =1 {1 élément} other {{total, number} éléments}}',
+    previousPageLabel: 'Aller à la page précédente',
+    pageNumber: 'Page {current, number} / {total, number}',
+    nextPageLabel: 'Aller à la page suivante',
+  },
+};

--- a/addon/translations/index.js
+++ b/addon/translations/index.js
@@ -1,0 +1,32 @@
+import { createIntl } from '@formatjs/intl';
+import en from './en';
+import fr from './fr';
+
+export function formatMessage(locale, message, values) {
+  return locales[locale].formatMessage({ id: message }, values);
+}
+
+const locales = {
+  fr: createIntl({
+    locale: 'fr',
+    messages: flattenObject(fr),
+  }),
+  en: createIntl({
+    locale: 'en',
+    messages: flattenObject(en),
+  }),
+};
+
+export function flattenObject(object) {
+  const entries = Object.entries(object);
+
+  const flatEntries = entries.flatMap(([key, value]) => {
+    if (typeof value !== 'object') return [[key, value]];
+
+    const childEntries = Object.entries(flattenObject(value));
+
+    return childEntries.map(([childKey, childValue]) => [`${key}.${childKey}`, childValue]);
+  });
+
+  return Object.fromEntries(flatEntries);
+}

--- a/app/components/pix-pagination.js
+++ b/app/components/pix-pagination.js
@@ -1,0 +1,1 @@
+export { default } from '@1024pix/pix-ui/components/pix-pagination';

--- a/app/components/pix-pagination.js
+++ b/app/components/pix-pagination.js
@@ -1,1 +1,4 @@
+// WORKAROUND: necessary for storybook to resolve the import
+import '@formatjs/intl';
+
 export { default } from '@1024pix/pix-ui/components/pix-pagination';

--- a/app/stories/pix-pagination.stories.js
+++ b/app/stories/pix-pagination.stories.js
@@ -6,6 +6,7 @@ export const Template = (args) => {
       <PixPagination
         @pagination={{pagination}}
         @locale = {{locale}}
+        @pageOptions= {{pageOptions}}
             />
     `,
     context: args,
@@ -16,10 +17,16 @@ export const French = Template.bind({});
 French.args = {
   pagination: {
     page: 1,
-    pageSize: 10,
+    pageSize: 5,
     rowCount: 12,
-    pageCount: 2,
+    pageCount: 3,
   },
+  pageOptions: [
+    { label: '5', value: 5 },
+    { label: '20', value: 20 },
+    { label: '50', value: 50 },
+    { label: '100', value: 100 },
+  ],
   locale: 'fr',
 };
 
@@ -31,6 +38,12 @@ English.args = {
     rowCount: 12,
     pageCount: 2,
   },
+  pageOptions: [
+    { label: '10', value: 10 },
+    { label: '20', value: 20 },
+    { label: '50', value: 50 },
+    { label: '100', value: 100 },
+  ],
   locale: 'en',
 };
 
@@ -42,6 +55,12 @@ OnePage.args = {
     rowCount: 2,
     pageCount: 1,
   },
+  pageOptions: [
+    { label: '10', value: 10 },
+    { label: '20', value: 20 },
+    { label: '50', value: 50 },
+    { label: '100', value: 100 },
+  ],
   locale: 'fr',
 };
 
@@ -49,12 +68,23 @@ OnePage.args = {
 export const argTypes = {
   pagination: {
     name: 'pagination',
-    description: 'object including pagination informations',
-    type: { name: 'object', required: false },
+    description:
+      "Un objet de pagination tel que l'on en trouve au retour de `knex-utils.fetchPage`",
+    type: { name: 'object', required: true },
+  },
+  pageOptions: {
+    name: 'pageOptions',
+    description: "Un tableau d'objet `options` pour configurer le select",
+    type: { name: 'array', required: true },
   },
   locale: {
     name: 'locale',
-    description: 'Selected locale',
+    description: "La langue de l'utilisateur",
     type: { name: 'string', required: false },
+    control: { type: 'select', options: ['fr', 'en'] },
+    table: {
+      type: { summary: 'string' },
+      defaultValue: { summary: 'fr' },
+    },
   },
 };

--- a/app/stories/pix-pagination.stories.js
+++ b/app/stories/pix-pagination.stories.js
@@ -1,0 +1,90 @@
+import { hbs } from 'ember-cli-htmlbars';
+
+export const Template = (args) => {
+  return {
+    template: hbs`
+      <PixPagination
+        @pagination={{pagination}}
+        @beforeResultsPerPage = {{beforeResultsPerPage}}
+        @selectPageSizeLabel = {{selectPageSizeLabel}}
+        @pageResults = {{pageResults}}
+        @pageInfo = {{pageInfo}}
+        @previousPageLabel = {{previousPageLabel}}
+        @pageNumber = {{pageNumber}}
+        @nextPageLabel = {{nextPageLabel}}
+            />
+    `,
+    context: args,
+  };
+};
+
+export const Default = Template.bind({});
+Default.args = {
+  pagination: {
+    page: 1,
+    pageSize: 10,
+    rowCount: 12,
+    pageCount: 2,
+  },
+  beforeResultsPerPage: ' Voir',
+  selectPageSizeLabel: "Nombre d'élément à afficher par page",
+  pageResults: '{total, plural, =0 {0 élément} =1 {1 élément} other {{total, number} éléments}}',
+  pageInfo:
+    '{start, number}-{end, number} sur {total, plural, =0 {0 élément} =1 {1 élément} other {{total, number} éléments}}',
+  previousPageLabel: 'Go to previous page',
+  pageNumber: 'Page {current, number} / {total, number}',
+  nextPageLabel: 'Aller à la page suivante',
+};
+
+// TODO: add component attributes information
+// select attribute data type from https://storybook.js.org/docs/react/essentials/controls
+export const argTypes = {
+  pagination: {
+    name: 'pagination',
+    description: 'attribute description',
+    type: { name: 'string', required: false },
+    defaultValue: '',
+  },
+  beforeResultsPerPage: {
+    name: 'beforeResultsPerPage',
+    description: 'Label devant l input select',
+    type: { name: 'string', required: true },
+    defaultValue: '',
+  },
+  selectPageSizeLabel: {
+    name: 'selectPageSizeLabel',
+    description: 'Label pour l aria-label pour pix-select',
+    type: { name: 'string', required: false },
+    defaultValue: '',
+  },
+  pageResults: {
+    name: 'pageResults',
+    description: 'Label pour l aria-label de l icone right-arrow ',
+    type: { name: 'string', required: false },
+    defaultValue: '',
+  },
+  pageInfo: {
+    name: 'pageInfo',
+    description: 'Label pour l aria-label de l icone right-arrow ',
+    type: { name: 'string', required: false },
+    defaultValue: '',
+  },
+  previousPageLabel: {
+    name: 'previousPageLabel',
+    description: 'Label pour l aria-label de l icone left-arrow ',
+    type: { name: 'string', required: false },
+    defaultValue: '',
+  },
+  pageNumber: {
+    name: 'pageNumber',
+    description: 'Label pour l aria-label de l icone right-arrow ',
+    type: { name: 'string', required: false },
+    defaultValue: '',
+  },
+  nextPageLabel: {
+    name: 'nextPageLabel',
+    description: 'Label pour l aria-label de l icone right-arrow ',
+    type: { name: 'string', required: false },
+    defaultValue: '',
+  },
+};

--- a/app/stories/pix-pagination.stories.js
+++ b/app/stories/pix-pagination.stories.js
@@ -5,86 +5,56 @@ export const Template = (args) => {
     template: hbs`
       <PixPagination
         @pagination={{pagination}}
-        @beforeResultsPerPage = {{beforeResultsPerPage}}
-        @selectPageSizeLabel = {{selectPageSizeLabel}}
-        @pageResults = {{pageResults}}
-        @pageInfo = {{pageInfo}}
-        @previousPageLabel = {{previousPageLabel}}
-        @pageNumber = {{pageNumber}}
-        @nextPageLabel = {{nextPageLabel}}
+        @locale = {{locale}}
             />
     `,
     context: args,
   };
 };
 
-export const Default = Template.bind({});
-Default.args = {
+export const French = Template.bind({});
+French.args = {
   pagination: {
     page: 1,
     pageSize: 10,
     rowCount: 12,
     pageCount: 2,
   },
-  beforeResultsPerPage: ' Voir',
-  selectPageSizeLabel: "Nombre d'élément à afficher par page",
-  pageResults: '{total, plural, =0 {0 élément} =1 {1 élément} other {{total, number} éléments}}',
-  pageInfo:
-    '{start, number}-{end, number} sur {total, plural, =0 {0 élément} =1 {1 élément} other {{total, number} éléments}}',
-  previousPageLabel: 'Go to previous page',
-  pageNumber: 'Page {current, number} / {total, number}',
-  nextPageLabel: 'Aller à la page suivante',
+  locale: 'fr',
 };
 
-// TODO: add component attributes information
+export const English = Template.bind({});
+English.args = {
+  pagination: {
+    page: 2,
+    pageSize: 10,
+    rowCount: 12,
+    pageCount: 2,
+  },
+  locale: 'en',
+};
+
+export const OnePage = Template.bind({});
+OnePage.args = {
+  pagination: {
+    page: 1,
+    pageSize: 10,
+    rowCount: 2,
+    pageCount: 1,
+  },
+  locale: 'fr',
+};
+
 // select attribute data type from https://storybook.js.org/docs/react/essentials/controls
 export const argTypes = {
   pagination: {
     name: 'pagination',
-    description: 'attribute description',
-    type: { name: 'string', required: false },
-    defaultValue: '',
+    description: 'object including pagination informations',
+    type: { name: 'object', required: false },
   },
-  beforeResultsPerPage: {
-    name: 'beforeResultsPerPage',
-    description: 'Label devant l input select',
-    type: { name: 'string', required: true },
-    defaultValue: '',
-  },
-  selectPageSizeLabel: {
-    name: 'selectPageSizeLabel',
-    description: 'Label pour l aria-label pour pix-select',
+  locale: {
+    name: 'locale',
+    description: 'Selected locale',
     type: { name: 'string', required: false },
-    defaultValue: '',
-  },
-  pageResults: {
-    name: 'pageResults',
-    description: 'Label pour l aria-label de l icone right-arrow ',
-    type: { name: 'string', required: false },
-    defaultValue: '',
-  },
-  pageInfo: {
-    name: 'pageInfo',
-    description: 'Label pour l aria-label de l icone right-arrow ',
-    type: { name: 'string', required: false },
-    defaultValue: '',
-  },
-  previousPageLabel: {
-    name: 'previousPageLabel',
-    description: 'Label pour l aria-label de l icone left-arrow ',
-    type: { name: 'string', required: false },
-    defaultValue: '',
-  },
-  pageNumber: {
-    name: 'pageNumber',
-    description: 'Label pour l aria-label de l icone right-arrow ',
-    type: { name: 'string', required: false },
-    defaultValue: '',
-  },
-  nextPageLabel: {
-    name: 'nextPageLabel',
-    description: 'Label pour l aria-label de l icone right-arrow ',
-    type: { name: 'string', required: false },
-    defaultValue: '',
   },
 };

--- a/app/stories/pix-pagination.stories.js
+++ b/app/stories/pix-pagination.stories.js
@@ -21,12 +21,6 @@ French.args = {
     rowCount: 12,
     pageCount: 3,
   },
-  pageOptions: [
-    { label: '5', value: 5 },
-    { label: '20', value: 20 },
-    { label: '50', value: 50 },
-    { label: '100', value: 100 },
-  ],
   locale: 'fr',
 };
 
@@ -70,6 +64,50 @@ export const argTypes = {
     name: 'pageOptions',
     description: "Un tableau d'objet `options` pour configurer le select",
     type: { name: 'array', required: false },
+    control: {
+      type: 'array',
+      value: [
+        {
+          label: '10',
+          value: 10,
+        },
+        {
+          label: '25',
+          value: 25,
+        },
+        {
+          label: '50',
+          value: 50,
+        },
+        {
+          label: '100',
+          value: 100,
+        },
+      ],
+    },
+    table: {
+      type: { summary: 'array' },
+      defaultValue: {
+        summary: JSON.stringify([
+          {
+            label: '10',
+            value: 10,
+          },
+          {
+            label: '25',
+            value: 25,
+          },
+          {
+            label: '50',
+            value: 50,
+          },
+          {
+            label: '100',
+            value: 100,
+          },
+        ]),
+      },
+    },
   },
   locale: {
     name: 'locale',

--- a/app/stories/pix-pagination.stories.js
+++ b/app/stories/pix-pagination.stories.js
@@ -55,12 +55,6 @@ OnePage.args = {
     rowCount: 2,
     pageCount: 1,
   },
-  pageOptions: [
-    { label: '10', value: 10 },
-    { label: '20', value: 20 },
-    { label: '50', value: 50 },
-    { label: '100', value: 100 },
-  ],
   locale: 'fr',
 };
 
@@ -75,7 +69,7 @@ export const argTypes = {
   pageOptions: {
     name: 'pageOptions',
     description: "Un tableau d'objet `options` pour configurer le select",
-    type: { name: 'array', required: true },
+    type: { name: 'array', required: false },
   },
   locale: {
     name: 'locale',

--- a/app/stories/pix-pagination.stories.mdx
+++ b/app/stories/pix-pagination.stories.mdx
@@ -22,6 +22,18 @@ PixPagination est un élément permettant de trigger le changement de page dans 
 >
 >** Installer la dépendance `@formatjs/intl` sur votre projet.**
 
+Le paramètre `pageOptions` n'est pas  requis et  a une valeur par défaut :
+
+>[
+>  { label: '10', value: 10 },
+>  { label: '20', value: 20 },
+>  { label: '50', value: 50 },
+>  { label: '100', value: 100 },
+>]
+
+** ⚠ Si vous voulez utiliser des options différentes, il ne faut pas oublier que l'API fait le premier call avec un pageSize
+ à 10 par défaut.**
+
 PixPagination en français
 <Canvas>
   <Story name='French' story={stories.French} height={110}/>
@@ -43,6 +55,7 @@ PixPagination comprenant qu'une seule page
 <PixPagination
    @pagination={{pagination}}
    @locale = {{locale}}
+   @pageOptions = {{pageOptions}
 />
 ```
 

--- a/app/stories/pix-pagination.stories.mdx
+++ b/app/stories/pix-pagination.stories.mdx
@@ -1,0 +1,29 @@
+import { Meta, Story, Canvas, ArgsTable } from '@storybook/addon-docs/blocks';
+import centered from '@storybook/addon-centered/ember';
+
+import * as stories from './pix-pagination.stories.js';
+
+<Meta
+  title='Others/Pagination'
+  component='PixPagination'
+  decorators={[centered]}
+  argTypes={stories.argTypes}
+/>
+
+# PixPagination
+
+PixPagination est un élément permettant de trigger le changement de page dans l'élément parent.
+
+<Canvas>
+  <Story name='Default' story={stories.Default} height={60} />
+</Canvas>
+
+## Usage
+
+```html
+<PixPagination/>
+```
+
+## Arguments
+
+<ArgsTable story="Default" />

--- a/app/stories/pix-pagination.stories.mdx
+++ b/app/stories/pix-pagination.stories.mdx
@@ -22,24 +22,24 @@ PixPagination est un élément permettant de trigger le changement de page dans 
 >
 >** Installer la dépendance `@formatjs/intl` sur votre projet.**
 
-Le paramètre `pageOptions` n'est pas  requis et  possède une valeur par défaut.
+Le paramètre `pageOptions` n'est pas requis et possède une valeur par défaut.
 
 ** ⚠ Si vous voulez utiliser des options différentes, il ne faut pas oublier que l'API fait le premier call avec un pageSize
  à 10 par défaut.**
 
 Sur mobile, le select qui permet de choisir le nombre d'élément à afficher sur la page est retiré.
 
-PixPagination en français
+## En français avec paramètres par défaut
 <Canvas>
   <Story name='French' story={stories.French} height={110}/>
 </Canvas>
 
-PixPagination en anglais
+## En anglais avec le paramètre `pageOptions` custom
 <Canvas>
   <Story name='English' story={stories.English} height={110} />
 </Canvas>
 
-PixPagination comprenant qu'une seule page
+## Avec une seule page
 <Canvas>
   <Story name='OnePage' story={stories.OnePage} height={110} />
 </Canvas>

--- a/app/stories/pix-pagination.stories.mdx
+++ b/app/stories/pix-pagination.stories.mdx
@@ -6,7 +6,6 @@ import * as stories from './pix-pagination.stories.js';
 <Meta
   title='Others/Pagination'
   component='PixPagination'
-  decorators={[centered]}
   argTypes={stories.argTypes}
 />
 
@@ -14,16 +13,30 @@ import * as stories from './pix-pagination.stories.js';
 
 PixPagination est un élément permettant de trigger le changement de page dans l'élément parent.
 
+PixPagination en français
 <Canvas>
-  <Story name='Default' story={stories.Default} height={60} />
+  <Story name='French' story={stories.French} height={110}/>
+</Canvas>
+
+PixPagination en anglais
+<Canvas>
+  <Story name='English' story={stories.English} height={110} />
+</Canvas>
+
+PixPagination comprenant qu'une seule page
+<Canvas>
+  <Story name='OnePage' story={stories.OnePage} height={110} />
 </Canvas>
 
 ## Usage
 
 ```html
-<PixPagination/>
+<PixPagination
+   @pagination={{pagination}}
+   @locale = {{locale}}
+/>
 ```
 
 ## Arguments
 
-<ArgsTable story="Default" />
+<ArgsTable story="French" />

--- a/app/stories/pix-pagination.stories.mdx
+++ b/app/stories/pix-pagination.stories.mdx
@@ -4,7 +4,7 @@ import centered from '@storybook/addon-centered/ember';
 import * as stories from './pix-pagination.stories.js';
 
 <Meta
-  title='Others/Pagination'
+  title='Basics/Pagination'
   component='PixPagination'
   argTypes={stories.argTypes}
 />

--- a/app/stories/pix-pagination.stories.mdx
+++ b/app/stories/pix-pagination.stories.mdx
@@ -22,17 +22,12 @@ PixPagination est un élément permettant de trigger le changement de page dans 
 >
 >** Installer la dépendance `@formatjs/intl` sur votre projet.**
 
-Le paramètre `pageOptions` n'est pas  requis et  a une valeur par défaut :
-
->[
->  { label: '10', value: 10 },
->  { label: '20', value: 20 },
->  { label: '50', value: 50 },
->  { label: '100', value: 100 },
->]
+Le paramètre `pageOptions` n'est pas  requis et  possède une valeur par défaut.
 
 ** ⚠ Si vous voulez utiliser des options différentes, il ne faut pas oublier que l'API fait le premier call avec un pageSize
  à 10 par défaut.**
+
+Sur mobile, le select qui permet de choisir le nombre d'élément à afficher sur la page est retiré.
 
 PixPagination en français
 <Canvas>

--- a/app/stories/pix-pagination.stories.mdx
+++ b/app/stories/pix-pagination.stories.mdx
@@ -13,6 +13,15 @@ import * as stories from './pix-pagination.stories.js';
 
 PixPagination est un élément permettant de trigger le changement de page dans l'élément parent.
 
+> ** ⚠️ Pour utiliser ce composant, il est recommandé d'ajouter cette config dans les routes où tu l'utiliseras.**
+>
+> ** Cela permettra de reload le `model` si les queryParams `pageNumber` & `pageSize` ont été modifiés.**
+> ```javascript
+>  queryParams = { pageNumber: { refreshModel: true }, pageSize: { refreshModel: true }, };
+>```
+>
+>** Installer la dépendance `@formatjs/intl` sur votre projet.**
+
 PixPagination en français
 <Canvas>
   <Story name='French' story={stories.French} height={110}/>

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "@1024pix/ember-testing-library": "^0.5.0",
         "@ember/optional-features": "^2.0.0",
         "@ember/test-helpers": "^2.6.0",
+        "@formatjs/intl": "^2.1.0",
         "@fortawesome/ember-fontawesome": "^0.2.3",
         "@fortawesome/free-regular-svg-icons": "^5.15.4",
         "@fortawesome/free-solid-svg-icons": "^5.15.4",
@@ -2854,6 +2855,148 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/@formatjs/ecma402-abstract": {
+      "version": "1.11.3",
+      "resolved": "https://registry.npmjs.org/@formatjs/ecma402-abstract/-/ecma402-abstract-1.11.3.tgz",
+      "integrity": "sha512-kP/Buv5vVFMAYLHNvvUzr0lwRTU0u2WTy44Tqwku1X3C3lJ5dKqDCYVqA8wL+Y19Bq+MwHgxqd5FZJRCIsLRyQ==",
+      "dev": true,
+      "dependencies": {
+        "@formatjs/intl-localematcher": "0.2.24",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@formatjs/ecma402-abstract/node_modules/tslib": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+      "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+      "dev": true
+    },
+    "node_modules/@formatjs/fast-memoize": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@formatjs/fast-memoize/-/fast-memoize-1.2.1.tgz",
+      "integrity": "sha512-Rg0e76nomkz3vF9IPlKeV+Qynok0r7YZjL6syLz4/urSg0IbjPZCB/iYUMNsYA643gh4mgrX3T7KEIFIxJBQeg==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@formatjs/fast-memoize/node_modules/tslib": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+      "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+      "dev": true
+    },
+    "node_modules/@formatjs/icu-messageformat-parser": {
+      "version": "2.0.18",
+      "resolved": "https://registry.npmjs.org/@formatjs/icu-messageformat-parser/-/icu-messageformat-parser-2.0.18.tgz",
+      "integrity": "sha512-vquIzsAJJmZ5jWVH8dEgUKcbG4yu3KqtyPet+q35SW5reLOvblkfeCXTRW2TpIwNXzdVqsJBwjbTiRiSU9JxwQ==",
+      "dev": true,
+      "dependencies": {
+        "@formatjs/ecma402-abstract": "1.11.3",
+        "@formatjs/icu-skeleton-parser": "1.3.5",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@formatjs/icu-messageformat-parser/node_modules/tslib": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+      "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+      "dev": true
+    },
+    "node_modules/@formatjs/icu-skeleton-parser": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/@formatjs/icu-skeleton-parser/-/icu-skeleton-parser-1.3.5.tgz",
+      "integrity": "sha512-Nhyo2/6kG7ZfgeEfo02sxviOuBcvtzH6SYUharj3DLCDJH3A/4OxkKcmx/2PWGX4bc6iSieh+FA94CsKDxnZBQ==",
+      "dev": true,
+      "dependencies": {
+        "@formatjs/ecma402-abstract": "1.11.3",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@formatjs/icu-skeleton-parser/node_modules/tslib": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+      "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+      "dev": true
+    },
+    "node_modules/@formatjs/intl": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@formatjs/intl/-/intl-2.1.0.tgz",
+      "integrity": "sha512-1iGGqKcCym+ZH+cktHa6YILVGn8Sve+yuYK7hJpN21JiPKCPJuFJViKFY6rDM5jnj5LDCeH8N5YbhQjccDVOVA==",
+      "dev": true,
+      "dependencies": {
+        "@formatjs/ecma402-abstract": "1.11.3",
+        "@formatjs/fast-memoize": "1.2.1",
+        "@formatjs/icu-messageformat-parser": "2.0.18",
+        "@formatjs/intl-displaynames": "5.4.2",
+        "@formatjs/intl-listformat": "6.5.2",
+        "intl-messageformat": "9.11.4",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "typescript": "^4.5"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@formatjs/intl-displaynames": {
+      "version": "5.4.2",
+      "resolved": "https://registry.npmjs.org/@formatjs/intl-displaynames/-/intl-displaynames-5.4.2.tgz",
+      "integrity": "sha512-SLesCDan9NCMqBbHPXMEwqAcPn3tnbQw0sv0rssH1JQDLDUQYwKXL93kz30X3yskTyQS7N+pd47bhoIe3kbXyw==",
+      "dev": true,
+      "dependencies": {
+        "@formatjs/ecma402-abstract": "1.11.3",
+        "@formatjs/intl-localematcher": "0.2.24",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@formatjs/intl-displaynames/node_modules/tslib": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+      "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+      "dev": true
+    },
+    "node_modules/@formatjs/intl-listformat": {
+      "version": "6.5.2",
+      "resolved": "https://registry.npmjs.org/@formatjs/intl-listformat/-/intl-listformat-6.5.2.tgz",
+      "integrity": "sha512-/IYagQJkzTvpBlhhaysGYNgM3o72WBg1ZWZcpookkgXEJbINwLP5kVagHxmgxffYKs1CDzQ8rmKHghu2qR/7zw==",
+      "dev": true,
+      "dependencies": {
+        "@formatjs/ecma402-abstract": "1.11.3",
+        "@formatjs/intl-localematcher": "0.2.24",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@formatjs/intl-listformat/node_modules/tslib": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+      "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+      "dev": true
+    },
+    "node_modules/@formatjs/intl-localematcher": {
+      "version": "0.2.24",
+      "resolved": "https://registry.npmjs.org/@formatjs/intl-localematcher/-/intl-localematcher-0.2.24.tgz",
+      "integrity": "sha512-K/HRGo6EMnCbhpth/y3u4rW4aXkmQNqRe1L2G+Y5jNr3v0gYhvaucV8WixNju/INAMbPBlbsRBRo/nfjnoOnxQ==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@formatjs/intl-localematcher/node_modules/tslib": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+      "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+      "dev": true
+    },
+    "node_modules/@formatjs/intl/node_modules/tslib": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+      "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+      "dev": true
     },
     "node_modules/@fortawesome/ember-fontawesome": {
       "version": "0.2.3",
@@ -22628,6 +22771,24 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/intl-messageformat": {
+      "version": "9.11.4",
+      "resolved": "https://registry.npmjs.org/intl-messageformat/-/intl-messageformat-9.11.4.tgz",
+      "integrity": "sha512-77TSkNubIy/hsapz6LQpyR6OADcxhWdhSaboPb5flMaALCVkPvAIxr48AlPqaMl4r1anNcvR9rpLWVdwUY1IKg==",
+      "dev": true,
+      "dependencies": {
+        "@formatjs/ecma402-abstract": "1.11.3",
+        "@formatjs/fast-memoize": "1.2.1",
+        "@formatjs/icu-messageformat-parser": "2.0.18",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/intl-messageformat/node_modules/tslib": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+      "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+      "dev": true
+    },
     "node_modules/into-stream": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/into-stream/-/into-stream-3.1.0.tgz",
@@ -36089,6 +36250,156 @@
           "version": "0.20.2",
           "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
           "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
+          "dev": true
+        }
+      }
+    },
+    "@formatjs/ecma402-abstract": {
+      "version": "1.11.3",
+      "resolved": "https://registry.npmjs.org/@formatjs/ecma402-abstract/-/ecma402-abstract-1.11.3.tgz",
+      "integrity": "sha512-kP/Buv5vVFMAYLHNvvUzr0lwRTU0u2WTy44Tqwku1X3C3lJ5dKqDCYVqA8wL+Y19Bq+MwHgxqd5FZJRCIsLRyQ==",
+      "dev": true,
+      "requires": {
+        "@formatjs/intl-localematcher": "0.2.24",
+        "tslib": "^2.1.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+          "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+          "dev": true
+        }
+      }
+    },
+    "@formatjs/fast-memoize": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@formatjs/fast-memoize/-/fast-memoize-1.2.1.tgz",
+      "integrity": "sha512-Rg0e76nomkz3vF9IPlKeV+Qynok0r7YZjL6syLz4/urSg0IbjPZCB/iYUMNsYA643gh4mgrX3T7KEIFIxJBQeg==",
+      "dev": true,
+      "requires": {
+        "tslib": "^2.1.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+          "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+          "dev": true
+        }
+      }
+    },
+    "@formatjs/icu-messageformat-parser": {
+      "version": "2.0.18",
+      "resolved": "https://registry.npmjs.org/@formatjs/icu-messageformat-parser/-/icu-messageformat-parser-2.0.18.tgz",
+      "integrity": "sha512-vquIzsAJJmZ5jWVH8dEgUKcbG4yu3KqtyPet+q35SW5reLOvblkfeCXTRW2TpIwNXzdVqsJBwjbTiRiSU9JxwQ==",
+      "dev": true,
+      "requires": {
+        "@formatjs/ecma402-abstract": "1.11.3",
+        "@formatjs/icu-skeleton-parser": "1.3.5",
+        "tslib": "^2.1.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+          "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+          "dev": true
+        }
+      }
+    },
+    "@formatjs/icu-skeleton-parser": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/@formatjs/icu-skeleton-parser/-/icu-skeleton-parser-1.3.5.tgz",
+      "integrity": "sha512-Nhyo2/6kG7ZfgeEfo02sxviOuBcvtzH6SYUharj3DLCDJH3A/4OxkKcmx/2PWGX4bc6iSieh+FA94CsKDxnZBQ==",
+      "dev": true,
+      "requires": {
+        "@formatjs/ecma402-abstract": "1.11.3",
+        "tslib": "^2.1.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+          "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+          "dev": true
+        }
+      }
+    },
+    "@formatjs/intl": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@formatjs/intl/-/intl-2.1.0.tgz",
+      "integrity": "sha512-1iGGqKcCym+ZH+cktHa6YILVGn8Sve+yuYK7hJpN21JiPKCPJuFJViKFY6rDM5jnj5LDCeH8N5YbhQjccDVOVA==",
+      "dev": true,
+      "requires": {
+        "@formatjs/ecma402-abstract": "1.11.3",
+        "@formatjs/fast-memoize": "1.2.1",
+        "@formatjs/icu-messageformat-parser": "2.0.18",
+        "@formatjs/intl-displaynames": "5.4.2",
+        "@formatjs/intl-listformat": "6.5.2",
+        "intl-messageformat": "9.11.4",
+        "tslib": "^2.1.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+          "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+          "dev": true
+        }
+      }
+    },
+    "@formatjs/intl-displaynames": {
+      "version": "5.4.2",
+      "resolved": "https://registry.npmjs.org/@formatjs/intl-displaynames/-/intl-displaynames-5.4.2.tgz",
+      "integrity": "sha512-SLesCDan9NCMqBbHPXMEwqAcPn3tnbQw0sv0rssH1JQDLDUQYwKXL93kz30X3yskTyQS7N+pd47bhoIe3kbXyw==",
+      "dev": true,
+      "requires": {
+        "@formatjs/ecma402-abstract": "1.11.3",
+        "@formatjs/intl-localematcher": "0.2.24",
+        "tslib": "^2.1.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+          "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+          "dev": true
+        }
+      }
+    },
+    "@formatjs/intl-listformat": {
+      "version": "6.5.2",
+      "resolved": "https://registry.npmjs.org/@formatjs/intl-listformat/-/intl-listformat-6.5.2.tgz",
+      "integrity": "sha512-/IYagQJkzTvpBlhhaysGYNgM3o72WBg1ZWZcpookkgXEJbINwLP5kVagHxmgxffYKs1CDzQ8rmKHghu2qR/7zw==",
+      "dev": true,
+      "requires": {
+        "@formatjs/ecma402-abstract": "1.11.3",
+        "@formatjs/intl-localematcher": "0.2.24",
+        "tslib": "^2.1.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+          "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+          "dev": true
+        }
+      }
+    },
+    "@formatjs/intl-localematcher": {
+      "version": "0.2.24",
+      "resolved": "https://registry.npmjs.org/@formatjs/intl-localematcher/-/intl-localematcher-0.2.24.tgz",
+      "integrity": "sha512-K/HRGo6EMnCbhpth/y3u4rW4aXkmQNqRe1L2G+Y5jNr3v0gYhvaucV8WixNju/INAMbPBlbsRBRo/nfjnoOnxQ==",
+      "dev": true,
+      "requires": {
+        "tslib": "^2.1.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+          "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
           "dev": true
         }
       }
@@ -52105,6 +52416,26 @@
       "resolved": "https://registry.npmjs.org/interpret/-/interpret-2.2.0.tgz",
       "integrity": "sha512-Ju0Bz/cEia55xDwUWEa8+olFpCiQoypjnQySseKtmjNrnps3P+xfpUmGr90T7yjlVJmOtybRvPXhKMbHr+fWnw==",
       "dev": true
+    },
+    "intl-messageformat": {
+      "version": "9.11.4",
+      "resolved": "https://registry.npmjs.org/intl-messageformat/-/intl-messageformat-9.11.4.tgz",
+      "integrity": "sha512-77TSkNubIy/hsapz6LQpyR6OADcxhWdhSaboPb5flMaALCVkPvAIxr48AlPqaMl4r1anNcvR9rpLWVdwUY1IKg==",
+      "dev": true,
+      "requires": {
+        "@formatjs/ecma402-abstract": "1.11.3",
+        "@formatjs/fast-memoize": "1.2.1",
+        "@formatjs/icu-messageformat-parser": "2.0.18",
+        "tslib": "^2.1.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+          "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+          "dev": true
+        }
+      }
     },
     "into-stream": {
       "version": "3.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "@1024pix/pix-ui",
-      "version": "13.0.0",
+      "version": "13.3.3",
       "license": "MIT",
       "dependencies": {
         "ember-cli-babel": "^7.26.6",

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "@1024pix/ember-testing-library": "^0.5.0",
     "@ember/optional-features": "^2.0.0",
     "@ember/test-helpers": "^2.6.0",
+    "@formatjs/intl": "^2.1.0",
     "@fortawesome/ember-fontawesome": "^0.2.3",
     "@fortawesome/free-regular-svg-icons": "^5.15.4",
     "@fortawesome/free-solid-svg-icons": "^5.15.4",

--- a/tests/integration/components/pix-pagination-test.js
+++ b/tests/integration/components/pix-pagination-test.js
@@ -1,0 +1,21 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+
+module('Integration | Component | pagination', function (hooks) {
+  setupRenderingTest(hooks);
+
+  const COMPONENT_SELECTOR = '.pagination-control';
+
+  test('it renders the default PixPagination', async function (assert) {
+    // when
+    await render(hbs`
+      <PixPagination/>
+    `);
+    const componentElement = this.element.querySelector(COMPONENT_SELECTOR);
+
+    // then
+    assert.equal(componentElement.textContent.trim(), 'content');
+  });
+});

--- a/tests/integration/components/pix-pagination-test.js
+++ b/tests/integration/components/pix-pagination-test.js
@@ -7,6 +7,12 @@ module('Integration | Component | pagination', function (hooks) {
   setupRenderingTest(hooks);
 
   const COMPONENT_SELECTOR = '.pagination-control';
+  const paginationData = {
+    page: 1,
+    pageSize: 10,
+    rowCount: 2,
+    pageCount: 1,
+  };
 
   test('it renders the default PixPagination', async function (assert) {
     // when
@@ -17,5 +23,39 @@ module('Integration | Component | pagination', function (hooks) {
 
     // then
     assert.equal(componentElement.textContent.trim(), 'content');
+  });
+
+  test('Use locale params to translate component', async function (assert) {
+    // given
+    this.locale = 'en';
+    const COMPONENT_SELECTOR = '.page-size__label';
+    this.set('pagination', paginationData);
+
+    // when
+    await render(hbs`
+      <PixPagination
+        @locale={{this.locale}}
+        @pagination={{pagination}}
+      />
+    `);
+    const componentElement = this.element.querySelector(COMPONENT_SELECTOR);
+
+    // then
+    assert.equal(componentElement.textContent.trim(), 'See');
+  });
+  test('Use PixPagination without locale params', async function (assert) {
+    // given
+    const COMPONENT_SELECTOR = '.page-size__label';
+    this.set('pagination', paginationData);
+    // when
+    await render(hbs`
+      <PixPagination
+         @pagination={{pagination}}
+      />
+    `);
+    const componentElement = this.element.querySelector(COMPONENT_SELECTOR);
+
+    // then
+    assert.equal(componentElement.textContent.trim(), 'Voir');
   });
 });

--- a/tests/integration/components/pix-pagination-test.js
+++ b/tests/integration/components/pix-pagination-test.js
@@ -1,61 +1,78 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import { render } from '@ember/test-helpers';
+import { render } from '@1024pix/ember-testing-library';
 import { hbs } from 'ember-cli-htmlbars';
 
 module('Integration | Component | pagination', function (hooks) {
   setupRenderingTest(hooks);
 
-  const COMPONENT_SELECTOR = '.pagination-control';
-  const paginationData = {
-    page: 1,
-    pageSize: 10,
-    rowCount: 2,
-    pageCount: 1,
-  };
-
-  test('it renders the default PixPagination', async function (assert) {
-    // when
-    await render(hbs`
-      <PixPagination/>
-    `);
-    const componentElement = this.element.querySelector(COMPONENT_SELECTOR);
-
-    // then
-    assert.equal(componentElement.textContent.trim(), 'content');
-  });
-
-  test('Use locale params to translate component', async function (assert) {
-    // given
-    this.locale = 'en';
-    const COMPONENT_SELECTOR = '.page-size__label';
-    this.set('pagination', paginationData);
-
-    // when
-    await render(hbs`
-      <PixPagination
-        @locale={{this.locale}}
-        @pagination={{pagination}}
-      />
-    `);
-    const componentElement = this.element.querySelector(COMPONENT_SELECTOR);
-
-    // then
-    assert.equal(componentElement.textContent.trim(), 'See');
-  });
   test('Use PixPagination without locale params', async function (assert) {
     // given
-    const COMPONENT_SELECTOR = '.page-size__label';
+    const paginationData = {
+      page: 1,
+      pageSize: 10,
+      rowCount: 2,
+      pageCount: 1,
+    };
     this.set('pagination', paginationData);
     // when
-    await render(hbs`
+    const screen = await render(hbs`
       <PixPagination
          @pagination={{pagination}}
       />
     `);
-    const componentElement = this.element.querySelector(COMPONENT_SELECTOR);
 
     // then
-    assert.equal(componentElement.textContent.trim(), 'Voir');
+    assert.dom(screen.getByText('Voir')).exists();
+    assert.dom(screen.getByText('2 éléments')).exists();
+    assert.dom(screen.getByText('Page 1 / 1')).exists();
+  });
+
+  test('Use locale params to translate component', async function (assert) {
+    // given
+    const paginationData = {
+      page: 1,
+      pageSize: 10,
+      rowCount: 2,
+      pageCount: 1,
+    };
+    this.set('locale', 'en');
+    this.set('pagination', paginationData);
+
+    // when
+    const screen = await render(hbs`
+      <PixPagination
+        @pagination={{pagination}}
+        @locale={{this.locale}}
+      />
+    `);
+
+    // then
+    assert.dom(screen.getByText('See')).exists();
+    assert.dom(screen.getByText('2 items')).exists();
+    assert.dom(screen.getByText('Page 1 / 1')).exists();
+  });
+
+  test('When pagination params have options to display several pages', async function (assert) {
+    // given
+    const paginationData = {
+      page: 2,
+      pageSize: 10,
+      rowCount: 12,
+      pageCount: 2,
+    };
+    this.set('pagination', paginationData);
+
+    // when
+    const screen = await render(hbs`
+      <PixPagination
+        @pagination={{pagination}}
+      />
+    `);
+
+    // then
+    assert.dom(screen.getByText('Voir')).exists();
+    assert.dom(screen.getByText('11-12 sur 12 éléments')).exists();
+    assert.dom(screen.getByText('Page 2 / 2')).exists();
   });
 });

--- a/tests/unit/translations/flatten-object-test.js
+++ b/tests/unit/translations/flatten-object-test.js
@@ -1,0 +1,37 @@
+import { module, test } from 'qunit';
+import { flattenObject } from '@1024pix/pix-ui/translations';
+
+module('Unit | Translations', function () {
+  module('#flattenObject', function () {
+    test('it should deeply flatten an object using dot notation', function (assert) {
+      // given
+      const object = {
+        nested1: {
+          nested11: {
+            nested111: 'nested111',
+          },
+          nested12: 'nested12',
+        },
+        nested2: {
+          nested21: {
+            nested211: 'nested211',
+            nested212: 'nested212',
+          },
+        },
+        nested3: 'nested3',
+      };
+
+      // when
+      const result = flattenObject(object);
+
+      // then
+      assert.deepEqual(result, {
+        'nested1.nested11.nested111': 'nested111',
+        'nested1.nested12': 'nested12',
+        'nested2.nested21.nested211': 'nested211',
+        'nested2.nested21.nested212': 'nested212',
+        nested3: 'nested3',
+      });
+    });
+  });
+});


### PR DESCRIPTION
## :boom: BREAKING_CHANGES

N/A

## :christmas_tree: Problème

On a des composants de pagination avec des fonctionnalités identiques réimplémentés dans différentes applis.

## :gift: Solution

Implémenter un composant de pagination réutilisable dans pix-ui !

## :star2: Remarques
- Lors de l'intégration dans les différentes applications, quelques changements peuvent se faire sentir :
  * Le composant est responsive : changer le nombre d'élements par page n'est possible qu'à partir du breakpoint `tablet`.
  * Les `IconButton` ont maintenant une `size="big"` pour accéder plus facilement aux boutons.
- Point de vigilance sur l'i18n du composant.
- Pour les tests, doit-on tester si les fonctions, `goToNextPage()` & `goToPreviousPage()`, sont call ?
-  ⚠️ On ne peut pas tester fonctionnellement les changements de pages car nous n'avons pas accès au `query parameters` nécessaires.

## :santa: Pour tester

- Aller sur Storybook & sur l'onglet pagination.
- Vérifier si les traductions sont bonnes.
- Vérifier que les aria-label sont disponibles pour les icônes.
- Vérifier que l'aria-label du pix-Select est bien défini
