### PR TITLE
[FEATURE] Permettre à pix-pagination d'avoir une version condensée (PIX-4715)

### DIFF
--- a/addon/components/pix-pagination.hbs
+++ b/addon/components/pix-pagination.hbs
@@ -1,4 +1,4 @@
-<footer class="pix-pagination">
+<footer class={{this.isCondensed}}>
   <section class="pix-pagination__size">
     <span class="pagination-size__label">{{this.beforeResultsPerPage}}</span>
     <PixSelect
@@ -17,8 +17,9 @@
         {{this.pageInfo}}
       {{/if}}
     </span>
-    <div class="pix-pagination__navigation-action">
+    <div class="pix-pagination-navigation__action">
       <PixIconButton
+        class="pix-pagination-navigation__action-button"
         @icon="arrow-left"
         aria-label={{this.previousPageLabel}}
         @triggerAction={{this.goToPreviousPage}}
@@ -32,6 +33,7 @@
         {{this.pageNumber}}
       </span>
       <PixIconButton
+        class="pix-pagination-navigation__action-button"
         @icon="arrow-right"
         aria-label={{this.nextPageLabel}}
         @triggerAction={{this.goToNextPage}}

--- a/addon/components/pix-pagination.js
+++ b/addon/components/pix-pagination.js
@@ -9,8 +9,13 @@ const DEFAULT_PAGE_OPTIONS = [
   { label: '50', value: 50 },
   { label: '100', value: 100 },
 ];
+
 export default class PixPagination extends Component {
   @service router;
+
+  get isCondensed() {
+    return this.args.isCondensed ? 'pix-pagination-condensed' : 'pix-pagination';
+  }
 
   get beforeResultsPerPage() {
     return this.formatMessage('beforeResultsPerPage');

--- a/addon/styles/_pix-pagination.scss
+++ b/addon/styles/_pix-pagination.scss
@@ -1,9 +1,10 @@
-.pix-pagination{
+.pix-pagination, .pix-pagination-condensed {
   display: flex;
   justify-content: center;
   margin: 16px 0;
   color: $grey-60;
   font-size: 0.875rem;
+
   &__size {
     display: none;
     align-items: center;
@@ -21,15 +22,22 @@
     }
   }
 
-  &__navigation{
+  &__navigation {
     display: flex;
     align-items: center;
     padding: 0;
     gap: 12px;
     flex-direction: column-reverse;
-    &-action {
-      display: flex;
-      align-items: center;
+  }
+}
+
+.pix-pagination-navigation {
+  &__action {
+    display: flex;
+    align-items: center;
+
+    &-button {
+      margin: 0 8px;
     }
   }
 }
@@ -37,12 +45,15 @@
 @include device-is('tablet') {
   .pix-pagination {
     justify-content: space-between;
-    &__size{
+  }
+  .pix-pagination > .pix-pagination {
+    &__size {
       display: flex;
     }
-    &__navigation{
+
+    &__navigation {
       gap: initial;
-      flex-direction:initial ;
+      flex-direction: initial;
     }
   }
 }

--- a/app/stories/pix-pagination.stories.js
+++ b/app/stories/pix-pagination.stories.js
@@ -7,6 +7,7 @@ export const Template = (args) => {
         @pagination={{pagination}}
         @locale = {{locale}}
         @pageOptions= {{pageOptions}}
+        @isCondensed= {{isCondensed}}
             />
     `,
     context: args,
@@ -50,6 +51,18 @@ OnePage.args = {
     pageCount: 1,
   },
   locale: 'fr',
+};
+
+export const Condensed = Template.bind({});
+Condensed.args = {
+  pagination: {
+    page: 1,
+    pageSize: 10,
+    rowCount: 2,
+    pageCount: 1,
+  },
+  locale: 'fr',
+  isCondensed: true,
 };
 
 // select attribute data type from https://storybook.js.org/docs/react/essentials/controls
@@ -117,6 +130,17 @@ export const argTypes = {
     table: {
       type: { summary: 'string' },
       defaultValue: { summary: 'fr' },
+    },
+  },
+  isCondensed: {
+    name: 'isCondensed',
+    description:
+      "En desktop, retire le contrôle du nombre d'élèments par page pour simplifier l'usage",
+    type: { name: 'boolean', required: false },
+    control: { type: 'boolean' },
+    table: {
+      type: { summary: 'boolean' },
+      defaultValue: { summary: 'false' },
     },
   },
 };

--- a/app/stories/pix-pagination.stories.mdx
+++ b/app/stories/pix-pagination.stories.mdx
@@ -44,6 +44,11 @@ Sur mobile, le select qui permet de choisir le nombre d'élément à afficher su
   <Story name='OnePage' story={stories.OnePage} height={110} />
 </Canvas>
 
+## Version condensée
+<Canvas>
+  <Story name='Condensed' story={stories.Condensed} height={140} />
+</Canvas>
+
 ## Usage
 
 ```html
@@ -51,6 +56,7 @@ Sur mobile, le select qui permet de choisir le nombre d'élément à afficher su
    @pagination={{pagination}}
    @locale = {{locale}}
    @pageOptions = {{pageOptions}
+   @isCondensed = {{isCondensed}
 />
 ```
 

--- a/tests/integration/components/pix-pagination-test.js
+++ b/tests/integration/components/pix-pagination-test.js
@@ -1,6 +1,6 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import { render } from '@1024pix/ember-testing-library';
+import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 
 module('Integration | Component | pagination', function (hooks) {
@@ -16,16 +16,18 @@ module('Integration | Component | pagination', function (hooks) {
     };
     this.set('pagination', paginationData);
     // when
-    const screen = await render(hbs`
+    await render(hbs`
       <PixPagination
          @pagination={{pagination}}
       />
     `);
 
-    // then
-    assert.dom(screen.getByText('Voir')).exists();
-    assert.dom(screen.getByText('2 éléments')).exists();
-    assert.dom(screen.getByText('Page 1 / 1')).exists();
+    const PixPaginationElement = this.element.querySelector('.pix-pagination');
+    //then
+    assert.ok(PixPaginationElement);
+    assert.contains('Voir');
+    assert.contains('2 éléments');
+    assert.contains('Page 1 / 1');
   });
 
   test('Use locale params to translate component', async function (assert) {
@@ -40,17 +42,19 @@ module('Integration | Component | pagination', function (hooks) {
     this.set('pagination', paginationData);
 
     // when
-    const screen = await render(hbs`
+    await render(hbs`
       <PixPagination
         @pagination={{pagination}}
         @locale={{this.locale}}
       />
     `);
 
-    // then
-    assert.dom(screen.getByText('See')).exists();
-    assert.dom(screen.getByText('2 items')).exists();
-    assert.dom(screen.getByText('Page 1 / 1')).exists();
+    const PixPaginationElement = this.element.querySelector('.pix-pagination');
+    //then
+    assert.ok(PixPaginationElement);
+    assert.contains('See');
+    assert.contains('2 items');
+    assert.contains('Page 1 / 1');
   });
 
   test('When pagination params have options to display several pages', async function (assert) {
@@ -64,15 +68,38 @@ module('Integration | Component | pagination', function (hooks) {
     this.set('pagination', paginationData);
 
     // when
-    const screen = await render(hbs`
+    await render(hbs`
       <PixPagination
         @pagination={{pagination}}
       />
     `);
 
-    // then
-    assert.dom(screen.getByText('Voir')).exists();
-    assert.dom(screen.getByText('11-12 sur 12 éléments')).exists();
-    assert.dom(screen.getByText('Page 2 / 2')).exists();
+    const PixPaginationElement = this.element.querySelector('.pix-pagination');
+    //then
+    assert.ok(PixPaginationElement);
+    assert.contains('Voir');
+    assert.contains('11-12 sur 12 éléments');
+    assert.contains('Page 2 / 2');
+  });
+  test('When params isCondensed is true', async function (assert) {
+    // given
+    const paginationData = {
+      page: 2,
+      pageSize: 10,
+      rowCount: 12,
+      pageCount: 2,
+    };
+    this.set('pagination', paginationData);
+    // when
+    await render(hbs`
+      <PixPagination
+        @pagination={{pagination}}
+        @isCondensed=true
+      />
+    `);
+
+    const PixPaginationCondensedElement = this.element.querySelector('.pix-pagination-condensed');
+    //then
+    assert.ok(PixPaginationCondensedElement);
   });
 });


### PR DESCRIPTION
## :boom: BREAKING_CHANGES
/
## :christmas_tree: Problème
Pouvoir choisir si la pagination est condensée ou non

## :gift: Solution
Ajout d'un paramètre  ` isCondensed ` qui va permettre d'utiliser la class ` pix-pagination-condensed ` 

## :star2: Remarques
J'ai remarqué que la majorité des composants utilisent '@ember/test-helpers'.
Du coup, j'ai mis à jour les tests de `pix-pagination` pour utiliser cet outils.

## :santa: Pour tester
Vérifier sur storybook que la version condensé est active en mode desktop.
