### PR TITLE
[TECH] Suppression de la margin dans Pix-Pagination (PIX-4733)

### DIFF
--- a/addon/styles/_pix-pagination.scss
+++ b/addon/styles/_pix-pagination.scss
@@ -1,7 +1,6 @@
 .pix-pagination, .pix-pagination-condensed {
   display: flex;
   justify-content: center;
-  margin: 16px 0;
   color: $grey-60;
   font-size: 0.875rem;
 


### PR DESCRIPTION
## :boom: BREAKING_CHANGES
/

## :christmas_tree: Problème
Enlever la margin de Pix-pagination.

## :gift: Solution
Suppression  de la margin dans le fichier `_pix-pagination.scss`

## :star2: Remarques
X

## :santa: Pour tester
Verifier sur storybook, que la classe `.pix-pagination` &  `.pix-pagination-condensed` ne possède pas de `margin`. 
