### PR TITLE
[BREAKING_CHANGES][BUGFIX] Ajouter un aria-label au Pix Input (PIX-4759).

### DIFF
--- a/addon/components/pix-input.hbs
+++ b/addon/components/pix-input.hbs
@@ -18,6 +18,7 @@
       id={{this.id}}
       class={{this.className}}
       value={{@value}}
+      aria-label={{this.ariaLabel}}
       aria-required="{{if @requiredLabel true false}}"
       required={{if @requiredLabel true false}}
       aria-describedby={{if @errorMessage "text-input-error"}}

--- a/addon/components/pix-input.js
+++ b/addon/components/pix-input.js
@@ -1,5 +1,7 @@
 import Component from '@glimmer/component';
 
+const ERROR_MESSAGE = 'ERROR in PixInput component, you must provide @label or @ariaLabel params';
+
 export default class PixInput extends Component {
   get id() {
     if (!this.args.id || !this.args.id.toString().trim()) {
@@ -14,5 +16,19 @@ export default class PixInput extends Component {
     this.args.icon && classNames.push('pix-input__input--icon');
     this.args.isIconLeft && classNames.push('pix-input__input--icon-left');
     return classNames.join(' ');
+  }
+
+  get label() {
+    if (!this.args.label && !this.args.ariaLabel) {
+      throw new Error(ERROR_MESSAGE);
+    }
+    return this.args.label;
+  }
+
+  get ariaLabel() {
+    if (!this.args.label && !this.args.ariaLabel) {
+      throw new Error(ERROR_MESSAGE);
+    }
+    return this.args.label ? null : this.args.ariaLabel;
   }
 }

--- a/app/stories/pix-input-password.stories.js
+++ b/app/stories/pix-input-password.stories.js
@@ -72,7 +72,7 @@ export const argTypes = {
   },
   ariaLabel: {
     name: 'ariaLabel',
-    description: "L'action du bouton, pour l'accessibilité. Requis si label n'est pas définit.",
+    description: "L'action du champ, pour l'accessibilité. Requis si label n'est pas définit.",
     type: { name: 'string', required: true },
     defaultValue: null,
   },

--- a/app/stories/pix-input.stories.js
+++ b/app/stories/pix-input.stories.js
@@ -12,6 +12,7 @@ export const Template = (args) => {
         @isIconLeft={{isIconLeft}}
         placeholder='Jeanne, Pierre ...'
         @requiredLabel={{requiredLabel}}
+        @ariaLabel={{ariaLabel}}
       />
     `,
     context: args,
@@ -21,6 +22,7 @@ export const Template = (args) => {
 export const Default = Template.bind({});
 Default.args = {
   id: 'firstName',
+  ariaLabel: 'Prénom',
 };
 
 export const withLabel = Template.bind({});
@@ -53,6 +55,12 @@ withRequiredLabel.args = {
 };
 
 export const argTypes = {
+  ariaLabel: {
+    name: 'ariaLabel',
+    description: "L'action du champ, pour l'accessibilité. Requis si label n'est pas définit.",
+    type: { name: 'string', required: true },
+    defaultValue: null,
+  },
   id: {
     name: 'id',
     description: 'Identifiant du champ permettant de lui attacher un label',

--- a/app/stories/pix-input.stories.mdx
+++ b/app/stories/pix-input.stories.mdx
@@ -14,6 +14,12 @@ import * as stories from './pix-input.stories.js';
 
 Le PixInput permet de créer un champ de texte.
 
+## Accessibilité
+
+Si vous utilisez le `PixInput` sans label alors il faut renseigner le paramètre `ariaLabel`, sinon le composant renvoie une erreur.
+
+> Si vous renseignez les paramètres label et ariaLabel ensemble, ariaLabel sera nullifié.
+
 
 ## Default
 

--- a/tests/integration/components/pix-input-test.js
+++ b/tests/integration/components/pix-input-test.js
@@ -33,7 +33,7 @@ module('Integration | Component | input', function (hooks) {
 
   test('it should be possible to give a number as id', async function (assert) {
     // given & when
-    await render(hbs`<PixInput @id={{123}} />`);
+    await render(hbs`<PixInput @id={{123}} @label="Prénom" />`);
 
     // then
     const selectorElement = this.element.querySelector(INPUT_SELECTOR);
@@ -61,7 +61,7 @@ module('Integration | Component | input', function (hooks) {
   test('it should be possible to give an error message to input', async function (assert) {
     // given & when
     await render(
-      hbs`<PixInput @id="firstName" @errorMessage="Seul les caractères alphanumériques sont autorisés" />`
+      hbs`<PixInput @id="firstName" @label="Prénom" @errorMessage="Seul les caractères alphanumériques sont autorisés" />`
     );
 
     // then
@@ -70,7 +70,7 @@ module('Integration | Component | input', function (hooks) {
 
   test('it should be possible to give an icon to input', async function (assert) {
     // given & when
-    await render(hbs`<PixInput @id="firstName" @icon="times" />`);
+    await render(hbs`<PixInput @id="firstName" @label="Prénom" @icon="times" />`);
 
     // then
     assert.dom('.pix-input__icon').exists();
@@ -78,7 +78,9 @@ module('Integration | Component | input', function (hooks) {
 
   test('it should be possible to put an icon to the left of input', async function (assert) {
     // given & when
-    await render(hbs`<PixInput @id="firstName" @icon="times" @isIconLeft={{true}} />`);
+    await render(
+      hbs`<PixInput @id="firstName" @label="Prénom" @icon="times" @isIconLeft={{true}} />`
+    );
 
     // then
     assert.dom('.pix-input__icon.pix-input__icon--left').exists();
@@ -111,5 +113,22 @@ module('Integration | Component | input', function (hooks) {
     // then
     const requiredInput = screen.getByLabelText('* Prénom');
     assert.dom(requiredInput).isRequired();
+  });
+
+  test('it should throw an error if pix input has neither a label nor an ariaLabel param', async function (assert) {
+    // given & when
+    const componentParams = { label: null, ariaLabel: null };
+    const component = createGlimmerComponent('component:pix-input', componentParams);
+
+    // then
+    const expectedError = new Error(
+      'ERROR in PixInput component, you must provide @label or @ariaLabel params'
+    );
+    assert.throws(function () {
+      component.label;
+    }, expectedError);
+    assert.throws(function () {
+      component.ariaLabel;
+    }, expectedError);
   });
 });


### PR DESCRIPTION
## :boom: BREAKING_CHANGES
Plusieurs Pix Input (notamment Pix Admin) n'ont pas de label, avec cette PR ils ne s'afficheront plus si on ne les corrige pas.
![Capture d’écran 2022-04-12 à 10 40 01](https://user-images.githubusercontent.com/58915422/162919445-2e8df0e2-661f-4a54-b98f-1a2070858b67.png)


## :christmas_tree: Problème
Actuellement, il est possible d’ajouter le Pix Input sans label. Or pour l’accessibilité, il est nécessaire de fournir une information à l’utilisateur, même sans label. Pour cela on utilise l’aria-label, que l’on inclut dans le champ.

## :gift: Solution
Il faut donc permettre d’ajouter un aria-label au composant quand on souhaite ne pas mettre de label.

## :star2: Remarques
Si on ne renseigne ni le label, ni l’aria-label, on retourne une erreur pour obliger l’ajout de cette information.

## :santa: Pour tester
Pour vérifier le comportement sans aria-label sur Wave : 

- Aller sur https://ui.pix.fr/?path=/story/form-inputs-input--default
- Rester sur le default et cliquer sur Canvas
- Cliquer sur le bouton pour ouvrir une nouvelle fenêtre pour lancer Wave
<img width="1558" alt="Capture d’écran 2022-04-11 à 15 17 05" src="https://user-images.githubusercontent.com/58915422/162916704-a9d8c8c2-75e4-4ffe-90b4-b902104e330e.png">

- Maintenant aller sur la RA et faire le même scénario
- Constater que Wave est content.