### PR TITLE
[FEATURE] Retirer l'option d'ajouter une icône dans le composant Pix Input (PIX-4766).

### DIFF
--- a/addon/components/pix-input.hbs
+++ b/addon/components/pix-input.hbs
@@ -16,7 +16,7 @@
   <div class="pix-input__container">
     <input
       id={{this.id}}
-      class={{this.className}}
+      class={{if @errorMessage "pix-input__input--error"}}
       value={{@value}}
       aria-label={{this.ariaLabel}}
       aria-required="{{if @requiredLabel true false}}"
@@ -27,10 +27,6 @@
 
     {{#if @errorMessage}}
       <FaIcon @icon="times" class="pix-input__error-icon" />
-    {{/if}}
-
-    {{#if @icon}}
-      <FaIcon @icon={{@icon}} class="pix-input__icon {{if @isIconLeft 'pix-input__icon--left'}}" />
     {{/if}}
   </div>
 

--- a/addon/components/pix-input.js
+++ b/addon/components/pix-input.js
@@ -10,14 +10,6 @@ export default class PixInput extends Component {
     return this.args.id;
   }
 
-  get className() {
-    const classNames = [];
-    this.args.errorMessage && classNames.push('pix-input__input--error');
-    this.args.icon && classNames.push('pix-input__input--icon');
-    this.args.isIconLeft && classNames.push('pix-input__input--icon-left');
-    return classNames.join(' ');
-  }
-
   get label() {
     if (!this.args.label && !this.args.ariaLabel) {
       throw new Error(ERROR_MESSAGE);

--- a/addon/styles/_pix-input.scss
+++ b/addon/styles/_pix-input.scss
@@ -25,25 +25,6 @@
     position: relative;
   }
 
-  svg.pix-input__icon {
-    position: absolute;
-    bottom: 9px;
-    right: 6px;
-    color: $grey-25;
-    font-size: 1.125rem;
-    width: 18px;
-    height: 18px;
-
-    &--left {
-      left: 6px;
-    }
-  }
-
-  svg ~ svg.pix-input__icon {
-    right: calc(6px + 12px + 2px);
-    margin-right: 8px;
-  }
-
   svg.pix-input__error-icon {
     position: absolute;
     bottom: 10px;
@@ -83,18 +64,6 @@
     &.pix-input__input--error {
       padding-right: 32px;
       @include formElementInError();
-    }
-
-    &.pix-input__input--icon {
-      padding-right: 32px;
-    }
-
-    &.pix-input__input--icon.pix-input__input--icon-left {
-      padding-left: 32px;
-    }
-
-    &.pix-input__input--error.pix-input__input--icon:not(.pix-input__input--icon-left) {
-      padding-right: 32px;
     }
   }
 }

--- a/app/stories/pix-input.stories.js
+++ b/app/stories/pix-input.stories.js
@@ -8,8 +8,6 @@ export const Template = (args) => {
         @label={{label}}
         @information={{information}}
         @errorMessage={{errorMessage}}
-        @icon={{icon}}
-        @isIconLeft={{isIconLeft}}
         placeholder='Jeanne, Pierre ...'
         @requiredLabel={{requiredLabel}}
         @ariaLabel={{ariaLabel}}
@@ -38,13 +36,6 @@ withErrorMessage.args = {
   label: 'Prénom',
   information: 'a small information',
   errorMessage: "un message d'erreur",
-};
-
-export const withIcon = Template.bind({});
-withIcon.args = {
-  id: 'firstName',
-  label: 'Prénom',
-  icon: 'eye',
 };
 
 export const withRequiredLabel = Template.bind({});
@@ -90,23 +81,6 @@ export const argTypes = {
     description: "Affiche le message d'erreur donné et encadre en rouge le champ",
     type: { name: 'string', required: false },
     defaultValue: null,
-  },
-  icon: {
-    name: 'icon',
-    description: "Affiche l'icône choisie à la fin de l'input",
-    type: { name: 'string', required: false },
-    defaultValue: null,
-  },
-  isIconLeft: {
-    name: 'isIconLeft',
-    description: "Permet d'afficher l'icône choisie sur la gauche",
-    type: { name: 'boolean', required: false },
-    control: { type: 'boolean' },
-    defaultValue: false,
-    table: {
-      type: { summary: 'boolean' },
-      defaultValue: { summary: 'false' },
-    },
   },
   requiredLabel: {
     name: 'requiredLabel',

--- a/app/stories/pix-input.stories.mdx
+++ b/app/stories/pix-input.stories.mdx
@@ -39,12 +39,6 @@ Si vous utilisez le `PixInput` sans label alors il faut renseigner le paramètre
   <Story story={stories.withErrorMessage} height={130} />
 </Canvas>
 
-## With icon
-
-<Canvas>
-  <Story story={stories.withIcon} height={130} />
-</Canvas>
-
 ## With required label
 
 <Canvas>
@@ -59,8 +53,6 @@ Si vous utilisez le `PixInput` sans label alors il faut renseigner le paramètre
   @label='Prénom'
   @information='Complément du label'
   @errorMessage='Un message d`erreur'
-  @icon='eye'
-  @isIconLeft={{false}}
   @requiredLabel='Champ obligatoire'
 />
 ```

--- a/tests/integration/components/pix-input-test.js
+++ b/tests/integration/components/pix-input-test.js
@@ -68,24 +68,6 @@ module('Integration | Component | input', function (hooks) {
     assert.contains('Seul les caractères alphanumériques sont autorisés');
   });
 
-  test('it should be possible to give an icon to input', async function (assert) {
-    // given & when
-    await render(hbs`<PixInput @id="firstName" @label="Prénom" @icon="times" />`);
-
-    // then
-    assert.dom('.pix-input__icon').exists();
-  });
-
-  test('it should be possible to put an icon to the left of input', async function (assert) {
-    // given & when
-    await render(
-      hbs`<PixInput @id="firstName" @label="Prénom" @icon="times" @isIconLeft={{true}} />`
-    );
-
-    // then
-    assert.dom('.pix-input__icon.pix-input__icon--left').exists();
-  });
-
   test('it should be possible to track value from input', async function (assert) {
     // given & when
     await render(hbs`<PixInput @label="Prénom" @id="firstName" @value='Jeanne' />`);


### PR DESCRIPTION
## :boom: BREAKING_CHANGES
L'option n'est pas utilisé dans les applications.

## :christmas_tree: Problème
Actuellement nous avons la possibilité d’ajouter une icône dans le composant Pix Input. 
Or celle-ci n’est pas utilisé dans nos applications.

Il a été implémenté à la [création du composant Pix Input](https://github.com/1024pix/pix-ui/pull/121). D'après le contenu de la PR il n'a pas une utilité très clair et nous avons désormais le composant Pix Input Password pour notre besoin d'un champ mot de passe avec une icône pour voir ou masquer le contenu du champ.

## :gift: Solution
Supprimer l'option icône.

## :star2: Remarques
Cette option se compose de 2 paramètres en réalité :
- `icon`, pour choisir l'icone que l'on veut ajouter (exemple 'eye', 'times')
- `isIconLeft`, un booléen si on veut ajouter cette icône à droite du champ.

## :santa: Pour tester
Vérifier dans le code, que tout ce qui est associé à cette option a été intégralement supprimé.
Vérifier que les tests passent.
Constater que la doc ne comporte plus cette option
