### PR TITLE
[BUGFIX] Ajouter  params à la méthode triggerAction à PixIconButton (PIX-4790)

### DIFF
--- a/addon/components/pix-icon-button.js
+++ b/addon/components/pix-icon-button.js
@@ -25,9 +25,9 @@ export default class PixIconButton extends Component {
   }
 
   @action
-  triggerAction() {
+  triggerAction(params) {
     if (this.args.triggerAction) {
-      this.args.triggerAction();
+      this.args.triggerAction(params);
     }
   }
 }


### PR DESCRIPTION
## :boom: BREAKING_CHANGES
pas de breaking changes

## :christmas_tree: Problème
Il n'était pas possible de récupérer `event` après une action.

## :gift: Solution
Passer l'attribut `params` en paramètre de la fonction triggerAction pour faire passer l'event.

## :star2: Remarques


## :santa: Pour tester

