### PR TITLE
[TECH] Rajouter les classes de typographie et les mixins de box-shadow du design system

### DIFF
--- a/addon/styles/_shadows.scss
+++ b/addon/styles/_shadows.scss
@@ -1,0 +1,46 @@
+// See https://www.figma.com/file/8RJ3aCSfdeQ8AZZVBBYKS8/Design-System-Pix?node-id=54%3A5141
+
+// Mixin pour permettre l'utilisation dans une classe css si jamais le tag html a trop de classe
+@mixin shadow($verticalSize, $blur) {
+  box-shadow: 0 $verticalSize $blur rgba(7, 20, 46, 0.08);
+}
+
+@mixin shadow-xs() {
+  @include shadow(4px, 8px);
+}
+
+@mixin shadow-sm() {
+  @include shadow(6px, 12px);
+}
+
+@mixin shadow-md() {
+  @include shadow(8px, 16px);
+}
+
+@mixin shadow-lg() {
+  @include shadow(10px, 20px);
+}
+
+@mixin shadow-xl() {
+  @include shadow(12px, 24px);
+}
+
+.pix-shadow-xs {
+  @include shadow-xs;
+}
+
+.pix-shadow-sm {
+  @include shadow-sm;
+}
+
+.pix-shadow-md {
+  @include shadow-md;
+}
+
+.pix-shadow-lg {
+  @include shadow-lg;
+}
+
+.pix-shadow-xl {
+  @include shadow-xl;
+}

--- a/addon/styles/_typography.scss
+++ b/addon/styles/_typography.scss
@@ -1,0 +1,255 @@
+// See https://www.figma.com/file/8RJ3aCSfdeQ8AZZVBBYKS8/Design-System-Pix?node-id=24%3A8
+
+// Mixin pour permettre l'utilisation dans une classe css si jamais le tag html a trop de classe
+@mixin display1() {
+  font-family: $font-open-sans;
+  font-weight: $font-light;
+  font-size: 4.5rem;
+  line-height: 5.5rem;
+  letter-spacing: -0.04em;
+}
+
+@mixin display2() {
+  font-family: $font-open-sans;
+  font-weight: $font-light;
+  font-size: 3.75rem;
+  line-height: 4.5rem;
+  letter-spacing: -0.04em;
+}
+
+@mixin display3() {
+  font-family: $font-open-sans;
+  font-weight: $font-light;
+  font-size: 3rem;
+  line-height: 3.75rem;
+  letter-spacing: -0.04em;
+
+  @include device-is('mobile') {
+    font-weight: $font-medium;
+    font-size: 2.25rem;
+    line-height: 2.75rem;
+  }
+}
+
+@mixin h1() {
+  font-family: $font-open-sans;
+  font-weight: $font-light;
+  font-size: 2.5rem;
+  line-height: 3rem;
+  letter-spacing: -0.04em;
+
+  @include device-is('mobile') {
+    font-weight: $font-medium;
+    font-size: 2rem;
+    line-height: 2.5rem;
+  }
+}
+
+@mixin h2() {
+  font-family: $font-open-sans;
+  font-weight: $font-medium;
+  font-size: 2rem;
+  line-height: 2.5rem;
+  letter-spacing: -0.04em;
+
+  @include device-is('mobile') {
+    font-size: 1.75rem;
+    line-height: 2.25rem;
+  }
+}
+
+@mixin h3() {
+  font-family: $font-open-sans;
+  font-weight: $font-medium;
+  font-size: 1.75rem;
+  line-height: 2.25rem;
+  letter-spacing: -0.04em;
+
+  @include device-is('mobile') {
+    font-size: 1.5rem;
+    line-height: 2rem;
+  }
+}
+
+@mixin h4() {
+  font-family: $font-open-sans;
+  font-weight: $font-medium;
+  font-size: 1.5rem;
+  line-height: 2rem;
+  letter-spacing: -0.02em;
+}
+
+@mixin subheading() {
+  font-family: $font-open-sans;
+  font-weight: $font-semi-bold;
+  font-size: 1.25rem;
+  line-height: 1.75rem;
+
+  @include device-is('mobile') {
+    font-size: 1.125rem;
+    line-height: 1.575rem;
+  }
+}
+
+@mixin text() {
+  font-family: $font-roboto;
+  font-weight: $font-normal;
+  font-size: 1rem;
+  line-height: 1.375rem;
+
+  b,
+  strong {
+    font-weight: $font-medium;
+  }
+
+  a {
+    font-weight: $font-medium;
+    color: $blue;
+  }
+}
+
+@mixin text-bold() {
+  @include text;
+  font-weight: $font-medium;
+}
+
+@mixin text-link() {
+  @include text;
+  font-weight: $font-medium;
+  color: $blue;
+}
+
+@mixin text-small() {
+  @include text;
+  font-size: 0.875rem;
+  line-height: 1.25rem;
+}
+
+@mixin text-large() {
+  @include text;
+  font-size: 1.125rem;
+  line-height: 1.625rem;
+}
+
+@mixin caption() {
+  font-family: $font-roboto;
+  font-weight: $font-normal;
+  font-size: 0.75rem;
+  line-height: 1.125rem;
+
+  b,
+  strong {
+    font-weight: $font-bold;
+  }
+}
+
+@mixin caption-bold() {
+  @include caption;
+  font-weight: $font-bold;
+}
+
+@mixin caption-uppercase() {
+  @include caption;
+  text-transform: uppercase;
+}
+
+@mixin footer() {
+  font-family: $font-roboto;
+  font-weight: $font-normal;
+  font-size: 0.625rem;
+  line-height: 0.875rem;
+  letter-spacing: 0.02em;
+
+  b,
+  strong {
+    font-weight: $font-bold;
+  }
+}
+
+@mixin footer-bold() {
+  @include footer;
+  font-weight: $font-bold;
+}
+
+@mixin footer-uppercase() {
+  @include footer;
+  font-weight: $font-bold;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.pix-display1 {
+  @include display1;
+}
+
+.pix-display2 {
+  @include display2;
+}
+
+.pix-display3 {
+  @include display3;
+}
+
+.pix-h1 {
+  @include h1;
+}
+
+.pix-h2 {
+  @include h2;
+}
+
+.pix-h3 {
+  @include h3;
+}
+
+.pix-h4 {
+  @include h4;
+}
+
+.pix-subheading {
+  @include subheading;
+}
+
+.pix-text {
+  @include text;
+
+  &--bold {
+    @include text-bold;
+  }
+
+  &--link {
+    @include text-link;
+  }
+
+  &--small {
+    @include text-small;
+  }
+
+  &--large {
+    @include text-large;
+  }
+}
+
+.pix-caption {
+  @include caption;
+
+  &--bold {
+    @include caption-bold;
+  }
+
+  &--uppercase {
+    @include caption-uppercase;
+  }
+}
+
+.pix-footer {
+  @include footer;
+
+  &--bold {
+    @include footer-bold;
+  }
+
+  &--uppercase {
+    @include footer-uppercase;
+  }
+}

--- a/addon/styles/addon.scss
+++ b/addon/styles/addon.scss
@@ -1,10 +1,4 @@
-@import 'breakpoints';
-@import 'colors';
-@import 'fonts';
-@import 'spacing';
-@import 'form';
-@import 'shadows';
-@import 'typography';
+@import 'design-tokens';
 @import 'pix-background-header';
 @import 'pix-banner';
 @import 'pix-block';

--- a/addon/styles/addon.scss
+++ b/addon/styles/addon.scss
@@ -3,6 +3,8 @@
 @import 'fonts';
 @import 'spacing';
 @import 'form';
+@import 'shadows';
+@import 'typography';
 @import 'pix-background-header';
 @import 'pix-banner';
 @import 'pix-block';

--- a/addon/styles/design-tokens.scss
+++ b/addon/styles/design-tokens.scss
@@ -1,0 +1,7 @@
+@import 'breakpoints';
+@import 'colors';
+@import 'fonts';
+@import 'spacing';
+@import 'form';
+@import 'shadows';
+@import 'typography';

--- a/docs/design-system.stories.mdx
+++ b/docs/design-system.stories.mdx
@@ -10,7 +10,7 @@ import { Meta } from '@storybook/addon-docs/blocks';
 
 Voir : https://www.usabilis.com/design-system/
 
-Chez Pix, nos UX/UI designers guident notre Design System dont on retrouve la documentation sur [Zeroheight](https://zeroheight.com/8dd127da7/p/45cb0c-introduction).
+Chez Pix, nos UX/UI designers guident notre Design System dont on retrouve la documentation sur [Figma](https://www.figma.com/file/8RJ3aCSfdeQ8AZZVBBYKS8/Design-System-Pix).
 
 Puis ce sont les développeurs qui s'occupent d'implémenter le Design System avec une [librairie de composants Ember](https://cli.emberjs.com/release/writing-addons/)
 et dont la documentation est générée par [Storybook](https://storybook.js.org/docs/react/get-started/introduction).

--- a/docs/design-tokens-dev.stories.mdx
+++ b/docs/design-tokens-dev.stories.mdx
@@ -1,0 +1,40 @@
+import { Meta } from '@storybook/addon-docs/blocks';
+
+<Meta title="Développement/Design Tokens" />
+
+# Design Tokens
+
+> Les design tokens contiennent plusieurs éléments de base de la charte graphique (les couleurs, la typographie, les icones, etc.)
+
+## Rajouter des design tokens dans Pix UI
+
+Quand vous êtes amenés à ajouter ou à modifier des éléments des design tokens, faites le dans le scss associé,
+par example `addon/styles/_typography.scss` ou `addon/styles/_colors.scss` et s'il n'est pas déjà importé, rajoutez l'import dans `addon/styles/design-tokens.scss`.
+Ceci nous permettra d'utiliser les mixin dans nos applications par la suite.
+
+Le standard d'équipe est de créer un mixin et une classe et de préfixer la classe avec `pix-`.
+
+Par example :
+
+```
+@mixin text() {
+  font-family: $font-roboto;
+  font-weight: $font-normal;
+  font-size: 1rem;
+  line-height: 1.375rem;
+
+  b,
+  strong {
+    font-weight: $font-medium;
+  }
+
+  a {
+    font-weight: $font-medium;
+    color: $blue;
+  }
+}
+
+.pix-text {
+  @include text;
+}
+```

--- a/docs/design-tokens.stories.mdx
+++ b/docs/design-tokens.stories.mdx
@@ -1,0 +1,32 @@
+import { Meta } from '@storybook/addon-docs/blocks';
+
+<Meta title="Utiliser Pix UI/Design Tokens" />
+
+# Design Tokens
+
+> Les design tokens contiennent plusieurs éléments de base de la charte graphique (les couleurs, la typographie, les icones, etc.)
+
+## Utiliser les classes, mixin et variables dans votre css
+
+En ajoutant la dépendance dans votre application avec `npm install`, vous avez déjà accès aux classes, mais pour avoir accès aux mixin et variables,
+il faut ajouter le code ci-dessous dans le `new EmberApp()` de votre `ember-cli.build.js` qui se trouve à la racine du projet :
+
+```
+sassOptions: {
+  includePaths: ['node_modules/@1024pix/pix-ui/addon/styles'],
+},
+```
+
+Par la suite vous aurez accès à toutes les variables des design tokens avec le `$`, par example `border: 1px solid $blue;`.
+
+Et pour les mixin, dans le scss voulu, il faudra importer (avec `@use`) les design tokens au haut du fichier et puis vous pourrez les utiliser
+
+Par example :
+
+```
+@use 'design-tokens`;
+
+.organization-title {
+  @include design-tokens.text-bold;
+}
+```


### PR DESCRIPTION
## :boom: BREAKING_CHANGES
RAS

## 🦄  Description
Figma contient les design tokens de typographie, font, box-shadow, etc. Avec cette PR on crée des classes pour les typographies et des mixins pour les box-shadows pour pouvoir les utiliser par la suite sur nos composant Pix UI ainsi que dans les applis Pix.

## 💯  Pour tester
- Choisissez un composant dans storybook et dans le dev tool, rajouter une des classe de typographie à un élément
- Constatez que l'élément a bien été impacté par la classe ajoutée précédemment
