### PR TITLE
A11Y: add role=img on the stars container + add aria-label

### DIFF
--- a/addon/components/pix-stars.hbs
+++ b/addon/components/pix-stars.hbs
@@ -1,7 +1,6 @@
-<div class={{this.pixStarsClass}} ...attributes>
-  <span class="sr-only">{{@alt}}</span>
+<div class={{this.pixStarsClass}} ...attributes role="img" aria-label={{@alt}}>
   {{#each this.stars as |star|}}
-    <svg class="pix-stars__{{star}}" data-test-status={{star}} viewBox="0 0 36 36">
+    <svg class="pix-stars__{{star}}" data-test-status={{star}} viewBox="0 0 36 36" role="img">
       <defs>
         <linearGradient id="pix-stars-default" x1="68.643%" y1="0%" x2="68.643%" y2="100%">
           <stop stop-color="#FEDC41" offset="0%"></stop>

--- a/tests/integration/components/pix-stars-test.js
+++ b/tests/integration/components/pix-stars-test.js
@@ -1,6 +1,6 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import { render } from '@ember/test-helpers';
+import { render } from '@1024pix/ember-testing-library';
 import { hbs } from 'ember-cli-htmlbars';
 
 module('Integration | Component | stars', function (hooks) {
@@ -35,13 +35,11 @@ module('Integration | Component | stars', function (hooks) {
     assert.equal(unacquiredStars.length, 2);
   });
 
-  test('it renders alternative message', async function (assert) {
+  test('it renders aria-label message', async function (assert) {
     // when
-    await render(hbs`<PixStars @total={{3}} @alt="message"/>`);
-    const srOnly = this.element.querySelector('.sr-only');
-
+    const screen = await render(hbs`<PixStars @total={{3}} @alt="message"/>`);
     // then
-    assert.equal(srOnly.textContent.trim(), 'message');
+    assert.dom(screen.getByLabelText('message')).exists();
   });
 
   test('it renders the acquired start but hide unacquired', async function (assert) {


### PR DESCRIPTION
## :boom: BREAKING_CHANGES
pas de breaking changes

## :christmas_tree: Problème
Lors de l'audit accessibilité de l'application Pix Orga pour la page Résultat d'une campagne d'évaluation dans le graphe "Répartition des participations par paliers", lorsqu'elle en possède, les paliers sont affichés sous forme de groupe d'étoiles.
Ce groupe d'étoiles n'avait pas de rôle, ce qui provoquait une lecture de tout ce qui était à l'intérieur et donc qui alourdissait le rendu des lecteur d'écrans.

## :gift: Solution
Ajouter au groupe d'étoiles un rôle img afin de le considérer comme une image à part entière et lui ajouter un aria-label pour une description adéquate. De plus, un sr-only était utlisé pour donner une description mais en mettant un role=img à la div contenant les images, le sr-only ne sera plus lu. Pour garder la description, on a remplacé le sr-only par un aria-label.

## :star2: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :santa: Pour tester
> _Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc._
