### PR TITLE
[TECH] Ajouter les variables du design system dans Pix-UI.(PIX-2307)

### DIFF
--- a/addon/styles/_colors.scss
+++ b/addon/styles/_colors.scss
@@ -1,5 +1,175 @@
-// See https://zeroheight.com/8dd127da7/p/839645-couleurs/b/21317a
+// See https://www.figma.com/file/8RJ3aCSfdeQ8AZZVBBYKS8/Design-System-Pix?node-id=16%3A2
 
+//// SOLID
+// Primary
+$pix-primary: #3D68FF;
+$pix-primary-80: #000E87;
+$pix-primary-70: #0D25B3;
+$pix-primary-60: #2044DC;
+$pix-primary-40: #5B94FF;
+$pix-primary-30: #88BEFF;
+$pix-primary-20: #C4E6FF;
+$pix-primary-10: #DCF1FF;
+$pix-primary-5: #F2F9FF;
+
+// Secondary
+$pix-secondary: #FFD235;
+$pix-secondary-80: #874D00;
+$pix-secondary-70: #A95800;
+$pix-secondary-60: #CE8900;
+$pix-secondary-50: #EAA600;
+$pix-secondary-40: #EAA600;
+$pix-secondary-20: #FFE381;
+$pix-secondary-10: #FFEEB3;
+$pix-secondary-5: #FFF9E6;
+
+// Secondary Pix Certif
+$pix-secondary-certif: #20B4AF;
+$pix-secondary-certif-80: #093432 ;
+$pix-secondary-certif-70: #0E4D4C ;
+$pix-secondary-certif-60: #126765;
+$pix-secondary-certif-50: #17817E;
+$pix-secondary-certif-30: #34DBD6;
+$pix-secondary-certif-20: #67E4E0;
+$pix-secondary-certif-10: #9AEDEB;
+$pix-secondary-certif-5: #CCF6F5;
+
+// Secondary Pix Orga
+$pix-secondary-orga: #00DDFF;
+$pix-secondary-orga-80: #006E80 ;
+$pix-secondary-orga-70: #008A9F ;
+$pix-secondary-orga-60: #00A6BF;
+$pix-secondary-orga-50: #00C1DF;
+$pix-secondary-orga-30: #55E8FF;
+$pix-secondary-orga-20: #80EEFF;
+$pix-secondary-orga-10: #AAF4FF;
+$pix-secondary-orga-5: #D5F9FF;
+
+// Tertiary
+$pix-tertiary: #9D67FF;
+$pix-tertiary-80: #3B00A4;
+$pix-tertiary-70: #4E00DB;
+$pix-tertiary-60: #6712FF;
+$pix-tertiary-50: #8A49FF;
+$pix-tertiary-30: #B186FF;
+$pix-tertiary-20: #C4A4FF;
+$pix-tertiary-10: #D8C2FF;
+$pix-tertiary-5: #EBE1FF;
+
+// Success
+$pix-success: #34D399;
+$pix-success-80: #104834;
+$pix-success-70: #176C4D;
+$pix-success-60: #14865D;
+$pix-success-50: #27B481;
+$pix-success-30: #6EE7B7;
+$pix-success-20: #A7F3D0;
+$pix-success-10: #D1FAE5;
+$pix-success-5: #ECFDF5;
+
+// Warning
+$pix-warning-80: #874D00;
+$pix-warning-70: #AC6A00;
+$pix-warning-60: #CE8900;
+$pix-warning-50: #EAA600;
+$pix-warning-40: #FFBE00;
+$pix-warning-30: #FFD235;
+$pix-warning-20: #FFE381;
+$pix-warning-10: #FFF1C5;
+$pix-warning-5: #FFF9E6;
+
+// Error
+$pix-error-80: #991B1B;
+$pix-error-70: #B91C1C;
+$pix-error-60: #DC2626;
+$pix-error-50: #EF4444;
+$pix-error-40: #F87171;
+$pix-error-30: #FCA5A5;
+$pix-error-20: #FECACA;
+$pix-error-10: #FEE2E2;
+$pix-error-5: #FEF2F2;
+
+// Neutral
+// Dark
+$pix-neutral-110: #07142E;
+$pix-neutral-100: #091E42;
+$pix-neutral-90: #172B4D;
+$pix-neutral-80: #253858;
+$pix-neutral-70: #344563;
+
+// Medium
+$pix-neutral-60: #505F79;
+$pix-neutral-50: #5E6C84;
+$pix-neutral-45: #6B778C;
+$pix-neutral-40: #7A869A;
+$pix-neutral-35: #8993A4;
+$pix-neutral-30: #97A0AF;
+
+// Light
+$pix-neutral-25: #A5ADBA;
+$pix-neutral-22: #C1C7D0;
+$pix-neutral-20: #DFE1E6;
+$pix-neutral-15: #EAECF0;
+$pix-neutral-10: #F4F5F7;
+$pix-neutral-5: #FAFBFC;
+$pix-neutral-0: #FFFFFF;
+
+// Shades
+$pix-shades-100: #000000;
+
+/// Domain
+// Information
+$pix-information-dark: #F24645;
+$pix-information-light: #F1A141;
+
+// Content
+$pix-content-dark: #1A8C89;
+$pix-content-light: #52D987;
+
+// Communication
+$pix-communication-dark: #3D68FF;
+$pix-communication-light: #12A3FF;
+
+// Security
+$pix-security-dark: #AC008D;
+$pix-security-light: #FF3F94;
+
+// Environment
+$pix-environment-dark: #5E2563;
+$pix-environment-light: #564DA6;
+
+////GRADIENT
+
+// Primary Pix App
+$pix-primary-app-gradient : linear-gradient(91.59deg, $pix-communication-dark 0%, #8845FF 100%);
+
+// Secondary Pix App
+$pix-secondary-app-gradient: linear-gradient(91.59deg, #FEDC41 0%, #FF9F00 100%);
+
+// Primary Certif
+$pix-primary-certif-gradient: linear-gradient(91.59deg, $pix-content-light 0%, $pix-content-dark 100%);
+
+// Primary Orga
+$pix-primary-orga-gradient: linear-gradient(91.59deg, $pix-secondary-orga 0%, #0095C0 100%);
+
+// Secondary Orga
+$pix-secondary-orga-gradient: linear-gradient(91.59deg, #0D7DC4 0%, #213371 100%);
+
+/// Domain
+// Information
+$pix-information-gradient: linear-gradient(180deg, $pix-information-dark 0%, $pix-information-light 100%);
+$pix-content-gradient: linear-gradient(180deg, #1A8C89 0%, #52D987 100%);
+
+// Communication
+$pix-communication-gradient: linear-gradient(180deg, $pix-primary 0%, #12A3FF 100%);
+
+// Security
+$pix-security-gradient: linear-gradient(180deg, #AC008D 0%, #FF3F94 100%);
+
+// Environment
+$pix-environment-gradient: linear-gradient(180deg, #5E2563 0%, #564DA6 100%);
+
+////DEPRECATED
 // primary
 $blue: #3D68FF;
 $yellow: #FFBE00;
@@ -23,7 +193,6 @@ $purple: #8845FF;
 }
 
 // gradients
-$pix-gradient: linear-gradient(135deg, $blue 0%, $purple 100%);
 $pix-blue-gradient: linear-gradient(135deg, #12A3FF 0%, #3D68FF 100%);
 $pix-certif-gradient: linear-gradient(0deg, #52D987 0%, #1A8C89 100%);
 $pix-certif-old-gradient: linear-gradient(135deg, #FF3F93 0%, #AC008D 100%);
@@ -32,8 +201,8 @@ $pix-orga-gradient: linear-gradient(134deg, #00DDFF 0%, #0095C0 100%);
 $pix-orga-old-gradient: linear-gradient(0deg, #0D7DC4 0%, #213371 100%);
 $pix-pink-gradient: linear-gradient(0deg, #FF3F93 0%, #AC008D 100%);
 $pix-purple-gradient: linear-gradient(180deg, #5E2563 0%, #564DA6 100%);
-$pix-yellow-gradient: linear-gradient(135deg, #FFBE00 0%, #FF9F00 100%);
-$pix-yellow-gradient-right: linear-gradient(to right, #FFBE00, #FF9F00);
+$pix-yellow-gradient: linear-gradient(135deg,$pix-primary-60 0%, #FF9F00 100%);
+$pix-yellow-gradient-right: linear-gradient(to right,$pix-primary-60, #FF9F00);
 // light
 $grey-5: #FAFBFC;
 $grey-10: #F4F5F7;
@@ -80,7 +249,6 @@ $green-alert-light: #EFFFD8;
 $green-alert-dark: #006134;
 $yellow-alert-light: #FFF1C5;
 $yellow-alert-dark: #A95800;
-
 
 // status
 $error: #FF4B00;

--- a/addon/styles/_colors.scss
+++ b/addon/styles/_colors.scss
@@ -445,12 +445,12 @@ $security-dark: #ac008d;
 $security-light: #ff3f94;
 
 /**
- * @deprecated
+ * @deprecated Please use '$pix-error-10' instead!
  */
 $pink-alert-light: #ffe1e1;
 
 /**
- * @deprecated
+ * @deprecated Please use '$pix-error-70' instead!
  */
 $pink-alert-dark: #a71e1a;
 
@@ -465,12 +465,12 @@ $blue-alert-light: #dcf1ff;
 $blue-alert-dark: #0d25b3;
 
 /**
- * @deprecated
+ * @deprecated Please use '$pix-success-10' instead!
  */
 $green-alert-light: #efffd8;
 
 /**
- * @deprecated
+ * @deprecated Please use '$pix-success-70' instead!
  */
 $green-alert-dark: #006134;
 
@@ -480,7 +480,7 @@ $green-alert-dark: #006134;
 $yellow-alert-light: #fff1c5;
 
 /**
- * @deprecated Please use '$pix-secondary-70' instead!
+ * @deprecated Please use '$pix-secondary-60' instead!
  */
 $yellow-alert-dark: #a95800;
 
@@ -488,15 +488,21 @@ $yellow-alert-dark: #a95800;
 
 /**
  * @deprecated
+ *-To style text or border : $pix-error-70
+ *-To style background : $pix-error-10
  */
 $error: #ff4b00;
 
 /**
  * @deprecated
+ *-To style text or border : $pix-success-70
+ *-To style background : $pix-success-10
  */
 $success: #57c884;
 
 /**
- * @deprecated Please use '$pix-warning-40' instead!
+ * @deprecated
+ *-To style text or border : $pix-warning-60
+ *-To style background : $pix-warning-10
  */
 $warning: #ffbe00;

--- a/addon/styles/_colors.scss
+++ b/addon/styles/_colors.scss
@@ -2,117 +2,118 @@
 
 //// SOLID
 // Primary
-$pix-primary: #3D68FF;
-$pix-primary-80: #000E87;
-$pix-primary-70: #0D25B3;
-$pix-primary-60: #2044DC;
-$pix-primary-40: #5B94FF;
-$pix-primary-30: #88BEFF;
-$pix-primary-20: #C4E6FF;
-$pix-primary-10: #DCF1FF;
 $pix-primary-5: #F2F9FF;
+$pix-primary-10: #DCF1FF;
+$pix-primary-20: #C4E6FF;
+$pix-primary-30: #88BEFF;
+$pix-primary-40: #5B94FF;
+$pix-primary: #3D68FF;
+$pix-primary-60: #2044DC;
+$pix-primary-70: #0D25B3;
+$pix-primary-80: #000E87;
 
 // Secondary
-$pix-secondary: #FFD235;
-$pix-secondary-80: #874D00;
-$pix-secondary-70: #A95800;
-$pix-secondary-60: #CE8900;
-$pix-secondary-50: #EAA600;
-$pix-secondary-40: #EAA600;
-$pix-secondary-20: #FFE381;
-$pix-secondary-10: #FFEEB3;
 $pix-secondary-5: #FFF9E6;
+$pix-secondary-10: #FFEEB3;
+$pix-secondary-20: #FFE381;
+$pix-secondary: #FFD235;
+$pix-secondary-40: #EAA600;
+$pix-secondary-50: #EAA600;
+$pix-secondary-60: #CE8900;
+$pix-secondary-70: #A95800;
+$pix-secondary-80: #874D00;
 
 // Secondary Pix Certif
-$pix-secondary-certif: #20B4AF;
-$pix-secondary-certif-80: #093432 ;
-$pix-secondary-certif-70: #0E4D4C ;
-$pix-secondary-certif-60: #126765;
-$pix-secondary-certif-50: #17817E;
-$pix-secondary-certif-30: #34DBD6;
-$pix-secondary-certif-20: #67E4E0;
-$pix-secondary-certif-10: #9AEDEB;
 $pix-secondary-certif-5: #CCF6F5;
+$pix-secondary-certif-10: #9AEDEB;
+$pix-secondary-certif-20: #67E4E0;
+$pix-secondary-certif-30: #34DBD6;
+$pix-secondary-certif: #20B4AF;
+$pix-secondary-certif-50: #17817E;
+$pix-secondary-certif-60: #126765;
+$pix-secondary-certif-70: #0E4D4C;
+$pix-secondary-certif-80: #093432;
 
 // Secondary Pix Orga
-$pix-secondary-orga: #00DDFF;
-$pix-secondary-orga-80: #006E80 ;
-$pix-secondary-orga-70: #008A9F ;
-$pix-secondary-orga-60: #00A6BF;
-$pix-secondary-orga-50: #00C1DF;
-$pix-secondary-orga-30: #55E8FF;
-$pix-secondary-orga-20: #80EEFF;
-$pix-secondary-orga-10: #AAF4FF;
 $pix-secondary-orga-5: #D5F9FF;
+$pix-secondary-orga-10: #AAF4FF;
+$pix-secondary-orga-20: #80EEFF;
+$pix-secondary-orga-30: #55E8FF;
+$pix-secondary-orga: #00DDFF;
+$pix-secondary-orga-50: #00C1DF;
+$pix-secondary-orga-60: #00A6BF;
+$pix-secondary-orga-70: #008A9F;
+$pix-secondary-orga-80: #006E80;
 
 // Tertiary
-$pix-tertiary: #9D67FF;
-$pix-tertiary-80: #3B00A4;
-$pix-tertiary-70: #4E00DB;
-$pix-tertiary-60: #6712FF;
-$pix-tertiary-50: #8A49FF;
-$pix-tertiary-30: #B186FF;
-$pix-tertiary-20: #C4A4FF;
-$pix-tertiary-10: #D8C2FF;
 $pix-tertiary-5: #EBE1FF;
+$pix-tertiary-10: #D8C2FF;
+$pix-tertiary-20: #C4A4FF;
+$pix-tertiary-30: #B186FF;
+$pix-tertiary: #9D67FF;
+$pix-tertiary-50: #8A49FF;
+$pix-tertiary-60: #6712FF;
+$pix-tertiary-70: #4E00DB;
+$pix-tertiary-80: #3B00A4;
 
 // Success
-$pix-success: #34D399;
-$pix-success-80: #104834;
-$pix-success-70: #176C4D;
-$pix-success-60: #14865D;
-$pix-success-50: #27B481;
-$pix-success-30: #6EE7B7;
-$pix-success-20: #A7F3D0;
-$pix-success-10: #D1FAE5;
 $pix-success-5: #ECFDF5;
+$pix-success-10: #D1FAE5;
+$pix-success-20: #A7F3D0;
+$pix-success-30: #6EE7B7;
+$pix-success: #34D399;
+$pix-success-50: #27B481;
+$pix-success-60: #14865D;
+$pix-success-70: #176C4D;
+$pix-success-80: #104834;
 
 // Warning
-$pix-warning-80: #874D00;
-$pix-warning-70: #AC6A00;
-$pix-warning-60: #CE8900;
-$pix-warning-50: #EAA600;
-$pix-warning-40: #FFBE00;
-$pix-warning-30: #FFD235;
-$pix-warning-20: #FFE381;
-$pix-warning-10: #FFF1C5;
 $pix-warning-5: #FFF9E6;
+$pix-warning-10: #FFF1C5;
+$pix-warning-20: #FFE381;
+$pix-warning-30: #FFD235;
+$pix-warning-40: #FFBE00;
+$pix-warning-50: #EAA600;
+$pix-warning-60: #CE8900;
+$pix-warning-70: #AC6A00;
+$pix-warning-80: #874D00;
 
 // Error
-$pix-error-80: #991B1B;
-$pix-error-70: #B91C1C;
-$pix-error-60: #DC2626;
-$pix-error-50: #EF4444;
-$pix-error-40: #F87171;
-$pix-error-30: #FCA5A5;
-$pix-error-20: #FECACA;
-$pix-error-10: #FEE2E2;
 $pix-error-5: #FEF2F2;
+$pix-error-10: #FEE2E2;
+$pix-error-20: #FECACA;
+$pix-error-30: #FCA5A5;
+$pix-error-40: #F87171;
+$pix-error-50: #EF4444;
+$pix-error-60: #DC2626;
+$pix-error-70: #B91C1C;
+$pix-error-80: #991B1B;
 
 // Neutral
-// Dark
-$pix-neutral-110: #07142E;
-$pix-neutral-100: #091E42;
-$pix-neutral-90: #172B4D;
-$pix-neutral-80: #253858;
-$pix-neutral-70: #344563;
+// Light
+$pix-neutral-0: #FFFFFF;
+$pix-neutral-5: #FAFBFC;
+$pix-neutral-10: #F4F5F7;
+$pix-neutral-15: #EAECF0;
+$pix-neutral-20: #DFE1E6;
+$pix-neutral-22: #C1C7D0;
+$pix-neutral-25: #A5ADBA;
+
 
 // Medium
-$pix-neutral-60: #505F79;
-$pix-neutral-50: #5E6C84;
-$pix-neutral-45: #6B778C;
-$pix-neutral-40: #7A869A;
-$pix-neutral-35: #8993A4;
 $pix-neutral-30: #97A0AF;
+$pix-neutral-35: #8993A4;
+$pix-neutral-40: #7A869A;
+$pix-neutral-45: #6B778C;
+$pix-neutral-50: #5E6C84;
+$pix-neutral-60: #505F79;
 
-// Light
-$pix-neutral-25: #A5ADBA;
-$pix-neutral-22: #C1C7D0;
-$pix-neutral-20: #DFE1E6;
-$pix-neutral-15: #EAECF0;
-$pix-neutral-10: #F4F5F7;
-$pix-neutral-5: #FAFBFC;
-$pix-neutral-0: #FFFFFF;
+// Dark
+$pix-neutral-70: #344563;
+$pix-neutral-80: #253858;
+$pix-neutral-90: #172B4D;
+$pix-neutral-100: #091E42;
+$pix-neutral-110: #07142E;
 
 // Shades
 $pix-shades-100: #000000;

--- a/addon/styles/_colors.scss
+++ b/addon/styles/_colors.scss
@@ -139,8 +139,7 @@ $pix-environment-dark: #5E2563;
 $pix-environment-light: #564DA6;
 
 ////GRADIENT
-
-// Primary Pix App
+// Primary Pix APP
 $pix-primary-app-gradient : linear-gradient(91.59deg, $pix-communication-dark 0%, #8845FF 100%);
 
 // Secondary Pix App
@@ -158,6 +157,7 @@ $pix-secondary-orga-gradient: linear-gradient(91.59deg, #0D7DC4 0%, #213371 100%
 /// Domain
 // Information
 $pix-information-gradient: linear-gradient(180deg, $pix-information-dark 0%, $pix-information-light 100%);
+// Content
 $pix-content-gradient: linear-gradient(180deg, #1A8C89 0%, #52D987 100%);
 
 // Communication

--- a/addon/styles/_colors.scss
+++ b/addon/styles/_colors.scss
@@ -171,20 +171,76 @@ $pix-environment-gradient: linear-gradient(180deg, #5e2563 0%, #564da6 100%);
 
 ////DEPRECATED
 // primary
+/**
+ * @deprecated Please use '$pix-primary' instead!
+ */
 $blue: #3d68ff;
+
+/**
+ * @deprecated Please use '$pix-warning-40' instead!
+ */
 $yellow: #ffbe00;
+
+/**
+ * @deprecated
+ */
 $orange: #da7601;
+
+/**
+ * @deprecated
+ */
 $red: #d63f00;
+
+/**
+ * @deprecated Please use '$pix-neutral-60' instead!
+ */
 $blue-zodiac: #505f79;
+
+/**
+ * @deprecated Please use '$pix-neutral-110' instead!
+ */
 $black: #07142e;
+
+/**
+ * @deprecated Please use '$pix-neutral-0' instead!
+ */
 $white: #ffffff;
+
 // secondary
+
+/**
+ * @deprecated
+ */
 $blue-hover: #3257d9;
+
+/**
+ * @deprecated
+ */
 $dark-blue-pro: #1a38a0;
+
+/**
+ * @deprecated Please use '$pix-secondary-certif-50' instead!
+ */
 $dark-green-certif: #17817e;
+
+/**
+ * @deprecated
+ */
 $dark-orga: #006c87;
+
+/**
+ * @deprecated
+ */
 $green: #038125;
+
+/**
+ * @deprecated Please use '$pix-secondary-orga' instead!
+ */
 $orga: #00ddff;
+
+/**
+ * @deprecated
+ */
 $purple: #8845ff;
 
 @mixin colorize($color, $percentageDarkenForColor, $percentageLightenForBackground) {
@@ -203,26 +259,99 @@ $pix-pink-gradient: linear-gradient(0deg, #ff3f93 0%, #ac008d 100%);
 $pix-purple-gradient: linear-gradient(180deg, #5e2563 0%, #564da6 100%);
 $pix-yellow-gradient: linear-gradient(135deg, #ffbe00 0%, #ff9f00 100%);
 $pix-yellow-gradient-right: linear-gradient(to right, #ffbe00, #ff9f00);
+
 // light
+
+/**
+ * @deprecated Please use '$pix-neutral-5' instead!
+ */
 $grey-5: #fafbfc;
+
+/**
+ * @deprecated Please use '$pix-neutral-10' instead!
+ */
 $grey-10: #f4f5f7;
+
+/**
+ * @deprecated Please use '$pix-neutral-15' instead!
+ */
 $grey-15: #eaecf0;
+
+/**
+ * @deprecated Please use '$pix-neutral-20' instead!
+ */
 $grey-20: #dfe1e6;
+
+/**
+ * @deprecated Please use '$pix-neutral-22' instead!
+ */
 $grey-22: #c1c7d0;
+
+/**
+ * @deprecated Please use '$pix-neutral-25' instead!
+ */
 $grey-25: #a5adba;
 // medium
+
+/**
+ * @deprecated Please use '$pix-neutral-30' instead!
+ */
 $grey-30: #97a0af;
+
+/**
+ * @deprecated Please use '$pix-neutral-35' instead!
+ */
 $grey-35: #8993a4;
+
+/**
+ * @deprecated Please use '$pix-neutral-40' instead!
+ */
 $grey-40: #7a869a;
+
+/**
+ * @deprecated Please use '$pix-neutral-45' instead!
+ */
 $grey-45: #6b778c;
+
+/**
+ * @deprecated Please use '$pix-neutral-5O' instead!
+ */
 $grey-50: #5e6c84;
+
+/**
+ * @deprecated Please use '$pix-neutral-60' instead!
+ */
 $grey-60: #505f79;
+
 // dark
+/**
+ * @deprecated Please use '$pix-neutral-70' instead!
+ */
 $grey-70: #344563;
+
+/**
+ * @deprecated Please use '$pix-neutral-80' instead!
+ */
 $grey-80: #253858;
+
+/**
+ * @deprecated Please use '$pix-neutral-90' instead!
+ */
 $grey-90: #172b4d;
+
+/**
+ * @deprecated Please use '$pix-neutral-100' instead!
+ */
 $grey-100: #091e42;
+
+/**
+ * @deprecated Please use '$pix-neutral-150' instead!
+ */
 $grey-150: #0c163a;
+
+/**
+ * @deprecated Please use '$pix-neutral-200' instead!
+ */
 $grey-200: #07142e;
 // gradients domain
 $information-gradient: linear-gradient(180deg, #f24645 0%, #f1a141 100%);
@@ -231,26 +360,110 @@ $communication-gradient: linear-gradient(0deg, #12a3ff 0%, #3d68ff 100%);
 $security-gradient: linear-gradient(0deg, #ff3f93 0%, #ac008d 100%);
 $environment-gradient: linear-gradient(180deg, #5e2563 0%, #564da6 100%);
 // solids
+
+/**
+ * @deprecated Please use '$pix-environment-dark' instead!
+ */
 $environment-dark: #5e2563;
+
+/**
+ * @deprecated Please use '$pix-environment-light' instead!
+ */
 $environment-light: #564da6;
+
+/**
+ * @deprecated Please use '$pix-communication-dark' instead!
+ */
 $communication-dark: #3d68ff;
+
+/**
+ * @deprecated Please use '$pix-communication-light' instead!
+ */
 $communication-light: #12a3ff;
+
+/**
+ * @deprecated Please use '$pix-content-dark' instead!
+ */
 $content-dark: #1a8c89;
+
+/**
+ * @deprecated Please use '$pix-content-light' instead!
+ */
 $content-light: #52d987;
+
+/**
+ * @deprecated Please use '$pix-information-dark' instead!
+ */
 $information-dark: #f24645;
+
+/**
+ * @deprecated Please use '$pix-information-light' instead!
+ */
 $information-light: #f1a141;
+
+/**
+ * @deprecated Please use '$pix-security-dark' instead!
+ */
 $security-dark: #ac008d;
+
+/**
+ * @deprecated Please use '$pix-security-light' instead!
+ */
 $security-light: #ff3f94;
+
+/**
+ * @deprecated
+ */
 $pink-alert-light: #ffe1e1;
+
+/**
+ * @deprecated
+ */
 $pink-alert-dark: #a71e1a;
+
+/**
+ * @deprecated Please use '$pix-primary-10' instead!
+ */
 $blue-alert-light: #dcf1ff;
+
+/**
+ * @deprecated Please use '$pix-primary-70' instead!
+ */
 $blue-alert-dark: #0d25b3;
+
+/**
+ * @deprecated
+ */
 $green-alert-light: #efffd8;
+
+/**
+ * @deprecated
+ */
 $green-alert-dark: #006134;
+
+/**
+ * @deprecated Please use '$pix-warning-10' instead!
+ */
 $yellow-alert-light: #fff1c5;
+
+/**
+ * @deprecated Please use '$pix-secondary-70' instead!
+ */
 $yellow-alert-dark: #a95800;
 
 // status
+
+/**
+ * @deprecated
+ */
 $error: #ff4b00;
+
+/**
+ * @deprecated
+ */
 $success: #57c884;
+
+/**
+ * @deprecated Please use '$pix-warning-40' instead!
+ */
 $warning: #ffbe00;

--- a/addon/styles/_colors.scss
+++ b/addon/styles/_colors.scss
@@ -90,7 +90,6 @@ $pix-error-70: #b91c1c;
 $pix-error-80: #991b1b;
 
 // Neutral
-// Light
 $pix-neutral-0: #ffffff;
 $pix-neutral-5: #fafbfc;
 $pix-neutral-10: #f4f5f7;
@@ -98,16 +97,12 @@ $pix-neutral-15: #eaecf0;
 $pix-neutral-20: #dfe1e6;
 $pix-neutral-22: #c1c7d0;
 $pix-neutral-25: #a5adba;
-
-// Medium
 $pix-neutral-30: #97a0af;
 $pix-neutral-35: #8993a4;
 $pix-neutral-40: #7a869a;
 $pix-neutral-45: #6b778c;
 $pix-neutral-50: #5e6c84;
 $pix-neutral-60: #505f79;
-
-// Dark
 $pix-neutral-70: #344563;
 $pix-neutral-80: #253858;
 $pix-neutral-90: #172b4d;
@@ -117,59 +112,37 @@ $pix-neutral-110: #07142e;
 // Shades
 $pix-shades-100: #000000;
 
-/// Domain
-// Information
+// Domain
 $pix-information-dark: #f24645;
 $pix-information-light: #f1a141;
 
-// Content
 $pix-content-dark: #1a8c89;
 $pix-content-light: #52d987;
 
-// Communication
 $pix-communication-dark: #3d68ff;
 $pix-communication-light: #12a3ff;
 
-// Security
 $pix-security-dark: #ac008d;
 $pix-security-light: #ff3f94;
 
-// Environment
 $pix-environment-dark: #5e2563;
 $pix-environment-light: #564da6;
 
-////GRADIENT
-// Primary Pix APP
+//// GRADIENT
 $pix-primary-app-gradient: linear-gradient(91.59deg, #3d68ff 0%, #8845ff 100%);
-
-// Secondary Pix App
 $pix-secondary-app-gradient: linear-gradient(91.59deg, #fedc41 0%, #ff9f00 100%);
-
-// Primary Certif
 $pix-primary-certif-gradient: linear-gradient(91.59deg, #52d987 0%, #1a8c89 100%);
-
-// Primary Orga
 $pix-primary-orga-gradient: linear-gradient(91.59deg, #00ddff 0%, #0095c0 100%);
-
-// Secondary Orga
 $pix-secondary-orga-gradient: linear-gradient(91.59deg, #0d7dc4 0%, #213371 100%);
 
-/// Domain
-// Information
+// Domain
 $pix-information-gradient: linear-gradient(180deg, #3d68ff 0%, #f1a141 100%);
-// Content
 $pix-content-gradient: linear-gradient(180deg, #1a8c89 0%, #52d987 100%);
-
-// Communication
 $pix-communication-gradient: linear-gradient(180deg, #3d68ff 0%, #12a3ff 100%);
-
-// Security
 $pix-security-gradient: linear-gradient(180deg, #ac008d 0%, #ff3f94 100%);
-
-// Environment
 $pix-environment-gradient: linear-gradient(180deg, #5e2563 0%, #564da6 100%);
 
-////DEPRECATED
+//// DEPRECATED
 // primary
 /**
  * @deprecated Please use '$pix-primary' instead!

--- a/addon/styles/_colors.scss
+++ b/addon/styles/_colors.scss
@@ -136,7 +136,7 @@ $pix-primary-orga-gradient: linear-gradient(91.59deg, #00ddff 0%, #0095c0 100%);
 $pix-secondary-orga-gradient: linear-gradient(91.59deg, #0d7dc4 0%, #213371 100%);
 
 // Domain
-$pix-information-gradient: linear-gradient(180deg, #3d68ff 0%, #f1a141 100%);
+$pix-information-gradient: linear-gradient(180deg, #f24645 0%, #f1a141 100%);
 $pix-content-gradient: linear-gradient(180deg, #1a8c89 0%, #52d987 100%);
 $pix-communication-gradient: linear-gradient(180deg, #3d68ff 0%, #12a3ff 100%);
 $pix-security-gradient: linear-gradient(180deg, #ac008d 0%, #ff3f94 100%);
@@ -222,15 +222,54 @@ $purple: #8845ff;
 }
 
 // gradients
+/**
+ * @deprecated Please use '$pix-primary-app-gradient' instead!
+ */
 $pix-blue-gradient: linear-gradient(135deg, #12a3ff 0%, #3d68ff 100%);
+
+/**
+ * @deprecated Please use '$pix-primary-certif-gradient' instead!
+ */
 $pix-certif-gradient: linear-gradient(0deg, #52d987 0%, #1a8c89 100%);
+
+/**
+ * @deprecated Please use '$pix-security-gradient' instead!
+ */
 $pix-certif-old-gradient: linear-gradient(135deg, #ff3f93 0%, #ac008d 100%);
+
+/**
+ * @deprecated Please use '$pix-information-gradient' instead!
+ */
 $pix-orange-gradient: linear-gradient(180deg, #f24645 0%, #f1a141 100%);
+
+/**
+ * @deprecated Please use '$pix-primary-orga-gradient' instead!
+ */
 $pix-orga-gradient: linear-gradient(134deg, #00ddff 0%, #0095c0 100%);
+
+/**
+ * @deprecated Please use '$pix-primary-orga-gradient' instead!
+ */
 $pix-orga-old-gradient: linear-gradient(0deg, #0d7dc4 0%, #213371 100%);
+
+/**
+ * @deprecated Please use '$pix-security-gradient' instead!
+ */
 $pix-pink-gradient: linear-gradient(0deg, #ff3f93 0%, #ac008d 100%);
+
+/**
+ * @deprecated Please use '$pix-environment-gradient' instead!
+ */
 $pix-purple-gradient: linear-gradient(180deg, #5e2563 0%, #564da6 100%);
+
+/**
+ * Still in use for PixProgressGauge, may be removed in the future.
+ */
 $pix-yellow-gradient: linear-gradient(135deg, #ffbe00 0%, #ff9f00 100%);
+
+/**
+ * Still in use for PixProgressGauge, may be removed in the future.
+ */
 $pix-yellow-gradient-right: linear-gradient(to right, #ffbe00, #ff9f00);
 
 // light
@@ -326,12 +365,33 @@ $grey-150: #0c163a;
  * @deprecated Please use '$pix-neutral-200' instead!
  */
 $grey-200: #07142e;
+
 // gradients domain
+/**
+ * @deprecated Please use '$pix-information-gradient' instead!
+ */
 $information-gradient: linear-gradient(180deg, #f24645 0%, #f1a141 100%);
+
+/**
+ * @deprecated Please use '$pix-content-gradient' instead!
+ */
 $content-gradient: linear-gradient(0deg, #52d987 0%, #1a8c89 100%);
+
+/**
+ * @deprecated Please use '$pix-communication-gradient' instead!
+ */
 $communication-gradient: linear-gradient(0deg, #12a3ff 0%, #3d68ff 100%);
+
+/**
+ * @deprecated Please use '$pix-security-gradient' instead!
+ */
 $security-gradient: linear-gradient(0deg, #ff3f93 0%, #ac008d 100%);
+
+/**
+ * @deprecated Please use '$pix-environment-gradient' instead!
+ */
 $environment-gradient: linear-gradient(180deg, #5e2563 0%, #564da6 100%);
+
 // solids
 
 /**

--- a/addon/styles/_colors.scss
+++ b/addon/styles/_colors.scss
@@ -2,256 +2,263 @@
 
 //// SOLID
 // Primary
-$pix-primary-5: #F2F9FF;
-$pix-primary-10: #DCF1FF;
-$pix-primary-20: #C4E6FF;
-$pix-primary-30: #88BEFF;
-$pix-primary-40: #5B94FF;
-$pix-primary: #3D68FF;
-$pix-primary-60: #2044DC;
-$pix-primary-70: #0D25B3;
-$pix-primary-80: #000E87;
+$pix-primary-5: #f2f9ff;
+$pix-primary-10: #dcf1ff;
+$pix-primary-20: #c4e6ff;
+$pix-primary-30: #88beff;
+$pix-primary-40: #5b94ff;
+$pix-primary: #3d68ff;
+$pix-primary-60: #2044dc;
+$pix-primary-70: #0d25b3;
+$pix-primary-80: #000e87;
 
 // Secondary
-$pix-secondary-5: #FFF9E6;
-$pix-secondary-10: #FFEEB3;
-$pix-secondary-20: #FFE381;
-$pix-secondary: #FFD235;
-$pix-secondary-40: #EAA600;
-$pix-secondary-50: #EAA600;
-$pix-secondary-60: #CE8900;
-$pix-secondary-70: #A95800;
-$pix-secondary-80: #874D00;
+$pix-secondary-5: #fff9e6;
+$pix-secondary-10: #ffeeb3;
+$pix-secondary-20: #ffe381;
+$pix-secondary: #ffd235;
+$pix-secondary-40: #eaa600;
+$pix-secondary-50: #eaa600;
+$pix-secondary-60: #ce8900;
+$pix-secondary-70: #a95800;
+$pix-secondary-80: #874d00;
 
 // Secondary Pix Certif
-$pix-secondary-certif-5: #CCF6F5;
-$pix-secondary-certif-10: #9AEDEB;
-$pix-secondary-certif-20: #67E4E0;
-$pix-secondary-certif-30: #34DBD6;
-$pix-secondary-certif: #20B4AF;
-$pix-secondary-certif-50: #17817E;
+$pix-secondary-certif-5: #ccf6f5;
+$pix-secondary-certif-10: #9aedeb;
+$pix-secondary-certif-20: #67e4e0;
+$pix-secondary-certif-30: #34dbd6;
+$pix-secondary-certif: #20b4af;
+$pix-secondary-certif-50: #17817e;
 $pix-secondary-certif-60: #126765;
-$pix-secondary-certif-70: #0E4D4C;
+$pix-secondary-certif-70: #0e4d4c;
 $pix-secondary-certif-80: #093432;
 
 // Secondary Pix Orga
-$pix-secondary-orga-5: #D5F9FF;
-$pix-secondary-orga-10: #AAF4FF;
-$pix-secondary-orga-20: #80EEFF;
-$pix-secondary-orga-30: #55E8FF;
-$pix-secondary-orga: #00DDFF;
-$pix-secondary-orga-50: #00C1DF;
-$pix-secondary-orga-60: #00A6BF;
-$pix-secondary-orga-70: #008A9F;
-$pix-secondary-orga-80: #006E80;
+$pix-secondary-orga-5: #d5f9ff;
+$pix-secondary-orga-10: #aaf4ff;
+$pix-secondary-orga-20: #80eeff;
+$pix-secondary-orga-30: #55e8ff;
+$pix-secondary-orga: #00ddff;
+$pix-secondary-orga-50: #00c1df;
+$pix-secondary-orga-60: #00a6bf;
+$pix-secondary-orga-70: #008a9f;
+$pix-secondary-orga-80: #006e80;
 
 // Tertiary
-$pix-tertiary-5: #EBE1FF;
-$pix-tertiary-10: #D8C2FF;
-$pix-tertiary-20: #C4A4FF;
-$pix-tertiary-30: #B186FF;
-$pix-tertiary: #9D67FF;
-$pix-tertiary-50: #8A49FF;
-$pix-tertiary-60: #6712FF;
-$pix-tertiary-70: #4E00DB;
-$pix-tertiary-80: #3B00A4;
+$pix-tertiary-5: #ebe1ff;
+$pix-tertiary-10: #d8c2ff;
+$pix-tertiary-20: #c4a4ff;
+$pix-tertiary-30: #b186ff;
+$pix-tertiary: #9d67ff;
+$pix-tertiary-50: #8a49ff;
+$pix-tertiary-60: #6712ff;
+$pix-tertiary-70: #4e00db;
+$pix-tertiary-80: #3b00a4;
 
 // Success
-$pix-success-5: #ECFDF5;
-$pix-success-10: #D1FAE5;
-$pix-success-20: #A7F3D0;
-$pix-success-30: #6EE7B7;
-$pix-success: #34D399;
-$pix-success-50: #27B481;
-$pix-success-60: #14865D;
-$pix-success-70: #176C4D;
+$pix-success-5: #ecfdf5;
+$pix-success-10: #d1fae5;
+$pix-success-20: #a7f3d0;
+$pix-success-30: #6ee7b7;
+$pix-success: #34d399;
+$pix-success-50: #27b481;
+$pix-success-60: #14865d;
+$pix-success-70: #176c4d;
 $pix-success-80: #104834;
 
 // Warning
-$pix-warning-5: #FFF9E6;
-$pix-warning-10: #FFF1C5;
-$pix-warning-20: #FFE381;
-$pix-warning-30: #FFD235;
-$pix-warning-40: #FFBE00;
-$pix-warning-50: #EAA600;
-$pix-warning-60: #CE8900;
-$pix-warning-70: #AC6A00;
-$pix-warning-80: #874D00;
+$pix-warning-5: #fff9e6;
+$pix-warning-10: #fff1c5;
+$pix-warning-20: #ffe381;
+$pix-warning-30: #ffd235;
+$pix-warning-40: #ffbe00;
+$pix-warning-50: #eaa600;
+$pix-warning-60: #ce8900;
+$pix-warning-70: #ac6a00;
+$pix-warning-80: #874d00;
 
 // Error
-$pix-error-5: #FEF2F2;
-$pix-error-10: #FEE2E2;
-$pix-error-20: #FECACA;
-$pix-error-30: #FCA5A5;
-$pix-error-40: #F87171;
-$pix-error-50: #EF4444;
-$pix-error-60: #DC2626;
-$pix-error-70: #B91C1C;
-$pix-error-80: #991B1B;
+$pix-error-5: #fef2f2;
+$pix-error-10: #fee2e2;
+$pix-error-20: #fecaca;
+$pix-error-30: #fca5a5;
+$pix-error-40: #f87171;
+$pix-error-50: #ef4444;
+$pix-error-60: #dc2626;
+$pix-error-70: #b91c1c;
+$pix-error-80: #991b1b;
 
 // Neutral
 // Light
-$pix-neutral-0: #FFFFFF;
-$pix-neutral-5: #FAFBFC;
-$pix-neutral-10: #F4F5F7;
-$pix-neutral-15: #EAECF0;
-$pix-neutral-20: #DFE1E6;
-$pix-neutral-22: #C1C7D0;
-$pix-neutral-25: #A5ADBA;
-
+$pix-neutral-0: #ffffff;
+$pix-neutral-5: #fafbfc;
+$pix-neutral-10: #f4f5f7;
+$pix-neutral-15: #eaecf0;
+$pix-neutral-20: #dfe1e6;
+$pix-neutral-22: #c1c7d0;
+$pix-neutral-25: #a5adba;
 
 // Medium
-$pix-neutral-30: #97A0AF;
-$pix-neutral-35: #8993A4;
-$pix-neutral-40: #7A869A;
-$pix-neutral-45: #6B778C;
-$pix-neutral-50: #5E6C84;
-$pix-neutral-60: #505F79;
+$pix-neutral-30: #97a0af;
+$pix-neutral-35: #8993a4;
+$pix-neutral-40: #7a869a;
+$pix-neutral-45: #6b778c;
+$pix-neutral-50: #5e6c84;
+$pix-neutral-60: #505f79;
 
 // Dark
 $pix-neutral-70: #344563;
 $pix-neutral-80: #253858;
-$pix-neutral-90: #172B4D;
-$pix-neutral-100: #091E42;
-$pix-neutral-110: #07142E;
+$pix-neutral-90: #172b4d;
+$pix-neutral-100: #091e42;
+$pix-neutral-110: #07142e;
 
 // Shades
 $pix-shades-100: #000000;
 
 /// Domain
 // Information
-$pix-information-dark: #F24645;
-$pix-information-light: #F1A141;
+$pix-information-dark: #f24645;
+$pix-information-light: #f1a141;
 
 // Content
-$pix-content-dark: #1A8C89;
-$pix-content-light: #52D987;
+$pix-content-dark: #1a8c89;
+$pix-content-light: #52d987;
 
 // Communication
-$pix-communication-dark: #3D68FF;
-$pix-communication-light: #12A3FF;
+$pix-communication-dark: #3d68ff;
+$pix-communication-light: #12a3ff;
 
 // Security
-$pix-security-dark: #AC008D;
-$pix-security-light: #FF3F94;
+$pix-security-dark: #ac008d;
+$pix-security-light: #ff3f94;
 
 // Environment
-$pix-environment-dark: #5E2563;
-$pix-environment-light: #564DA6;
+$pix-environment-dark: #5e2563;
+$pix-environment-light: #564da6;
 
 ////GRADIENT
 // Primary Pix APP
-$pix-primary-app-gradient : linear-gradient(91.59deg, $pix-communication-dark 0%, #8845FF 100%);
+$pix-primary-app-gradient: linear-gradient(91.59deg, $pix-communication-dark 0%, #8845ff 100%);
 
 // Secondary Pix App
-$pix-secondary-app-gradient: linear-gradient(91.59deg, #FEDC41 0%, #FF9F00 100%);
+$pix-secondary-app-gradient: linear-gradient(91.59deg, #fedc41 0%, #ff9f00 100%);
 
 // Primary Certif
-$pix-primary-certif-gradient: linear-gradient(91.59deg, $pix-content-light 0%, $pix-content-dark 100%);
+$pix-primary-certif-gradient: linear-gradient(
+  91.59deg,
+  $pix-content-light 0%,
+  $pix-content-dark 100%
+);
 
 // Primary Orga
-$pix-primary-orga-gradient: linear-gradient(91.59deg, $pix-secondary-orga 0%, #0095C0 100%);
+$pix-primary-orga-gradient: linear-gradient(91.59deg, $pix-secondary-orga 0%, #0095c0 100%);
 
 // Secondary Orga
-$pix-secondary-orga-gradient: linear-gradient(91.59deg, #0D7DC4 0%, #213371 100%);
+$pix-secondary-orga-gradient: linear-gradient(91.59deg, #0d7dc4 0%, #213371 100%);
 
 /// Domain
 // Information
-$pix-information-gradient: linear-gradient(180deg, $pix-information-dark 0%, $pix-information-light 100%);
+$pix-information-gradient: linear-gradient(
+  180deg,
+  $pix-information-dark 0%,
+  $pix-information-light 100%
+);
 // Content
-$pix-content-gradient: linear-gradient(180deg, #1A8C89 0%, #52D987 100%);
+$pix-content-gradient: linear-gradient(180deg, #1a8c89 0%, #52d987 100%);
 
 // Communication
-$pix-communication-gradient: linear-gradient(180deg, $pix-primary 0%, #12A3FF 100%);
+$pix-communication-gradient: linear-gradient(180deg, $pix-primary 0%, #12a3ff 100%);
 
 // Security
-$pix-security-gradient: linear-gradient(180deg, #AC008D 0%, #FF3F94 100%);
+$pix-security-gradient: linear-gradient(180deg, #ac008d 0%, #ff3f94 100%);
 
 // Environment
-$pix-environment-gradient: linear-gradient(180deg, #5E2563 0%, #564DA6 100%);
+$pix-environment-gradient: linear-gradient(180deg, #5e2563 0%, #564da6 100%);
 
 ////DEPRECATED
 // primary
-$blue: #3D68FF;
-$yellow: #FFBE00;
-$orange: #DA7601;
-$red: #D63F00;
-$blue-zodiac: #505F79;
-$black: #07142E;
+$blue: #3d68ff;
+$yellow: #ffbe00;
+$orange: #da7601;
+$red: #d63f00;
+$blue-zodiac: #505f79;
+$black: #07142e;
 $white: #ffffff;
 // secondary
-$blue-hover: #3257D9;
-$dark-blue-pro: #1A38A0;
-$dark-green-certif: #17817E;
-$dark-orga: #006C87;
+$blue-hover: #3257d9;
+$dark-blue-pro: #1a38a0;
+$dark-green-certif: #17817e;
+$dark-orga: #006c87;
 $green: #038125;
-$orga: #00DDFF;
-$purple: #8845FF;
+$orga: #00ddff;
+$purple: #8845ff;
 
-@mixin colorize($color, $percentageDarkenForColor, $percentageLightenForBackground){
+@mixin colorize($color, $percentageDarkenForColor, $percentageLightenForBackground) {
   color: darken($color, $percentageDarkenForColor);
   background-color: lighten($color, $percentageLightenForBackground);
 }
 
 // gradients
-$pix-blue-gradient: linear-gradient(135deg, #12A3FF 0%, #3D68FF 100%);
-$pix-certif-gradient: linear-gradient(0deg, #52D987 0%, #1A8C89 100%);
-$pix-certif-old-gradient: linear-gradient(135deg, #FF3F93 0%, #AC008D 100%);
-$pix-orange-gradient: linear-gradient(180deg, #F24645 0%, #F1A141 100%);
-$pix-orga-gradient: linear-gradient(134deg, #00DDFF 0%, #0095C0 100%);
-$pix-orga-old-gradient: linear-gradient(0deg, #0D7DC4 0%, #213371 100%);
-$pix-pink-gradient: linear-gradient(0deg, #FF3F93 0%, #AC008D 100%);
-$pix-purple-gradient: linear-gradient(180deg, #5E2563 0%, #564DA6 100%);
-$pix-yellow-gradient: linear-gradient(135deg,$pix-primary-60 0%, #FF9F00 100%);
-$pix-yellow-gradient-right: linear-gradient(to right,$pix-primary-60, #FF9F00);
+$pix-blue-gradient: linear-gradient(135deg, #12a3ff 0%, #3d68ff 100%);
+$pix-certif-gradient: linear-gradient(0deg, #52d987 0%, #1a8c89 100%);
+$pix-certif-old-gradient: linear-gradient(135deg, #ff3f93 0%, #ac008d 100%);
+$pix-orange-gradient: linear-gradient(180deg, #f24645 0%, #f1a141 100%);
+$pix-orga-gradient: linear-gradient(134deg, #00ddff 0%, #0095c0 100%);
+$pix-orga-old-gradient: linear-gradient(0deg, #0d7dc4 0%, #213371 100%);
+$pix-pink-gradient: linear-gradient(0deg, #ff3f93 0%, #ac008d 100%);
+$pix-purple-gradient: linear-gradient(180deg, #5e2563 0%, #564da6 100%);
+$pix-yellow-gradient: linear-gradient(135deg, $pix-primary-60 0%, #ff9f00 100%);
+$pix-yellow-gradient-right: linear-gradient(to right, $pix-primary-60, #ff9f00);
 // light
-$grey-5: #FAFBFC;
-$grey-10: #F4F5F7;
-$grey-15: #EAECF0;
-$grey-20: #DFE1E6;
-$grey-22: #C1C7D0;
-$grey-25: #A5ADBA;
+$grey-5: #fafbfc;
+$grey-10: #f4f5f7;
+$grey-15: #eaecf0;
+$grey-20: #dfe1e6;
+$grey-22: #c1c7d0;
+$grey-25: #a5adba;
 // medium
-$grey-30: #97A0AF;
-$grey-35: #8993A4;
-$grey-40: #7A869A;
-$grey-45: #6B778C;
-$grey-50: #5E6C84;
-$grey-60: #505F79;
+$grey-30: #97a0af;
+$grey-35: #8993a4;
+$grey-40: #7a869a;
+$grey-45: #6b778c;
+$grey-50: #5e6c84;
+$grey-60: #505f79;
 // dark
 $grey-70: #344563;
 $grey-80: #253858;
-$grey-90: #172B4D;
-$grey-100: #091E42;
-$grey-150: #0C163A;
-$grey-200: #07142E;
+$grey-90: #172b4d;
+$grey-100: #091e42;
+$grey-150: #0c163a;
+$grey-200: #07142e;
 // gradients domain
-$information-gradient: linear-gradient(180deg, #F24645 0%, #F1A141 100%);
-$content-gradient: linear-gradient(0deg, #52D987 0%, #1A8C89 100%);
-$communication-gradient: linear-gradient(0deg, #12A3FF 0%, #3D68FF 100%);
-$security-gradient: linear-gradient(0deg, #FF3F93 0%, #AC008D 100%);
-$environment-gradient: linear-gradient(180deg, #5E2563 0%, #564DA6 100%);
+$information-gradient: linear-gradient(180deg, #f24645 0%, #f1a141 100%);
+$content-gradient: linear-gradient(0deg, #52d987 0%, #1a8c89 100%);
+$communication-gradient: linear-gradient(0deg, #12a3ff 0%, #3d68ff 100%);
+$security-gradient: linear-gradient(0deg, #ff3f93 0%, #ac008d 100%);
+$environment-gradient: linear-gradient(180deg, #5e2563 0%, #564da6 100%);
 // solids
-$environment-dark: #5E2563;
-$environment-light: #564DA6;
-$communication-dark: #3D68FF;
-$communication-light: #12A3FF;
-$content-dark: #1A8C89;
-$content-light: #52D987;
-$information-dark: #F24645;
-$information-light: #F1A141;
-$security-dark: #AC008D;
-$security-light: #FF3F94;
-$pink-alert-light: #FFE1E1;
-$pink-alert-dark: #A71E1A;
-$blue-alert-light: #DCF1FF;
-$blue-alert-dark: #0D25B3;
-$green-alert-light: #EFFFD8;
+$environment-dark: #5e2563;
+$environment-light: #564da6;
+$communication-dark: #3d68ff;
+$communication-light: #12a3ff;
+$content-dark: #1a8c89;
+$content-light: #52d987;
+$information-dark: #f24645;
+$information-light: #f1a141;
+$security-dark: #ac008d;
+$security-light: #ff3f94;
+$pink-alert-light: #ffe1e1;
+$pink-alert-dark: #a71e1a;
+$blue-alert-light: #dcf1ff;
+$blue-alert-dark: #0d25b3;
+$green-alert-light: #efffd8;
 $green-alert-dark: #006134;
-$yellow-alert-light: #FFF1C5;
-$yellow-alert-dark: #A95800;
+$yellow-alert-light: #fff1c5;
+$yellow-alert-dark: #a95800;
 
 // status
-$error: #FF4B00;
-$success: #57C884;
-$warning: #FFBE00;
+$error: #ff4b00;
+$success: #57c884;
+$warning: #ffbe00;

--- a/addon/styles/_colors.scss
+++ b/addon/styles/_colors.scss
@@ -140,36 +140,28 @@ $pix-environment-light: #564da6;
 
 ////GRADIENT
 // Primary Pix APP
-$pix-primary-app-gradient: linear-gradient(91.59deg, $pix-communication-dark 0%, #8845ff 100%);
+$pix-primary-app-gradient: linear-gradient(91.59deg, #3d68ff 0%, #8845ff 100%);
 
 // Secondary Pix App
 $pix-secondary-app-gradient: linear-gradient(91.59deg, #fedc41 0%, #ff9f00 100%);
 
 // Primary Certif
-$pix-primary-certif-gradient: linear-gradient(
-  91.59deg,
-  $pix-content-light 0%,
-  $pix-content-dark 100%
-);
+$pix-primary-certif-gradient: linear-gradient(91.59deg, #52d987 0%, #1a8c89 100%);
 
 // Primary Orga
-$pix-primary-orga-gradient: linear-gradient(91.59deg, $pix-secondary-orga 0%, #0095c0 100%);
+$pix-primary-orga-gradient: linear-gradient(91.59deg, #00ddff 0%, #0095c0 100%);
 
 // Secondary Orga
 $pix-secondary-orga-gradient: linear-gradient(91.59deg, #0d7dc4 0%, #213371 100%);
 
 /// Domain
 // Information
-$pix-information-gradient: linear-gradient(
-  180deg,
-  $pix-information-dark 0%,
-  $pix-information-light 100%
-);
+$pix-information-gradient: linear-gradient(180deg, #3d68ff 0%, #f1a141 100%);
 // Content
 $pix-content-gradient: linear-gradient(180deg, #1a8c89 0%, #52d987 100%);
 
 // Communication
-$pix-communication-gradient: linear-gradient(180deg, $pix-primary 0%, #12a3ff 100%);
+$pix-communication-gradient: linear-gradient(180deg, #3d68ff 0%, #12a3ff 100%);
 
 // Security
 $pix-security-gradient: linear-gradient(180deg, #ac008d 0%, #ff3f94 100%);
@@ -209,8 +201,8 @@ $pix-orga-gradient: linear-gradient(134deg, #00ddff 0%, #0095c0 100%);
 $pix-orga-old-gradient: linear-gradient(0deg, #0d7dc4 0%, #213371 100%);
 $pix-pink-gradient: linear-gradient(0deg, #ff3f93 0%, #ac008d 100%);
 $pix-purple-gradient: linear-gradient(180deg, #5e2563 0%, #564da6 100%);
-$pix-yellow-gradient: linear-gradient(135deg, $pix-primary-60 0%, #ff9f00 100%);
-$pix-yellow-gradient-right: linear-gradient(to right, $pix-primary-60, #ff9f00);
+$pix-yellow-gradient: linear-gradient(135deg, #ffbe00 0%, #ff9f00 100%);
+$pix-yellow-gradient-right: linear-gradient(to right, #ffbe00, #ff9f00);
 // light
 $grey-5: #fafbfc;
 $grey-10: #f4f5f7;

--- a/addon/styles/_form.scss
+++ b/addon/styles/_form.scss
@@ -1,10 +1,10 @@
-@mixin hoverFormElement(){
+@mixin hoverFormElement() {
   &:hover {
     box-shadow: inset 0px 0px 0px 0.6px $pix-neutral-40;
   }
 }
 
-@mixin focusFormElement(){
+@mixin focusFormElement() {
   &:focus {
     border-color: $pix-primary;
     box-shadow: inset 0px 0px 0px 0.6px $pix-primary;
@@ -12,7 +12,7 @@
   }
 }
 
-@mixin focusWithinFormElement(){
+@mixin focusWithinFormElement() {
   &:focus {
     border-color: $pix-primary;
     box-shadow: inset 0px 0px 0px 0.6px $pix-primary;
@@ -56,7 +56,6 @@
 .pix-radio-button {
   padding: $spacing-xs 0 $spacing-xs 0;
 }
-
 
 .pix-form__actions {
   display: flex;

--- a/addon/styles/_form.scss
+++ b/addon/styles/_form.scss
@@ -31,12 +31,12 @@
 @mixin errorMessage() {
   font-family: $font-roboto;
   font-size: 0.75rem;
-  color: $red;
+  color: $pix-error-70;
 }
 
 @mixin formElementInError() {
-  border-color: $red;
-  box-shadow: inset 0px 0px 0px 0.6px $red;
+  border-color: $pix-error-70;
+  box-shadow: inset 0px 0px 0px 0.6px $pix-error-70;
 }
 
 @mixin input() {

--- a/addon/styles/_form.scss
+++ b/addon/styles/_form.scss
@@ -6,16 +6,16 @@
 
 @mixin focusFormElement(){
   &:focus {
-    border-color: $blue;
-    box-shadow: inset 0px 0px 0px 0.6px $blue;
+    border-color: $pix-primary;
+    box-shadow: inset 0px 0px 0px 0.6px $pix-primary;
     outline: none;
   }
 }
 
 @mixin focusWithinFormElement(){
   &:focus {
-    border-color: $blue;
-    box-shadow: inset 0px 0px 0px 0.6px $blue;
+    border-color: $pix-primary;
+    box-shadow: inset 0px 0px 0px 0.6px $pix-primary;
     outline: none;
   }
 }

--- a/addon/styles/_form.scss
+++ b/addon/styles/_form.scss
@@ -68,7 +68,7 @@
 
 abbr.mandatory-mark {
   cursor: help;
-  color: $pink-alert-dark;
+  color: $pix-error-70;
   text-decoration: none;
   border: none;
 }

--- a/addon/styles/_form.scss
+++ b/addon/styles/_form.scss
@@ -1,6 +1,6 @@
 @mixin hoverFormElement(){
   &:hover {
-    box-shadow: inset 0px 0px 0px 0.6px $grey-40;
+    box-shadow: inset 0px 0px 0px 0.6px $pix-neutral-40;
   }
 }
 
@@ -24,7 +24,7 @@
   display: block;
   font-family: $font-roboto;
   font-size: 0.875rem;
-  color: $grey-70;
+  color: $pix-neutral-70;
   margin-bottom: 4px;
 }
 
@@ -43,7 +43,7 @@
   font-family: $font-roboto;
   font-size: 0.875rem;
   font-weight: 400;
-  color: $grey-90;
+  color: $pix-neutral-90;
   border-radius: $spacing-xxs;
   padding: 0 $spacing-s 0 $spacing-s;
 }

--- a/addon/styles/_pix-background-header.scss
+++ b/addon/styles/_pix-background-header.scss
@@ -15,6 +15,6 @@
     min-height: 270px;
     background: $pix-gradient;
     box-shadow: 0 2px 8px 0 rgba(0, 0, 0, 0.1);
-    color: $white;
+    color: $pix-neutral-0;
   }
 }

--- a/addon/styles/_pix-background-header.scss
+++ b/addon/styles/_pix-background-header.scss
@@ -13,7 +13,7 @@
     z-index: -1;
     width: 100%;
     min-height: 270px;
-    background: $pix-gradient;
+    background: $pix-primary-app-gradient;
     box-shadow: 0 2px 8px 0 rgba(0, 0, 0, 0.1);
     color: $pix-neutral-0;
   }

--- a/addon/styles/_pix-background-header.scss
+++ b/addon/styles/_pix-background-header.scss
@@ -9,7 +9,8 @@
 
   &__background {
     position: absolute;
-    top: 0; left: 0;
+    top: 0;
+    left: 0;
     z-index: -1;
     width: 100%;
     min-height: 270px;

--- a/addon/styles/_pix-banner.scss
+++ b/addon/styles/_pix-banner.scss
@@ -52,16 +52,16 @@
 
   &--communication {
     background-color: $pix-primary;
-    color: $white;
+    color: $pix-neutral-0;
 
     &-orga {
       background-color: $dark-orga;
-      color: $white;
+      color: $pix-neutral-0;
     }
 
     &-certif {
-      background-color: $dark-green-certif;
-      color: $white;
+      background-color: $pix-secondary-certif-50;
+      color: $pix-neutral-0;
     }
   }
 }

--- a/addon/styles/_pix-banner.scss
+++ b/addon/styles/_pix-banner.scss
@@ -36,18 +36,18 @@
   }
 
   &--information {
-    background-color: $blue-alert-light;
-    color: $blue-alert-dark;
+    background-color: $pix-primary-10;
+    color: $pix-primary-70;
   }
 
   &--warning {
-    background-color: $yellow-alert-light;
-    color: $yellow-alert-dark;
+    background-color: $pix-warning-10;
+    color: $pix-warning-60;
   }
 
   &--error {
-    background-color: $pink-alert-light;
-    color: $pink-alert-dark;
+    background-color: $pix-error-10;
+    color: $pix-error-70;
   }
 
   &--communication {

--- a/addon/styles/_pix-banner.scss
+++ b/addon/styles/_pix-banner.scss
@@ -51,7 +51,7 @@
   }
 
   &--communication {
-    background-color: $blue;
+    background-color: $pix-primary;
     color: $white;
 
     &-orga {

--- a/addon/styles/_pix-block.scss
+++ b/addon/styles/_pix-block.scss
@@ -11,8 +11,8 @@
     box-shadow: 0 10px 20px 0 rgba($pix-primary, .06);
   }
   &--shadow-heavy {
-    box-shadow: 0 50px 54px -40px rgba($grey-200, .4),
-                0 7px 14px 0 rgba($grey-150, .1);
+    box-shadow: 0 50px 54px -40px rgba($pix-neutral-110, .4),
+                0 7px 14px 0 rgba($pix-neutral-100, .1);
   }
 }
 

--- a/addon/styles/_pix-block.scss
+++ b/addon/styles/_pix-block.scss
@@ -8,11 +8,11 @@
   border-radius: 5px;
 
   &--shadow-light {
-    box-shadow: 0 10px 20px 0 rgba($pix-primary, .06);
+    box-shadow: 0 10px 20px 0 rgba($pix-primary, 0.06);
   }
   &--shadow-heavy {
-    box-shadow: 0 50px 54px -40px rgba($pix-neutral-110, .4),
-                0 7px 14px 0 rgba($pix-neutral-100, .1);
+    box-shadow: 0 50px 54px -40px rgba($pix-neutral-110, 0.4),
+      0 7px 14px 0 rgba($pix-neutral-100, 0.1);
   }
 }
 

--- a/addon/styles/_pix-block.scss
+++ b/addon/styles/_pix-block.scss
@@ -6,9 +6,9 @@
   margin-bottom: 32px;
   background-color: $white;
   border-radius: 5px;
-  
+
   &--shadow-light {
-    box-shadow: 0 10px 20px 0 rgba($blue, .06);
+    box-shadow: 0 10px 20px 0 rgba($pix-primary, .06);
   }
   &--shadow-heavy {
     box-shadow: 0 50px 54px -40px rgba($grey-200, .4),

--- a/addon/styles/_pix-block.scss
+++ b/addon/styles/_pix-block.scss
@@ -4,7 +4,7 @@
   max-width: 980px;
   padding: 14px 24px;
   margin-bottom: 32px;
-  background-color: $white;
+  background-color: $pix-neutral-0;
   border-radius: 5px;
 
   &--shadow-light {

--- a/addon/styles/_pix-button-base.scss
+++ b/addon/styles/_pix-button-base.scss
@@ -6,7 +6,7 @@
   font-size: 0.875rem;
   font-weight: 500;
   white-space: nowrap;
-  letter-spacing: .028rem;
+  letter-spacing: 0.028rem;
   cursor: pointer;
   background-color: $pix-primary;
   border: 2px solid transparent;
@@ -36,7 +36,7 @@
   }
 
   &--disabled {
-    opacity: .5;
+    opacity: 0.5;
     cursor: not-allowed;
   }
 
@@ -45,7 +45,9 @@
     border-color: $backgroundColor;
 
     &:not(.pix-button--disabled) {
-      &:hover, &:focus, &:focus-visible {
+      &:hover,
+      &:focus,
+      &:focus-visible {
         background-color: darken($backgroundColor, 8%);
         box-shadow: 0 0 0 2px darken($outlineColor, 8%);
         border-color: $pix-neutral-0;
@@ -93,7 +95,9 @@
     color: $pix-neutral-90;
 
     &:not(.pix-button--disabled) {
-      &:hover, &:focus, &:focus-visible {
+      &:hover,
+      &:focus,
+      &:focus-visible {
         background-color: rgba($pix-neutral-110, 0.1);
         outline: none;
       }
@@ -107,7 +111,8 @@
       border-color: $pix-neutral-50;
 
       &:not(.pix-button--disabled) {
-        &:hover, &:active {
+        &:hover,
+        &:active {
           border-color: $pix-neutral-80;
         }
       }
@@ -120,7 +125,9 @@
     color: $pix-neutral-0;
 
     &:not(.pix-button--disabled) {
-      &:hover, &:focus, &:focus-visible {
+      &:hover,
+      &:focus,
+      &:focus-visible {
         background-color: rgba($pix-neutral-110, 0.1);
         outline: none;
       }

--- a/addon/styles/_pix-button-base.scss
+++ b/addon/styles/_pix-button-base.scss
@@ -77,7 +77,7 @@
   }
 
   &--background-grey {
-    @include colorizeBackground($blue-zodiac, $blue-zodiac);
+    @include colorizeBackground($pix-neutral-60, $pix-neutral-60);
   }
 
   /* deprecated in favor of --background-transparent-light + --border */

--- a/addon/styles/_pix-button-base.scss
+++ b/addon/styles/_pix-button-base.scss
@@ -8,7 +8,7 @@
   white-space: nowrap;
   letter-spacing: .028rem;
   cursor: pointer;
-  background-color: $blue;
+  background-color: $pix-primary;
   border: 2px solid transparent;
   display: flex;
   justify-content: center;
@@ -59,7 +59,7 @@
   }
 
   &--background-blue {
-    @include colorizeBackground($blue, $blue);
+    @include colorizeBackground($pix-primary, $pix-primary);
   }
 
   &--background-green {

--- a/addon/styles/_pix-button-base.scss
+++ b/addon/styles/_pix-button-base.scss
@@ -1,7 +1,7 @@
 .pix-button {
   @import 'reset-css';
 
-  color: $white;
+  color: $pix-neutral-0;
   font-family: $font-roboto;
   font-size: 0.875rem;
   font-weight: 500;
@@ -48,7 +48,7 @@
       &:hover, &:focus, &:focus-visible {
         background-color: darken($backgroundColor, 8%);
         box-shadow: 0 0 0 2px darken($outlineColor, 8%);
-        border-color: $white;
+        border-color: $pix-neutral-0;
         outline: none;
       }
 
@@ -68,12 +68,12 @@
 
   &--background-yellow {
     color: $pix-neutral-100;
-    @include colorizeBackground($yellow, $yellow);
+    @include colorizeBackground($pix-warning-40, $pix-warning-40);
   }
 
   &--background-red {
-    color: $white;
-    @include colorizeBackground($red, $red);
+    color: $pix-neutral-0;
+    @include colorizeBackground($pix-error-70, $pix-error-70);
   }
 
   &--background-grey {
@@ -94,12 +94,12 @@
 
     &:not(.pix-button--disabled) {
       &:hover, &:focus, &:focus-visible {
-        background-color: rgba($black, 0.1);
+        background-color: rgba($pix-neutral-110, 0.1);
         outline: none;
       }
 
       &:active {
-        background-color: rgba($black, 0.2);
+        background-color: rgba($pix-neutral-110, 0.2);
       }
     }
 
@@ -117,21 +117,21 @@
   &--background-transparent-dark {
     background-color: transparent;
     border-color: transparent;
-    color: $white;
+    color: $pix-neutral-0;
 
     &:not(.pix-button--disabled) {
       &:hover, &:focus, &:focus-visible {
-        background-color: rgba($black, 0.1);
+        background-color: rgba($pix-neutral-110, 0.1);
         outline: none;
       }
 
       &:active {
-        background-color: rgba($black, 0.2);
+        background-color: rgba($pix-neutral-110, 0.2);
       }
     }
 
     &.pix-button--border {
-      border-color: $white;
+      border-color: $pix-neutral-0;
     }
   }
 }

--- a/addon/styles/_pix-button-base.scss
+++ b/addon/styles/_pix-button-base.scss
@@ -67,7 +67,7 @@
   }
 
   &--background-yellow {
-    color: $grey-100;
+    color: $pix-neutral-100;
     @include colorizeBackground($yellow, $yellow);
   }
 
@@ -83,14 +83,14 @@
   /* deprecated in favor of --background-transparent-light + --border */
   &--background-transparent {
     background-color: transparent;
-    color: $grey-50;
-    border: 2px solid $grey-50;
+    color: $pix-neutral-50;
+    border: 2px solid $pix-neutral-50;
   }
 
   &--background-transparent-light {
     background-color: transparent;
     border-color: transparent;
-    color: $grey-90;
+    color: $pix-neutral-90;
 
     &:not(.pix-button--disabled) {
       &:hover, &:focus, &:focus-visible {
@@ -104,11 +104,11 @@
     }
 
     &.pix-button--border {
-      border-color: $grey-50;
+      border-color: $pix-neutral-50;
 
       &:not(.pix-button--disabled) {
         &:hover, &:active {
-          border-color: $grey-80;
+          border-color: $pix-neutral-80;
         }
       }
     }

--- a/addon/styles/_pix-button-link.scss
+++ b/addon/styles/_pix-button-link.scss
@@ -1,4 +1,3 @@
 .pix-button-link {
   @import 'reset-css';
-
 }

--- a/addon/styles/_pix-button.scss
+++ b/addon/styles/_pix-button.scss
@@ -10,14 +10,14 @@
   .loader > div {
     width: 10px;
     height: 10px;
-    background-color: $white;
+    background-color: $pix-neutral-0;
     border-radius: 100%;
     display: inline-block;
     animation: sk-bouncedelay 1.4s infinite ease-in-out both;
   }
 
   .loader--white > div {
-    background-color: $white;
+    background-color: $pix-neutral-0;
   }
   .loader--grey > div {
     background-color: $pix-neutral-80;

--- a/addon/styles/_pix-button.scss
+++ b/addon/styles/_pix-button.scss
@@ -6,7 +6,7 @@
       visibility: hidden;
     }
   }
-  
+
   .loader > div {
     width: 10px;
     height: 10px;
@@ -20,7 +20,7 @@
     background-color: $white;
   }
   .loader--grey > div {
-    background-color: $grey-80;
+    background-color: $pix-neutral-80;
   }
   .loader .bounce1 {
     animation-delay: -0.32s;

--- a/addon/styles/_pix-button.scss
+++ b/addon/styles/_pix-button.scss
@@ -31,10 +31,13 @@
   }
 
   @keyframes sk-bouncedelay {
-    0%, 80%, 100% {
+    0%,
+    80%,
+    100% {
       transform: scale(0);
-    } 40% {
-      transform: scale(1.0);
+    }
+    40% {
+      transform: scale(1);
     }
   }
 }

--- a/addon/styles/_pix-collapsible.scss
+++ b/addon/styles/_pix-collapsible.scss
@@ -6,7 +6,7 @@
   flex-direction: column;
   font-family: $font-roboto;
   font-size: 1rem;
-  border: 1px solid $grey-20;
+  border: 1px solid $pix-neutral-20;
   padding: 0;
   cursor: pointer;
   background-color: $white;
@@ -19,28 +19,28 @@
     justify-content: space-between;
     background: transparent;
     border: none;
-    color: $grey-60;
+    color: $pix-neutral-60;
     font-size: 1rem;
     font-weight: 500;
 
     .pix-collapsible-title__icon {
-      color: $grey-45;
+      color: $pix-neutral-45;
       margin-right: 6px;
     }
 
     &:hover {
-      background-color: $grey-10;
+      background-color: $pix-neutral-10;
     }
 
     &:focus {
-      background-color: $grey-10;
+      background-color: $pix-neutral-10;
     }
 
     &--uncollapsed {
-      background-color: $grey-10;
+      background-color: $pix-neutral-10;
     }
   }
-  
+
   &__content {
     padding: 16px 20px;
     display: none;

--- a/addon/styles/_pix-collapsible.scss
+++ b/addon/styles/_pix-collapsible.scss
@@ -9,7 +9,7 @@
   border: 1px solid $pix-neutral-20;
   padding: 0;
   cursor: pointer;
-  background-color: $white;
+  background-color: $pix-neutral-0;
 
   &__title {
     padding: 14px 10px 14px 16px;
@@ -64,7 +64,7 @@
 .pix-collapsible--uncollapsed {
   margin-top: 10px;
   margin-bottom: 10px;
-  box-shadow: 0 2px 5px 0 rgba($black, 0.05);
+  box-shadow: 0 2px 5px 0 rgba($pix-neutral-110, 0.05);
   border-radius: 4px;
 }
 

--- a/addon/styles/_pix-collapsible.scss
+++ b/addon/styles/_pix-collapsible.scss
@@ -77,6 +77,7 @@
 }
 
 // Pour le deuxième élément d'affilé qui est refermé, on enlève la bordure-top
-.pix-collapsible:not(.pix-collapsible--uncollapsed) + .pix-collapsible:not(.pix-collapsible--uncollapsed) {
+.pix-collapsible:not(.pix-collapsible--uncollapsed)
+  + .pix-collapsible:not(.pix-collapsible--uncollapsed) {
   border-top: none;
 }

--- a/addon/styles/_pix-dropdown.scss
+++ b/addon/styles/_pix-dropdown.scss
@@ -23,7 +23,7 @@
       width: 100%;
       min-width: 250px;
       min-height: 34px;
-      border: 1px solid $grey-40;
+      border: 1px solid $pix-neutral-40;
       border-radius: $spacing-xxs;
       padding: 0;
       background: $white;
@@ -35,7 +35,7 @@
     }
 
     &--placeholder-text {
-      color: $grey-90;
+      color: $pix-neutral-90;
       margin: 0;
       font-size: 0.875rem;
       overflow: hidden;
@@ -44,7 +44,7 @@
       padding: 8px 68px 8px 16px;
 
       &.default {
-        color: $grey-60;
+        color: $pix-neutral-60;
         padding-right: 36px;
       }
     }
@@ -52,17 +52,17 @@
     &--clear {
       background: transparent;
       font-size: 1rem;
-      color: $grey-50;
+      color: $pix-neutral-50;
       position: absolute;
       padding: 8px 8px 6px;
       border: none;
-      border-right: 2px solid $grey-40;
+      border-right: 2px solid $pix-neutral-40;
       right: 38px;
       top: 1px;
       width: fit-content;
 
       &:hover {
-        color: $grey-70;
+        color: $pix-neutral-70;
       }
     }
 
@@ -73,11 +73,11 @@
       position: absolute;
       top: 9px;
       right: 12px;
-      color: $grey-50;
+      color: $pix-neutral-50;
       cursor: pointer;
 
       &:hover {
-        color: $grey-70;
+        color: $pix-neutral-70;
       }
     }
   }
@@ -95,7 +95,7 @@
 
     &.expanded {
       max-height: 300px;
-      border: 1px solid $grey-40;
+      border: 1px solid $pix-neutral-40;
       border-top: none;
       border-radius: 0 0 $spacing-xxs $spacing-xxs;
     }
@@ -105,7 +105,7 @@
       position: relative;
 
       &-icon {
-        color: $grey-30;
+        color: $pix-neutral-30;
         margin: 4px;
         position: absolute;
         left: 16px;
@@ -114,7 +114,7 @@
 
       &-input {
         border: none;
-        border-bottom: 1px solid $grey-40;
+        border-bottom: 1px solid $pix-neutral-40;
         font-size: 0.875rem;
         flex-grow: 1;
         margin: 12px 12px 8px;
@@ -122,7 +122,7 @@
         outline: none;
 
         &:hover {
-          box-shadow: inset 0 -0.7px 0 0 $grey-40;
+          box-shadow: inset 0 -0.7px 0 0 $pix-neutral-40;
         }
 
         &:focus {
@@ -144,13 +144,13 @@
       cursor: pointer;
 
       &.selected {
-        color: $grey-70;
+        color: $pix-neutral-70;
       }
 
       &:focus,
       &:hover {
         outline: none;
-        background: $grey-15;
+        background: $pix-neutral-15;
       }
     }
   }

--- a/addon/styles/_pix-dropdown.scss
+++ b/addon/styles/_pix-dropdown.scss
@@ -126,8 +126,8 @@
         }
 
         &:focus {
-          box-shadow: inset 0 -0.7px 0 0 $blue;
-          border-color: $blue;
+          box-shadow: inset 0 -0.7px 0 0 $pix-primary;
+          border-color: $pix-primary;
         }
 
         &-label {

--- a/addon/styles/_pix-dropdown.scss
+++ b/addon/styles/_pix-dropdown.scss
@@ -26,7 +26,7 @@
       border: 1px solid $pix-neutral-40;
       border-radius: $spacing-xxs;
       padding: 0;
-      background: $white;
+      background: $pix-neutral-0;
 
       &.expanded {
         border-bottom-left-radius: 0;
@@ -83,7 +83,7 @@
   }
 
   &__menu {
-    background: white;
+    background: $pix-neutral-0;
     position: absolute;
     top: 100%;
     width: 100%;

--- a/addon/styles/_pix-filter-banner.scss
+++ b/addon/styles/_pix-filter-banner.scss
@@ -7,8 +7,8 @@
   gap: 6px;
   width: 100%;
 
-  background-color: $white;
-  box-shadow: 0 2px 5px 0 rgba($black, 0.05);
+  background-color: $pix-neutral-0;
+  box-shadow: 0 2px 5px 0 rgba($pix-neutral-110, 0.05);
   min-height: 64px;
   padding: 14px 24px;
 

--- a/addon/styles/_pix-filter-banner.scss
+++ b/addon/styles/_pix-filter-banner.scss
@@ -16,7 +16,7 @@
     display: flex;
     flex-direction: column;
     gap: 12px;
-    
+
     > * > * {
       width: 100%;
     }
@@ -28,20 +28,20 @@
   }
 
   &__title {
-    color: $grey-60;
+    color: $pix-neutral-60;
     font-family: $font-roboto;
     font-size: 0.875rem;
     margin: 0;
   }
 
   p.pix-filter-banner__details {
-    color: $grey-60;
+    color: $pix-neutral-60;
     font-family: $font-roboto;
     font-weight: $font-medium;
     font-size: 0.875rem;
     margin-top: 10px;
     padding-top: 10px;
-    border-top: 1px solid $grey-15;
+    border-top: 1px solid$pix-neutral-15;
   }
 
   &__button {
@@ -97,7 +97,7 @@
     }
 
     &__button-container {
-      border-left: 1px solid $grey-15;
+      border-left: 1px solid $pix-neutral-15;
       padding-left: 16px;
     }
   }

--- a/addon/styles/_pix-icon-button.scss
+++ b/addon/styles/_pix-icon-button.scss
@@ -12,11 +12,12 @@
   background-color: transparent;
 
   &:disabled {
-    opacity: .5;
+    opacity: 0.5;
     cursor: default;
   }
 
-  &:hover, &:focus {
+  &:hover,
+  &:focus {
     transition: background-color 0.2s ease;
     background-color: $pix-neutral-15;
     &:disabled {
@@ -31,7 +32,9 @@
 
   &--background {
     background-color: $pix-neutral-10;
-    &:hover, &:focus, &:active {
+    &:hover,
+    &:focus,
+    &:active {
       &:disabled {
         background-color: $pix-neutral-15;
       }

--- a/addon/styles/_pix-icon-button.scss
+++ b/addon/styles/_pix-icon-button.scss
@@ -18,7 +18,7 @@
 
   &:hover, &:focus {
     transition: background-color 0.2s ease;
-    background-color: $grey-15;
+    background-color: $pix-neutral-15;
     &:disabled {
       background-color: transparent;
     }
@@ -26,14 +26,14 @@
 
   &:active {
     transition: background-color 0.2s ease;
-    background-color: $grey-20;
+    background-color: $pix-neutral-20;
   }
 
   &--background {
-    background-color: $grey-10;
+    background-color: $pix-neutral-10;
     &:hover, &:focus, &:active {
       &:disabled {
-        background-color: $grey-15;
+        background-color: $pix-neutral-15;
       }
     }
   }
@@ -51,10 +51,10 @@
   }
 
   &--dark-grey {
-    color: $grey-60;
+    color: $pix-neutral-60;
   }
 
   &--light-grey {
-    color: $grey-60;
+    color: $pix-neutral-60;
   }
 }

--- a/addon/styles/_pix-input-code.scss
+++ b/addon/styles/_pix-input-code.scss
@@ -57,7 +57,7 @@
     &:active,
     &:focus {
       border-color: $pix-primary;
-      background-color: $white;
+      background-color: $pix-neutral-0;
 
       &::placeholder {
         opacity: 0;
@@ -65,7 +65,7 @@
     }
 
     &.filled {
-      background-color: $white;
+      background-color: $pix-neutral-0;
     }
   }
 }

--- a/addon/styles/_pix-input-code.scss
+++ b/addon/styles/_pix-input-code.scss
@@ -56,7 +56,7 @@
 
     &:active,
     &:focus {
-      border-color: $blue;
+      border-color: $pix-primary;
       background-color: $white;
 
       &::placeholder {

--- a/addon/styles/_pix-input-code.scss
+++ b/addon/styles/_pix-input-code.scss
@@ -31,11 +31,11 @@
     height: 44px;
     width: 38px;
     padding: 10px 12px 8px;
-    background-color: $grey-10;
-    border: 1.4px solid $grey-50;
+    background-color: $pix-neutral-10;
+    border: 1.4px solid $pix-neutral-50;
     font-family: $font-roboto;
     font-size: 1.25rem;
-    color: $grey-90;
+    color: $pix-neutral-90;
     border-radius: 4px;
     text-align: center;
     outline: none;
@@ -47,11 +47,11 @@
     }
 
     &::placeholder {
-      color: $grey-50;
+      color: $pix-neutral-50;
     }
 
     &:hover {
-      border-color: $grey-70;
+      border-color: $pix-neutral-70;
     }
 
     &:active,

--- a/addon/styles/_pix-input-code.scss
+++ b/addon/styles/_pix-input-code.scss
@@ -3,7 +3,7 @@
   display: flex;
 
   // hide up/down cursors
-  input[type=number] {
+  input[type='number'] {
     // Firefox
     -moz-appearance: textfield;
 
@@ -22,7 +22,7 @@
     display: none;
   }
 
-  input:nth-of-type(3n+4) {
+  input:nth-of-type(3n + 4) {
     margin-left: 12px;
   }
 

--- a/addon/styles/_pix-input-password.scss
+++ b/addon/styles/_pix-input-password.scss
@@ -9,7 +9,7 @@
     position: relative;
     display: flex;
     align-items: center;
-    border: 1px solid $grey-40;
+    border: 1px solid $pix-neutral-40;
     border-radius: $spacing-xxs;
     padding: 1px 0 1px 1px;
 
@@ -44,7 +44,7 @@
     &:active,
     &:focus {
       background-color: transparent;
-      color: $grey-90;
+      color: $pix-neutral-90;
     }
   }
 

--- a/addon/styles/_pix-input-password.scss
+++ b/addon/styles/_pix-input-password.scss
@@ -16,8 +16,8 @@
     @include hoverFormElement();
 
     &:focus-within {
-      border-color: $blue;
-      box-shadow: inset 0 0 0 0.6px $blue;
+      border-color: $pix-primary;
+      box-shadow: inset 0 0 0 0.6px $pix-primary;
     }
 
     input {

--- a/addon/styles/_pix-input-password.scss
+++ b/addon/styles/_pix-input-password.scss
@@ -57,8 +57,8 @@
     position: absolute;
     bottom: 10px;
     right: 6px;
-    color: $white;
-    background: $red;
+    color: $pix-neutral-0;
+    background: $pix-error-70;
     border-radius: 50%;
     font-size: 0.6rem;
     padding: 2px;

--- a/addon/styles/_pix-input.scss
+++ b/addon/styles/_pix-input.scss
@@ -29,8 +29,8 @@
     position: absolute;
     bottom: 10px;
     right: 6px;
-    color: $white;
-    background: $red;
+    color: $pix-neutral-0;
+    background: $pix-error-70;
     border-radius: 50%;
     font-size: 0.6rem;
     padding: 2px;

--- a/addon/styles/_pix-input.scss
+++ b/addon/styles/_pix-input.scss
@@ -16,7 +16,7 @@
     font-family: $font-roboto;
     font-size: 0.75rem;
     margin-top: 4px;
-    color: $blue-zodiac;
+    color: $pix-neutral-60;
 
     display: block;
   }

--- a/addon/styles/_pix-input.scss
+++ b/addon/styles/_pix-input.scss
@@ -8,7 +8,7 @@
   &__label {
     font-family: $font-roboto;
     font-size: 0.875rem;
-    color: $grey-70;
+    color: $pix-neutral-70;
     margin-bottom: 4px;
   }
 
@@ -51,14 +51,14 @@
   input {
     width: 100%;
     height: 36px;
-    border: 1px solid $grey-40;
+    border: 1px solid $pix-neutral-40;
 
     @include input();
     @include hoverFormElement();
     @include focusFormElement();
 
     &::placeholder {
-      color: $grey-30;
+      color: $pix-neutral-30;
     }
 
     &.pix-input__input--error {

--- a/addon/styles/_pix-input.scss
+++ b/addon/styles/_pix-input.scss
@@ -44,7 +44,7 @@
     bottom: calc(-4px - 1px - 0.75rem);
 
     &.pix-input__error-message {
-      margin-top:4px;
+      margin-top: 4px;
     }
   }
 

--- a/addon/styles/_pix-message.scss
+++ b/addon/styles/_pix-message.scss
@@ -9,24 +9,24 @@
   display: flex;
 
   &.pix-message--info {
-    color: $blue-alert-dark;
-    background-color: $blue-alert-light;
+    color: $pix-primary-70;
+    background-color: $pix-primary-10;
   }
   &.pix-message--alert {
-    color: $pink-alert-dark;
-    background-color: $pink-alert-light;
+    color: $pix-error-70;
+    background-color: $pix-error-10;
   }
   &.pix-message--error {
-    color: $pink-alert-dark;
-    background-color: $pink-alert-light;
+    color: $pix-error-70;
+    background-color: $pix-error-10;
   }
   &.pix-message--success {
-    color: $green-alert-dark;
-    background-color: $green-alert-light;
+    color: $pix-success-70;
+    background-color: $pix-success-10;
   }
   &.pix-message--warning {
-    color: $yellow-alert-dark;
-    background-color: $yellow-alert-light;
+    color: $pix-warning-60;
+    background-color: $pix-warning-10;
   }
 
   svg {

--- a/addon/styles/_pix-modal.scss
+++ b/addon/styles/_pix-modal.scss
@@ -24,7 +24,7 @@ $button-margin: 16px;
 
   &__header {
     background: $white;
-    border-bottom: 1px solid $grey-20;
+    border-bottom: 1px solid $pix-neutral-20;
     border-top-left-radius: 4px;
     border-top-right-radius: 4px;
     padding: $modal-padding;
@@ -46,7 +46,7 @@ $button-margin: 16px;
   &__title {
     margin-bottom: 0;
     font-family: $font-open-sans;
-    color: $grey-90;
+    color: $pix-neutral-90;
     font-size: 1.25rem;
     line-height: 1.875rem;
     font-weight: $font-normal;
@@ -58,10 +58,10 @@ $button-margin: 16px;
   }
 
   &__content {
-    background-color: $grey-10;
+    background-color: $pix-neutral-10;
     padding: $modal-padding;
     font-size: 0.875rem;
-    color: $grey-90;
+    color: $pix-neutral-90;
     line-height: 1.375rem;
     font-family: $font-roboto;
     font-weight: $font-normal;
@@ -72,7 +72,7 @@ $button-margin: 16px;
   }
 
   &__footer {
-    background-color: $grey-10;
+    background-color: $pix-neutral-10;
     padding: 0 $modal-padding $modal-padding - $button-margin;
     border-bottom-left-radius: 4px;
     border-bottom-right-radius: 4px;

--- a/addon/styles/_pix-modal.scss
+++ b/addon/styles/_pix-modal.scss
@@ -23,7 +23,7 @@ $button-margin: 16px;
   width: calc(100% - 24px);
 
   &__header {
-    background: $white;
+    background: $pix-neutral-0;
     border-bottom: 1px solid $pix-neutral-20;
     border-top-left-radius: 4px;
     border-top-right-radius: 4px;

--- a/addon/styles/_pix-modal.scss
+++ b/addon/styles/_pix-modal.scss
@@ -1,5 +1,5 @@
 .pix-modal__overlay {
-  background-color: rgba(52, 69, 99, .7);
+  background-color: rgba(52, 69, 99, 0.7);
   bottom: 0;
   left: 0;
   overflow-y: scroll;
@@ -16,8 +16,8 @@ $space-between-title-and-close-button: 8px;
 $button-margin: 16px;
 
 .pix-modal {
-  @import "reset-css";
-  box-shadow: 1px 1px 5px rgba(0,0,0,.1);
+  @import 'reset-css';
+  box-shadow: 1px 1px 5px rgba(0, 0, 0, 0.1);
   margin: 20vh auto;
   max-width: 512px;
   width: calc(100% - 24px);

--- a/addon/styles/_pix-multi-select.scss
+++ b/addon/styles/_pix-multi-select.scss
@@ -16,7 +16,7 @@
   font-family: $font-roboto;
   font-weight: $font-normal;
   position: relative;
-  border: 1px $grey-40 solid;
+  border: 1px $pix-neutral-40 solid;
   height: 36px;
   padding: 0px 32px 0px 16px;
   width: 100%;
@@ -25,7 +25,7 @@
   outline: none;
   font-size: 0.875rem;
   cursor: pointer;
-  color: $grey-90;
+  color: $pix-neutral-90;
 
   @include hoverFormElement();
   @include focusWithinFormElement();
@@ -35,7 +35,7 @@
   }
 
   &__search-icon {
-    color: $grey-30;
+    color: $pix-neutral-30;
   }
 
   &__title {
@@ -53,13 +53,13 @@
     padding: 0 10px;
     border-radius: 3px;
     font-size: 0.875rem;
-    color: $grey-90;
+    color: $pix-neutral-90;
     background: transparent;
   }
 
   &__dropdown-icon {
     font-size: 11px;
-    color: $grey-30;
+    color: $pix-neutral-30;
     right: 10px;
     top: calc(50% - 6px);
     padding: 0 0 2px;
@@ -96,21 +96,21 @@
   }
   &::-webkit-scrollbar-track {
     border-radius: 4px;
-    border: 1px solid $grey-20;
+    border: 1px solid $pix-neutral-20;
     background: $white;
   }
   &::-webkit-scrollbar-thumb {
     border-radius: 4px;
-    background: $grey-30;
+    background: $pix-neutral-30;
   }
   &::-webkit-scrollbar-thumb:hover {
-    background: $grey-35;
+    background: $pix-neutral-35;
   }
 
   li.pix-multi-select-list__item {
     font-family: $font-roboto;
     position: relative;
-    border-bottom: 1px solid $grey-15;
+    border-bottom: 1px solid $pix-neutral-15;
     list-style: none;
     font-size: 0.9rem;
 
@@ -147,7 +147,7 @@
       min-height: 16px;
       border-radius: 4px;
       background: $white;
-      border: 1px solid $grey-20;
+      border: 1px solid $pix-neutral-20;
     }
 
     &:checked + label:before {

--- a/addon/styles/_pix-multi-select.scss
+++ b/addon/styles/_pix-multi-select.scss
@@ -67,7 +67,7 @@
     pointer-events: none;
 
     &--expand {
-      color: $blue;
+      color: $pix-primary;
     }
   }
 }
@@ -89,7 +89,7 @@
 
   &--hidden {
     display: none;
-  }  
+  }
 
   &::-webkit-scrollbar {
     width: 11px;
@@ -114,22 +114,22 @@
     list-style: none;
     font-size: 0.9rem;
 
-    @include hoverFormElement();  
+    @include hoverFormElement();
 
     &--no-result {
       text-align: center;
       padding: 12px 0;
     }
-  
+
     &:last-of-type {
       border-bottom: none;
     }
   }
-  
+
   &__checkbox {
     position: absolute;
     opacity: 0;
-  
+
     & + label {
       position: relative;
       display: flex;
@@ -137,7 +137,7 @@
       padding: 11px 16px;
       cursor: pointer;
     }
-  
+
     & + label:before {
       content: '';
       margin-right: 12px;
@@ -149,12 +149,12 @@
       background: $white;
       border: 1px solid $grey-20;
     }
-        
+
     &:checked + label:before {
-      background: $blue;
-      border-color: $blue;
+      background: $pix-primary;
+      border-color: $pix-primary;
     }
-      
+
     &:checked + label:after {
       position: absolute;
       top: calc(50% - 5px);
@@ -173,7 +173,7 @@
       & + label {
         padding: 11px 36px;
       }
-      
+
       &:checked + label:after {
         left: 41px;
       }

--- a/addon/styles/_pix-multi-select.scss
+++ b/addon/styles/_pix-multi-select.scss
@@ -20,7 +20,7 @@
   height: 36px;
   padding: 0px 32px 0px 16px;
   width: 100%;
-  background-color: $white;
+  background-color: $pix-neutral-0;
   border-radius: 4px;
   outline: none;
   font-size: 0.875rem;
@@ -77,7 +77,7 @@
   width: 100%;
   margin: 0px;
   z-index: 200;
-  background-color: $white;
+  background-color: $pix-neutral-0;
   position: absolute;
   border-top: none;
   border-radius: 0 0 4px 4px;
@@ -97,7 +97,7 @@
   &::-webkit-scrollbar-track {
     border-radius: 4px;
     border: 1px solid $pix-neutral-20;
-    background: $white;
+    background: $pix-neutral-0;
   }
   &::-webkit-scrollbar-thumb {
     border-radius: 4px;
@@ -146,7 +146,7 @@
       min-width: 16px;
       min-height: 16px;
       border-radius: 4px;
-      background: $white;
+      background: $pix-neutral-0;
       border: 1px solid $pix-neutral-20;
     }
 
@@ -162,7 +162,7 @@
       width: 7px;
       height: 5px;
       background: transparent;
-      border: 2px solid $white;
+      border: 2px solid $pix-neutral-0;
       border-top: none;
       border-right: none;
       transform: rotate(-45deg);

--- a/addon/styles/_pix-multi-select.scss
+++ b/addon/styles/_pix-multi-select.scss
@@ -72,7 +72,6 @@
   }
 }
 
-
 .pix-multi-select-list {
   width: 100%;
   margin: 0px;

--- a/addon/styles/_pix-pagination.scss
+++ b/addon/styles/_pix-pagination.scss
@@ -1,4 +1,5 @@
-.pix-pagination, .pix-pagination-condensed {
+.pix-pagination,
+.pix-pagination-condensed {
   display: flex;
   justify-content: center;
   color: $pix-neutral-60;

--- a/addon/styles/_pix-pagination.scss
+++ b/addon/styles/_pix-pagination.scss
@@ -1,7 +1,7 @@
 .pix-pagination, .pix-pagination-condensed {
   display: flex;
   justify-content: center;
-  color: $grey-60;
+  color: $pix-neutral-60;
   font-size: 0.875rem;
 
   &__size {

--- a/addon/styles/_pix-progress-gauge.scss
+++ b/addon/styles/_pix-progress-gauge.scss
@@ -54,7 +54,7 @@
 
   &--white {
     & .progress-gauge__referrer {
-      background-color: lighten($blue, 15%);
+      background-color: lighten($pix-primary, 15%);
     }
 
     & .progress-gauge__marker {
@@ -63,7 +63,7 @@
 
     & .progress-gauge__tooltip {
       background: $white;
-      color: $blue;
+      color: $pix-primary;
 
       &::before {
         color: $white;

--- a/addon/styles/_pix-progress-gauge.scss
+++ b/addon/styles/_pix-progress-gauge.scss
@@ -13,7 +13,8 @@
     text-transform: uppercase;
   }
 
-  &__marker, &__referrer {
+  &__marker,
+  &__referrer {
     height: 4px;
     border-radius: 5px;
     text-align: right;

--- a/addon/styles/_pix-progress-gauge.scss
+++ b/addon/styles/_pix-progress-gauge.scss
@@ -78,7 +78,7 @@
 
   &--yellow {
     & .progress-gauge__referrer {
-      background-color: $grey-20;
+      background-color: $pix-neutral-20;
     }
 
     & .progress-gauge__marker {

--- a/addon/styles/_pix-progress-gauge.scss
+++ b/addon/styles/_pix-progress-gauge.scss
@@ -7,7 +7,7 @@
   &__sub-title {
     font-size: 0.813rem;
     font-weight: $font-light;
-    color: $yellow;
+    color: $pix-warning-40;
     margin: 6px 0;
     letter-spacing: 0.4px;
     text-transform: uppercase;
@@ -90,13 +90,13 @@
       color: $pix-neutral-0;
 
       &::before {
-        color: $yellow;
-        border-top-color: $yellow;
+        color: $pix-warning-40;
+        border-top-color: $pix-warning-40;
       }
     }
 
     & .progress-gauge__sub-title {
-      color: $yellow;
+      color: $pix-warning-40;
     }
   }
 

--- a/addon/styles/_pix-progress-gauge.scss
+++ b/addon/styles/_pix-progress-gauge.scss
@@ -58,21 +58,21 @@
     }
 
     & .progress-gauge__marker {
-      background: $white;
+      background: $pix-neutral-0;
     }
 
     & .progress-gauge__tooltip {
-      background: $white;
+      background: $pix-neutral-0;
       color: $pix-primary;
 
       &::before {
-        color: $white;
-        border-top-color: $white;
+        color: $pix-neutral-0;
+        border-top-color: $pix-neutral-0;
       }
     }
 
     & .progress-gauge__sub-title {
-      color: $white;
+      color: $pix-neutral-0;
     }
   }
 
@@ -87,7 +87,7 @@
 
     & .progress-gauge__tooltip {
       background: $pix-yellow-gradient;
-      color: $white;
+      color: $pix-neutral-0;
 
       &::before {
         color: $yellow;

--- a/addon/styles/_pix-radio-button.scss
+++ b/addon/styles/_pix-radio-button.scss
@@ -27,7 +27,7 @@
     }
 
     &:focus-visible {
-      box-shadow: $white 0 0 0 2px, $blue 0 0 0 4px;
+      box-shadow: $pix-neutral-0 0 0 0 2px, $pix-primary 0 0 0 4px;
       outline: none;
     }
 

--- a/addon/styles/_pix-radio-button.scss
+++ b/addon/styles/_pix-radio-button.scss
@@ -43,7 +43,7 @@
       &:after {
         background-color: $pix-primary;
         border-radius: 50%;
-        content: "";
+        content: '';
         height: 12px;
         width: 12px;
         position: absolute;

--- a/addon/styles/_pix-radio-button.scss
+++ b/addon/styles/_pix-radio-button.scss
@@ -2,7 +2,7 @@
   cursor: pointer;
   font-family: $font-roboto;
   font-size: 0.875rem;
-  color: $grey-70;
+  color: $pix-neutral-70;
 
   label {
     display: flex;
@@ -16,13 +16,13 @@
     width: 18px;
     height: 18px;
     margin: 0 10px 0 0;
-    border: 1px solid $grey-70;
+    border: 1px solid $pix-neutral-70;
     cursor: pointer;
     background-color: transparent;
 
     &:hover {
-      background-color: $grey-15;
-      box-shadow: 0 0 0 8px $grey-15;
+      background-color: $pix-neutral-15;
+      box-shadow: 0 0 0 8px $pix-neutral-15;
       transition: all 0.3s ease;
     }
 
@@ -54,19 +54,19 @@
     }
 
     &:disabled {
-      border: 1px solid $grey-45;
+      border: 1px solid $pix-neutral-45;
       background-color: transparent;
       box-shadow: none;
       cursor: not-allowed;
 
       &:checked:after {
-        background-color: $grey-25;
+        background-color: $pix-neutral-25;
       }
     }
   }
 
   &--disabled {
     cursor: not-allowed;
-    color: $grey-45;
+    color: $pix-neutral-45;
   }
 }

--- a/addon/styles/_pix-radio-button.scss
+++ b/addon/styles/_pix-radio-button.scss
@@ -32,16 +32,16 @@
     }
 
     &:active {
-      border-color: $blue;
+      border-color: $pix-primary;
       background-color: transparent;
       box-shadow: none;
     }
 
     &:checked {
-      border-color: $blue;
+      border-color: $pix-primary;
 
       &:after {
-        background-color: $blue;
+        background-color: $pix-primary;
         border-radius: 50%;
         content: "";
         height: 12px;

--- a/addon/styles/_pix-return-to.scss
+++ b/addon/styles/_pix-return-to.scss
@@ -8,14 +8,14 @@
   align-items: center;
   border-bottom: transparent solid 2px;
   text-decoration: none;
-  
+
   &__icon {
     position: relative;
     z-index: 3;
     padding: 4px 7px;
     font-size: 1rem;
   }
-  
+
   &__icon::before {
     content: '';
     position: absolute;
@@ -39,7 +39,7 @@
 
   &:focus-visible {
     background-color: $yellow;
-    border-bottom: $grey-100 solid 2px;
+    border-bottom: $pix-neutral-100 solid 2px;
 
     .pix-return-to__text {
       padding-right: 6px;
@@ -58,7 +58,7 @@
     }
   }
 
-  &--white { @include coloriseLink($grey-10, $white, $white); }
-  &--black { @include coloriseLink($grey-80, $grey-200, $grey-60); }
+  &--white { @include coloriseLink($pix-neutral-10, $white, $white); }
+  &--black { @include coloriseLink($pix-neutral-80, $pix-neutral-110, $pix-neutral-60); }
   &--blue { @include coloriseLink($communication-dark, $blue-hover, $communication-dark); }
 }

--- a/addon/styles/_pix-return-to.scss
+++ b/addon/styles/_pix-return-to.scss
@@ -58,7 +58,7 @@
     }
   }
 
-  &--white { @include coloriseLink($pix-neutral-10, $white, $white); }
+  &--white { @include coloriseLink($pix-neutral-10, $pix-neutral-0, $pix-neutral-0); }
   &--black { @include coloriseLink($pix-neutral-80, $pix-neutral-110, $pix-neutral-60); }
   &--blue { @include coloriseLink($communication-dark, $blue-hover, $communication-dark); }
 }

--- a/addon/styles/_pix-return-to.scss
+++ b/addon/styles/_pix-return-to.scss
@@ -20,21 +20,28 @@
     content: '';
     position: absolute;
     z-index: -1;
-    width: 100%; height: 100%;
-    top: 0; left: 0;
+    width: 100%;
+    height: 100%;
+    top: 0;
+    left: 0;
     opacity: 0;
     border-radius: 50%;
     transition: 0.3s ease opacity;
   }
 
-  &__text { margin-left: 4px; }
+  &__text {
+    margin-left: 4px;
+  }
 
-  &:hover, &:active {
+  &:hover,
+  &:active {
     cursor: pointer;
     background-color: transparent;
     border-bottom-color: transparent;
 
-    ::before { opacity: 0.2; }
+    ::before {
+      opacity: 0.2;
+    }
   }
 
   &:focus-visible {
@@ -49,16 +56,27 @@
   @mixin coloriseLink($textColor, $textHoverColor, $arrowColor) {
     color: $textColor;
 
-    .pix-return-to__icon { color: $arrowColor; }
+    .pix-return-to__icon {
+      color: $arrowColor;
+    }
 
-    &:hover, &:active {
+    &:hover,
+    &:active {
       color: $textHoverColor;
 
-      ::before { background-color: $arrowColor; }
+      ::before {
+        background-color: $arrowColor;
+      }
     }
   }
 
-  &--white { @include coloriseLink($pix-neutral-10, $pix-neutral-0, $pix-neutral-0); }
-  &--black { @include coloriseLink($pix-neutral-80, $pix-neutral-110, $pix-neutral-60); }
-  &--blue { @include coloriseLink($pix-communication-dark, $pix-primary-60, $pix-communication-dark); }
+  &--white {
+    @include coloriseLink($pix-neutral-10, $pix-neutral-0, $pix-neutral-0);
+  }
+  &--black {
+    @include coloriseLink($pix-neutral-80, $pix-neutral-110, $pix-neutral-60);
+  }
+  &--blue {
+    @include coloriseLink($pix-communication-dark, $pix-primary-60, $pix-communication-dark);
+  }
 }

--- a/addon/styles/_pix-return-to.scss
+++ b/addon/styles/_pix-return-to.scss
@@ -38,7 +38,7 @@
   }
 
   &:focus-visible {
-    background-color: $yellow;
+    background-color: $pix-warning-40;
     border-bottom: $pix-neutral-100 solid 2px;
 
     .pix-return-to__text {
@@ -60,5 +60,5 @@
 
   &--white { @include coloriseLink($pix-neutral-10, $pix-neutral-0, $pix-neutral-0); }
   &--black { @include coloriseLink($pix-neutral-80, $pix-neutral-110, $pix-neutral-60); }
-  &--blue { @include coloriseLink($pix-communication-dark, $blue-hover, $pix-communication-dark); }
+  &--blue { @include coloriseLink($pix-communication-dark, $pix-primary-60, $pix-communication-dark); }
 }

--- a/addon/styles/_pix-return-to.scss
+++ b/addon/styles/_pix-return-to.scss
@@ -60,5 +60,5 @@
 
   &--white { @include coloriseLink($pix-neutral-10, $pix-neutral-0, $pix-neutral-0); }
   &--black { @include coloriseLink($pix-neutral-80, $pix-neutral-110, $pix-neutral-60); }
-  &--blue { @include coloriseLink($communication-dark, $blue-hover, $communication-dark); }
+  &--blue { @include coloriseLink($pix-communication-dark, $blue-hover, $pix-communication-dark); }
 }

--- a/addon/styles/_pix-select.scss
+++ b/addon/styles/_pix-select.scss
@@ -5,9 +5,9 @@
 
   @mixin pixSelect {
     appearance: none;
-    border: 1px $grey-40 solid;
+    border: 1px $pix-neutral-40 solid;
     border-radius: 4px;
-    color: $grey-90;
+    color: $pix-neutral-90;
     font-family: $font-roboto;
     font-size: 0.875rem;
     height: 36px;
@@ -53,7 +53,7 @@
 
   &__icon {
     font-size: 11px;
-    color: $grey-30;
+    color: $pix-neutral-30;
     right: 10px;
     top: calc(50% - 6px);
     padding: 0 0 2px;

--- a/addon/styles/_pix-selectable-tag.scss
+++ b/addon/styles/_pix-selectable-tag.scss
@@ -74,9 +74,9 @@ $checkmark-width-with-space: $checkmark-width + 0.438rem;
 
   &:focus-within {
     @include checkmarkColor($white);
-    background-color: $blue-zodiac;
+    background-color: $pix-neutral-60;
     color: $white;
-    box-shadow: 0 0 0 1px $blue-zodiac;
+    box-shadow: 0 0 0 1px $pix-neutral-60;
     border-color: $white;
     outline: none;
 

--- a/addon/styles/_pix-selectable-tag.scss
+++ b/addon/styles/_pix-selectable-tag.scss
@@ -1,7 +1,7 @@
 $checkmark-width: 0.625rem;
 $checkmark-width-with-space: $checkmark-width + 0.438rem;
 @mixin checkmarkColor($borderColor) {
-  
+
   input[type="checkbox"]:checked + label::before {
     position: absolute;
     top: 6px;
@@ -25,8 +25,8 @@ $checkmark-width-with-space: $checkmark-width + 0.438rem;
   padding: 3px calc(8px + #{$checkmark-width-with-space} / 2);
   letter-spacing: 0.009rem;
   border-radius: 0.75rem;
-  border: $grey-30 solid 1px;
-  color: $grey-60;
+  border: $pix-neutral-30 solid 1px;
+  color: $pix-neutral-60;
   background-color: $white;
   font-family: $font-roboto;
   font-size: 0.8125rem;
@@ -48,23 +48,23 @@ $checkmark-width-with-space: $checkmark-width + 0.438rem;
   }
 
   &:hover {
-    background-color: $grey-22;
-    border: $grey-25 solid 1px;
-    color: $grey-70;
+    background-color:$pix-neutral-22;
+    border: $pix-neutral-25 solid 1px;
+    color: $pix-neutral-70;
   }
-  
+
   &--checked {
-    @include checkmarkColor($grey-70);
-    border: $grey-22 solid 1px;
-    background-color: $grey-20;
-    color: $grey-70;
+    @include checkmarkColor($pix-neutral-70);
+    border: $pix-neutral-22 solid 1px;
+    background-color: $pix-neutral-20;
+    color: $pix-neutral-70;
     padding: 3px 8px;
 
     &:hover {
-      @include checkmarkColor($grey-70);
-      background-color: $grey-22;
-      border: $grey-25 solid 1px;
-      color: $grey-70;
+      @include checkmarkColor($pix-neutral-70);
+      background-color: $pix-neutral-22;
+      border: $pix-neutral-25 solid 1px;
+      color: $pix-neutral-70;
     }
 
     & label {
@@ -81,10 +81,10 @@ $checkmark-width-with-space: $checkmark-width + 0.438rem;
     outline: none;
 
     &:hover {
-      @include checkmarkColor($grey-70);
-      color: $grey-70;
-      background-color: $grey-22;
-      border: $grey-25 solid 1px;
+      @include checkmarkColor($pix-neutral-70);
+      color: $pix-neutral-70;
+      background-color: $pix-neutral-22;
+      border: $pix-neutral-25 solid 1px;
     }
   }
 }

--- a/addon/styles/_pix-selectable-tag.scss
+++ b/addon/styles/_pix-selectable-tag.scss
@@ -1,8 +1,7 @@
 $checkmark-width: 0.625rem;
 $checkmark-width-with-space: $checkmark-width + 0.438rem;
 @mixin checkmarkColor($borderColor) {
-
-  input[type="checkbox"]:checked + label::before {
+  input[type='checkbox']:checked + label::before {
     position: absolute;
     top: 6px;
     left: 8px;
@@ -13,7 +12,7 @@ $checkmark-width-with-space: $checkmark-width + 0.438rem;
     border-top: none;
     border-right: none;
     transform: rotate(-45deg);
-    content: "";
+    content: '';
   }
 }
 
@@ -48,7 +47,7 @@ $checkmark-width-with-space: $checkmark-width + 0.438rem;
   }
 
   &:hover {
-    background-color:$pix-neutral-22;
+    background-color: $pix-neutral-22;
     border: $pix-neutral-25 solid 1px;
     color: $pix-neutral-70;
   }

--- a/addon/styles/_pix-selectable-tag.scss
+++ b/addon/styles/_pix-selectable-tag.scss
@@ -27,7 +27,7 @@ $checkmark-width-with-space: $checkmark-width + 0.438rem;
   border-radius: 0.75rem;
   border: $pix-neutral-30 solid 1px;
   color: $pix-neutral-60;
-  background-color: $white;
+  background-color: $pix-neutral-0;
   font-family: $font-roboto;
   font-size: 0.8125rem;
   font-weight: $font-normal;
@@ -73,11 +73,11 @@ $checkmark-width-with-space: $checkmark-width + 0.438rem;
   }
 
   &:focus-within {
-    @include checkmarkColor($white);
+    @include checkmarkColor($pix-neutral-0);
     background-color: $pix-neutral-60;
-    color: $white;
+    color: $pix-neutral-0;
     box-shadow: 0 0 0 1px $pix-neutral-60;
-    border-color: $white;
+    border-color: $pix-neutral-0;
     outline: none;
 
     &:hover {

--- a/addon/styles/_pix-stars.scss
+++ b/addon/styles/_pix-stars.scss
@@ -7,7 +7,7 @@
   }
 
   &--blue > &__acquired {
-    fill: $blue;
+    fill: $pix-primary;
   }
 
   &--blue > &__unacquired {

--- a/addon/styles/_pix-stars.scss
+++ b/addon/styles/_pix-stars.scss
@@ -11,7 +11,7 @@
   }
 
   &--blue > &__unacquired {
-    fill:$pix-neutral-15;
+    fill: $pix-neutral-15;
   }
 
   &--grey > &__acquired {
@@ -38,6 +38,6 @@
   padding: 0;
   margin: -1px;
   overflow: hidden;
-  clip: rect(0,0,0,0);
+  clip: rect(0, 0, 0, 0);
   border: 0;
 }

--- a/addon/styles/_pix-stars.scss
+++ b/addon/styles/_pix-stars.scss
@@ -15,11 +15,11 @@
   }
 
   &--grey > &__acquired {
-    fill: $grey-40;
+    fill: $pix-neutral-40;
   }
   &--grey > &__unacquired {
     fill: white;
-    stroke: $grey-40;
+    stroke: $pix-neutral-40;
   }
 
   &__acquired {

--- a/addon/styles/_pix-stars.scss
+++ b/addon/styles/_pix-stars.scss
@@ -11,7 +11,7 @@
   }
 
   &--blue > &__unacquired {
-    fill: #e9eafc;
+    fill:$pix-neutral-15;
   }
 
   &--grey > &__acquired {
@@ -27,7 +27,7 @@
   }
 
   &__unacquired {
-    fill: #e9eafc;
+    fill: $pix-neutral-15;
   }
 }
 

--- a/addon/styles/_pix-stars.scss
+++ b/addon/styles/_pix-stars.scss
@@ -18,7 +18,7 @@
     fill: $pix-neutral-40;
   }
   &--grey > &__unacquired {
-    fill: white;
+    fill: $pix-neutral-0;
     stroke: $pix-neutral-40;
   }
 

--- a/addon/styles/_pix-tag.scss
+++ b/addon/styles/_pix-tag.scss
@@ -15,11 +15,11 @@
   border-radius: 0.75rem;
 
   color: $white;
-  background-color: $blue;
+  background-color: $pix-primary;
 
   &--blue-light {
-    color: darken($blue, 10%);
-    background-color: lighten($blue, 30%);
+    color: darken($pix-primary, 10%);
+    background-color: lighten($pix-primary, 30%);
   }
 
   &--green {

--- a/addon/styles/_pix-tag.scss
+++ b/addon/styles/_pix-tag.scss
@@ -41,7 +41,7 @@
   }
 
   &--yellow {
-    color: $grey-90;
+    color: $pix-neutral-90;
     background-color: $yellow;
   }
 
@@ -60,13 +60,13 @@
   }
 
   &--grey {
-    color: $grey-15;
-    background-color: $grey-60;
+    color: $pix-neutral-15;
+    background-color: $pix-neutral-60;
   }
 
   &--grey-light {
-    color: $grey-60;
-    background-color: $grey-15;
+    color: $pix-neutral-60;
+    background-color: $pix-neutral-15;
   }
 
   &--compact {

--- a/addon/styles/_pix-tag.scss
+++ b/addon/styles/_pix-tag.scss
@@ -42,12 +42,12 @@
 
   &--yellow {
     color: $pix-neutral-90;
-    background-color: $yellow;
+    background-color: $pix-warning-40;
   }
 
   &--yellow-light {
-    color: darken($yellow, 25%);
-    background-color: lighten($yellow, 35%);
+    color: darken($pix-warning-40, 25%);
+    background-color: lighten($pix-warning-40, 35%);
   }
 
   &--orange {

--- a/addon/styles/_pix-tag.scss
+++ b/addon/styles/_pix-tag.scss
@@ -14,7 +14,7 @@
   border: 1px solid transparent;
   border-radius: 0.75rem;
 
-  color: $white;
+  color: $pix-neutral-0;
   background-color: $pix-primary;
 
   &--blue-light {

--- a/addon/styles/_pix-textarea.scss
+++ b/addon/styles/_pix-textarea.scss
@@ -3,12 +3,12 @@
 
   textarea {
     width: 100%;
-    border: 1px solid $grey-40;
+    border: 1px solid $pix-neutral-40;
     border-style: solid;
     border-radius: 4px;
     padding: 10px 16px;
     font-family: $font-roboto;
-    color: $grey-90;
+    color: $pix-neutral-90;
     font-size: 0.875rem;
     resize: vertical;
 
@@ -21,7 +21,7 @@
   }
 
   p {
-    color: $grey-45;
+    color: $pix-neutral-45;
     margin-top: 6px;
     font-size: 12px;
     display: flex;

--- a/addon/styles/_pix-textarea.scss
+++ b/addon/styles/_pix-textarea.scss
@@ -29,7 +29,7 @@
     margin-bottom: 0;
   }
 
-  &__label{
+  &__label {
     @include label();
   }
 

--- a/addon/styles/_pix-tooltip.scss
+++ b/addon/styles/_pix-tooltip.scss
@@ -22,7 +22,7 @@
   z-index: 100;
   padding: 8px 16px;
   left: auto;
-  color: $white;
+  color: $pix-neutral-0;
   font-family: $font-roboto;
   font-size: 0.875rem;
   border-radius: 6px;
@@ -46,7 +46,7 @@
 
   &--light {
     font-weight: $font-medium;
-    background-color: $white;
+    background-color: $pix-neutral-0;
     color: $pix-neutral-60;
     box-shadow: 0px 6px 24px 0px rgba($pix-neutral-70, 0.14);
 
@@ -54,7 +54,7 @@
       border-width: 0px;
       height: 8px;
       width: 8px;
-      background-color: $white;
+      background-color: $pix-neutral-0;
     }
   }
 }

--- a/addon/styles/_pix-tooltip.scss
+++ b/addon/styles/_pix-tooltip.scss
@@ -17,7 +17,7 @@
   display: none;
   opacity: 0;
   pointer-events: none;
-  background-color: $grey-100;
+  background-color: $pix-neutral-100;
   position: absolute;
   z-index: 100;
   padding: 8px 16px;
@@ -47,8 +47,8 @@
   &--light {
     font-weight: $font-medium;
     background-color: $white;
-    color: $grey-60;
-    box-shadow: 0px 6px 24px 0px rgba($grey-70, 0.14);
+    color: $pix-neutral-60;
+    box-shadow: 0px 6px 24px 0px rgba($pix-neutral-70, 0.14);
 
     &::before {
       border-width: 0px;
@@ -65,13 +65,13 @@
   &::before {
     top: calc(50% - 5px); // 50% is the height of the parent and 5px the height of the triangle
     left: -10px; // 10px is width of the ::before elmt
-    border-color: transparent $grey-100 transparent transparent;
+    border-color: transparent $pix-neutral-100 transparent transparent;
   }
 
   &.pix-tooltip__content--light::before {
     left: -5px;
     transform: rotate(315deg);
-    border-color: $grey-40 transparent transparent $grey-40;
+    border-color: $pix-neutral-40 transparent transparent $pix-neutral-40;
   }
 }
 
@@ -83,13 +83,13 @@
   &::before {
     top: 100%;
     left: calc(50% - 5px);
-    border-color: $grey-100 transparent transparent transparent;
+    border-color: $pix-neutral-100 transparent transparent transparent;
   }
 
   &.pix-tooltip__content--light::before {
     top: calc(100% - 5px);
     transform: rotate(225deg);
-    border-color: $grey-40 transparent transparent $grey-40;
+    border-color: $pix-neutral-40 transparent transparent $pix-neutral-40;
   }
 }
 
@@ -100,14 +100,14 @@
   &::before {
     top: 100%;
     left: calc(100% - 27px);
-    border-color: $grey-100 transparent transparent transparent;
+    border-color:$pix-neutral-100 transparent transparent transparent;
   }
 
   &.pix-tooltip__content--light::before {
     top: calc(100% - 5px);
     left: calc(100% - 26px);
     transform: rotate(225deg);
-    border-color: $grey-40 transparent transparent $grey-40;
+    border-color: $pix-neutral-40 transparent transparent $pix-neutral-40;
   }
 }
 
@@ -117,13 +117,13 @@
 
   &::before {
     top: 100%;
-    border-color: $grey-100 transparent transparent transparent;
+    border-color: $pix-neutral-100 transparent transparent transparent;
   }
 
   &.pix-tooltip__content--light::before {
     top: calc(100% - 5px);
     transform: rotate(225deg);
-    border-color: $grey-40 transparent transparent $grey-40;
+    border-color: $pix-neutral-40 transparent transparent $pix-neutral-40;
   }
 }
 
@@ -135,13 +135,13 @@
   &::before {
     top: -10px;
     left: calc(50% - 5px);
-    border-color: transparent transparent $grey-100 transparent;
+    border-color: transparent transparent $pix-neutral-100 transparent;
   }
 
   &.pix-tooltip__content--light::before {
     top: -5px;
     transform: rotate(45deg);
-    border-color: $grey-40 transparent transparent $grey-40;
+    border-color: $pix-neutral-40 transparent transparent $pix-neutral-40;
   }
 }
 
@@ -152,14 +152,14 @@
   &::before {
     top: -10px;
     left: calc(100% - 27px);
-    border-color: transparent transparent $grey-100 transparent;
+    border-color: transparent transparent $pix-neutral-100 transparent;
   }
 
   &.pix-tooltip__content--light::before {
     top: -5px;
     left: calc(100% - 26px);
     transform: rotate(45deg);
-    border-color: $grey-40 transparent transparent $grey-40;
+    border-color: $pix-neutral-40 transparent transparent $pix-neutral-40;
   }
 }
 
@@ -169,13 +169,13 @@
 
   &::before {
     top: -10px;
-    border-color: transparent transparent $grey-100 transparent;
+    border-color: transparent transparent $pix-neutral-100 transparent;
   }
 
   &.pix-tooltip__content--light::before {
     top: -5px;
     transform: rotate(45deg);
-    border-color: $grey-40 transparent transparent $grey-40;
+    border-color: $pix-neutral-40 transparent transparent $pix-neutral-40;
   }
 }
 
@@ -185,12 +185,12 @@
   &::before {
     top: calc(50% - 5px);
     right: -10px;
-    border-color: transparent transparent transparent $grey-100;
+    border-color: transparent transparent transparent $pix-neutral-100;
   }
 
   &.pix-tooltip__content--light::before {
     right: -5px;
     transform: rotate(135deg);
-    border-color: $grey-40 transparent transparent $grey-40;
+    border-color: $pix-neutral-40 transparent transparent $pix-neutral-40;
   }
 }

--- a/addon/styles/_pix-tooltip.scss
+++ b/addon/styles/_pix-tooltip.scss
@@ -7,7 +7,7 @@
   align-items: center;
 
   & > *:first-child:hover + .pix-tooltip__content,
-  & > *:first-child:focus + .pix-tooltip__content{
+  & > *:first-child:focus + .pix-tooltip__content {
     display: block;
     opacity: 1;
   }
@@ -34,7 +34,7 @@
   }
 
   &::before {
-    content: "";
+    content: '';
     position: absolute;
     border-width: 5px;
     border-style: solid;
@@ -100,7 +100,7 @@
   &::before {
     top: 100%;
     left: calc(100% - 27px);
-    border-color:$pix-neutral-100 transparent transparent transparent;
+    border-color: $pix-neutral-100 transparent transparent transparent;
   }
 
   &.pix-tooltip__content--light::before {

--- a/addon/styles/_typography.scss
+++ b/addon/styles/_typography.scss
@@ -104,7 +104,7 @@
 
   a {
     font-weight: $font-medium;
-    color: $blue;
+    color: $pix-primary;
   }
 }
 
@@ -116,7 +116,7 @@
 @mixin text-link() {
   @include text;
   font-weight: $font-medium;
-  color: $blue;
+  color: $pix-primary;
 }
 
 @mixin text-small() {

--- a/docs/design-tokens.stories.mdx
+++ b/docs/design-tokens.stories.mdx
@@ -1,0 +1,32 @@
+import { Meta } from '@storybook/addon-docs/blocks';
+
+<Meta title="Utiliser Pix UI/Design Tokens" />
+
+# Design Tokens
+
+> Les design tokens contiennent plusieurs éléments de base de la charte graphique (les couleurs, la typographie, les icônes, etc.)
+
+## Utiliser les classes, mixins et variables dans votre css
+
+En ajoutant la dépendance dans votre application avec `npm install`, vous avez déjà accès aux classes, mais pour avoir accès aux mixins et variables,
+il faut ajouter le code ci-dessous dans le `new EmberApp()` de votre `ember-cli.build.js` qui se trouve à la racine du projet :
+
+```
+sassOptions: {
+  includePaths: ['node_modules/@1024pix/pix-ui/addon/styles'],
+},
+```
+
+Par la suite vous aurez accès à toutes les variables des design tokens avec le `$`, par exemple `border: 1px solid $pix-primary;`.
+
+Et pour les mixins, dans le scss voulu, il faudra importer (avec `@use`) les design tokens en haut du fichier pour les utiliser
+
+Par exemple :
+
+```
+@use 'design-tokens`;
+
+.organization-title {
+  @include design-tokens.text-bold;
+}
+```

--- a/docs/pix-design-tokens-dev.stories.mdx
+++ b/docs/pix-design-tokens-dev.stories.mdx
@@ -30,7 +30,7 @@ Par exemple :
 
   a {
     font-weight: $font-medium;
-    color: $blue;
+    color: $pix-primary;
   }
 }
 


### PR DESCRIPTION
## :boom: BREAKING_CHANGES
N/A

## :christmas_tree: Problème
Actuellement, les couleurs du 'design system' ne sont pas définies dans **Pix-UI**. Pour faciliter l'intégration des nouveaux composants, toutes les variables du 'design system' commenceront par 'pix-'.

## :gift: Solution
Ajouter les différents couleurs du design system dans le fichier de style 'colors'.
Remplacer les anciennes variables par les nouvelles variables.

## :star2: Remarques
⚠️ Petit changement au niveau des différentes couleurs pour les alertes :

1. `$pink-alert-light`& `$pink-alert-dark` sont remplacés par  `$pix-error-10`& `$pix-error-70`.

`$error` est remplacé  selon le cas d'usage : 

- texte ou border => `$pix-error-70`
- background => `$pix-error-10`.

2. `$blue-alert-light`& `$blue-alert-dark` sont remplacés par  `$pix-primary-10` & `$pix-primary-70`.

3. `$green-alert-light`& `$green-alert-dark` sont remplacés par  `$pix-success-10` & `$pix-success-70`.

`$sucess` est remplacé  selon le cas d'usage : 

- texte ou border => `$pix-success-70`
- background => `$pix-success-10`.

5. `$yellow-alert-light` & `$yellow-alert-dark` sont remplacé par  `$pix-warning-10` & `$pix-warning-60`. 

`$warning` est remplacé  selon le cas d'usage : 

- texte ou border => `$pix-warning-60`
- background => `$pix-warning-10`.

Quelques évolutions à noter sur les gradients lors de la migration : 
- Le passage de `$pix-blue-gradient` à `$pix-primary-app-gradient` change un peu les couleurs et l'angle du gradient. (ex d'utilisation : `<PixBackgroundHeader>`). Raison : meilleure accessibilité
- Le passage de `$pix-certif-gradient` à `$pix-primary-certif-gradient` change l'angle du gradient. (ex : background page login pix certif)
- Le passage de `$pix-orga-old-gradient` à `$pix-primary-orga-gradient` change un peu les couleurs et l'angle du gradient. (ex : page login pix orga)
- Le passage de `$pix-certif-old-gradient` à `$pix-security-gradient` change un peu les couleurs et l'angle du gradient. (ex : aucun, semble inutilisé)
- Le passage de `$pix-orga-gradient` à `$pix-primary-orga-gradient` change l'angle du gradient. (ex : aucun, semble inutilisé)
- Le passage de `$pix-pink-gradient` à `$pix-security-gradient` change un peu les couleurs et l'angle du gradient. (ex : aucun, semble inutilisé)

⚠️  Ne pas supprimer les variables 'deprecated' tant que les autres application utilisant **pix-ui** n'ont pas été clean.

## :santa: Pour tester
- Vérifier en local que les nouvelles variables sont utilisées dans les différents "SCSS" des composants de **pix-ui** & pouvoir les utiliser dans les autres app.
