### PR TITLE
Mise à jour de la doc pour tester pixInput via testing-library

### DIFF
--- a/app/stories/pix-input.stories.mdx
+++ b/app/stories/pix-input.stories.mdx
@@ -20,6 +20,33 @@ Si vous utilisez le `PixInput` sans label alors il faut renseigner le paramètre
 
 > Si vous renseignez les paramètres label et ariaLabel ensemble, ariaLabel sera nullifié.
 
+Pour acceder à l'élément via son label/aria-label avec testing-library:
+
+```html
+<PixInput
+  @id='firstName'
+  @label='Prénom'
+/>
+```
+
+```javascript
+screen.getByLabelText('Prénom')
+````
+
+Si le paramètre @information est utilisé, il faudra concatener les valeurs de `@label`/`@ariaLabel` et `@information`
+
+```html
+<PixInput
+  @id='firstName'
+  @label='Prénom'
+  @information='exemple: Barry'
+/>
+```
+
+```javascript
+screen.getByLabelText('Prénom exemple: Barry')
+````
+
 
 ## Default
 


### PR DESCRIPTION
## :christmas_tree: Problème
Lorsque l'on sélectionne par label dans testing-library avec la prop information, la selection ne renvoi rien. Il faut concatener les 2 valeurs

## :gift: Solution
Mettre à jour la doc pour l'expliciter
