### PR TITLE
[A11Y] Ajouter un aria hidden aux étoiles des paliers (PIX-5076)

### DIFF
--- a/addon/components/pix-stars.hbs
+++ b/addon/components/pix-stars.hbs
@@ -1,6 +1,12 @@
 <div class={{this.pixStarsClass}} ...attributes role="img" aria-label={{@alt}}>
   {{#each this.stars as |star|}}
-    <svg class="pix-stars__{{star}}" data-test-status={{star}} viewBox="0 0 36 36" role="img">
+    <svg
+      class="pix-stars__{{star}}"
+      data-test-status={{star}}
+      viewBox="0 0 36 36"
+      role="img"
+      aria-hidden="true"
+    >
       <defs>
         <linearGradient id="pix-stars-default" x1="68.643%" y1="0%" x2="68.643%" y2="100%">
           <stop stop-color="#FEDC41" offset="0%"></stop>


### PR DESCRIPTION
## :boom: BREAKING_CHANGES
pas de breaking changes

## :christmas_tree: Problème
Lors de l'audit accessibilité de l'application Pix Orga pour la page Résultat d'une campagne d'évaluation dans le graphe "Répartition des participations par paliers", lorsqu'elle en possède, les paliers sont affichés sous forme de groupe d'étoiles.
Ce groupe d'étoiles n'avait pas de rôle, ce qui provoquait une lecture de tout ce qui était à l'intérieur et donc qui alourdissait le rendu des lecteur d'écrans. On a ajouté un role="img" dans cette [PR](https://github.com/1024pix/pix-ui/pull/216) mais il est aussi recommandé d'ajouter un aria-hidden="true"

## :gift: Solution
ajouter un aria-hidden="true"

## :star2: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :santa: Pour tester
> _Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc._
