### PR TITLE
[FEATURE] Rendre le contenu de PixCollapsible en lazy

### DIFF
--- a/addon/components/pix-collapsible.hbs
+++ b/addon/components/pix-collapsible.hbs
@@ -24,6 +24,8 @@
     class="pix-collapsible__content
       {{if this.isUnCollapsed ' pix-collapsible__content--uncollapse'}}"
   >
-    {{yield}}
+    {{#if this.isContentRendered}}
+      {{yield}}
+    {{/if}}
   </div>
 </div>

--- a/addon/components/pix-collapsible.js
+++ b/addon/components/pix-collapsible.js
@@ -8,9 +8,14 @@ export default class PixCollapsible extends Component {
   contentId = 'pix-collapsible-' + guidFor(this);
 
   @tracked isCollapsed = true;
+  @tracked hasUnCollapsedOnce = false;
 
   get isUnCollapsed() {
     return !this.isCollapsed;
+  }
+
+  get isContentRendered() {
+    return !this.args.lazyRender || this.hasUnCollapsedOnce;
   }
 
   get title() {
@@ -23,5 +28,6 @@ export default class PixCollapsible extends Component {
   @action
   toggleCollapsible() {
     this.isCollapsed = !this.isCollapsed;
+    this.hasUnCollapsedOnce = true;
   }
 }

--- a/addon/components/pix-collapsible.js
+++ b/addon/components/pix-collapsible.js
@@ -15,7 +15,7 @@ export default class PixCollapsible extends Component {
   }
 
   get isContentRendered() {
-    return !this.args.lazyRender || this.hasUnCollapsedOnce;
+    return this.hasUnCollapsedOnce;
   }
 
   get title() {

--- a/app/stories/pix-collapsible.stories.js
+++ b/app/stories/pix-collapsible.stories.js
@@ -31,8 +31,7 @@ export const multipleCollapsible = (args) => {
 
       <PixCollapsible
         @title="Titre C"
-        @titleIcon={{titleIcon}}
-        @lazyRender={{true}}>
+        @titleIcon={{titleIcon}}>
           <div>Contenu C</div>
       </PixCollapsible>
     </div>
@@ -53,12 +52,5 @@ export const argTypes = {
     description: "Ajoute l'icône donnée en paramètre avant le titre du PixCollapsible",
     type: { name: 'string', required: false },
     defaultValue: 'user',
-  },
-  lazyRender: {
-    name: 'lazyRender',
-    description:
-      'Rendre le contenu dans le DOM uniquement quand le composant est déroulé pour la 1ère fois',
-    type: { name: 'boolean', required: false },
-    defaultValue: false,
   },
 };

--- a/app/stories/pix-collapsible.stories.js
+++ b/app/stories/pix-collapsible.stories.js
@@ -31,7 +31,8 @@ export const multipleCollapsible = (args) => {
 
       <PixCollapsible
         @title="Titre C"
-        @titleIcon={{titleIcon}}>
+        @titleIcon={{titleIcon}}
+        @lazyRender={{true}}>
           <div>Contenu C</div>
       </PixCollapsible>
     </div>
@@ -52,5 +53,12 @@ export const argTypes = {
     description: "Ajoute l'icône donnée en paramètre avant le titre du PixCollapsible",
     type: { name: 'string', required: false },
     defaultValue: 'user',
+  },
+  lazyRender: {
+    name: 'lazyRender',
+    description:
+      'Rendre le contenu dans le DOM uniquement quand le composant est déroulé pour la 1ère fois',
+    type: { name: 'boolean', required: false },
+    defaultValue: false,
   },
 };

--- a/tests/integration/components/pix-collapsible-test.js
+++ b/tests/integration/components/pix-collapsible-test.js
@@ -1,6 +1,6 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import { render } from '@ember/test-helpers';
+import { render } from '@1024pix/ember-testing-library';
 import { hbs } from 'ember-cli-htmlbars';
 import createGlimmerComponent from '../../helpers/create-glimmer-component';
 import clickByLabel from '../../helpers/click-by-label';
@@ -8,9 +8,9 @@ import clickByLabel from '../../helpers/click-by-label';
 module('Integration | Component | collapsible', function (hooks) {
   setupRenderingTest(hooks);
 
-  test('it show only PixCollapsible title by default', async function (assert) {
+  test('it should show only PixCollapsible title by default', async function (assert) {
     // when
-    await render(hbs`
+    const screen = await render(hbs`
       <PixCollapsible @title="Titre de mon élément déroulable">
         <p>Contenu de mon élément</p>
       </PixCollapsible>
@@ -18,11 +18,12 @@ module('Integration | Component | collapsible', function (hooks) {
 
     // then
     assert.contains('Titre de mon élément déroulable');
+    assert.dom(screen.queryByText('Contenu de mon élément')).isNotVisible();
   });
 
-  test('it shows content on click on PixCollapsible title', async function (assert) {
+  test('it should show content on click on PixCollapsible title', async function (assert) {
     // when
-    await render(hbs`
+    const screen = await render(hbs`
       <PixCollapsible
         @title="Titre de mon élément déroulable"
         aria-label="collapsible label"
@@ -34,7 +35,7 @@ module('Integration | Component | collapsible', function (hooks) {
 
     // then
     assert.contains('Titre de mon élément déroulable');
-    assert.contains('Contenu de mon élément');
+    assert.dom(screen.queryByText('Contenu de mon élément')).isVisible();
   });
 
   test('it should not show PixCollapsible if title is not provided', async function (assert) {
@@ -49,5 +50,59 @@ module('Integration | Component | collapsible', function (hooks) {
     assert.throws(function () {
       component.title;
     }, expectedError);
+  });
+
+  module('@lazyRender', function () {
+    test('it should not render content when it has not been uncollapsed', async function (assert) {
+      // when
+      const screen = await render(hbs`
+        <PixCollapsible
+          @title="Titre de mon élément déroulable"
+          aria-label="collapsible label"
+          @lazyRender={{true}}
+        >
+          <p>Contenu de mon élément</p>
+        </PixCollapsible>
+      `);
+
+      // then
+      assert.dom(screen.queryByText('Contenu de mon élément')).doesNotExist();
+    });
+
+    test('it should render content when uncollapsed for the first time', async function (assert) {
+      // when
+      const screen = await render(hbs`
+        <PixCollapsible
+          @title="Titre de mon élément déroulable"
+          aria-label="collapsible label"
+          @lazyRender={{true}}
+        >
+          <p>Contenu de mon élément</p>
+        </PixCollapsible>
+      `);
+      await clickByLabel('collapsible label');
+
+      // then
+      assert.dom(screen.queryByText('Contenu de mon élément')).isVisible();
+    });
+
+    test('it should not re-render content when uncollapsed then collapsed again', async function (assert) {
+      // when
+      const screen = await render(hbs`
+        <PixCollapsible
+          @title="Titre de mon élément déroulable"
+          aria-label="collapsible label"
+          @lazyRender={{true}}
+        >
+          <p>Contenu de mon élément</p>
+        </PixCollapsible>
+      `);
+      await clickByLabel('collapsible label');
+      await clickByLabel('collapsible label');
+
+      // then
+      assert.dom(screen.queryByText('Contenu de mon élément')).isNotVisible();
+      assert.dom(screen.queryByText('Contenu de mon élément')).exists();
+    });
   });
 });

--- a/tests/integration/components/pix-collapsible-test.js
+++ b/tests/integration/components/pix-collapsible-test.js
@@ -1,14 +1,13 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import { render } from '@1024pix/ember-testing-library';
+import { render, clickByText } from '@1024pix/ember-testing-library';
 import { hbs } from 'ember-cli-htmlbars';
 import createGlimmerComponent from '../../helpers/create-glimmer-component';
-import clickByLabel from '../../helpers/click-by-label';
 
 module('Integration | Component | collapsible', function (hooks) {
   setupRenderingTest(hooks);
 
-  test('it should show only PixCollapsible title by default', async function (assert) {
+  test('it should only render PixCollapsible title by default', async function (assert) {
     // when
     const screen = await render(hbs`
       <PixCollapsible @title="Titre de mon élément déroulable">
@@ -17,11 +16,11 @@ module('Integration | Component | collapsible', function (hooks) {
     `);
 
     // then
-    assert.contains('Titre de mon élément déroulable');
-    assert.dom(screen.queryByText('Contenu de mon élément')).isNotVisible();
+    assert.dom(screen.queryByText('Titre de mon élément déroulable')).isVisible();
+    assert.dom(screen.queryByText('Contenu de mon élément')).doesNotExist();
   });
 
-  test('it should show content on click on PixCollapsible title', async function (assert) {
+  test('it should render and show content on click on PixCollapsible title', async function (assert) {
     // when
     const screen = await render(hbs`
       <PixCollapsible
@@ -31,10 +30,10 @@ module('Integration | Component | collapsible', function (hooks) {
         <p>Contenu de mon élément</p>
       </PixCollapsible>
     `);
-    await clickByLabel('collapsible label');
+    await clickByText('Titre de mon élément déroulable');
 
     // then
-    assert.contains('Titre de mon élément déroulable');
+    assert.dom(screen.queryByText('Titre de mon élément déroulable')).isVisible();
     assert.dom(screen.queryByText('Contenu de mon élément')).isVisible();
   });
 
@@ -52,57 +51,22 @@ module('Integration | Component | collapsible', function (hooks) {
     }, expectedError);
   });
 
-  module('@lazyRender', function () {
-    test('it should not render content when it has not been uncollapsed', async function (assert) {
-      // when
-      const screen = await render(hbs`
-        <PixCollapsible
-          @title="Titre de mon élément déroulable"
-          aria-label="collapsible label"
-          @lazyRender={{true}}
-        >
-          <p>Contenu de mon élément</p>
-        </PixCollapsible>
-      `);
+  test('it should not destroy content when uncollapsed then collapsed again', async function (assert) {
+    // when
+    const screen = await render(hbs`
+      <PixCollapsible
+        @title="Titre de mon élément déroulable"
+        aria-label="collapsible label"
+      >
+        <p>Contenu de mon élément</p>
+      </PixCollapsible>
+    `);
+    await clickByText('Titre de mon élément déroulable');
+    await clickByText('Titre de mon élément déroulable');
 
-      // then
-      assert.dom(screen.queryByText('Contenu de mon élément')).doesNotExist();
-    });
-
-    test('it should render content when uncollapsed for the first time', async function (assert) {
-      // when
-      const screen = await render(hbs`
-        <PixCollapsible
-          @title="Titre de mon élément déroulable"
-          aria-label="collapsible label"
-          @lazyRender={{true}}
-        >
-          <p>Contenu de mon élément</p>
-        </PixCollapsible>
-      `);
-      await clickByLabel('collapsible label');
-
-      // then
-      assert.dom(screen.queryByText('Contenu de mon élément')).isVisible();
-    });
-
-    test('it should not re-render content when uncollapsed then collapsed again', async function (assert) {
-      // when
-      const screen = await render(hbs`
-        <PixCollapsible
-          @title="Titre de mon élément déroulable"
-          aria-label="collapsible label"
-          @lazyRender={{true}}
-        >
-          <p>Contenu de mon élément</p>
-        </PixCollapsible>
-      `);
-      await clickByLabel('collapsible label');
-      await clickByLabel('collapsible label');
-
-      // then
-      assert.dom(screen.queryByText('Contenu de mon élément')).isNotVisible();
-      assert.dom(screen.queryByText('Contenu de mon élément')).exists();
-    });
+    // then
+    assert.dom(screen.queryByText('Titre de mon élément déroulable')).isVisible();
+    assert.dom(screen.queryByText('Contenu de mon élément')).isNotVisible();
+    assert.dom(screen.queryByText('Contenu de mon élément')).exists();
   });
 });


### PR DESCRIPTION
## :boom: BREAKING_CHANGES

Normalement cela ne devrait pas être un breaking change.

## :christmas_tree: Problème

Le contenu de PixCollapsible est rendu dans le DOM même quand celui-ci n'a jamais été déroulé.

## :gift: Solution

Rendre le contenu de PixCollapsible dans le DOM lorsqu'il est déroulé pour la première fois.

## :star2: Remarques

Quelques tests de PixCollapsible ont été améliorés au passage, il y avait des risques de faux positif.

## :santa: Pour tester

Vérifier que le Collapsible fonctionne bien dans la review app : https://ui-pr225.review.pix.fr/?path=/docs/others-collapsible--collapsible