### PR TITLE
[TECH] Permettre le passage en multi ligne du bandeau (PIX-5213)

### DIFF
--- a/addon/components/pix-filter-banner.hbs
+++ b/addon/components/pix-filter-banner.hbs
@@ -1,26 +1,33 @@
 <div class="pix-filter-banner" ...attributes>
-  <div class="pix-filter-banner__container-left">
-    {{#if this.displayTitle}}
+  {{#if this.displayTitle}}
+    <div class="pix-filter-banner__container-title">
       <p class="pix-filter-banner__title">{{@title}}</p>
-    {{/if}}
+    </div>
+  {{/if}}
+
+  <div class="pix-filter-banner__container-filter">
     {{yield}}
   </div>
-  <div class="pix-filter-banner__container-right">
-    {{#if this.displayDetails}}
-      <p class="pix-filter-banner__details">{{@details}}</p>
-    {{/if}}
-    {{#if this.displayClearFilters}}
-      <div class="pix-filter-banner__button-container">
-        <PixButton
-          class="pix-filter-banner__button"
-          @shape="squircle"
-          @size="small"
-          @triggerAction={{@onClearFilters}}
-        >
-          <FaIcon class="pix-filter-banner-button__icon" @icon="trash-alt" @prefix="far" />
-          {{@clearFiltersLabel}}
-        </PixButton>
-      </div>
-    {{/if}}
-  </div>
+
+  {{#if this.displayActionMenu}}
+    <div class="pix-filter-banner__container-action">
+      {{#if this.displayDetails}}
+        <p class="pix-filter-banner__details">{{@details}}</p>
+      {{/if}}
+
+      {{#if this.displayClearFilters}}
+        <div class="pix-filter-banner__button-container">
+          <PixButton
+            class="pix-filter-banner__button"
+            @shape="squircle"
+            @size="small"
+            @triggerAction={{@onClearFilters}}
+          >
+            <FaIcon class="pix-filter-banner-button__icon" @icon="trash-alt" @prefix="far" />
+            {{@clearFiltersLabel}}
+          </PixButton>
+        </div>
+      {{/if}}
+    </div>
+  {{/if}}
 </div>

--- a/addon/components/pix-filter-banner.js
+++ b/addon/components/pix-filter-banner.js
@@ -10,4 +10,8 @@ export default class PixFilterBanner extends Component {
   get displayClearFilters() {
     return Boolean(this.args.clearFiltersLabel);
   }
+
+  get displayActionMenu() {
+    return this.displayClearFilters || this.displayDetails;
+  }
 }

--- a/addon/styles/_pix-filter-banner.scss
+++ b/addon/styles/_pix-filter-banner.scss
@@ -1,31 +1,14 @@
 .pix-filter-banner {
   @import 'reset-css';
-
-  position: relative;
   display: flex;
   flex-direction: column;
-  gap: 6px;
+  position: relative;
+  gap: $spacing-xs;
   width: 100%;
-
   background-color: $pix-neutral-0;
   box-shadow: 0 2px 5px 0 rgba($pix-neutral-110, 0.05);
   min-height: 64px;
-  padding: 14px 24px;
-
-  &__container-left {
-    display: flex;
-    flex-direction: column;
-    gap: 12px;
-
-    > * > * {
-      width: 100%;
-    }
-  }
-
-  &__container-right {
-    display: flex;
-    flex-direction: column;
-  }
+  padding: $spacing-s $spacing-m;
 
   &__title {
     color: $pix-neutral-60;
@@ -34,14 +17,20 @@
     margin: 0;
   }
 
-  p.pix-filter-banner__details {
+  &__container-filter {
+    display: flex;
+    flex-direction: column;
+    gap: $spacing-s;
+  }
+
+  &__details {
     color: $pix-neutral-60;
     font-family: $font-roboto;
     font-weight: $font-medium;
+    padding: $spacing-xs 0 $spacing-xs 0;
+    margin: 0;
     font-size: 0.875rem;
-    margin-top: 10px;
-    padding-top: 10px;
-    border-top: 1px solid$pix-neutral-15;
+    border-top: 1px solid $pix-neutral-15;
   }
 
   &__button {
@@ -50,55 +39,41 @@
 }
 
 .pix-filter-banner-button__icon {
-  padding-right: 4px;
+  padding-right: $spacing-xxs;
 }
 
 @include device-is('tablet') {
   .pix-filter-banner {
-    flex-direction: row;
     justify-content: space-between;
     align-items: center;
+    flex-direction: row;
+    gap: $spacing-m;
 
-    &__container-left {
-      flex-direction: row;
-      height: 36px;
+    &__container-title {
+      display: flex;
       align-items: center;
     }
 
-    &__container-right {
+    &__container-filter {
       flex-direction: row;
-      height: 36px;
+      flex-wrap: wrap;
+    }
+
+    &__container-action {
+      display: flex;
       align-items: center;
       justify-content: flex-end;
     }
 
-    &__content {
-      > * {
-        margin-right: 16px;
-      }
-
-      > *:last-child {
-        margin-right: 0;
-      }
-    }
-
-    &__title {
-      padding-right: 24px;
-      margin: 0;
-    }
-
-    p.pix-filter-banner__details {
-      margin: 0;
-      margin-right: 16px;
-      padding-left: 16px;
-      padding-top: 4px;
+    &__details {
+      padding: 0 $spacing-s 0 0;
       text-align: center;
       border: none;
     }
 
     &__button-container {
       border-left: 1px solid $pix-neutral-15;
-      padding-left: 16px;
+      padding-left: $spacing-s;
     }
   }
 }

--- a/addon/styles/_pix-select.scss
+++ b/addon/styles/_pix-select.scss
@@ -11,7 +11,7 @@
     font-family: $font-roboto;
     font-size: 0.875rem;
     height: 36px;
-    max-width: 100%;
+    width: 100%;
     text-overflow: ellipsis;
 
     @include hoverFormElement();
@@ -55,7 +55,7 @@
     font-size: 11px;
     color: $pix-neutral-30;
     right: 10px;
-    top: calc(50% - 6px);
+    top: calc(50% - 4px);
     padding: 0 0 2px;
     position: absolute;
     pointer-events: none;

--- a/app/stories/pix-filter-banner.stories.js
+++ b/app/stories/pix-filter-banner.stories.js
@@ -7,6 +7,8 @@ export const filterBanner = (args) => {
       <PixFilterBanner @title={{title}} @details={{details}} @clearFiltersLabel={{clearFiltersLabel}} @onClearFilters={{onClearFilters}}>
         <PixSelect @options={{this.options}} @onChange={{this.onChange}} />
         <PixSelect @options={{this.options}} @onChange={{this.onChange}} />
+        <PixSelect @options={{this.options}} @onChange={{this.onChange}} />
+        <PixSelect @options={{this.options}} @onChange={{this.onChange}} />
       </PixFilterBanner>
     `,
     context: args,

--- a/app/stories/pix-filter-banner.stories.mdx
+++ b/app/stories/pix-filter-banner.stories.mdx
@@ -25,6 +25,7 @@ Une `FilterBanner` permet de wrapper les éléments de filtres (`Select`, `Multi
 <PixFilterBanner aria-label="Filtres sur les campagnes">
   <PixSelect @options={{options}} @onChange={{onChange}} />
   <PixSelect @options={{options}} @onChange={{onChange}} />
+  <PixSelect @options={{options}} @onChange={{onChange}} />
 </PixFilterBanner>
 ```
 


### PR DESCRIPTION
## :boom: BREAKING_CHANGES
RAS

## :christmas_tree: Problème
La bannière des filtres actul est limité en hauteur a 36px, les elements sont flex et s'ajoute les uns a la suite des autres sans aucun retour à la ligne

## :gift: Solution
Permettre les éléments de passer à la ligne une fois la taille du conteneur atteint avec un `flex-wrap: wrap`

## :star2: Remarques
Petit BSR sur pix select pour l'alignement de la flèche qui n'était pas centré, et un `max-width` changé en `width `afin de de ne plus avoir la flèche en dehors du pix select lors du passage en mobile de la bannière filtres

## :santa: Pour tester
Aller sur pix-ui réduire son viewport et vérifier que les filtres passent à la ligne