### PR TITLE
[DOCS] Ajoute des infos de breaking change sur la v14.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,10 @@
 
 ## v14.4.0 (17/06/2022)
 
+### :warning: Breaking Change
+La variable `$pix-gradient` a été supprimée par erreur, elle doit être remplacée par `$pix-primary-app-gradient`.
+
+La totalité des couleurs du Design System ont été apportées dans cette version. Les remplacements nécessaires sont documentés dans [cette PR](https://github.com/1024pix/pix-ui/pull/219). Une version majeure suivra lorsque tous les fronts Pix auront migré.
 
 ### :building_construction: Tech
 - [#219](https://github.com/1024pix/pix-ui/pull/219) [TECH] Ajouter les variables du design system dans Pix-UI.(PIX-2307)

--- a/addon/styles/_colors.scss
+++ b/addon/styles/_colors.scss
@@ -362,7 +362,7 @@ $grey-100: #091e42;
 $grey-150: #0c163a;
 
 /**
- * @deprecated Please use '$pix-neutral-200' instead!
+ * @deprecated Please use '$pix-neutral-110' instead!
  */
 $grey-200: #07142e;
 


### PR DESCRIPTION
## :boom: BREAKING_CHANGES
N/A

## :christmas_tree: Problème
- La v14.4.0 apporte un breaking change avec la disparition de la variable SCSS `$pix-gradient`.
- Une erreur a aussi été détectée sur la documentation du remplacement de la variable `$black`.

## :gift: Solution
- Ajouter l'info dans le CHANGELOG et documenter qu'elle doit être remplacée par `$pix-primary-app-gradient`.
- Corriger le remplacement de `$black` (devient `$pix-neutral-110`)

## :star2: Remarques
RAS

## :santa: Pour tester
N/A
