### PR TITLE
[TECH] Retirer la taille par defaut du composant PixMultiSelect

### DIFF
--- a/addon/styles/_pix-multi-select.scss
+++ b/addon/styles/_pix-multi-select.scss
@@ -1,8 +1,6 @@
 .pix-multi-select {
   display: inline-block;
   position: relative;
-  min-width: 250px;
-  width: 100%;
 
   &__label {
     @include label();
@@ -62,7 +60,6 @@
     color: $pix-neutral-30;
     right: 10px;
     top: calc(50% - 6px);
-    padding: 0 0 2px;
     position: absolute;
     pointer-events: none;
 

--- a/addon/styles/_pix-select.scss
+++ b/addon/styles/_pix-select.scss
@@ -55,8 +55,7 @@
     font-size: 11px;
     color: $pix-neutral-30;
     right: 10px;
-    top: calc(50% - 4px);
-    padding: 0 0 2px;
+    top: calc(50% - 6px);
     position: absolute;
     pointer-events: none;
   }


### PR DESCRIPTION
## :boom: BREAKING_CHANGES
Breaking Change seulement visuel (adaptation CSS sur certains cas)

## :christmas_tree: Problème
Le composant multi select avait deux attributs midth ( min-width 250px, width: 100%) sur l'élement parent. Après discussion, nous somme tombé d'accord que c'est à l'application utilisant le composant de dire la taille qu'il doit prendre au sein de la page.

## :gift: Solution
Retirer les deux éléments CSS indésirable, si modification d'affichage il y a . le `...attributes` défini sur l'element principal permet de rajouter` class="new-width"` dans les applications.

## :star2: Remarques
RAS

## :santa: Pour tester
Vérifier le bonne affichage du composant dans pix-ui