### PR TITLE
[FEATURE] Ajout du composant checkbox (PIX-3030)

### DIFF
--- a/addon/components/pix-checkbox.hbs
+++ b/addon/components/pix-checkbox.hbs
@@ -4,6 +4,7 @@
     id={{this.id}}
     type="checkbox"
     aria-label={{this.ariaLabel}}
+    class="{{if @isIndeterminate ' pix-checkbox__input--indeterminate'}}"
     ...attributes
   />
 </div>

--- a/addon/components/pix-checkbox.hbs
+++ b/addon/components/pix-checkbox.hbs
@@ -1,11 +1,13 @@
 <div class="pix-checkbox">
-  <label class="pix-checkbox__label {{this.labelSizeClass}}" for={{this.id}}>
+  <label
+    class="pix-checkbox__label {{this.labelSizeClass}} {{if @screenReaderOnly 'sr-only'}}"
+    for={{this.id}}
+  >
     {{this.label}}
   </label>
   <input
     id={{this.id}}
     type="checkbox"
-    aria-label={{this.ariaLabel}}
     class="pix-checkbox__input {{if @isIndeterminate ' pix-checkbox__input--indeterminate'}}"
     ...attributes
   />

--- a/addon/components/pix-checkbox.hbs
+++ b/addon/components/pix-checkbox.hbs
@@ -1,10 +1,12 @@
 <div class="pix-checkbox">
-  <label for={{this.id}}>{{this.label}}</label>
+  <label class="pix-checkbox__label {{this.labelSizeClass}}" for={{this.id}}>
+    {{this.label}}
+  </label>
   <input
     id={{this.id}}
     type="checkbox"
     aria-label={{this.ariaLabel}}
-    class="{{if @isIndeterminate ' pix-checkbox__input--indeterminate'}}"
+    class="pix-checkbox__input {{if @isIndeterminate ' pix-checkbox__input--indeterminate'}}"
     ...attributes
   />
 </div>

--- a/addon/components/pix-checkbox.hbs
+++ b/addon/components/pix-checkbox.hbs
@@ -1,0 +1,9 @@
+<div class="pix-checkbox">
+  <label for={{this.id}}>{{this.label}}</label>
+  <input
+    id={{this.id}}
+    type="checkbox"
+    aria-label={{this.ariaLabel}}
+    ...attributes
+  />
+</div>

--- a/addon/components/pix-checkbox.js
+++ b/addon/components/pix-checkbox.js
@@ -1,9 +1,6 @@
 import Component from '@glimmer/component';
 import { htmlSafe } from '@ember/string';
 
-const ERROR_MESSAGE =
-  'ERROR in PixCheckbox component, you must provide @label or @ariaLabel params';
-
 const labelSizeToClass = new Map([
   ['small', 'pix-checkbox__label--small'],
   ['default', 'pix-checkbox__label--default'],
@@ -11,25 +8,20 @@ const labelSizeToClass = new Map([
 ]);
 
 export default class PixCheckbox extends Component {
+  constructor() {
+    super(...arguments);
+
+    if (!this.args.label) {
+      throw new Error('ERROR in PixCheckbox component, you must provide @label params');
+    }
+    this.label = htmlSafe(this.args.label);
+  }
+
   get id() {
     if (!this.args.id || !this.args.id.toString().trim()) {
       throw new Error('ERROR in PixCheckbox component, @id param is not provided');
     }
     return this.args.id;
-  }
-
-  get label() {
-    if (!this.args.label && !this.args.ariaLabel) {
-      throw new Error(ERROR_MESSAGE);
-    }
-    return htmlSafe(this.args.label);
-  }
-
-  get ariaLabel() {
-    if (!this.args.label && !this.args.ariaLabel) {
-      throw new Error(ERROR_MESSAGE);
-    }
-    return this.args.label ? null : this.args.ariaLabel;
   }
 
   get labelSizeClass() {

--- a/addon/components/pix-checkbox.js
+++ b/addon/components/pix-checkbox.js
@@ -1,0 +1,27 @@
+import Component from '@glimmer/component';
+
+const ERROR_MESSAGE =
+  'ERROR in PixCheckbox component, you must provide @label or @ariaLabel params';
+
+export default class PixCheckbox extends Component {
+  get id() {
+    if (!this.args.id || !this.args.id.toString().trim()) {
+      throw new Error('ERROR in PixCheckbox component, @id param is not provided');
+    }
+    return this.args.id;
+  }
+
+  get label() {
+    if (!this.args.label && !this.args.ariaLabel) {
+      throw new Error(ERROR_MESSAGE);
+    }
+    return this.args.label;
+  }
+
+  get ariaLabel() {
+    if (!this.args.label && !this.args.ariaLabel) {
+      throw new Error(ERROR_MESSAGE);
+    }
+    return this.args.label ? null : this.args.ariaLabel;
+  }
+}

--- a/addon/components/pix-checkbox.js
+++ b/addon/components/pix-checkbox.js
@@ -1,4 +1,5 @@
 import Component from '@glimmer/component';
+import { htmlSafe } from '@ember/string';
 
 const ERROR_MESSAGE =
   'ERROR in PixCheckbox component, you must provide @label or @ariaLabel params';
@@ -21,7 +22,7 @@ export default class PixCheckbox extends Component {
     if (!this.args.label && !this.args.ariaLabel) {
       throw new Error(ERROR_MESSAGE);
     }
-    return this.args.label;
+    return htmlSafe(this.args.label);
   }
 
   get ariaLabel() {

--- a/addon/components/pix-checkbox.js
+++ b/addon/components/pix-checkbox.js
@@ -3,6 +3,12 @@ import Component from '@glimmer/component';
 const ERROR_MESSAGE =
   'ERROR in PixCheckbox component, you must provide @label or @ariaLabel params';
 
+const labelSizeToClass = new Map([
+  ['small', 'pix-checkbox__label--small'],
+  ['default', 'pix-checkbox__label--default'],
+  ['large', 'pix-checkbox__label--large'],
+]);
+
 export default class PixCheckbox extends Component {
   get id() {
     if (!this.args.id || !this.args.id.toString().trim()) {
@@ -23,5 +29,9 @@ export default class PixCheckbox extends Component {
       throw new Error(ERROR_MESSAGE);
     }
     return this.args.label ? null : this.args.ariaLabel;
+  }
+
+  get labelSizeClass() {
+    return labelSizeToClass.get(this.args.labelSize);
   }
 }

--- a/addon/styles/_pix-checkbox.scss
+++ b/addon/styles/_pix-checkbox.scss
@@ -7,16 +7,32 @@
 
   label, input {
     cursor: pointer;
-    @include text-small;
   }
 
-  input {
+  &__label {
+    @include text;
+
+    &--small {
+      @include text-small;
+    }
+    &--default {
+      @include text;
+    }
+    &--large {
+      @include text-large;
+    }
+  }
+
+  &__input {
     appearance: none;
     margin: 0 10px;
     width: 18px;
     height: 18px;
     border: 1.2px solid $pix-neutral-90;
     border-radius: 2px;
+    display: flex;
+    justify-content: center;
+    align-items: center;
 
     &:hover, &:focus {
       box-shadow: inset 0 1px 3px rgba(0,0,0, .1), 0 0 0 6px $pix-neutral-15;
@@ -31,15 +47,13 @@
       border-color: $pix-primary;
 
       &::after {
-        content: url("data:image/svg+xml,%3Csvg width='13' height='10' viewBox='0 0 13 10' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M1.5 3L0 4.5L5 9.5L13 1.5L11.5 0L5 6.5L1.5 3Z' fill='white'/%3E%3C/svg%3E%0A");
-        color: $white;
-        display: block;
-        position: relative;
-        top: -1px;
-        left: 1.4px;
-        font-weight: bold;
-        height: 16px;
-        width: 16px;
+        content: '';
+        background-image: url("data:image/svg+xml,%3Csvg width='13' height='10' viewBox='0 0 13 10' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M1.5 3L0 4.5L5 9.5L13 1.5L11.5 0L5 6.5L1.5 3Z' fill='white'/%3E%3C/svg%3E%0A");
+        background-repeat: no-repeat;
+        background-position: center;
+        width: 100%;
+        height: 100%;
+
       }
     }
 
@@ -49,16 +63,12 @@
         border-color: $pix-neutral-60;
 
         &::after {
-          content: url("data:image/svg+xml,%3Csvg width='10' height='2' viewBox='0 0 10 2' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Crect width='10' height='2' fill='white'/%3E%3C/svg%3E%0A");
-          color: $white;
-          font-size: 1.25rem;
-          display: block;
-          position: relative;
-          left: 2.8px;
-          top: -7px;
-          font-weight: bold;
-          height: 16px;
-          width: 16px;
+          content: '';
+          background-image: url("data:image/svg+xml,%3Csvg width='10' height='2' viewBox='0 0 10 2' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Crect width='10' height='2' fill='white'/%3E%3C/svg%3E%0A");
+          background-repeat: no-repeat;
+          background-position: center;
+          width: 100%;
+          height: 100%;
         }
       }
     }

--- a/addon/styles/_pix-checkbox.scss
+++ b/addon/styles/_pix-checkbox.scss
@@ -10,6 +10,7 @@
   }
 
   &__label {
+    color: $pix-neutral-70;
     @include text;
 
     &--small {
@@ -26,8 +27,8 @@
   &__input {
     appearance: none;
     margin: 0 10px;
-    width: 18px;
-    height: 18px;
+    min-width: 18px;
+    min-height: 18px;
     border: 1.2px solid $pix-neutral-90;
     border-radius: 2px;
     display: flex;
@@ -51,8 +52,8 @@
         background-image: url("data:image/svg+xml,%3Csvg width='13' height='10' viewBox='0 0 13 10' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M1.5 3L0 4.5L5 9.5L13 1.5L11.5 0L5 6.5L1.5 3Z' fill='white'/%3E%3C/svg%3E%0A");
         background-repeat: no-repeat;
         background-position: center;
-        width: 100%;
-        height: 100%;
+        width: 16px;
+        height: 16px;
 
       }
     }
@@ -67,8 +68,8 @@
           background-image: url("data:image/svg+xml,%3Csvg width='10' height='2' viewBox='0 0 10 2' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Crect width='10' height='2' fill='white'/%3E%3C/svg%3E%0A");
           background-repeat: no-repeat;
           background-position: center;
-          width: 100%;
-          height: 100%;
+          width: 16px;
+          height: 16px;
         }
       }
     }

--- a/addon/styles/_pix-checkbox.scss
+++ b/addon/styles/_pix-checkbox.scss
@@ -2,6 +2,8 @@
   @import 'reset-css';
   display: flex;
   align-items: center;
+  display: flex;
+  flex-direction: row-reverse;
 
   label, input {
     cursor: pointer;
@@ -9,8 +11,6 @@
   }
 
   input {
-    display: flex;
-    flex-direction: row-reverse;
     appearance: none;
     margin: 0 10px;
     width: 18px;
@@ -31,12 +31,12 @@
       border-color: $pix-primary;
 
       &::after {
-        content: '✓';
+        content: url("data:image/svg+xml,%3Csvg width='13' height='10' viewBox='0 0 13 10' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M1.5 3L0 4.5L5 9.5L13 1.5L11.5 0L5 6.5L1.5 3Z' fill='white'/%3E%3C/svg%3E%0A");
         color: $white;
         display: block;
         position: relative;
         top: -1px;
-        left: 2px;
+        left: 1.4px;
         font-weight: bold;
         height: 16px;
         width: 16px;
@@ -49,12 +49,12 @@
         border-color: $pix-neutral-60;
 
         &::after {
-          content: '-';
+          content: url("data:image/svg+xml,%3Csvg width='10' height='2' viewBox='0 0 10 2' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Crect width='10' height='2' fill='white'/%3E%3C/svg%3E%0A");
           color: $white;
           font-size: 1.25rem;
           display: block;
           position: relative;
-          left: 2px;
+          left: 2.8px;
           top: -7px;
           font-weight: bold;
           height: 16px;

--- a/addon/styles/_pix-checkbox.scss
+++ b/addon/styles/_pix-checkbox.scss
@@ -42,5 +42,25 @@
         width: 16px;
       }
     }
+
+    &.pix-checkbox__input--indeterminate {
+      &:checked {
+        background: $pix-neutral-60 border-box;
+        border-color: $pix-neutral-60;
+
+        &::after {
+          content: '-';
+          color: $white;
+          font-size: 1.25rem;
+          display: block;
+          position: relative;
+          left: 2px;
+          top: -7px;
+          font-weight: bold;
+          height: 16px;
+          width: 16px;
+        }
+      }
+    }
   }
 }

--- a/addon/styles/_pix-checkbox.scss
+++ b/addon/styles/_pix-checkbox.scss
@@ -1,4 +1,46 @@
 .pix-checkbox {
   @import 'reset-css';
+  display: flex;
+  align-items: center;
 
+  label, input {
+    cursor: pointer;
+    @include text-small;
+  }
+
+  input {
+    display: flex;
+    flex-direction: row-reverse;
+    appearance: none;
+    margin: 0 10px;
+    width: 18px;
+    height: 18px;
+    border: 1.2px solid $pix-neutral-90;
+    border-radius: 2px;
+
+    &:hover, &:focus {
+      box-shadow: inset 0 1px 3px rgba(0,0,0, .1), 0 0 0 6px $pix-neutral-15;
+    }
+
+    &:active {
+      box-shadow: inset 0 1px 3px rgba(0,0,0, .1), 0 0 0 6px $pix-neutral-22;
+    }
+
+    &:checked {
+      background: $pix-primary border-box;
+      border-color: $pix-primary;
+
+      &::after {
+        content: '✓';
+        color: $white;
+        display: block;
+        position: relative;
+        top: -1px;
+        left: 2px;
+        font-weight: bold;
+        height: 16px;
+        width: 16px;
+      }
+    }
+  }
 }

--- a/addon/styles/_pix-checkbox.scss
+++ b/addon/styles/_pix-checkbox.scss
@@ -1,0 +1,4 @@
+.pix-checkbox {
+  @import 'reset-css';
+
+}

--- a/addon/styles/addon.scss
+++ b/addon/styles/addon.scss
@@ -26,6 +26,7 @@
 @import 'pix-selectable-tag';
 @import 'pix-dropdown';
 @import 'pix-pagination';
+@import 'pix-checkbox';
 
 html {
   font-size: 16px;

--- a/app/components/pix-checkbox.js
+++ b/app/components/pix-checkbox.js
@@ -1,0 +1,1 @@
+export { default } from '@1024pix/pix-ui/components/pix-checkbox';

--- a/app/stories/form.stories.js
+++ b/app/stories/form.stories.js
@@ -67,6 +67,10 @@ export const form = (args) => {
       />
       <br>
 
+      <PixCheckbox @id="spam-pub" @labelSize="small" @label="Acceptez-vous de vous faire spammer de PUB ?" />
+
+      <br><br>
+
       <div class="pix-form__actions">
         <PixButton @triggerAction={{cancel}} @backgroundColor="transparent-light" @isBorderVisible={{true}}>
           Annuler

--- a/app/stories/pix-checkbox.stories.js
+++ b/app/stories/pix-checkbox.stories.js
@@ -6,6 +6,7 @@ export const Template = (args) => {
       <PixCheckbox
         @id={{id}}
         @label={{label}}
+        @isIndeterminate={{isIndeterminate}}
       />
     `,
     context: args,
@@ -16,6 +17,13 @@ export const Default = Template.bind({});
 Default.args = {
   id: 'acceptNewsletter',
   label: 'Recevoir la newsletter',
+};
+
+export const isIndeterminateCheckbox = Template.bind({});
+isIndeterminateCheckbox.args = {
+  id: 'acceptNewsletter2',
+  label: 'Recevoir la newsletter',
+  isIndeterminate: true,
 };
 
 export const argTypes = {
@@ -36,5 +44,15 @@ export const argTypes = {
     description: "L'action du champ, pour l'accessibilité. Requis si label n'est pas définit.",
     type: { name: 'string', required: true },
     defaultValue: null,
+  },
+  isIndeterminate: {
+    name: 'isIndeterminate',
+    description:
+      "Rendre la checkbox indeterminée, état indiquant que la/les case(s) n'est ni cochée(s) ni décochée(s) (exemple: une checkbox parent indiquant la sélection partielle de plusieurs checkbox enfants)",
+    type: { name: 'boolean', required: true },
+    table: {
+      type: { summary: 'boolean' },
+      defaultValue: { summary: false },
+    },
   },
 };

--- a/app/stories/pix-checkbox.stories.js
+++ b/app/stories/pix-checkbox.stories.js
@@ -7,6 +7,7 @@ export const Template = (args) => {
         @id={{id}}
         @label={{label}}
         @isIndeterminate={{isIndeterminate}}
+        @labelSize={{labelSize}}
       />
     `,
     context: args,
@@ -19,11 +20,25 @@ Default.args = {
   label: 'Recevoir la newsletter',
 };
 
-export const isIndeterminateCheckbox = Template.bind({});
-isIndeterminateCheckbox.args = {
+export const indeterminateCheckbox = Template.bind({});
+indeterminateCheckbox.args = {
   id: 'acceptNewsletter2',
   label: 'Recevoir la newsletter',
   isIndeterminate: true,
+};
+
+export const checkboxWithSmallLabel = Template.bind({});
+checkboxWithSmallLabel.args = {
+  id: 'acceptNewsletter2',
+  label: 'Recevoir la newsletter',
+  labelSize: 'small',
+};
+
+export const checkboxWithLargeLabel = Template.bind({});
+checkboxWithLargeLabel.args = {
+  id: 'acceptNewsletter2',
+  label: 'Recevoir la newsletter',
+  labelSize: 'large',
 };
 
 export const argTypes = {
@@ -53,6 +68,16 @@ export const argTypes = {
     table: {
       type: { summary: 'boolean' },
       defaultValue: { summary: false },
+    },
+  },
+  labelSize: {
+    name: 'labelSize',
+    description: 'Correspond à la taille de la police du label.',
+    type: { name: 'string', required: false },
+    defaultValue: { summary: 'default' },
+    control: {
+      type: 'select',
+      options: ['small', 'default', 'large'],
     },
   },
 };

--- a/app/stories/pix-checkbox.stories.js
+++ b/app/stories/pix-checkbox.stories.js
@@ -6,6 +6,7 @@ export const Template = (args) => {
       <PixCheckbox
         @id={{id}}
         @label={{label}}
+        @screenReaderOnly={{screenReaderOnly}}
         @isIndeterminate={{isIndeterminate}}
         @labelSize={{labelSize}}
       />
@@ -54,16 +55,20 @@ export const argTypes = {
     type: { name: 'string', required: false },
     defaultValue: null,
   },
-  ariaLabel: {
-    name: 'ariaLabel',
-    description: "L'action du champ, pour l'accessibilité. Requis si label n'est pas définit.",
-    type: { name: 'string', required: true },
-    defaultValue: null,
+  screenReaderOnly: {
+    name: 'screenReaderOnly',
+    description:
+      "Permet de ne pas afficher le label à l'écran. Sert à garder un label qui sera lisible par les lecteurs d'écran.",
+    type: { name: 'boolean', required: true },
+    table: {
+      type: { summary: 'boolean' },
+      defaultValue: { summary: false },
+    },
   },
   isIndeterminate: {
     name: 'isIndeterminate',
     description:
-      "Rendre la checkbox indeterminée, état indiquant que la/les case(s) n'est ni cochée(s) ni décochée(s) (exemple: une checkbox parent indiquant la sélection partielle de plusieurs checkbox enfants)",
+      "Rendre la checkbox indéterminée, état indiquant que la/les case(s) n'est/ne sont ni cochée(s) ni décochée(s) (exemple: une checkbox parente indiquant la sélection partielle de plusieurs checkbox enfants)",
     type: { name: 'boolean', required: true },
     table: {
       type: { summary: 'boolean' },

--- a/app/stories/pix-checkbox.stories.js
+++ b/app/stories/pix-checkbox.stories.js
@@ -1,0 +1,40 @@
+import { hbs } from 'ember-cli-htmlbars';
+
+export const Template = (args) => {
+  return {
+    template: hbs`
+      <PixCheckbox
+        @id={{id}}
+        @label={{label}}
+      />
+    `,
+    context: args,
+  };
+};
+
+export const Default = Template.bind({});
+Default.args = {
+  id: 'acceptNewsletter',
+  label: 'Recevoir la newsletter',
+};
+
+export const argTypes = {
+  id: {
+    name: 'id',
+    description: 'Identifiant du champ permettant de lui attacher un label',
+    type: { name: 'string', required: true },
+    defaultValue: null,
+  },
+  label: {
+    name: 'label',
+    description: "Le label de l'input",
+    type: { name: 'string', required: false },
+    defaultValue: null,
+  },
+  ariaLabel: {
+    name: 'ariaLabel',
+    description: "L'action du champ, pour l'accessibilité. Requis si label n'est pas définit.",
+    type: { name: 'string', required: true },
+    defaultValue: null,
+  },
+};

--- a/app/stories/pix-checkbox.stories.mdx
+++ b/app/stories/pix-checkbox.stories.mdx
@@ -12,10 +12,15 @@ import * as stories from './pix-checkbox.stories.js';
 
 # PixCheckbox
 
-TODO: insert component description
+La PixCheckbox permet de créer des checkbox basiques ou des checkbox mixées (checkbox servant d'indicateur lors d'une sélection mutliple).
 
 <Canvas>
   <Story name='Default' story={stories.Default} height={60} />
+</Canvas>
+
+## Checkbox indeterminée
+<Canvas>
+  <Story name='Indeterminate' story={stories.isIndeterminateCheckbox} height={60} />
 </Canvas>
 
 ## Usage
@@ -24,6 +29,8 @@ TODO: insert component description
 <PixCheckbox
   @id="superId"
   @label="Recevoir la newsletter"
+  @isLabelAtRightSide={{false}}
+  @isIndeterminate={{false}}
 />
 ```
 

--- a/app/stories/pix-checkbox.stories.mdx
+++ b/app/stories/pix-checkbox.stories.mdx
@@ -1,0 +1,32 @@
+import { Meta, Story, Canvas, ArgsTable } from '@storybook/addon-docs/blocks';
+import centered from '@storybook/addon-centered/ember';
+
+import * as stories from './pix-checkbox.stories.js';
+
+<Meta
+  title='Form/Checkbox'
+  component='PixCheckbox'
+  decorators={[centered]}
+  argTypes={stories.argTypes}
+/>
+
+# PixCheckbox
+
+TODO: insert component description
+
+<Canvas>
+  <Story name='Default' story={stories.Default} height={60} />
+</Canvas>
+
+## Usage
+
+```html
+<PixCheckbox
+  @id="superId"
+  @label="Recevoir la newsletter"
+/>
+```
+
+## Arguments
+
+<ArgsTable story="Default" />

--- a/app/stories/pix-checkbox.stories.mdx
+++ b/app/stories/pix-checkbox.stories.mdx
@@ -12,13 +12,13 @@ import * as stories from './pix-checkbox.stories.js';
 
 # PixCheckbox
 
-La PixCheckbox permet de créer des checkbox basiques ou des checkbox mixées (checkbox servant d'indicateur lors d'une sélection mutliple).
+La PixCheckbox permet de créer des checkbox basiques ou des checkbox mixées (checkbox servant d'indicateur lors d'une sélection multiple).
 
 <Canvas>
   <Story name='Default' story={stories.Default} height={60} />
 </Canvas>
 
-## Checkbox indeterminée
+## Checkbox indéterminée
 <Canvas>
   <Story name='Indeterminate' story={stories.indeterminateCheckbox} height={60} />
 </Canvas>
@@ -39,7 +39,7 @@ La PixCheckbox permet de créer des checkbox basiques ou des checkbox mixées (c
 <PixCheckbox
   @id="superId"
   @label="Recevoir la newsletter"
-  @isLabelAtRightSide={{false}}
+  @screenReaderOnly={{false}}
   @isIndeterminate={{false}}
   @labelSize="small"
 />

--- a/app/stories/pix-checkbox.stories.mdx
+++ b/app/stories/pix-checkbox.stories.mdx
@@ -20,7 +20,17 @@ La PixCheckbox permet de créer des checkbox basiques ou des checkbox mixées (c
 
 ## Checkbox indeterminée
 <Canvas>
-  <Story name='Indeterminate' story={stories.isIndeterminateCheckbox} height={60} />
+  <Story name='Indeterminate' story={stories.indeterminateCheckbox} height={60} />
+</Canvas>
+
+## Checkbox avec un petit label
+<Canvas>
+  <Story name='SmallLabel' story={stories.checkboxWithSmallLabel} height={60} />
+</Canvas>
+
+## Checkbox avec un grand label
+<Canvas>
+  <Story name='LargeLabel' story={stories.checkboxWithLargeLabel} height={60} />
 </Canvas>
 
 ## Usage
@@ -31,6 +41,7 @@ La PixCheckbox permet de créer des checkbox basiques ou des checkbox mixées (c
   @label="Recevoir la newsletter"
   @isLabelAtRightSide={{false}}
   @isIndeterminate={{false}}
+  @labelSize="small"
 />
 ```
 

--- a/tests/integration/components/pix-checkbox-test.js
+++ b/tests/integration/components/pix-checkbox-test.js
@@ -65,4 +65,14 @@ module('Integration | Component | checkbox', function (hooks) {
     // then
     assert.dom('.pix-checkbox__label--small').exists();
   });
+
+  test('it should be possible to insert html in label', async function (assert) {
+    // given & when
+    const labelWithHtml = 'Accepter les cgu, <a href="https://cgu.example.net">voir ici</a>';
+    this.set('label', labelWithHtml);
+    const screen = await render(hbs`<PixCheckbox @id="checkboxId" @label={{label}} />`);
+
+    // then
+    assert.dom(screen.getByLabelText('Accepter les cgu, voir ici')).exists();
+  });
 });

--- a/tests/integration/components/pix-checkbox-test.js
+++ b/tests/integration/components/pix-checkbox-test.js
@@ -1,7 +1,7 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { hbs } from 'ember-cli-htmlbars';
-import { render, clickByText, clickByName } from '@1024pix/ember-testing-library';
+import { render, clickByText } from '@1024pix/ember-testing-library';
 import createGlimmerComponent from '../../helpers/create-glimmer-component';
 
 module('Integration | Component | checkbox', function (hooks) {
@@ -21,7 +21,7 @@ module('Integration | Component | checkbox', function (hooks) {
 
   test('it should throw an error if there is no id', async function (assert) {
     // given & when
-    const componentParams = { id: '   ' };
+    const componentParams = { id: '   ', label: 'Super label' };
     const component = createGlimmerComponent('component:pix-checkbox', componentParams);
 
     // then
@@ -31,31 +31,17 @@ module('Integration | Component | checkbox', function (hooks) {
     }, expectedError);
   });
 
-  test('it should throw an error if pix checkbox has neither a label nor an ariaLabel param', async function (assert) {
+  test('it should throw an error if pix checkbox has no label param', async function (assert) {
     // given & when
     const componentParams = { id: 'superId', label: null, ariaLabel: null };
-    const component = createGlimmerComponent('component:pix-checkbox', componentParams);
 
     // then
     const expectedError = new Error(
-      'ERROR in PixCheckbox component, you must provide @label or @ariaLabel params'
+      'ERROR in PixCheckbox component, you must provide @label params'
     );
     assert.throws(function () {
-      component.label;
+      createGlimmerComponent('component:pix-checkbox', componentParams);
     }, expectedError);
-    assert.throws(function () {
-      component.ariaLabel;
-    }, expectedError);
-  });
-
-  test('it should be possible to render and click on aria-labelled checkbox (without label)', async function (assert) {
-    // given & when
-    await render(hbs`<PixCheckbox @id="checkboxId" @ariaLabel="Recevoir la newsletter" />`);
-    await clickByName('Recevoir la newsletter');
-
-    // then
-    const checkbox = this.element.querySelector(CHECKBOX_INPUT_SELECTOR);
-    assert.true(checkbox.checked);
   });
 
   test('it should be possible to make label small', async function (assert) {

--- a/tests/integration/components/pix-checkbox-test.js
+++ b/tests/integration/components/pix-checkbox-test.js
@@ -57,4 +57,12 @@ module('Integration | Component | checkbox', function (hooks) {
     const checkbox = this.element.querySelector(CHECKBOX_INPUT_SELECTOR);
     assert.true(checkbox.checked);
   });
+
+  test('it should be possible to make label small', async function (assert) {
+    // when
+    await render(hbs`<PixCheckbox @id="checkboxId" @label="Mini label" @labelSize="small" />`);
+
+    // then
+    assert.dom('.pix-checkbox__label--small').exists();
+  });
 });

--- a/tests/integration/components/pix-checkbox-test.js
+++ b/tests/integration/components/pix-checkbox-test.js
@@ -1,0 +1,60 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { hbs } from 'ember-cli-htmlbars';
+import { render, clickByText, clickByName } from '@1024pix/ember-testing-library';
+import createGlimmerComponent from '../../helpers/create-glimmer-component';
+
+module('Integration | Component | checkbox', function (hooks) {
+  setupRenderingTest(hooks);
+
+  const CHECKBOX_INPUT_SELECTOR = '.pix-checkbox input';
+
+  test('it should be possible to check the checkbox', async function (assert) {
+    // when
+    await render(hbs`<PixCheckbox @id="checkboxId" @label="Recevoir la newsletter" />`);
+    await clickByText('Recevoir la newsletter');
+
+    // then
+    const checkbox = this.element.querySelector(CHECKBOX_INPUT_SELECTOR);
+    assert.true(checkbox.checked);
+  });
+
+  test('it should throw an error if there is no id', async function (assert) {
+    // given & when
+    const componentParams = { id: '   ' };
+    const component = createGlimmerComponent('component:pix-checkbox', componentParams);
+
+    // then
+    const expectedError = new Error('ERROR in PixCheckbox component, @id param is not provided');
+    assert.throws(function () {
+      component.id;
+    }, expectedError);
+  });
+
+  test('it should throw an error if pix checkbox has neither a label nor an ariaLabel param', async function (assert) {
+    // given & when
+    const componentParams = { id: 'superId', label: null, ariaLabel: null };
+    const component = createGlimmerComponent('component:pix-checkbox', componentParams);
+
+    // then
+    const expectedError = new Error(
+      'ERROR in PixCheckbox component, you must provide @label or @ariaLabel params'
+    );
+    assert.throws(function () {
+      component.label;
+    }, expectedError);
+    assert.throws(function () {
+      component.ariaLabel;
+    }, expectedError);
+  });
+
+  test('it should be possible to render and click on aria-labelled checkbox (without label)', async function (assert) {
+    // given & when
+    await render(hbs`<PixCheckbox @id="checkboxId" @ariaLabel="Recevoir la newsletter" />`);
+    await clickByName('Recevoir la newsletter');
+
+    // then
+    const checkbox = this.element.querySelector(CHECKBOX_INPUT_SELECTOR);
+    assert.true(checkbox.checked);
+  });
+});


### PR DESCRIPTION
## :boom: BREAKING_CHANGES
RAS, c'est un nouveau composant

## :christmas_tree: Problème
La PixCheckbox n'existe pas.

## :gift: Solution
Ajouter le composant PixCheckbox

## :star2: Remarques
- [x] La taille de texte doit pouvoir changer en fonction du contexte : text / text-small / text-large.
- [x] Il peut y avoir des liens dans les labels. 
- [x] Mettre par défaut le texte à droite la checkbox à gauche et enlever l'option with-right-label
- [x] Remplacer les characters par les svg 
- [x] Reprendre le format dans les design tokens 
- [x] Ajouter l'aria-label (label optionnel) 

## :santa: Pour tester
Comparer le rendu avec les maquettes : https://www.figma.com/file/8RJ3aCSfdeQ8AZZVBBYKS8/Design-System-Pix?node-id=202%3A399
