### PR TITLE
[BUGFIX] Correction du déploiement de Storybook

### DIFF
--- a/.github/workflows/deploy-storybook.yml
+++ b/.github/workflows/deploy-storybook.yml
@@ -1,7 +1,7 @@
 name: Deploy Pix UI Storybook
 
-on: 
-  workflow_dispatch: 
+on:
+  workflow_dispatch:
   push:
     tags:
       - '*'
@@ -10,10 +10,11 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v1
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
         with:
-          node-version: 14
+          node-version: 16.14.0
+      - run: npm i -g npm@8.13.2
       - run: npm ci
       - name: Deploy storybook to Github Pages
         run: npm run deploy-storybook -- --ci


### PR DESCRIPTION
## :boom: BREAKING_CHANGES

N/A

## :christmas_tree: Problème

Le storybook ne se déploie plus lors des releases.

## :gift: Solution

Corriger les versions de NodeJS/npm utilisées par la github action.

## :star2: Remarques

N/A

## :santa: Pour tester

Déploiement testé depuis cette PR : https://github.com/1024pix/pix-ui/runs/7248724667

Cela a permis de déployer la 15.0.0 et la 15.0.1 qui ne l'avaient pas été : https://ui.pix.fr/?path=/docs/changelog--page
