### PR TITLE
[TECH] Changer les pré-requis engine du package.json (PIX-5319)

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "author": "GIP Pix",
   "engines": {
     "node": "16.14.0",
-    "npm": "8.13.2"
+    "npm": ">=8.3.1 <=8.13.2"
   },
   "ember": {
     "edition": "octane"


### PR DESCRIPTION
## :boom: BREAKING_CHANGES

## :christmas_tree: Problème
cette configuration à pour effet de faire ruisseler la config vers le package principal, ce qui bloque les déploiement des application dans le cas ou l'on met Pix-UI à jour.

## :gift: Solution
Autoriser `>=8.3.1 <=8.13.2` dans le package.json, même si la 8.3.1 n'est plus compatible avec les dernier package

## :star2: Remarques

## :santa: Pour tester
Vérifier que l'application tourne toujours correctement