### PR TITLE
[BREAKING_CHANGES][BUGFIX] Correction des couleurs du design system par rapport à Figma (PIX-5331).

### DIFF
--- a/addon/styles/_colors.scss
+++ b/addon/styles/_colors.scss
@@ -14,7 +14,7 @@ $pix-primary-80: #000e87;
 
 // Secondary
 $pix-secondary-5: #fff9e6;
-$pix-secondary-10: #ffeeb3;
+$pix-secondary-10: #fff1c5;
 $pix-secondary-20: #ffe381;
 $pix-secondary: #ffd235;
 $pix-secondary-40: #ffbe00;
@@ -75,7 +75,7 @@ $pix-warning-30: #ffd235;
 $pix-warning-40: #ffbe00;
 $pix-warning-50: #eaa600;
 $pix-warning-60: #ce8900;
-$pix-warning-70: #ac6a00;
+$pix-warning-70: #a95800;
 $pix-warning-80: #874d00;
 
 // Error
@@ -489,20 +489,20 @@ $yellow-alert-dark: #a95800;
 /**
  * @deprecated
  *-To style text or border : $pix-error-70
- *-To style background : $pix-error-10
+ *-To style background : $pix-error-5
  */
 $error: #ff4b00;
 
 /**
  * @deprecated
  *-To style text or border : $pix-success-70
- *-To style background : $pix-success-10
+ *-To style background : $pix-success-5
  */
 $success: #57c884;
 
 /**
  * @deprecated
- *-To style text or border : $pix-warning-60
- *-To style background : $pix-warning-10
+ *-To style text or border : $pix-warning-70
+ *-To style background : $pix-warning-5
  */
 $warning: #ffbe00;

--- a/addon/styles/_pix-banner.scss
+++ b/addon/styles/_pix-banner.scss
@@ -36,17 +36,17 @@
   }
 
   &--information {
-    background-color: $pix-primary-10;
+    background-color: $pix-primary-5;
     color: $pix-primary-70;
   }
 
   &--warning {
-    background-color: $pix-warning-10;
-    color: $pix-warning-60;
+    background-color: $pix-warning-5;
+    color: $pix-warning-70;
   }
 
   &--error {
-    background-color: $pix-error-10;
+    background-color: $pix-error-5;
     color: $pix-error-70;
   }
 

--- a/addon/styles/_pix-message.scss
+++ b/addon/styles/_pix-message.scss
@@ -10,23 +10,23 @@
 
   &.pix-message--info {
     color: $pix-primary-70;
-    background-color: $pix-primary-10;
+    background-color: $pix-primary-5;
   }
   &.pix-message--alert {
     color: $pix-error-70;
-    background-color: $pix-error-10;
+    background-color: $pix-error-5;
   }
   &.pix-message--error {
     color: $pix-error-70;
-    background-color: $pix-error-10;
+    background-color: $pix-error-5;
   }
   &.pix-message--success {
     color: $pix-success-70;
-    background-color: $pix-success-10;
+    background-color: $pix-success-5;
   }
   &.pix-message--warning {
-    color: $pix-warning-60;
-    background-color: $pix-warning-10;
+    color: $pix-warning-70;
+    background-color: $pix-warning-5;
   }
 
   svg {

--- a/docs/colors-palette.stories.mdx
+++ b/docs/colors-palette.stories.mdx
@@ -33,7 +33,7 @@ import { Meta, ColorPalette, ColorItem } from '@storybook/addon-docs';
     title="Pix Secondary"
     subtitle="$pix-secondary-"
     colors={{ 5: '#fff9e6',
-             10: '#ffeeb3',
+             10: '#fff1c5',
              20: '#ffe381',
              Secondary: '#ffd235',
              40: '#ffbe00',
@@ -104,7 +104,7 @@ import { Meta, ColorPalette, ColorItem } from '@storybook/addon-docs';
             40: '#ffbe00',
             50: '#eaa600',
             60: '#ce8900',
-            70: '#ac6a00',
+            70: '#a95800',
             80: '#874d00'}}
   />
   <ColorItem

--- a/docs/design-tokens.stories.mdx
+++ b/docs/design-tokens.stories.mdx
@@ -38,23 +38,23 @@ Les couleurs pour définir un état d'une alerte ont été attribuées pour unif
 ### Success
 ```
 Texte ou bordure : $pix-success-70
-Background : $pix-success-10
+Background : $pix-success-5
 ```
 
 ### Warning
 ```
-Texte ou bordure : $pix-warning-60
-Background : $pix-warning-10
+Texte ou bordure : $pix-warning-70
+Background : $pix-warning-5
 ```
 
 ### Error
 ```
 Texte ou bordure : $pix-error-70
-Background : $pix-error-10
+Background : $pix-error-5
 ```
 
 ### Information
 ```
 Texte ou bordure : $pix-primary-70
-Background : $pix-primary-10
+Background : $pix-primary-5
 ```


### PR DESCRIPTION
## :boom: BREAKING_CHANGES

- Changement du code hexadécimal pour deux variables : `pix-secondary-10` & `pix-warning-70`.
- Utilisation des nouvelles couleurs pour les différents status de `pix-banner` & `pix-message`.
Exemple : **background** :`pix-error-10`--> `pix-error-5`.

## :christmas_tree: Problème

- Les couleurs de la palette ne concordent pas avec les couleurs qui sont utilisées sur Figma.
- La documentation pour l'utilisation de la palette de couleur pour les alertes n'est pas à jour.

## :gift: Solution
- Mettre à jour les couleurs dans la palette
- Mettre à jour la documentation 

## :star2: Remarques
/

## :santa: Pour tester

- Vérifier que les couleurs de la palette concordent avec [Figma](https://www.figma.com/file/8RJ3aCSfdeQ8AZZVBBYKS8/Design-System-Pix?node-id=16%3A2)