### PR TITLE
[FEATURE] PixCollapsible : Autoriser l'utilisation d'un Block Content pour le titre

### DIFF
--- a/addon/components/pix-collapsible.hbs
+++ b/addon/components/pix-collapsible.hbs
@@ -8,14 +8,22 @@
     aria-expanded={{if this.isUnCollapsed "true" "false"}}
     ...attributes
   >
-    <span>
+    <span class="pix-collapsible-title__container">
       {{#if @titleIcon}}
         <FaIcon @icon={{@titleIcon}} class="pix-collapsible-title__icon" />
       {{/if}}
-      {{this.title}}
+
+      {{#if (has-block "title")}}
+        {{yield to="title"}}
+      {{else}}
+        {{this.title}}
+      {{/if}}
     </span>
 
-    <FaIcon @icon="{{if this.isCollapsed 'plus' 'minus'}}" class="pix-collapsible-title__icon" />
+    <FaIcon
+      @icon="{{if this.isCollapsed 'plus' 'minus'}}"
+      class="pix-collapsible-title__toggle-icon"
+    />
   </button>
 
   <div

--- a/addon/styles/_pix-collapsible.scss
+++ b/addon/styles/_pix-collapsible.scss
@@ -12,7 +12,7 @@
   background-color: $pix-neutral-0;
 
   &__title {
-    padding: 14px 10px 14px 16px;
+    padding: 14px 16px;
     min-width: 100%;
     cursor: pointer;
     display: flex;
@@ -22,11 +22,7 @@
     color: $pix-neutral-60;
     font-size: 1rem;
     font-weight: 500;
-
-    .pix-collapsible-title__icon {
-      color: $pix-neutral-45;
-      margin-right: 6px;
-    }
+    align-items: center;
 
     &:hover {
       background-color: $pix-neutral-10;
@@ -38,6 +34,25 @@
 
     &--uncollapsed {
       background-color: $pix-neutral-10;
+    }
+  }
+
+  &-title {
+
+    &__container {
+      align-items: center;
+      display: flex;
+      flex-grow: 1;
+    }
+
+    &__icon{
+      color: $pix-neutral-45;
+      margin-right: 6px;
+    }
+
+    &__toggle-icon{
+      color: $pix-neutral-45;
+      margin-left: 16px;
     }
   }
 

--- a/app/stories/pix-collapsible.stories.js
+++ b/app/stories/pix-collapsible.stories.js
@@ -13,6 +13,23 @@ export const collapsible = (args) => {
   };
 };
 
+export const collapsibleWithBlockTitle = (args) => {
+  return {
+    template: hbs`
+    <PixCollapsible
+      @titleIcon={{titleIcon}}>
+      <:title>
+        <span>Titre avec <em>contenu de type block</em></span>
+      </:title>
+      <:default>
+        <div>Contenu du PixCollapsible</div>
+      </:default>
+      </PixCollapsible>
+    `,
+    context: args,
+  };
+};
+
 export const multipleCollapsible = (args) => {
   return {
     template: hbs`

--- a/app/stories/pix-collapsible.stories.mdx
+++ b/app/stories/pix-collapsible.stories.mdx
@@ -21,6 +21,10 @@ Par défaut le contenu est masqué et cliquer sur le libellé permet de montrer 
 </Canvas>
 
 <Canvas>
+  <Story name='With block title' story={stories.collapsibleWithBlockTitle} height={150} />
+</Canvas>
+
+<Canvas>
   <Story name='MultiplePixCollapsible' story={stories.multipleCollapsible} height={260} />
 </Canvas>
 


### PR DESCRIPTION
## :boom: BREAKING_CHANGES

N/A

## :christmas_tree: Problème

Dans PixAdmin, on aimerait afficher du contenu aligné à droite dans le titre de PixCollapsible (à côté de l'icône `+` / `-`) :
https://www.figma.com/file/0bksLNTrEC1IBgTXu16z77/Pix-admin?node-id=761%3A8455

## :gift: Solution

Autoriser l'utilisation d'un [Block Content](https://www.figma.com/file/0bksLNTrEC1IBgTXu16z77/Pix-admin?node-id=761%3A8455) pour le titre de PixCollapsible.

## :star2: Remarques

N/A

## :santa: Pour tester

Aller voir la nouvelle Story "With Block Content" du PixCollapsible sur la RA.
