### PR TITLE
[FEATURE] Ajout d'un icone pour fermer Pix-Banner (PIX-5379)

### DIFF
--- a/addon/components/pix-banner.hbs
+++ b/addon/components/pix-banner.hbs
@@ -1,16 +1,33 @@
-<div class="pix-banner pix-banner--{{this.type}}" ...attributes>
-  <FaIcon @icon={{this.icon}} class="pix-banner__icon" />
-  <div>
-    {{yield}}
-    {{#if this.displayAction}}
-      {{#if this.isExternalLink}}
-        <a class="pix-banner__action" href={{@actionUrl}} target="_blank" rel="noopener noreferrer">
-          {{@actionLabel}}
-          <FaIcon class="external-link" @icon="up-right-from-square" />
-        </a>
-      {{else}}
-        <LinkTo class="pix-banner__action" @route={{@actionUrl}}>{{@actionLabel}}</LinkTo>
+{{#if this.displayBanner}}
+  <div class="pix-banner pix-banner--{{this.type}}" role="alert" ...attributes>
+    <FaIcon @icon={{this.icon}} class="pix-banner__icon" />
+    <div>
+      {{yield}}
+      {{#if this.displayAction}}
+        {{#if this.isExternalLink}}
+          <a
+            class="pix-banner__action"
+            href={{@actionUrl}}
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            {{@actionLabel}}
+            <FaIcon class="external-link" @icon="up-right-from-square" />
+          </a>
+        {{else}}
+          <LinkTo class="pix-banner__action" @route={{@actionUrl}}>{{@actionLabel}}</LinkTo>
+        {{/if}}
       {{/if}}
+    </div>
+    {{#if this.canCloseBanner}}
+      <div class="pix-banner__close">
+        <PixIconButton
+          @ariaLabel="Fermer"
+          @icon="xmark"
+          @size="small"
+          @triggerAction={{this.closeBanner}}
+        />
+      </div>
     {{/if}}
   </div>
-</div>
+{{/if}}

--- a/addon/components/pix-banner.js
+++ b/addon/components/pix-banner.js
@@ -1,4 +1,6 @@
 import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+import { action } from '@ember/object';
 const TYPE_INFO = 'information';
 const TYPE_ERROR = 'error';
 const TYPE_WARNING = 'warning';
@@ -25,6 +27,7 @@ const icons = {
 };
 
 export default class PixBanner extends Component {
+  @tracked isBannerVisible = true;
   get type() {
     return types.includes(this.args.type) ? this.args.type : TYPE_INFO;
   }
@@ -39,5 +42,18 @@ export default class PixBanner extends Component {
 
   get isExternalLink() {
     return this.args.actionUrl.includes('/');
+  }
+
+  get canCloseBanner() {
+    return this.args.canCloseBanner;
+  }
+
+  get displayBanner() {
+    return this.isBannerVisible;
+  }
+
+  @action
+  closeBanner() {
+    this.isBannerVisible = false;
   }
 }

--- a/addon/styles/_pix-banner.scss
+++ b/addon/styles/_pix-banner.scss
@@ -2,52 +2,73 @@
   @import 'reset-css';
   font-family: $font-roboto;
   font-weight: $font-normal;
-  padding: 10px 16px;
+  padding: 16px 24px;
   display: flex;
   align-items: center;
-  font-size: 0.75rem;
-
-  @include device-is('tablet') {
-    padding: 20px 60px;
-    font-size: 0.875rem;
-  }
+  font-size: 0.875rem;
+  box-shadow: 0px 4px 8px rgba(7, 20, 46, 0.08);
 
   &__action {
     text-decoration: underline;
-    letter-spacing: 0.028rem;
     color: inherit;
     .external-link {
-      margin-left: 3px;
-      font-size: 0.75rem;
-
-      @include device-is('tablet') {
-        font-size: 0.875rem;
-      }
+      margin-left: 4px;
+      font-size: 0.875rem;
     }
   }
-
+  &__close {
+    display: flex;
+    margin-left: auto;
+    padding-left: 8px;
+  }
   &__icon {
-    font-size: 0.875rem;
+    font-size: 1.125rem;
     margin-right: $spacing-xs;
-
-    @include device-is('tablet') {
-      font-size: 1rem;
-    }
   }
 
   &--information {
     background-color: $pix-primary-5;
     color: $pix-primary-70;
+    .pix-icon-button {
+      background-color: $pix-primary-5;
+      color: $pix-primary-70;
+      &:hover,
+      &:focus,
+      &:active {
+        background-color: $pix-primary-10;
+        color: $pix-primary-70;
+      }
+    }
   }
 
   &--warning {
     background-color: $pix-warning-5;
     color: $pix-warning-70;
+    .pix-icon-button {
+      background-color: $pix-warning-5;
+      color: $pix-warning-70;
+      &:hover,
+      &:focus,
+      &:active {
+        background-color: $pix-warning-10;
+        color: $pix-warning-70;
+      }
+    }
   }
 
   &--error {
     background-color: $pix-error-5;
     color: $pix-error-70;
+    .pix-icon-button {
+      background-color: $pix-error-5;
+      color: $pix-error-70;
+      &:hover,
+      &:focus,
+      &:active {
+        background-color: $pix-error-10;
+        color: $pix-error-70;
+      }
+    }
   }
 
   &--communication {

--- a/app/stories/pix-banner.stories.js
+++ b/app/stories/pix-banner.stories.js
@@ -7,6 +7,7 @@ const Template = (args) => {
         @type={{type}}
         @actionLabel={{actionLabel}}
         @actionUrl={{actionUrl}}
+        @canCloseBanner={{canCloseBanner}}
       >
         Parcours de rentrée 2020 : les codes sont disponibles dans l'onglet campagne. N’oubliez pas de les diffuser aux élèves avant la Toussaint.
       </PixBanner>
@@ -56,6 +57,12 @@ withInternalLink.args = {
   actionUrl: 'campaign.list',
 };
 
+export const withCloseIcon = Template.bind({});
+withCloseIcon.args = {
+  type: 'info',
+  canCloseBanner: true,
+};
+
 export const argsTypes = {
   actionLabel: {
     name: 'actionLabel',
@@ -84,6 +91,15 @@ export const argsTypes = {
         'communication-orga',
         'communication-certif',
       ],
+    },
+  },
+  canCloseBanner: {
+    name: 'canCloseBanner',
+    description: 'Afficher la croix pour fermer la bannière',
+    type: { name: 'boolean', required: false },
+    table: {
+      type: { summary: 'boolean' },
+      defaultValue: { summary: false },
     },
   },
 };

--- a/app/stories/pix-banner.stories.mdx
+++ b/app/stories/pix-banner.stories.mdx
@@ -67,6 +67,14 @@ Bannière contenant un lien externe.
   <Story name="With external link" story={stories.withExternalLink} height={100} />
 </Canvas>
 
+## With Close Icon
+
+Bannière contenant un bouton qui permet de fermer la bannière.
+
+<Canvas>
+  <Story name="With close icon" story={stories.withCloseIcon} height={100} />
+</Canvas>
+
 ## Usage
 
 ```html
@@ -98,6 +106,13 @@ Bannière Info par défaut
   @actionUrl='https://orga.pix.fr/eleves'
 >
   Bannière avec une route externe
+</PixBanner>
+
+<PixBanner
+  @type='warning'
+  @canCloseBanner=true
+>
+  Bannière posséndant un bouton de fermeture
 </PixBanner>
 
 ```

--- a/tests/integration/components/pix-banner-test.js
+++ b/tests/integration/components/pix-banner-test.js
@@ -1,6 +1,6 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import { render } from '@ember/test-helpers';
+import { click, render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 
 module('Integration | Component | Pix Banner', function (hooks) {
@@ -121,5 +121,22 @@ module('Integration | Component | Pix Banner', function (hooks) {
 
     // then
     assert.contains('Explorer');
+  });
+  test('it renders the PixBanner with close icon', async function (assert) {
+    // given
+    this.set('canCloseBanner', true);
+
+    //when
+    await render(hbs`
+      <PixBanner @type='warning' @canCloseBanner={{this.canCloseBanner}}>
+        Mon texte
+      </PixBanner>
+    `);
+
+    // then
+    assert.dom('.pix-banner__close').exists();
+    assert.dom('[aria-label="Fermer"]').exists();
+    await click('[aria-label="Fermer"]');
+    assert.dom('.pix-banner').doesNotExist();
   });
 });


### PR DESCRIPTION
## :boom: BREAKING_CHANGES
> _Décrivez ici les changements cassant (voir la doc associée)[https://github.com/1024pix/pix-ui/blob/dev/docs/breaking-changes.stories.mdx], s'il n'y en a pas indiquez le aussi.

## :christmas_tree: Problème
Actuellement, nous ne pouvons pas fermer une bannière qui est utilisée dans une application. Nous voulons donner la possibilité aux développeurs de pouvoir choisir si la bannière peut être fermée ou non.

## :gift: Solution
 - Ajouter la possibilité de pouvoir ajouter un bouton pour pouvoir fermer `Pix-Banner`.

## :star2: Remarques

- Vu avec Quentin, Surcharge de `pix-icon-button` pour changer les couleurs selon le statut de la bannière.
- Update de `pix-banner.scss`. (Vu avec QuentinC)

## :santa: Pour tester
Vérifier que la bannière n'existe plus  quand on clique sur l'icone `xmark`.
