### PR TITLE
[FEATURE] PixModal : ajouter des modifiers trap-focus et action au echap (PIX-5157)

### DIFF
--- a/addon/components/pix-modal.hbs
+++ b/addon/components/pix-modal.hbs
@@ -1,6 +1,6 @@
 <div
   class="pix-modal__overlay"
-  {{action "onCloseButtonClick"}}
+  {{on "click" this.closeAction}}
   {{trap-focus}}
 >
   <div
@@ -9,14 +9,14 @@
     aria-labelledby="modal-title"
     aria-describedby="modal-content"
     aria-modal="true"
-    onclick={{action "stopPropagation"}}
+    {{on "click" this.stopPropagation}}
     ...attributes
   >
     <header class="pix-modal__header">
       <h1 id="modal-title" class="pix-modal__title">{{@title}}</h1>
       <PixIconButton
         @icon="xmark"
-        @triggerAction={{@onCloseButtonClick}}
+        @triggerAction={{this.closeAction}}
         @ariaLabel="Fermer"
         @size="small"
         @withBackground={{true}}

--- a/addon/components/pix-modal.hbs
+++ b/addon/components/pix-modal.hbs
@@ -2,6 +2,7 @@
   class="pix-modal__overlay"
   {{on "click" this.closeAction}}
   {{trap-focus}}
+  {{on-escape-action this.closeAction}}
 >
   <div
     class="pix-modal"

--- a/addon/components/pix-modal.hbs
+++ b/addon/components/pix-modal.hbs
@@ -1,4 +1,4 @@
-<div class="pix-modal__overlay">
+<div class="pix-modal__overlay" {{trap-focus}}>
   <div
     class="pix-modal"
     role="dialog"

--- a/addon/components/pix-modal.hbs
+++ b/addon/components/pix-modal.hbs
@@ -1,10 +1,15 @@
-<div class="pix-modal__overlay" {{trap-focus}}>
+<div
+  class="pix-modal__overlay"
+  {{action "onCloseButtonClick"}}
+  {{trap-focus}}
+>
   <div
     class="pix-modal"
     role="dialog"
     aria-labelledby="modal-title"
     aria-describedby="modal-content"
     aria-modal="true"
+    onclick={{action "stopPropagation"}}
     ...attributes
   >
     <header class="pix-modal__header">

--- a/addon/components/pix-modal.js
+++ b/addon/components/pix-modal.js
@@ -1,4 +1,5 @@
 import Component from '@glimmer/component';
+import { action } from '@ember/object';
 
 export default class PixModal extends Component {
   constructor(...args) {
@@ -7,5 +8,10 @@ export default class PixModal extends Component {
     if (!this.args.title) {
       throw new Error('ERROR in PixModal component: @title argument is required.');
     }
+  }
+
+  @action
+  stopPropagation(event) {
+    event.stopPropagation();
   }
 }

--- a/addon/components/pix-modal.js
+++ b/addon/components/pix-modal.js
@@ -14,4 +14,11 @@ export default class PixModal extends Component {
   stopPropagation(event) {
     event.stopPropagation();
   }
+
+  @action
+  closeAction(params) {
+    if (this.args.onCloseButtonClick) {
+      this.args.onCloseButtonClick(params);
+    }
+  }
 }

--- a/app/modifiers/on-escape-action.js
+++ b/app/modifiers/on-escape-action.js
@@ -1,0 +1,19 @@
+import { modifier } from 'ember-modifier';
+
+export default modifier((element, [callback]) => {
+  function handleKeyUp(event) {
+    const TAB_KEY = 'Escape';
+
+    if (event.key !== TAB_KEY) {
+      return;
+    }
+
+    callback(event);
+  }
+
+  element.addEventListener('keyup', handleKeyUp);
+
+  return () => {
+    element.removeEventListener('keyup', handleKeyUp);
+  };
+});

--- a/app/modifiers/trap-focus.js
+++ b/app/modifiers/trap-focus.js
@@ -1,0 +1,52 @@
+import { modifier } from 'ember-modifier';
+
+export default modifier(function trapFocus(element) {
+  const [firstFocusableElement] = findFocusableElements(element);
+
+  firstFocusableElement.focus();
+
+  function handleKeyDown(event) {
+    const TAB_KEY = 9;
+    const focusableElements = findFocusableElements(element);
+    const [firstFocusableElement] = focusableElements;
+    const lastFocusableElement = focusableElements[focusableElements.length - 1];
+
+    if (event.keyCode !== TAB_KEY) {
+      return;
+    }
+
+    function handleBackwardTab() {
+      if (document.activeElement === firstFocusableElement) {
+        event.preventDefault();
+        lastFocusableElement.focus();
+      }
+    }
+
+    function handleForwardTab() {
+      if (document.activeElement === lastFocusableElement) {
+        event.preventDefault();
+        firstFocusableElement.focus();
+      }
+    }
+
+    if (event.shiftKey) {
+      handleBackwardTab();
+    } else {
+      handleForwardTab();
+    }
+  }
+
+  element.addEventListener('keydown', handleKeyDown);
+
+  return () => {
+    element.removeEventListener('keydown', handleKeyDown);
+  };
+});
+
+function findFocusableElements(element) {
+  return [
+    ...element.querySelectorAll(
+      'a[href], button, input, textarea, select, details,[tabindex]:not([tabindex="-1"])'
+    ),
+  ].filter((el) => !el.hasAttribute('disabled') && !el.getAttribute('aria-hidden'));
+}

--- a/app/stories/pix-modal.stories.js
+++ b/app/stories/pix-modal.stories.js
@@ -1,9 +1,9 @@
 import { hbs } from 'ember-cli-htmlbars';
 
-export const modal = (args) => {
+export const Template = (args) => {
   return {
     template: hbs`
-      <PixModal @title={{this.title}}>
+      <PixModal @title={{this.title}} @onCloseButtonClick={{onCloseButtonClick}}>
         <:content>
           <p>
             Une fenêtre modale est, dans une interface graphique, une fenêtre qui prend le contrôle total du clavier et
@@ -24,12 +24,20 @@ export const modal = (args) => {
   };
 };
 
+export const Default = Template.bind({});
+Default.args = {
+  title: "Qu'est-ce qu'une modale ?",
+  onCloseButtonClick: () => {
+    alert('Action : fermer modale');
+  },
+};
+
 export const argTypes = {
   title: {
     name: 'title',
     description: 'Titre de la modale',
-    type: { name: 'string', required: false },
-    defaultValue: "Qu'est-ce qu'une modale ?",
+    type: { name: 'string', required: true },
+    defaultValue: null,
   },
   onCloseButtonClick: {
     name: 'onCloseButtonClick',

--- a/app/stories/pix-modal.stories.js
+++ b/app/stories/pix-modal.stories.js
@@ -41,7 +41,7 @@ export const argTypes = {
   },
   onCloseButtonClick: {
     name: 'onCloseButtonClick',
-    description: 'Fonction à executer lors du clic sur le bouton de fermeture de la modale',
+    description: 'Fonction à exécuter à la fermeture de la modale',
     type: { name: 'function', required: true },
     defaultValue: null,
   },

--- a/app/stories/pix-modal.stories.mdx
+++ b/app/stories/pix-modal.stories.mdx
@@ -4,8 +4,8 @@ import centered from '@storybook/addon-centered/ember';
 import * as stories from './pix-modal.stories.js';
 
 <Meta
-  title='Basics/Modal'
-  component='PixModal'
+  title="Basics/Modal"
+  component="PixModal"
   decorators={[centered]}
   argTypes={stories.argTypes}
 />
@@ -15,13 +15,14 @@ import * as stories from './pix-modal.stories.js';
 Une fenêtre modale responsive et scrollable avec un overlay.
 
 Ce composant possède deux `yield` :
+
 - `:content` est destiné à accueillir le contenu principal de la fenêtre modale. Il peut accueillir tout type de
   contenu HTML (simple texte, image, formulaire, etc.)
 - `:footer` peut également accueillir tout type de contenu HTML, mais est destiné aux boutons permettant d'interagir
   avec la modale, ce qui permettra de les positionner correctement dans tous les cas de figure.
 
 <Canvas>
-  <Story name='PixModal' story={stories.modal} height={500} />
+  <Story name="Default" story={stories.Default} height={500} />
 </Canvas>
 
 ## Usage

--- a/tests/integration/modifiers/on-escape-action-test.js
+++ b/tests/integration/modifiers/on-escape-action-test.js
@@ -1,0 +1,31 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render, triggerKeyEvent } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+import sinon from 'sinon';
+
+module('Integration | Modifier | on-escape-action', function (hooks) {
+  setupRenderingTest(hooks);
+
+  test('it fires action on escape keyup', async function (assert) {
+    // given
+    this.title = 'Close me baby one more time';
+    this.onCloseButtonClick = sinon.stub();
+
+    // when
+    await render(hbs`
+      <PixModal
+        @title={{this.title}}
+        @onCloseButtonClick={{this.onCloseButtonClick}}
+        {{on-escape-action this.onCloseButtonClick}}
+        {{trap-focus}}
+      >
+        content
+      </PixModal>
+    `);
+    await triggerKeyEvent('.pix-modal__overlay', 'keyup', 'Escape');
+
+    // then
+    assert.ok(this.onCloseButtonClick.calledOnce);
+  });
+});


### PR DESCRIPTION
## :christmas_tree: Problème
Accessibilité :
- La modale ne gardait pas la tabulation en interne.
- Il n'y avait pas d'action au clic sur l'overlay.
- Il n'y avait pas d'action au "echap".

## :gift: Solution
- Ajouter un modifier `trap-focus` pour gérer le focus
- Ajouter un événement sur l'overlay
- Ajouter un modifier `on-escape-action` pour gérer l'échappement.

## :star2: Remarques
Serait-il utile d'exporter ces modifiers à l'avenir ?

## :santa: Pour tester
- Lancer Storybook
- Aller sur [cette page](http://localhost:9001/iframe.html?id=basics-modal--default&args=title:Info&viewMode=story)
- Tester que le focus reste bien dans la modale
- Tester le clic sur l'overlay, sur le bouton fermer (croix), et l'échappement : ils devraient tous déclencher une alerte.
