### PR TITLE
[FEATURE] Ajouter un composant Sidebar (PIX-4298)

### DIFF
--- a/addon/components/pix-sidebar.hbs
+++ b/addon/components/pix-sidebar.hbs
@@ -1,37 +1,34 @@
-{{#if @showSidebar}}
+<div
+  class="pix-sidebar__overlay {{unless @showSidebar ' pix-sidebar__overlay--hidden'}}"
+  {{on "click" this.closeAction}}
+  {{trap-focus}}
+  {{on-escape-action this.closeAction}}
+>
   <div
-    class="pix-sidebar__overlay"
-    {{on "click" this.closeAction}}
-    {{trap-focus}}
-    {{on-escape-action this.closeAction}}
+    class="pix-sidebar {{unless @showSidebar ' pix-sidebar--hidden'}}"
+    role="dialog"
+    aria-labelledby="sidebar-title"
+    aria-describedby="sidebar-content"
+    aria-modal="true"
+    {{on "click" this.stopPropagation}}
+    ...attributes
   >
-    <div
-      class="pix-sidebar
-        {{if @showSidebar 'pix-sidebar--visible'}}"
-      role="dialog"
-      aria-labelledby="sidebar-title"
-      aria-describedby="sidebar-content"
-      aria-modal="true"
-      {{on "click" this.stopPropagation}}
-      ...attributes
-    >
-      <header class="pix-sidebar__header">
-        <h1 id="sidebar-title" class="pix-sidebar__title">{{@title}}</h1>
-        <PixIconButton
-          @icon="xmark"
-          @triggerAction={{this.closeAction}}
-          @ariaLabel="Fermer"
-          @size="small"
-          @withBackground={{true}}
-          class="pix-sidebar__close-button"
-        />
-      </header>
-      <main id="sidebar-content" class="pix-sidebar__content">
-        {{yield to="content"}}
-      </main>
-      <footer class="pix-sidebar__footer">
-        {{yield to="footer"}}
-      </footer>
-    </div>
+    <header class="pix-sidebar__header">
+      <h1 id="sidebar-title" class="pix-sidebar__title">{{@title}}</h1>
+      <PixIconButton
+        @icon="xmark"
+        @triggerAction={{this.closeAction}}
+        @ariaLabel="Fermer"
+        @size="small"
+        @withBackground={{true}}
+        class="pix-sidebar__close-button"
+      />
+    </header>
+    <main id="sidebar-content" class="pix-sidebar__content">
+      {{yield to="content"}}
+    </main>
+    <footer class="pix-sidebar__footer">
+      {{yield to="footer"}}
+    </footer>
   </div>
-{{/if}}
+</div>

--- a/addon/components/pix-sidebar.hbs
+++ b/addon/components/pix-sidebar.hbs
@@ -1,0 +1,37 @@
+{{#if @showSidebar}}
+  <div
+    class="pix-sidebar__overlay"
+    {{on "click" this.closeAction}}
+    {{trap-focus}}
+    {{on-escape-action this.closeAction}}
+  >
+    <div
+      class="pix-sidebar
+        {{if @showSidebar 'pix-sidebar--visible'}}"
+      role="dialog"
+      aria-labelledby="sidebar-title"
+      aria-describedby="sidebar-content"
+      aria-modal="true"
+      {{on "click" this.stopPropagation}}
+      ...attributes
+    >
+      <header class="pix-sidebar__header">
+        <h1 id="sidebar-title" class="pix-sidebar__title">{{@title}}</h1>
+        <PixIconButton
+          @icon="xmark"
+          @triggerAction={{this.closeAction}}
+          @ariaLabel="Fermer"
+          @size="small"
+          @withBackground={{true}}
+          class="pix-sidebar__close-button"
+        />
+      </header>
+      <main id="sidebar-content" class="pix-sidebar__content">
+        {{yield to="content"}}
+      </main>
+      <footer class="pix-sidebar__footer">
+        {{yield to="footer"}}
+      </footer>
+    </div>
+  </div>
+{{/if}}

--- a/addon/components/pix-sidebar.js
+++ b/addon/components/pix-sidebar.js
@@ -1,0 +1,24 @@
+import Component from '@glimmer/component';
+import { action } from '@ember/object';
+
+export default class PixSidebar extends Component {
+  constructor(...args) {
+    super(...args);
+
+    if (!this.args.title) {
+      throw new Error('ERROR in PixSidebar component: @title argument is required.');
+    }
+  }
+
+  @action
+  stopPropagation(event) {
+    event.stopPropagation();
+  }
+
+  @action
+  closeAction(params) {
+    if (this.args.onClose) {
+      this.args.onClose(params);
+    }
+  }
+}

--- a/addon/styles/_pix-sidebar.scss
+++ b/addon/styles/_pix-sidebar.scss
@@ -7,6 +7,12 @@
   right: 0;
   overflow-y: scroll;
   background-color: rgba(52, 69, 99, 0.7);
+  transition: all .3s ease-in-out;
+
+  &--hidden {
+    visibility: hidden;
+    opacity: 0;
+  }
 }
 
 $sidebar-padding: 16px;
@@ -14,7 +20,6 @@ $mobile-close-button-size: 32px;
 $tablet-close-button-size: 40px;
 $space-between-title-and-close-button: 8px;
 $button-margin: 16px;
-
 
 .pix-sidebar {
   @import 'reset-css';
@@ -24,7 +29,13 @@ $button-margin: 16px;
   max-width: 320px;
   box-shadow: 1px 1px 5px rgba(0, 0, 0, 0.1);
   background: $pix-neutral-0;
-  
+  transform: translate(0);
+  transition: transform .3s ease-in-out;
+
+  &--hidden {
+    transform: translate(-100%);
+  }
+
   &__header {
     border-bottom: 1px solid $pix-neutral-20;
     padding: $sidebar-padding;

--- a/addon/styles/_pix-sidebar.scss
+++ b/addon/styles/_pix-sidebar.scss
@@ -1,0 +1,69 @@
+.pix-sidebar__overlay {
+  position: fixed;
+  z-index: 1000;
+  top: 0;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  overflow-y: scroll;
+  background-color: rgba(52, 69, 99, 0.7);
+}
+
+$sidebar-padding: 16px;
+$mobile-close-button-size: 32px;
+$tablet-close-button-size: 40px;
+$space-between-title-and-close-button: 8px;
+$button-margin: 16px;
+
+
+.pix-sidebar {
+  @import 'reset-css';
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  max-width: 320px;
+  box-shadow: 1px 1px 5px rgba(0, 0, 0, 0.1);
+  background: $pix-neutral-0;
+  
+  &__header {
+    border-bottom: 1px solid $pix-neutral-20;
+    padding: $sidebar-padding;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+  }
+
+  &__close-button {
+    flex-shrink: 0;
+
+    @include device-is('tablet') {
+      height: $tablet-close-button-size;
+      width: $tablet-close-button-size;
+    }
+  }
+
+  &__content {
+    flex-grow: 1;
+    overflow: auto;
+  }
+
+  &__title {
+    @include h4;
+    margin-bottom: 0;
+    color: $pix-neutral-90;
+    padding-right: $mobile-close-button-size + $space-between-title-and-close-button;
+
+    @include device-is('tablet') {
+      padding-right: $tablet-close-button-size + $space-between-title-and-close-button;
+    }
+  }
+
+  &__content {
+    padding: $sidebar-padding 0;
+  }
+
+  &__footer {
+    padding: $sidebar-padding;
+    border-top: 1px solid $pix-neutral-20;
+  }
+}

--- a/addon/styles/addon.scss
+++ b/addon/styles/addon.scss
@@ -22,6 +22,7 @@
 @import 'pix-input-password';
 @import 'pix-radio-button';
 @import 'pix-modal';
+@import 'pix-sidebar';
 @import 'pix-input-code';
 @import 'pix-selectable-tag';
 @import 'pix-dropdown';

--- a/app/components/pix-sidebar.js
+++ b/app/components/pix-sidebar.js
@@ -1,0 +1,1 @@
+export { default } from '@1024pix/pix-ui/components/pix-sidebar';

--- a/app/stories/pix-sidebar.stories.js
+++ b/app/stories/pix-sidebar.stories.js
@@ -1,0 +1,69 @@
+import { hbs } from 'ember-cli-htmlbars';
+
+export const Template = (args) => {
+  return {
+    template: hbs`
+      <PixSidebar @showSidebar={{this.showSidebar}} @title={{this.title}} @onClose={{onClose}}>
+        <:content>
+          <p>
+            Une fenêtre modale est, dans une interface graphique, une fenêtre qui prend le contrôle total du clavier et
+            de l'écran. Elle est en général associée à une question à laquelle il est impératif que l'utilisateur
+            réponde avant de poursuivre, ou de modifier quoi que ce soit. La fenêtre modale a pour propos : d'obtenir
+            des informations de l'utilisateur (ces informations sont nécessaires pour réaliser une opération) ; de
+            fournir une information à l'utilisateur (ce dernier doit en prendre connaissance avant de pouvoir continuer
+            à utiliser l'application).
+          </p>
+        </:content>
+        <:footer>
+          <PixButton @backgroundColor="transparent-light" @isBorderVisible="true">Annuler</PixButton>
+          <PixButton>Valider</PixButton>
+        </:footer>
+      </PixModal>
+    `,
+    context: args,
+  };
+};
+
+export const Default = Template.bind({});
+Default.args = {
+  showSidebar: true,
+  title: 'Filtrer',
+  onClose: () => {
+    console.log('coucou');
+    // alert('Action : fermer sidebar');
+  },
+};
+
+export const argTypes = {
+  showSidebar: {
+    name: 'showSidebar',
+    description: 'Visibilité de la sidebar',
+    type: { name: 'boolean', required: false },
+    defaultValue: 'false',
+    control: { type: 'boolean' },
+    table: {
+      type: { summary: 'boolean' },
+      defaultValue: { summary: 'false' },
+    },
+  },
+  title: {
+    name: 'title',
+    description: 'Titre de la modale',
+    type: { name: 'string', required: true },
+    defaultValue: null,
+    table: {
+      type: { summary: 'string' },
+      defaultValue: { summary: null },
+    },
+  },
+  onClose: {
+    name: 'onClose',
+    description: 'Fonction à exécuter à la fermeture de la sidebar',
+    type: { name: 'function', required: true },
+    defaultValue: null,
+    table: {
+      type: { summary: 'function' },
+      defaultValue: { summary: null },
+    },
+  },
+};

--- a/app/stories/pix-sidebar.stories.js
+++ b/app/stories/pix-sidebar.stories.js
@@ -3,22 +3,21 @@ import { hbs } from 'ember-cli-htmlbars';
 export const Template = (args) => {
   return {
     template: hbs`
-      <PixSidebar @showSidebar={{this.showSidebar}} @title={{this.title}} @onClose={{onClose}}>
+      <PixButton @triggerAction={{fn (mut showSidebar) (not showSidebar)}}>Ouvrir la sidebar</PixButton>
+      <PixSidebar @showSidebar={{showSidebar}} @title={{title}} @onClose={{fn (mut showSidebar) (not showSidebar)}}>
         <:content>
           <p>
-            Une fenêtre modale est, dans une interface graphique, une fenêtre qui prend le contrôle total du clavier et
-            de l'écran. Elle est en général associée à une question à laquelle il est impératif que l'utilisateur
-            réponde avant de poursuivre, ou de modifier quoi que ce soit. La fenêtre modale a pour propos : d'obtenir
-            des informations de l'utilisateur (ces informations sont nécessaires pour réaliser une opération) ; de
-            fournir une information à l'utilisateur (ce dernier doit en prendre connaissance avant de pouvoir continuer
-            à utiliser l'application).
+            Une sidebar est, dans une interface graphique, une fenêtre qui prend le contrôle total du clavier et
+            de l'écran. Elle est en général associée à du paramétrage d'écran.
           </p>
         </:content>
         <:footer>
+        <div style="display: flex; gap: 8px">
           <PixButton @backgroundColor="transparent-light" @isBorderVisible="true">Annuler</PixButton>
           <PixButton>Valider</PixButton>
+          </div>
         </:footer>
-      </PixModal>
+      </PixSidebar>
     `,
     context: args,
   };
@@ -28,10 +27,7 @@ export const Default = Template.bind({});
 Default.args = {
   showSidebar: true,
   title: 'Filtrer',
-  onClose: () => {
-    console.log('coucou');
-    // alert('Action : fermer sidebar');
-  },
+  onClose: () => {},
 };
 
 export const argTypes = {
@@ -39,31 +35,27 @@ export const argTypes = {
     name: 'showSidebar',
     description: 'Visibilité de la sidebar',
     type: { name: 'boolean', required: false },
-    defaultValue: 'false',
     control: { type: 'boolean' },
     table: {
       type: { summary: 'boolean' },
-      defaultValue: { summary: 'false' },
+      defaultValue: { summary: false },
     },
   },
   title: {
     name: 'title',
-    description: 'Titre de la modale',
+    description: 'Titre de la sidebar',
     type: { name: 'string', required: true },
-    defaultValue: null,
     table: {
       type: { summary: 'string' },
-      defaultValue: { summary: null },
+      defaultValue: { summary: '' },
     },
   },
   onClose: {
     name: 'onClose',
     description: 'Fonction à exécuter à la fermeture de la sidebar',
     type: { name: 'function', required: true },
-    defaultValue: null,
     table: {
       type: { summary: 'function' },
-      defaultValue: { summary: null },
     },
   },
 };

--- a/app/stories/pix-sidebar.stories.mdx
+++ b/app/stories/pix-sidebar.stories.mdx
@@ -1,0 +1,61 @@
+import { Meta, Story, Canvas, ArgsTable } from '@storybook/addon-docs/blocks';
+import centered from '@storybook/addon-centered/ember';
+
+import * as stories from './pix-modal.stories.js';
+
+<Meta
+  title="Basics/Modal"
+  component="PixModal"
+  decorators={[centered]}
+  argTypes={stories.argTypes}
+/>
+
+# PixModal
+
+Une fenêtre modale responsive et scrollable avec un overlay.
+
+Ce composant possède deux `yield` :
+
+- `:content` est destiné à accueillir le contenu principal de la fenêtre modale. Il peut accueillir tout type de
+  contenu HTML (simple texte, image, formulaire, etc.)
+- `:footer` peut également accueillir tout type de contenu HTML, mais est destiné aux boutons permettant d'interagir
+  avec la modale, ce qui permettra de les positionner correctement dans tous les cas de figure.
+
+<Canvas>
+  <Story name="Default" story={stories.Default} height={500} />
+</Canvas>
+
+## Usage
+
+```html
+<PixSidebar
+  @showSidebar={{true}}
+  @title="Filtrer"
+  @onClose={{this.closeSidebar}}
+>
+ <:content>
+  <p>
+    Une fenêtre modale est, dans une interface graphique, une fenêtre qui prend le contrôle total du clavier et
+    de l'écran. Elle est en général associée à une question à laquelle il est impératif que l'utilisateur
+    réponde avant de poursuivre, ou de modifier quoi que ce soit. La fenêtre modale a pour propos : d'obtenir
+    des informations de l'utilisateur (ces informations sont nécessaires pour réaliser une opération) ; de
+    fournir une information à l'utilisateur (ce dernier doit en prendre connaissance avant de pouvoir continuer
+    à utiliser l'application).
+  </p>
+ </:content>
+ <:footer>
+  <PixButton
+    @backgroundColor="transparent-light"
+    @isBorderVisible={{true}}
+    @triggerAction={{this.closeModal}}
+  >
+    Annuler
+  </PixButton>
+  <PixButton>Valider</PixButton>
+ </:footer>
+</PixModal>
+```
+
+## Arguments
+
+<ArgsTable story="PixModal" />

--- a/app/stories/pix-sidebar.stories.mdx
+++ b/app/stories/pix-sidebar.stories.mdx
@@ -1,25 +1,25 @@
 import { Meta, Story, Canvas, ArgsTable } from '@storybook/addon-docs/blocks';
 import centered from '@storybook/addon-centered/ember';
 
-import * as stories from './pix-modal.stories.js';
+import * as stories from './pix-sidebar.stories.js';
 
 <Meta
-  title="Basics/Modal"
-  component="PixModal"
+  title="Basics/Sidebar"
+  component="PixSidebar"
   decorators={[centered]}
   argTypes={stories.argTypes}
 />
 
-# PixModal
+# PixSidebar
 
-Une fenêtre modale responsive et scrollable avec un overlay.
+Une sidebar responsive et scrollable avec un overlay.
 
 Ce composant possède deux `yield` :
 
-- `:content` est destiné à accueillir le contenu principal de la fenêtre modale. Il peut accueillir tout type de
+- `:content` est destiné à accueillir le contenu principal de la fenêtre sidebar. Il peut accueillir tout type de
   contenu HTML (simple texte, image, formulaire, etc.)
 - `:footer` peut également accueillir tout type de contenu HTML, mais est destiné aux boutons permettant d'interagir
-  avec la modale, ce qui permettra de les positionner correctement dans tous les cas de figure.
+  avec la sidebar, ce qui permettra de les positionner correctement dans tous les cas de figure.
 
 <Canvas>
   <Story name="Default" story={stories.Default} height={500} />
@@ -35,27 +35,23 @@ Ce composant possède deux `yield` :
 >
  <:content>
   <p>
-    Une fenêtre modale est, dans une interface graphique, une fenêtre qui prend le contrôle total du clavier et
-    de l'écran. Elle est en général associée à une question à laquelle il est impératif que l'utilisateur
-    réponde avant de poursuivre, ou de modifier quoi que ce soit. La fenêtre modale a pour propos : d'obtenir
-    des informations de l'utilisateur (ces informations sont nécessaires pour réaliser une opération) ; de
-    fournir une information à l'utilisateur (ce dernier doit en prendre connaissance avant de pouvoir continuer
-    à utiliser l'application).
+    Une sidebar est, dans une interface graphique, une fenêtre qui prend le contrôle total du clavier et
+    de l'écran. Elle est en général associée à du paramétrage d'écran.
   </p>
  </:content>
  <:footer>
   <PixButton
     @backgroundColor="transparent-light"
     @isBorderVisible={{true}}
-    @triggerAction={{this.closeModal}}
+    @triggerAction={{this.closeSidebar}}
   >
     Annuler
   </PixButton>
   <PixButton>Valider</PixButton>
  </:footer>
-</PixModal>
+</PixSidebar>
 ```
 
 ## Arguments
 
-<ArgsTable story="PixModal" />
+<ArgsTable story="Default" />

--- a/tests/integration/components/pix-sidebar-test.js
+++ b/tests/integration/components/pix-sidebar-test.js
@@ -1,0 +1,120 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render, click, triggerKeyEvent } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+import sinon from 'sinon';
+import createGlimmerComponent from '../../helpers/create-glimmer-component';
+
+module('Integration | Component | Sidebar', function (hooks) {
+  setupRenderingTest(hooks);
+
+  module('when showSidebar is equal true', function () {
+    test('it renders the default PixSidebar', async function (assert) {
+      // given
+      this.title = "It's a sidebar!";
+      this.showSidebar = true;
+
+      // when
+      await render(hbs`
+        <PixSidebar @title={{this.title}} @showSidebar={{this.showSidebar}}>
+          <:content>
+            content
+          </:content>
+          <:footer>
+            footer
+          </:footer>
+        </PixSidebar>
+      `);
+
+      // then
+      assert.contains("It's a sidebar!");
+      assert.contains('content');
+      assert.contains('footer');
+    });
+
+    module('when close button is clicked', function () {
+      test('it should call onClose function passed in argument', async function (assert) {
+        // given
+        this.title = 'Close me baby one more time';
+        this.showSidebar = true;
+        this.onClose = sinon.stub();
+
+        // when
+        await render(hbs`
+          <PixSidebar
+            @title={{this.title}}
+            @onClose={{this.onClose}}
+            @showSidebar={{this.showSidebar}}
+          >
+            content
+          </PixSidebar>
+        `);
+        await click('[aria-label="Fermer"]');
+
+        // then
+        assert.ok(this.onClose.calledOnce);
+      });
+    });
+
+    module('when escape button is clicked', function () {
+      test('it should call onClose function passed in argument', async function (assert) {
+        // given
+        this.title = 'Close me baby one more time';
+        this.showSidebar = true;
+        this.onClose = sinon.stub();
+
+        // when
+        await render(hbs`
+          <PixSidebar
+            @title={{this.title}}
+            @onClose={{this.onClose}}
+            @showSidebar={{this.showSidebar}}
+          >
+            content
+          </PixSidebar>
+        `);
+        await triggerKeyEvent('.pix-sidebar__overlay', 'keyup', 'Escape');
+
+        // then
+        assert.ok(this.onClose.calledOnce);
+      });
+    });
+  });
+
+  module('when showSidebar is false', function () {
+    test('it should not show sidebar', async function (assert) {
+      // given
+      this.title = "It's a sidebar!";
+      this.showSidebar = false;
+
+      // when
+      await render(hbs`
+        <PixSidebar @title={{this.title}} @showSidebar={{this.showSidebar}}>
+          <:content>
+            content
+          </:content>
+          <:footer>
+            footer
+          </:footer>
+        </PixSidebar>
+      `);
+
+      // then
+      assert.dom('.pix-sidebar').doesNotExist();
+    });
+  });
+
+  test('it should throw an error if require @title argument is missing', async function (assert) {
+    // given
+    const componentParams = {};
+
+    // when
+    const renderComponent = function () {
+      createGlimmerComponent('component:pix-sidebar', componentParams);
+    };
+
+    // then
+    const expectedError = new Error('ERROR in PixSidebar component: @title argument is required.');
+    assert.throws(renderComponent, expectedError);
+  });
+});

--- a/tests/integration/components/pix-sidebar-test.js
+++ b/tests/integration/components/pix-sidebar-test.js
@@ -30,6 +30,8 @@ module('Integration | Component | Sidebar', function (hooks) {
       assert.contains("It's a sidebar!");
       assert.contains('content');
       assert.contains('footer');
+      assert.dom('.pix-sidebar--hidden').doesNotExist();
+      assert.dom('.pix-sidebar__overlay--hidden').doesNotExist();
     });
 
     module('when close button is clicked', function () {
@@ -100,7 +102,8 @@ module('Integration | Component | Sidebar', function (hooks) {
       `);
 
       // then
-      assert.dom('.pix-sidebar').doesNotExist();
+      assert.dom('.pix-sidebar--hidden').exists();
+      assert.dom('.pix-sidebar__overlay--hidden').exists();
     });
   });
 


### PR DESCRIPTION
## :christmas_tree: Problème
Actuellement, nos apps n'ont pas de composant Sidebar. 

## :gift: Solution
Ajouter un composant Sidebar, sa visibilité est géré grâce à un booléen passé en paramètre `showSidebar`. 
Une fonction `onClose` peut-être fourni pour par exemple modifier l'état du booléen.
 
La Sidebar apparait sur le côté gauche de l'écran avec une transition qui a été faite en utilisant la librairie [`ember-css-transitions`](https://github.com/miguelcobain/ember-css-transitions) qui reproduit les transitions qu'on peut trouver dans Vue.js. 

Nous avons ajouté le modifier `trap-focus`, pour que le focus se fasse uniquement avec les élements de la sidebar. 

## :star2: Remarques
Uniquement la transition d'affichage est observable sur storybook. 

## :santa: Pour tester
- Uniquement la transition d'affichage est observable sur storybook. 
