### PR TITLE
[BUGFIX] Mettre le focus sur le premier élement où est utiliser le `trap-focus`.

### DIFF
--- a/addon/components/pix-modal.hbs
+++ b/addon/components/pix-modal.hbs
@@ -1,7 +1,7 @@
 <div
-  class="pix-modal__overlay"
+  class="pix-modal__overlay {{unless @showModal ' pix-modal__overlay--hidden'}}"
   {{on "click" this.closeAction}}
-  {{trap-focus true}}
+  {{trap-focus @showModal}}
   {{on-escape-action this.closeAction}}
 >
   <div

--- a/addon/components/pix-modal.hbs
+++ b/addon/components/pix-modal.hbs
@@ -1,7 +1,7 @@
 <div
   class="pix-modal__overlay"
   {{on "click" this.closeAction}}
-  {{trap-focus}}
+  {{trap-focus true}}
   {{on-escape-action this.closeAction}}
 >
   <div

--- a/addon/components/pix-sidebar.hbs
+++ b/addon/components/pix-sidebar.hbs
@@ -1,7 +1,7 @@
 <div
   class="pix-sidebar__overlay {{unless @showSidebar ' pix-sidebar__overlay--hidden'}}"
   {{on "click" this.closeAction}}
-  {{trap-focus}}
+  {{trap-focus @showSidebar}}
   {{on-escape-action this.closeAction}}
 >
   <div

--- a/addon/styles/_pix-modal.scss
+++ b/addon/styles/_pix-modal.scss
@@ -7,6 +7,12 @@
   right: 0;
   top: 0;
   z-index: 1000;
+  transition: all .3s ease-in-out;
+
+  &--hidden {
+    visibility: hidden;
+    opacity: 0;
+  }
 }
 
 $modal-padding: 24px;

--- a/app/modifiers/trap-focus.js
+++ b/app/modifiers/trap-focus.js
@@ -34,8 +34,6 @@ function findFocusableElements(element) {
 function focusElement(elementToFocus, element) {
   let focusOnce = false;
 
-  const hasTransition = hasTransitionDuration(element) || hasAnimationDuration(element);
-
   const handleTransitionEnd = () => {
     if (!focusOnce) {
       elementToFocus.focus();
@@ -43,14 +41,20 @@ function focusElement(elementToFocus, element) {
     }
   };
 
-  if (hasTransition) {
+  if (hasTransitionDuration(element)) {
     element.addEventListener('transitionend', handleTransitionEnd);
+  } else if (hasAnimationDuration(element)) {
+    element.addEventListener('animationend', handleTransitionEnd);
   } else {
     elementToFocus.focus();
   }
 
   return () => {
-    element.removeEventListener('transitionend', handleTransitionEnd);
+    if (hasTransitionDuration(element)) {
+      element.removeEventListener('transitionend', handleTransitionEnd);
+    } else if (hasAnimationDuration(element)) {
+      element.removeEventListener('animationend', handleTransitionEnd);
+    }
   };
 }
 

--- a/app/stories/pix-modal.stories.js
+++ b/app/stories/pix-modal.stories.js
@@ -3,26 +3,23 @@ import { hbs } from 'ember-cli-htmlbars';
 export const Template = (args) => {
   return {
     template: hbs`
-    {{#if showModal}}
-      <PixModal @title={{this.title}} @onCloseButtonClick={{fn (mut showModal) (not showModal)}} >
-        <:content>
-          <p>
-            Une fenêtre modale est, dans une interface graphique, une fenêtre qui prend le contrôle total du clavier et
-            de l'écran. Elle est en général associée à une question à laquelle il est impératif que l'utilisateur
-            réponde avant de poursuivre, ou de modifier quoi que ce soit. La fenêtre modale a pour propos : d'obtenir
-            des informations de l'utilisateur (ces informations sont nécessaires pour réaliser une opération) ; de
-            fournir une information à l'utilisateur (ce dernier doit en prendre connaissance avant de pouvoir continuer
-            à utiliser l'application).
-          </p>
-        </:content>
-        <:footer>
-          <PixButton @backgroundColor="transparent-light" @isBorderVisible="true" @triggerAction>Annuler</PixButton>
-          <PixButton @triggerAction>Valider</PixButton>
-        </:footer>
-      </PixModal>
-      {{/if }}
-       <PixButton @triggerAction={{fn (mut showModal) (not showModal)}}>Ouvrir la modale</PixButton>
-
+    <PixModal @showModal={{showModal}} @title={{this.title}} @onCloseButtonClick={{fn (mut showModal) (not showModal)}} >
+      <:content>
+        <p>
+          Une fenêtre modale est, dans une interface graphique, une fenêtre qui prend le contrôle total du clavier et
+          de l'écran. Elle est en général associée à une question à laquelle il est impératif que l'utilisateur
+          réponde avant de poursuivre, ou de modifier quoi que ce soit. La fenêtre modale a pour propos : d'obtenir
+          des informations de l'utilisateur (ces informations sont nécessaires pour réaliser une opération) ; de
+          fournir une information à l'utilisateur (ce dernier doit en prendre connaissance avant de pouvoir continuer
+          à utiliser l'application).
+        </p>
+      </:content>
+      <:footer>
+        <PixButton @backgroundColor="transparent-light" @isBorderVisible="true" @triggerAction={{fn (mut showModal) (not showModal)}}>Annuler</PixButton>
+        <PixButton @triggerAction={{fn (mut showModal) (not showModal)}}>Valider</PixButton>
+      </:footer>
+    </PixModal>
+    <PixButton @triggerAction={{fn (mut showModal) (not showModal)}}>Ouvrir la modale</PixButton>
     `,
     context: args,
   };
@@ -47,5 +44,15 @@ export const argTypes = {
     description: 'Fonction à exécuter à la fermeture de la modale',
     type: { name: 'function', required: true },
     defaultValue: null,
+  },
+  showModal: {
+    name: 'showModal',
+    description: "Gérer l'ouverture de la modale",
+    type: { name: 'boolean', required: false },
+    control: { type: 'boolean' },
+    table: {
+      type: { summary: 'boolean' },
+      defaultValue: { summary: false },
+    },
   },
 };

--- a/app/stories/pix-modal.stories.js
+++ b/app/stories/pix-modal.stories.js
@@ -3,7 +3,8 @@ import { hbs } from 'ember-cli-htmlbars';
 export const Template = (args) => {
   return {
     template: hbs`
-      <PixModal @title={{this.title}} @onCloseButtonClick={{onCloseButtonClick}}>
+    {{#if showModal}}
+      <PixModal @title={{this.title}} @onCloseButtonClick={{fn (mut showModal) (not showModal)}} >
         <:content>
           <p>
             Une fenêtre modale est, dans une interface graphique, une fenêtre qui prend le contrôle total du clavier et
@@ -15,10 +16,13 @@ export const Template = (args) => {
           </p>
         </:content>
         <:footer>
-          <PixButton @backgroundColor="transparent-light" @isBorderVisible="true">Annuler</PixButton>
-          <PixButton>Valider</PixButton>
+          <PixButton @backgroundColor="transparent-light" @isBorderVisible="true" @triggerAction>Annuler</PixButton>
+          <PixButton @triggerAction>Valider</PixButton>
         </:footer>
       </PixModal>
+      {{/if }}
+       <PixButton @triggerAction={{fn (mut showModal) (not showModal)}}>Ouvrir la modale</PixButton>
+
     `,
     context: args,
   };
@@ -26,10 +30,9 @@ export const Template = (args) => {
 
 export const Default = Template.bind({});
 Default.args = {
+  showModal: true,
   title: "Qu'est-ce qu'une modale ?",
-  onCloseButtonClick: () => {
-    alert('Action : fermer modale');
-  },
+  onCloseButtonClick: () => {},
 };
 
 export const argTypes = {

--- a/app/stories/pix-modal.stories.mdx
+++ b/app/stories/pix-modal.stories.mdx
@@ -57,4 +57,4 @@ Ce composant possède deux `yield` :
 
 ## Arguments
 
-<ArgsTable story="PixModal" />
+<ArgsTable story="Default" />

--- a/app/stories/pix-sidebar.stories.js
+++ b/app/stories/pix-sidebar.stories.js
@@ -3,7 +3,6 @@ import { hbs } from 'ember-cli-htmlbars';
 export const Template = (args) => {
   return {
     template: hbs`
-      <PixButton @triggerAction={{fn (mut showSidebar) (not showSidebar)}}>Ouvrir la sidebar</PixButton>
       <PixSidebar @showSidebar={{showSidebar}} @title={{title}} @onClose={{fn (mut showSidebar) (not showSidebar)}}>
         <:content>
           <p>
@@ -18,6 +17,7 @@ export const Template = (args) => {
           </div>
         </:footer>
       </PixSidebar>
+      <PixButton @triggerAction={{fn (mut showSidebar) (not showSidebar)}}>Ouvrir la sidebar</PixButton>
     `,
     context: args,
   };

--- a/tests/integration/components/pix-modal-test.js
+++ b/tests/integration/components/pix-modal-test.js
@@ -1,6 +1,6 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import { render, click } from '@ember/test-helpers';
+import { render, click, triggerKeyEvent } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import sinon from 'sinon';
 import createGlimmerComponent from '../../helpers/create-glimmer-component';
@@ -8,26 +8,101 @@ import createGlimmerComponent from '../../helpers/create-glimmer-component';
 module('Integration | Component | modal', function (hooks) {
   setupRenderingTest(hooks);
 
-  test('it renders the default PixModal', async function (assert) {
-    // given
-    this.title = "It's a bird! It's a plane! It's a modal!";
+  module('when showModal is equal true', function () {
+    test('it renders the default PixModal', async function (assert) {
+      // given
+      this.title = "It's a modal!";
+      this.showModal = true;
 
-    // when
-    await render(hbs`
-      <PixModal @title={{this.title}}>
-        <:content>
-          content
-        </:content>
-        <:footer>
-          footer
-        </:footer>
-      </PixModal>
-    `);
+      // when
+      await render(hbs`
+        <PixModal @title={{this.title}} @showModal={{this.showModal}}>
+          <:content>
+            content
+          </:content>
+          <:footer>
+            footer
+          </:footer>
+        </PixModal>
+      `);
 
-    // then
-    assert.contains("It's a bird! It's a plane! It's a modal!");
-    assert.contains('content');
-    assert.contains('footer');
+      // then
+      assert.contains("It's a modal!");
+      assert.contains('content');
+      assert.contains('footer');
+      assert.dom('.pix-modal__overlay--hidden').doesNotExist();
+    });
+
+    module('when close button is clicked', function () {
+      test('it should call onClose function passed in argument', async function (assert) {
+        // given
+        this.title = 'Close me baby one more time';
+        this.showModal = true;
+        this.onCloseButtonClick = sinon.stub();
+
+        // when
+        await render(hbs`
+          <PixModal
+            @title={{this.title}}
+            @onCloseButtonClick={{this.onCloseButtonClick}}
+            @showModal={{this.showModal}}
+          >
+            content
+          </PixModal>
+        `);
+        await click('[aria-label="Fermer"]');
+
+        // then
+        assert.ok(this.onCloseButtonClick.calledOnce);
+      });
+    });
+
+    module('when escape button is clicked', function () {
+      test('it should call onClose function passed in argument', async function (assert) {
+        // given
+        this.title = 'Close me baby one more time';
+        this.showModal = true;
+        this.onCloseButtonClick = sinon.stub();
+
+        // when
+        await render(hbs`
+          <PixModal
+            @title={{this.title}}
+            @onCloseButtonClick={{this.onCloseButtonClick}}
+            @showModal={{this.showModal}}
+          >
+            content
+          </PixModal>
+        `);
+        await triggerKeyEvent('.pix-modal__overlay', 'keyup', 'Escape');
+
+        // then
+        assert.ok(this.onCloseButtonClick.calledOnce);
+      });
+    });
+  });
+
+  module('when showModal is false', function () {
+    test('it should not show modal', async function (assert) {
+      // given
+      this.title = "It's a modal!";
+      this.showModal = false;
+
+      // when
+      await render(hbs`
+        <PixModal @title={{this.title}} @showModal={{this.showModal}}>
+          <:content>
+            content
+          </:content>
+          <:footer>
+            footer
+          </:footer>
+        </PixModal>
+      `);
+
+      // then
+      assert.dom('.pix-modal__overlay--hidden').exists();
+    });
   });
 
   test('it should throw an error if require @title argument is missing', async function (assert) {
@@ -42,27 +117,5 @@ module('Integration | Component | modal', function (hooks) {
     // then
     const expectedError = new Error('ERROR in PixModal component: @title argument is required.');
     assert.throws(renderComponent, expectedError);
-  });
-
-  module('when close button is clicked', function () {
-    test('it closes the modal', async function (assert) {
-      // given
-      this.title = 'Close me baby one more time';
-      this.onCloseButtonClick = sinon.stub();
-
-      // when
-      await render(hbs`
-        <PixModal
-          @title={{this.title}}
-          @onCloseButtonClick={{this.onCloseButtonClick}}
-        >
-          content
-        </PixModal>
-      `);
-      await click('[aria-label="Fermer"]');
-
-      // then
-      assert.ok(this.onCloseButtonClick.calledOnce);
-    });
   });
 });


### PR DESCRIPTION
## :boom: BREAKING_CHANGES
Le composant `PixModal` gère maintenant lui-même son état de visibilité. Pour le contrôler, il suffit d'utiliser la propriété `@showModal` qui est un booléen.

## :christmas_tree: Problème
Le fonctionnement du `trap-focus` ne fonctionnait pas comme souhaité et n'était pas uniforme entre les composants PixSidebar et PixModal

## :gift: Solution
Les composants contrôlent eux-même leur état de visibilité via une propriété. Ainsi, on peut définir des classes CSS spécifiques pour afficher ou non les éléments, avec des transitions.

## :star2: Remarques

## :santa: Pour tester
- Visualiser les composants PixSidebar et PixModal dans Storybook.
- Les fermer une première fois, puis les ouvrir à nouveau.
- Vérifier que le trap-focus fonctionne bien en utilisation la touche `tabulation` de multiple fois.
- Fermer à nouveau (possibilité de le faire avec la touche `Echap`), vérifier que le focus se place bien automatiquement sur le bouton d'ouverture.
