### PR TITLE
[BUGFIX] Prévenir des erreurs à la première ouverture de la sidebar/modal

### DIFF
--- a/app/modifiers/trap-focus.js
+++ b/app/modifiers/trap-focus.js
@@ -8,7 +8,7 @@ export default modifier(function trapFocus(element, [isOpen]) {
   if (isOpen) {
     sourceActiveElement = document.activeElement;
     focusElement(firstFocusableElement, element);
-  } else {
+  } else if (sourceActiveElement) {
     focusElement(sourceActiveElement, element);
   }
 


### PR DESCRIPTION
## :christmas_tree: Problème
Dans mon-pix, à l'ouverture de la sidebar, on avait en console cette erreur indésirable :
`Uncaught TypeError: Cannot read properties of null (reading 'focus') at HTMLDivElement.handleTransitionEnd (trap-focus.js:39:22) 54`

## :gift: Solution
Vérifier que l'élément source (celui qui permet d'ouvrir la sidebar ou la modal) existe bien.

## :santa: Pour tester
#### Solution 1
- Modifier la story de la Sidebar en initialisant l'arg `showSidebar` à `false`.
- Toggle la sidebar
- Vérifier qu'il n'y a pas d'erreur en console

#### Solution 2
- Dans mon-pix, faire un `npm install "git://github.com/1024pix/pix-ui#fix-focus-trap-3" --save-dev`
- Ouvrir le panneau des filtres dans `Mes tutos` ou tout autre sidebar / modal
- Vérifier qu'il n'y a pas d'erreur en console
