### PR TITLE
[BUGFIX] Permettre le controle des checkboxs

### DIFF
--- a/addon/components/pix-checkbox.hbs
+++ b/addon/components/pix-checkbox.hbs
@@ -9,6 +9,7 @@
     id={{this.id}}
     type="checkbox"
     class="pix-checkbox__input {{if @isIndeterminate ' pix-checkbox__input--indeterminate'}}"
+    checked={{@checked}}
     ...attributes
   />
 </div>

--- a/app/stories/pix-checkbox.stories.js
+++ b/app/stories/pix-checkbox.stories.js
@@ -9,6 +9,7 @@ export const Template = (args) => {
         @screenReaderOnly={{screenReaderOnly}}
         @isIndeterminate={{isIndeterminate}}
         @labelSize={{labelSize}}
+        @checked={{checked}}
       />
     `,
     context: args,
@@ -83,6 +84,15 @@ export const argTypes = {
     control: {
       type: 'select',
       options: ['small', 'default', 'large'],
+    },
+  },
+  checked: {
+    name: 'checked',
+    description: 'Permet de cocher la checkbox',
+    type: { name: 'boolean', required: false },
+    table: {
+      type: { summary: 'boolean' },
+      defaultValue: { summary: false },
     },
   },
 };

--- a/tests/integration/components/pix-checkbox-test.js
+++ b/tests/integration/components/pix-checkbox-test.js
@@ -61,4 +61,20 @@ module('Integration | Component | checkbox', function (hooks) {
     // then
     assert.dom(screen.getByLabelText('Accepter les cgu, voir ici')).exists();
   });
+
+  test('it should be possible to control state', async function (assert) {
+    // given
+    this.set('checked', false);
+    await render(
+      hbs`<PixCheckbox @id="checkboxId" @label="Recevoir la newsletter" @checked={{checked}} />`
+    );
+    const checkbox = this.element.querySelector(CHECKBOX_INPUT_SELECTOR);
+    assert.false(checkbox.checked);
+
+    // when
+    this.set('checked', true);
+
+    // then
+    assert.true(checkbox.checked);
+  });
 });


### PR DESCRIPTION
## :christmas_tree: Problème
Actuellement, les checkbox utilisaient dans `<PixCheckbox>` ne permettent pas leur contrôle. En effet, pour contrôler une checkbox, il faut pouvoir utiliser l'attribut `checked` cependant cet attribut n'est pas dynamique lorsqu'il n'est pas défini. 

## :gift: Solution
Ajouter l'attribut `@checked`

## :star2: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :santa: Pour tester
Modifier le Template du fichier `pix-checkbox.stories.js` comme suit :

```js
export const Template = (args) => {
  return {
    template: hbs`
      <PixCheckbox
        @id={{id}}
        @label={{label}}
        @screenReaderOnly={{screenReaderOnly}}
        @isIndeterminate={{isIndeterminate}}
        @labelSize={{labelSize}}
        @checked={{checked}}
      />
      <PixButton @triggerAction={{fn (mut checked) (not checked)}}>Cocher/Décocher</PixButton>
    `,
    context: args,
  };
};
```

Constater qu'en appuyant sur le bouton la checkbox est coché/décoché
