### PR TITLE
[BUGFIX] Évite de casser les tests d'acceptance des applis (PIX-5619)

### DIFF
--- a/addon/components/pix-modal.hbs
+++ b/addon/components/pix-modal.hbs
@@ -2,7 +2,7 @@
   class="pix-modal__overlay {{unless @showModal ' pix-modal__overlay--hidden'}}"
   {{on "click" this.closeAction}}
   {{trap-focus @showModal}}
-  {{on-escape-action this.closeAction}}
+  {{on-escape-action @onCloseButtonClick}}
 >
   <div
     class="pix-modal"

--- a/addon/components/pix-modal.hbs
+++ b/addon/components/pix-modal.hbs
@@ -10,14 +10,13 @@
     aria-labelledby="modal-title"
     aria-describedby="modal-content"
     aria-modal="true"
-    {{on "click" this.stopPropagation}}
     ...attributes
   >
     <header class="pix-modal__header">
       <h1 id="modal-title" class="pix-modal__title">{{@title}}</h1>
       <PixIconButton
         @icon="xmark"
-        @triggerAction={{this.closeAction}}
+        @triggerAction={{@onCloseButtonClick}}
         @ariaLabel="Fermer"
         @size="small"
         @withBackground={{true}}

--- a/addon/components/pix-modal.js
+++ b/addon/components/pix-modal.js
@@ -11,14 +11,13 @@ export default class PixModal extends Component {
   }
 
   @action
-  stopPropagation(event) {
-    event.stopPropagation();
+  closeAction(event) {
+    if (this.args.onCloseButtonClick && this.isClickOnOverlay(event)) {
+      this.args.onCloseButtonClick(event);
+    }
   }
 
-  @action
-  closeAction(params) {
-    if (this.args.onCloseButtonClick) {
-      this.args.onCloseButtonClick(params);
-    }
+  isClickOnOverlay(event) {
+    return event.target.classList.contains('pix-modal__overlay');
   }
 }

--- a/addon/components/pix-sidebar.hbs
+++ b/addon/components/pix-sidebar.hbs
@@ -2,7 +2,7 @@
   class="pix-sidebar__overlay {{unless @showSidebar ' pix-sidebar__overlay--hidden'}}"
   {{on "click" this.closeAction}}
   {{trap-focus @showSidebar}}
-  {{on-escape-action this.closeAction}}
+  {{on-escape-action @onClose}}
 >
   <div
     class="pix-sidebar {{unless @showSidebar ' pix-sidebar--hidden'}}"

--- a/addon/components/pix-sidebar.hbs
+++ b/addon/components/pix-sidebar.hbs
@@ -10,14 +10,13 @@
     aria-labelledby="sidebar-title"
     aria-describedby="sidebar-content"
     aria-modal="true"
-    {{on "click" this.stopPropagation}}
     ...attributes
   >
     <header class="pix-sidebar__header">
       <h1 id="sidebar-title" class="pix-sidebar__title">{{@title}}</h1>
       <PixIconButton
         @icon="xmark"
-        @triggerAction={{this.closeAction}}
+        @triggerAction={{@onClose}}
         @ariaLabel="Fermer"
         @size="small"
         @withBackground={{true}}

--- a/addon/components/pix-sidebar.js
+++ b/addon/components/pix-sidebar.js
@@ -11,14 +11,13 @@ export default class PixSidebar extends Component {
   }
 
   @action
-  stopPropagation(event) {
-    event.stopPropagation();
+  closeAction(event) {
+    if (this.args.onClose && this.isClickOnOverlay(event)) {
+      this.args.onClose(event);
+    }
   }
 
-  @action
-  closeAction(params) {
-    if (this.args.onClose) {
-      this.args.onClose(params);
-    }
+  isClickOnOverlay(event) {
+    return event.target.classList.contains('pix-sidebar__overlay');
   }
 }

--- a/app/stories/pix-sidebar.stories.js
+++ b/app/stories/pix-sidebar.stories.js
@@ -12,8 +12,8 @@ export const Template = (args) => {
         </:content>
         <:footer>
         <div style="display: flex; gap: 8px">
-          <PixButton @backgroundColor="transparent-light" @isBorderVisible="true">Annuler</PixButton>
-          <PixButton>Valider</PixButton>
+          <PixButton @backgroundColor="transparent-light" @isBorderVisible="true" @triggerAction={{fn (mut showSidebar) (not showSidebar)}}>Annuler</PixButton>
+          <PixButton @triggerAction={{fn (mut showSidebar) (not showSidebar)}}>Valider</PixButton>
           </div>
         </:footer>
       </PixSidebar>

--- a/tests/acceptance/pix-modal-page-test.js
+++ b/tests/acceptance/pix-modal-page-test.js
@@ -1,0 +1,22 @@
+import { currentURL, click } from '@ember/test-helpers';
+import { visit } from '@1024pix/ember-testing-library';
+import { setupApplicationTest } from 'ember-qunit';
+import { module, test } from 'qunit';
+import { waitForDialog } from '../helpers/wait-for';
+
+module('Acceptance | PixModalPageTest', function (hooks) {
+  setupApplicationTest(hooks);
+
+  test('Should open the modal', async function (assert) {
+    // given
+    const screen = await visit('/modal');
+    await click(screen.getByRole('button', { name: 'Ouvrir la modale' }));
+    await waitForDialog();
+
+    // when
+    await click(screen.getByRole('link', { name: 'My link' }));
+
+    // then
+    assert.strictEqual(currentURL(), '/hello-world');
+  });
+});

--- a/tests/acceptance/pix-sidebar-page-test.js
+++ b/tests/acceptance/pix-sidebar-page-test.js
@@ -4,13 +4,13 @@ import { setupApplicationTest } from 'ember-qunit';
 import { module, test } from 'qunit';
 import { waitForDialog } from '../helpers/wait-for';
 
-module('Acceptance | PixModalPageTest', function (hooks) {
+module('Acceptance | PixSidebarPageTest', function (hooks) {
   setupApplicationTest(hooks);
 
   test('Should redirect to link', async function (assert) {
     // given
-    const screen = await visit('/modal');
-    await click(screen.getByRole('button', { name: 'Ouvrir la modale' }));
+    const screen = await visit('/sidebar');
+    await click(screen.getByRole('button', { name: 'Ouvrir la sidebar' }));
     await waitForDialog();
 
     // when

--- a/tests/dummy/app/controllers/modal-page.js
+++ b/tests/dummy/app/controllers/modal-page.js
@@ -1,0 +1,11 @@
+import Controller from '@ember/controller';
+import { tracked } from '@glimmer/tracking';
+import { action } from '@ember/object';
+
+export default class ModalPage extends Controller {
+  @tracked showModal = false;
+  title = "Qu'est-ce qu'une modale ?";
+
+  @action
+  onCloseButtonClick() {}
+}

--- a/tests/dummy/app/controllers/sidebar-page.js
+++ b/tests/dummy/app/controllers/sidebar-page.js
@@ -1,0 +1,11 @@
+import Controller from '@ember/controller';
+import { tracked } from '@glimmer/tracking';
+import { action } from '@ember/object';
+
+export default class SidebarPage extends Controller {
+  @tracked showModal = false;
+  title = "Qu'est-ce qu'une sidebar ?";
+
+  @action
+  onClose() {}
+}

--- a/tests/dummy/app/router.js
+++ b/tests/dummy/app/router.js
@@ -10,4 +10,5 @@ Router.map(function () {
   this.route('hello', { path: '/hello-world' });
   this.route('bye', { path: '/bye/:id' });
   this.route('modal-page', { path: '/modal' });
+  this.route('sidebar-page', { path: '/sidebar' });
 });

--- a/tests/dummy/app/router.js
+++ b/tests/dummy/app/router.js
@@ -9,4 +9,5 @@ export default class Router extends EmberRouter {
 Router.map(function () {
   this.route('hello', { path: '/hello-world' });
   this.route('bye', { path: '/bye/:id' });
+  this.route('modal-page', { path: '/modal' });
 });

--- a/tests/dummy/app/templates/modal-page.hbs
+++ b/tests/dummy/app/templates/modal-page.hbs
@@ -1,0 +1,19 @@
+<PixModal
+  @showModal={{this.showModal}}
+  @title={{this.title}}
+  @onCloseButtonClick={{fn (mut this.showModal) (not this.showModal)}}
+>
+  <:content>
+    <LinkTo @route="hello" class="internal-link">My link</LinkTo>
+  </:content>
+  <:footer>
+    <PixButton
+      @backgroundColor="transparent-light"
+      @isBorderVisible="true"
+      @triggerAction={{fn (mut this.showModal) (not this.showModal)}}
+    >Annuler</PixButton>
+    <PixButton @triggerAction={{fn (mut this.showModal) (not this.showModal)}}>Valider</PixButton>
+  </:footer>
+</PixModal>
+
+<PixButton @triggerAction={{fn (mut this.showModal) (not this.showModal)}}>Ouvrir la modale</PixButton>

--- a/tests/dummy/app/templates/sidebar-page.hbs
+++ b/tests/dummy/app/templates/sidebar-page.hbs
@@ -1,0 +1,23 @@
+<PixSidebar
+  @showSidebar={{this.showSidebar}}
+  @title={{this.title}}
+  @onClose={{fn (mut this.showSidebar) (not this.showSidebar)}}
+>
+  <:content>
+    <LinkTo @route="hello" class="internal-link">My link</LinkTo>
+  </:content>
+  <:footer>
+    <PixButton
+      @backgroundColor="transparent-light"
+      @isBorderVisible="true"
+      @triggerAction={{fn (mut this.showSidebar) (not this.showSidebar)}}
+    >
+      Annuler
+    </PixButton>
+    <PixButton
+      @triggerAction={{fn (mut this.showSidebar) (not this.showSidebar)}}
+    >Valider</PixButton>
+  </:footer>
+</PixSidebar>
+
+<PixButton @triggerAction={{fn (mut this.showSidebar) (not this.showSidebar)}}>Ouvrir la sidebar</PixButton>

--- a/tests/helpers/wait-for.js
+++ b/tests/helpers/wait-for.js
@@ -1,0 +1,15 @@
+import { getScreen } from '@1024pix/ember-testing-library';
+import { waitUntil } from '@ember/test-helpers';
+
+export async function waitForDialog() {
+  const screen = await getScreen();
+
+  await waitUntil(() => {
+    try {
+      screen.getByRole('dialog');
+      return true;
+    } catch {
+      return false;
+    }
+  });
+}


### PR DESCRIPTION
## :christmas_tree: Problème
Lors de la montée de version de Pix UI dans App, on s'est rendu compte d'une erreur aux tests d'acceptance en v17.1.0. Dans le cas où notre `PixModal` contient un lien vers une autre page, le `event.stopPropagation` fait que notre test change réellement la page courante donc les tests s'arrêtent là.

Dans une version ultérieure (A PRECISER), les tests d'acceptance utilisant une `PixModal` ne fonctionnent plus à cause de la transition CSS qu'elle apporte. Nous avons besoin d'ajouter un helper pour attendre la fin de cette animation pour utiliser les boutons qui s'y trouvent après son ouverture.

## :gift: Solution
Ne plus utiliser le `event.stopPropagation` en vérifiant là où l'utilisateur clique pour fermer la `PixModal`.

On en profiter pour ajouter des tests pour couvrir tout ce qu'on ne couvrait pas.

(Tout ça est aussi retranscrit pour la `PixSidebar`).

## :star2: Remarques
Aucune

## :santa: Pour tester
Vérifier que le fonctionnel de la `PixModal` et la `PixSidebar` sont ISO à la prod ui.pix.fr.

Vérifier en intégrant cette branche que la `PixModal` dans le test `fill-in-campaign-code` fonctionne de nouveau après avoir ajouté le helper `waitForDialog`.
