### PR TITLE
[FEATURE] Rendre accessible (a11y) le composant PixMultiSelect (PIX-5555)

### DIFF
--- a/addon/components/pix-checkbox.hbs
+++ b/addon/components/pix-checkbox.hbs
@@ -1,4 +1,11 @@
 <div class="pix-checkbox">
+  <input
+    id={{@id}}
+    type="checkbox"
+    class="pix-checkbox__input {{if @isIndeterminate ' pix-checkbox__input--indeterminate'}}"
+    checked={{@checked}}
+    ...attributes
+  />
   <label
     class="pix-checkbox__label {{this.labelSizeClass}} {{if @screenReaderOnly 'sr-only'}}"
     for={{@id}}
@@ -10,11 +17,4 @@
       {{@id}}.
     {{/if}}
   </label>
-  <input
-    id={{@id}}
-    type="checkbox"
-    class="pix-checkbox__input {{if @isIndeterminate ' pix-checkbox__input--indeterminate'}}"
-    checked={{@checked}}
-    ...attributes
-  />
 </div>

--- a/addon/components/pix-checkbox.hbs
+++ b/addon/components/pix-checkbox.hbs
@@ -1,12 +1,17 @@
 <div class="pix-checkbox">
   <label
     class="pix-checkbox__label {{this.labelSizeClass}} {{if @screenReaderOnly 'sr-only'}}"
-    for={{this.id}}
+    for={{@id}}
   >
-    {{this.label}}
+    {{#if (has-block)}}
+      {{yield}}
+    {{else}}
+      yield required to give a label for PixCheckBox
+      {{@id}}.
+    {{/if}}
   </label>
   <input
-    id={{this.id}}
+    id={{@id}}
     type="checkbox"
     class="pix-checkbox__input {{if @isIndeterminate ' pix-checkbox__input--indeterminate'}}"
     checked={{@checked}}

--- a/addon/components/pix-checkbox.js
+++ b/addon/components/pix-checkbox.js
@@ -1,5 +1,4 @@
 import Component from '@glimmer/component';
-import { htmlSafe } from '@ember/string';
 
 const labelSizeToClass = new Map([
   ['small', 'pix-checkbox__label--small'],
@@ -11,17 +10,9 @@ export default class PixCheckbox extends Component {
   constructor() {
     super(...arguments);
 
-    if (!this.args.label) {
-      throw new Error('ERROR in PixCheckbox component, you must provide @label params');
-    }
-    this.label = htmlSafe(this.args.label);
-  }
-
-  get id() {
     if (!this.args.id || !this.args.id.toString().trim()) {
       throw new Error('ERROR in PixCheckbox component, @id param is not provided');
     }
-    return this.args.id;
   }
 
   get labelSizeClass() {

--- a/addon/components/pix-multi-select.hbs
+++ b/addon/components/pix-multi-select.hbs
@@ -1,35 +1,51 @@
-<div class="pix-multi-select" ...attributes {{on-click-outside this.hideDropDown capture=true}}>
-
-  {{#if this.label}}
-    <label for={{@id}} class="pix-multi-select__label">{{this.label}}</label>
-  {{/if}}
+<div
+  class="pix-multi-select"
+  {{on-click-outside this.hideDropDown}}
+  {{on-arrow-down-up-action this.listId this.showDropDown this.isExpanded}}
+  {{on-escape-action this.hideDropDown @id}}
+>
 
   {{#if @isSearchable}}
-    <label class="pix-multi-select-header {{if this.isBig 'pix-multi-select-header--big'}}">
-
-      <span class="pix-multi-select-header__title">{{@title}}</span>
+    <label
+      for={{@id}}
+      class="pix-multi-select__label{{if @screenReaderOnly ' screen-reader-only'}}"
+    >{{@label}}</label>
+    <span class="pix-multi-select-header">
       <FaIcon @icon="magnifying-glass" class="pix-multi-select-header__search-icon" />
 
       <input
+        class="pix-multi-select-header__search-input"
         id={{@id}}
         type="text"
         name={{@id}}
-        placeholder={{this.placeholder}}
+        placeholder={{this.innerText}}
         autocomplete="off"
         {{on "input" this.updateSearch}}
-        {{on "focus" this.focusDropdown}}
-        class="pix-multi-select-header__search-input"
+        {{on "click" this.toggleDropDown}}
+        aria-expanded={{this.isAriaExpanded}}
+        aria-controls={{this.listId}}
+        aria-haspopup="menu"
+        ...attributes
       />
-
-    </label>
+    </span>
   {{else}}
+    <span
+      id={{this.labelId}}
+      class="pix-multi-select__label{{if @screenReaderOnly ' screen-reader-only'}}"
+    >{{@label}}</span>
+
     <button
+      aria-labelledby={{this.labelId}}
       id={{@id}}
       type="button"
-      class="pix-multi-select-header {{if this.isBig 'pix-multi-select-header--big'}}"
+      aria-expanded={{this.isAriaExpanded}}
+      aria-controls={{this.listId}}
+      aria-haspopup="menu"
+      class="pix-multi-select-header"
       {{on "click" this.toggleDropDown}}
+      ...attributes
     >
-      {{@title}}
+      {{this.innerText}}
       <FaIcon
         class="pix-multi-select-header__dropdown-icon
           {{if this.isExpanded ' pix-multi-select-header__dropdown-icon--expand'}}"
@@ -38,23 +54,25 @@
     </button>
   {{/if}}
 
-  <ul class="pix-multi-select-list {{unless this.isExpanded 'pix-multi-select-list--hidden'}}">
+  <ul
+    class="pix-multi-select-list {{unless this.isExpanded 'pix-multi-select-list--hidden'}}"
+    id={{this.listId}}
+    aria-multiselectable="true"
+    role="menu"
+  >
     {{#if (gt this.results.length 0)}}
       {{#each this.results as |option|}}
-        <li class="pix-multi-select-list__item">
-          <input
-            class="pix-multi-select-list__checkbox
-              {{if @isSearchable ' pix-multi-select-list__checkbox--searchable'}}"
-            type="checkbox"
-            checked={{option.checked}}
-            id={{concat @id "-" option.value}}
-            name={{option.label}}
+        <li class="pix-multi-select-list__item" role="menuitem">
+          <PixCheckbox
+            @id={{concat @id "-" option.value}}
+            @checked={{option.checked}}
             value={{option.value}}
             {{on "change" this.onSelect}}
-          />
-          <label for={{concat @id "-" option.value}}>
+            {{on-enter-action this.hideDropDown @id}}
+            tabindex={{if this.isExpanded "0" "-1"}}
+          >
             {{yield option}}
-          </label>
+          </PixCheckbox>
         </li>
       {{/each}}
     {{else if this.isLoadingOptions}}

--- a/addon/components/pix-multi-select.js
+++ b/addon/components/pix-multi-select.js
@@ -26,35 +26,47 @@ export default class PixMultiSelect extends Component {
 
   constructor(...args) {
     super(...args);
-    const { onLoadOptions, selected } = this.args;
+    const { onLoadOptions, id, label, innerText } = this.args;
+
+    const idIsNotDefined = !id || !id.trim();
+    const labelIsNotDefined = !label || !label.trim();
+    const innerTextIsNotDefined = !innerText || !innerText.trim();
+
+    if (idIsNotDefined || labelIsNotDefined || innerTextIsNotDefined) {
+      const missingParams = [];
+
+      if (idIsNotDefined) missingParams.push('@id');
+      if (labelIsNotDefined) missingParams.push('@label');
+      if (innerTextIsNotDefined) missingParams.push('@innerText');
+
+      throw new Error(
+        `ERROR in PixMultiSelect component, ${missingParams.join(', ')} ${
+          missingParams.length > 1 ? 'params are' : 'param is'
+        } necessary`
+      );
+    }
 
     if (onLoadOptions) {
       this.isLoadingOptions = true;
       onLoadOptions().then((options = []) => {
         this.options = options;
-        this._setDisplayedOptions(selected, true);
         this.isLoadingOptions = false;
       });
     } else {
       this.options = [...(this.args.options || [])];
-      this._setDisplayedOptions(selected, true);
     }
   }
 
-  get label() {
-    const labelIsDefined = this.args.label && this.args.label.trim();
-    const idIsNotDefined = this.args.id && !this.args.id.trim();
-
-    if (labelIsDefined && idIsNotDefined) {
-      throw new Error(
-        'ERROR in PixMultiSelect component, @id param is necessary when giving @label'
-      );
-    }
-    return this.args.label || null;
+  get listId() {
+    return `list-${this.args.id}`;
   }
 
-  get isBig() {
-    return this.args.size === 'big';
+  get labelId() {
+    return `label-${this.args.id}`;
+  }
+
+  get isAriaExpanded() {
+    return this.isExpanded ? 'true' : 'false';
   }
 
   get results() {
@@ -64,8 +76,8 @@ export default class PixMultiSelect extends Component {
     return this.options;
   }
 
-  get placeholder() {
-    const { selected, placeholder } = this.args;
+  get innerText() {
+    const { selected, innerText } = this.args;
     if (selected?.length > 0) {
       const selectedOptionLabels = this.options
         .filter(({ value, label }) => {
@@ -76,7 +88,7 @@ export default class PixMultiSelect extends Component {
         .join(', ');
       return selectedOptionLabels;
     }
-    return placeholder;
+    return innerText;
   }
 
   _setDisplayedOptions(selected, shouldSort) {
@@ -108,8 +120,6 @@ export default class PixMultiSelect extends Component {
       selected = selected.filter((value) => value !== event.target.value);
     }
 
-    this._setDisplayedOptions(selected, false);
-
     if (this.args.onSelect) {
       this.args.onSelect(selected);
     }
@@ -140,13 +150,6 @@ export default class PixMultiSelect extends Component {
       event.preventDefault();
     }
     this.isExpanded = false;
-  }
-
-  @action
-  focusDropdown() {
-    if (this.args.isSearchable && this.args.showOptionsOnInput) {
-      this.showDropDown();
-    }
   }
 
   @action

--- a/addon/styles/_a11y.scss
+++ b/addon/styles/_a11y.scss
@@ -1,0 +1,10 @@
+.screen-reader-only {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    border: 0;
+}

--- a/addon/styles/_form.scss
+++ b/addon/styles/_form.scss
@@ -13,7 +13,7 @@
 }
 
 @mixin focusWithinFormElement() {
-  &:focus {
+  &:focus-within {
     border-color: $pix-primary;
     box-shadow: inset 0px 0px 0px 0.6px $pix-primary;
     outline: none;

--- a/addon/styles/_pix-checkbox.scss
+++ b/addon/styles/_pix-checkbox.scss
@@ -2,7 +2,6 @@
   @import 'reset-css';
   align-items: center;
   display: flex;
-  flex-direction: row-reverse;
 
   label, input {
     cursor: pointer;

--- a/addon/styles/_pix-checkbox.scss
+++ b/addon/styles/_pix-checkbox.scss
@@ -1,6 +1,5 @@
 .pix-checkbox {
   @import 'reset-css';
-  display: flex;
   align-items: center;
   display: flex;
   flex-direction: row-reverse;
@@ -31,9 +30,7 @@
     min-height: 18px;
     border: 1.2px solid $pix-neutral-90;
     border-radius: 2px;
-    display: flex;
-    justify-content: center;
-    align-items: center;
+    position: relative;
 
     &:hover, &:focus {
       box-shadow: inset 0 1px 3px rgba(0,0,0, .1), 0 0 0 6px $pix-neutral-15;
@@ -54,6 +51,9 @@
         background-position: center;
         width: 16px;
         height: 16px;
+        position: absolute;
+        top: 0;
+        left: 0;
 
       }
     }

--- a/addon/styles/_pix-multi-select.scss
+++ b/addon/styles/_pix-multi-select.scss
@@ -71,7 +71,7 @@
 
 .pix-multi-select-list {
   width: 100%;
-  margin: 0px;
+  margin: 0;
   z-index: 200;
   background-color: $pix-neutral-0;
   position: absolute;
@@ -82,9 +82,11 @@
   list-style-type: none;
   padding: 0;
   box-shadow: 0px 8px 24px 0px rgba(23, 43, 77, 0.1);
+  transition: all .1s ease-in-out;
 
   &--hidden {
-    display: none;
+    visibility: hidden;
+    opacity: 0;
   }
 
   &::-webkit-scrollbar {
@@ -109,9 +111,10 @@
     border-bottom: 1px solid $pix-neutral-15;
     list-style: none;
     font-size: 0.9rem;
+    padding: 8px;
 
     @include hoverFormElement();
-
+    
     &--no-result {
       text-align: center;
       padding: 12px 0;
@@ -119,60 +122,6 @@
 
     &:last-of-type {
       border-bottom: none;
-    }
-  }
-
-  &__checkbox {
-    position: absolute;
-    opacity: 0;
-
-    & + label {
-      position: relative;
-      display: flex;
-      align-items: center;
-      padding: 11px 16px;
-      cursor: pointer;
-    }
-
-    & + label:before {
-      content: '';
-      margin-right: 12px;
-      display: inline-block;
-      vertical-align: text-top;
-      min-width: 16px;
-      min-height: 16px;
-      border-radius: 4px;
-      background: $pix-neutral-0;
-      border: 1px solid $pix-neutral-20;
-    }
-
-    &:checked + label:before {
-      background: $pix-primary;
-      border-color: $pix-primary;
-    }
-
-    &:checked + label:after {
-      position: absolute;
-      top: calc(50% - 5px);
-      left: 21px;
-      width: 7px;
-      height: 5px;
-      background: transparent;
-      border: 2px solid $pix-neutral-0;
-      border-top: none;
-      border-right: none;
-      transform: rotate(-45deg);
-      content: '';
-    }
-
-    &--searchable {
-      & + label {
-        padding: 11px 36px;
-      }
-
-      &:checked + label:after {
-        left: 41px;
-      }
     }
   }
 }

--- a/addon/styles/_pix-stars.scss
+++ b/addon/styles/_pix-stars.scss
@@ -30,14 +30,3 @@
     fill: $pix-neutral-15;
   }
 }
-
-.sr-only {
-  position: absolute;
-  width: 1px;
-  height: 1px;
-  padding: 0;
-  margin: -1px;
-  overflow: hidden;
-  clip: rect(0, 0, 0, 0);
-  border: 0;
-}

--- a/addon/styles/_pix-stars.scss
+++ b/addon/styles/_pix-stars.scss
@@ -1,5 +1,6 @@
 .pix-stars {
   @import 'reset-css';
+  line-height: 0;
 
   > svg {
     width: 36px;

--- a/addon/styles/addon.scss
+++ b/addon/styles/addon.scss
@@ -1,4 +1,5 @@
 @import 'pix-design-tokens';
+@import 'a11y';
 @import 'pix-background-header';
 @import 'pix-banner';
 @import 'pix-block';

--- a/app/modifiers/on-arrow-down-up-action.js
+++ b/app/modifiers/on-arrow-down-up-action.js
@@ -1,0 +1,82 @@
+import { modifier } from 'ember-modifier';
+
+export default modifier((element, [elementId, callback, isExpanded]) => {
+  const elementToTarget = document.getElementById(elementId);
+
+  element.addEventListener('keydown', handleKeyDown);
+
+  return () => {
+    element.removeEventListener('keydown', handleKeyDown);
+  };
+
+  function handleKeyDown(event) {
+    const ARROW_UP_KEY = 'ArrowUp';
+    const ARROW_DOWN_KEY = 'ArrowDown';
+
+    if (![ARROW_UP_KEY, ARROW_DOWN_KEY].includes(event.key)) {
+      return;
+    }
+    event.preventDefault();
+
+    const focusElement = () => {
+      const focusableElements = findFocusableElements(elementToTarget);
+
+      const [firstFocusableElement] = focusableElements;
+      const lastFocusableElement = focusableElements[focusableElements.length - 1];
+
+      const activeIndexElement = focusableElements.findIndex((elementToTarget) => {
+        return document.activeElement === elementToTarget;
+      });
+
+      const handleArrowDown = () => {
+        if (
+          !isExpanded ||
+          document.activeElement === lastFocusableElement ||
+          activeIndexElement === -1
+        ) {
+          firstFocusableElement.focus();
+        } else {
+          focusableElements[activeIndexElement + 1].focus();
+        }
+      };
+
+      const handleArrowUp = () => {
+        if (
+          !isExpanded ||
+          document.activeElement === firstFocusableElement ||
+          activeIndexElement === -1
+        ) {
+          lastFocusableElement.focus();
+        } else {
+          focusableElements[activeIndexElement - 1].focus();
+        }
+      };
+
+      if (ARROW_UP_KEY === event.key) {
+        handleArrowUp();
+      } else if (ARROW_DOWN_KEY === event.key) {
+        handleArrowDown();
+      }
+    };
+
+    if (!isExpanded) {
+      elementToTarget.addEventListener('transitionend', focusElement);
+
+      callback();
+
+      return () => {
+        elementToTarget.removeEventListener('transitionend', focusElement);
+      };
+    } else {
+      focusElement(elementToTarget);
+    }
+  }
+});
+
+function findFocusableElements(element) {
+  return [
+    ...element.querySelectorAll(
+      'a[href], button, input, textarea, select, details,[tabindex]:not([tabindex="-1"])'
+    ),
+  ].filter((el) => !el.hasAttribute('disabled') && !el.getAttribute('aria-hidden'));
+}

--- a/app/modifiers/on-enter-action.js
+++ b/app/modifiers/on-enter-action.js
@@ -1,0 +1,28 @@
+import { modifier } from 'ember-modifier';
+
+export default modifier((element, [callback, focusId = null]) => {
+  function handleKeyUp(event) {
+    const ENTER_KEY = 'Enter';
+
+    if (event.key !== ENTER_KEY) {
+      return;
+    }
+
+    if (element.type === 'checkbox') {
+      element.checked = !element.checked;
+      element.dispatchEvent(new Event('change'));
+    }
+
+    if (focusId) {
+      document.getElementById(focusId).focus();
+    }
+
+    callback(event);
+  }
+
+  element.addEventListener('keydown', handleKeyUp);
+
+  return () => {
+    element.removeEventListener('keydown', handleKeyUp);
+  };
+});

--- a/app/modifiers/on-escape-action.js
+++ b/app/modifiers/on-escape-action.js
@@ -1,14 +1,18 @@
 import { modifier } from 'ember-modifier';
 
-export default modifier((element, [callback]) => {
+export default modifier((element, [callback, focusId = null]) => {
   function handleKeyUp(event) {
-    const TAB_KEY = 'Escape';
+    const ESCAPE_KEY = 'Escape';
 
-    if (event.key !== TAB_KEY) {
+    if (event.key !== ESCAPE_KEY) {
       return;
     }
 
     callback(event);
+
+    if (focusId) {
+      document.getElementById(focusId).focus();
+    }
   }
 
   element.addEventListener('keyup', handleKeyUp);

--- a/app/modifiers/trap-focus.js
+++ b/app/modifiers/trap-focus.js
@@ -81,12 +81,12 @@ function hasDurationByKey(element, key) {
 }
 
 function handleKeyDown(event, element) {
-  const TAB_KEY = 9;
+  const TAB_KEY = 'Tab';
   const focusableElements = findFocusableElements(element);
   const [firstFocusableElement] = focusableElements;
   const lastFocusableElement = focusableElements[focusableElements.length - 1];
 
-  if (event.keyCode !== TAB_KEY) {
+  if (event.key !== TAB_KEY) {
     return;
   }
 

--- a/app/stories/form.stories.js
+++ b/app/stories/form.stories.js
@@ -11,7 +11,7 @@ export const form = (args) => {
       <br>
 
       <PixMultiSelect
-        @title="Votre notation en étoiles..."
+        @innerText="Votre notation en étoiles..."
         @id="form__pix-mutli-select"
         @label="A quel point aimez vous Pix UI ?"
         @onSelect={{onSelect}}
@@ -19,6 +19,19 @@ export const form = (args) => {
         @options={{options}} as |star|
       >
         <PixStars @count={{star.value}} @total={{star.total}} />
+      </PixMultiSelect>
+      <br><br>
+
+      <PixMultiSelect
+        @innerText="Mes condiements"
+        @id="form__pix-mutli-select-searchable"
+        @label="Choississez vos condiments"
+        @onSelect={{onSelect}}
+        @selected={{selected}}
+        @isSearchable={{true}}
+        @options={{optionsSearch}} as |condiment|
+      >
+        {{condiment.label}}
       </PixMultiSelect>
       <br><br>
 
@@ -89,6 +102,13 @@ form.args = {
     { value: '1', total: 3 },
     { value: '2', total: 3 },
     { value: '3', total: 3 },
+  ],
+  optionsSearch: [
+    { value: 'Cornichon', label: 'Cornichon' },
+    { value: 'Ail', label: 'Ail' },
+    { value: 'Oignon', label: 'Oignon' },
+    { value: 'Aigre-Doux', label: 'Aigre-douc' },
+    { value: 'Soja sucré', label: 'Soja sucré' },
   ],
   cancel: action('cancel'),
   onSelect: action('onSelect'),

--- a/app/stories/pix-checkbox.stories.js
+++ b/app/stories/pix-checkbox.stories.js
@@ -5,12 +5,12 @@ export const Template = (args) => {
     template: hbs`
       <PixCheckbox
         @id={{id}}
-        @label={{label}}
         @screenReaderOnly={{screenReaderOnly}}
         @isIndeterminate={{isIndeterminate}}
         @labelSize={{labelSize}}
-        @checked={{checked}}
-      />
+        @checked={{checked}}>
+        {{label}}
+      </PixCheckbox>
     `,
     context: args,
   };
@@ -53,7 +53,6 @@ export const argTypes = {
   label: {
     name: 'label',
     description: "Le label de l'input",
-    type: { name: 'string', required: false },
     defaultValue: null,
   },
   screenReaderOnly: {

--- a/app/stories/pix-checkbox.stories.mdx
+++ b/app/stories/pix-checkbox.stories.mdx
@@ -38,11 +38,12 @@ La PixCheckbox permet de créer des checkbox basiques ou des checkbox mixées (c
 ```html
 <PixCheckbox
   @id="superId"
-  @label="Recevoir la newsletter"
   @screenReaderOnly={{false}}
   @isIndeterminate={{false}}
   @labelSize="small"
-/>
+>
+  Recevoir la newsletter
+</PixCheckBox>
 ```
 
 ## Arguments

--- a/app/stories/pix-multi-select.stories.js
+++ b/app/stories/pix-multi-select.stories.js
@@ -20,14 +20,18 @@ export const multiSelectWithChildComponent = (args) => {
     template: hbs`
       <h4>⚠️ La sélection des éléments ne fonctionne pas dans Storybook.</h4>
       <PixMultiSelect
-        @title={{titleStars}}
-        @id={{id}}
-        @onSelect={{onSelect}}
-        @emptyMessage={{emptyMessage}}
-        @label={{label}}
-        @options={{options}} as |star|
+        @id={{this.id}}
+        @label={{this.label}}
+        @innerText={{this.titleStars}}
+        @screenReaderOnly={{this.screenReaderOnly}}
+        
+        @onSelect={{this.onSelect}}
+        @emptyMessage={{this.emptyMessage}}
+        
+        @options={{this.options}} as |star|
       >
         <PixStars
+          @alt={{concat "Étoiles " star.value " sur " star.total}}
           @count={{star.value}}
           @total={{star.total}}
         />
@@ -39,7 +43,9 @@ export const multiSelectWithChildComponent = (args) => {
 
 multiSelectWithChildComponent.args = {
   titleStars: 'Sélectionner le niveau souhaité',
+  label: 'Résultat évaluation',
   options: [
+    { value: '0', total: 3 },
     { value: '1', total: 3 },
     { value: '2', total: 3 },
     { value: '3', total: 3 },
@@ -52,17 +58,19 @@ export const multiSelectSearchable = (args) => {
       <h4>⚠️ La sélection des éléments ne fonctionne pas dans Storybook.</h4>
       <PixMultiSelect
         style="width:350px"
-        @id={{id}}
-        @title={{title}}
-        @placeholder={{placeholder}}
-        @isSearchable={{isSearchable}}
-        @showOptionsOnInput={{showOptionsOnInput}}
-        @strictSearch={{strictSearch}}
-        @onSelect={{doSomething}}
-        @emptyMessage={{emptyMessage}}
-        @size={{size}}
-        @selected={{selected}}
-        @options={{options}} as |option|
+        @id={{this.id}}
+        @label={{this.label}}
+        @screenReaderOnly={{this.screenReaderOnly}}
+        @innerText={{this.innerText}}
+
+        @isSearchable={{this.isSearchable}}
+        @strictSearch={{this.strictSearch}}
+
+        @onSelect={{this.doSomething}}
+        @selected={{this.selected}}
+
+        @emptyMessage={{this.emptyMessage}}
+        @options={{this.options}} as |option|
       >
         {{option.label}}
       </PixMultiSelect>
@@ -78,17 +86,19 @@ export const multiSelectAsyncOptions = (args) => {
       <h4>⚠️ La sélection des éléments ne fonctionne pas dans Storybook.</h4>
       <PixMultiSelect
         style="width:350px"
-        @id={{id}}
-        @title={{title}}
-        @placeholder={{placeholder}}
-        @isSearchable={{isSearchable}}
-        @showOptionsOnInput={{showOptionsOnInput}}
-        @strictSearch={{strictSearch}}
-        @onSelect={{doSomething}}
-        @emptyMessage={{emptyMessage}}
-        @size={{size}}
-        @selected={{selected}}
-        @onLoadOptions={{onLoadOptions}} as |option|
+        @id={{this.id}}
+        @label={{this.label}}
+        @screenReaderOnly={{this.screenReaderOnly}}
+        @innerText={{this.innerText}}
+
+        @isSearchable={{this.isSearchable}}
+        @strictSearch={{this.strictSearch}}
+
+        @onSelect={{this.doSomething}}
+        @selected={{this.selected}}
+
+        @emptyMessage={{this.emptyMessage}}
+        @onLoadOptions={{this.onLoadOptions}} as |option|
       >
         {{option.label}}
       </PixMultiSelect>
@@ -104,20 +114,18 @@ export const argTypes = {
     type: { name: 'string', required: true },
     defaultValue: 'aromate',
   },
-  title: {
-    name: 'title',
-    description: 'Donne un titre à sa liste de choix multiple.',
+  innerText: {
+    name: 'innerText',
+    description:
+      'Donne un titre à sa liste de choix multiple, utilisé comme placeholder lorsque ``isSearchable`` à ``true``',
     type: { name: 'string', required: true },
     defaultValue: 'Rechercher un condiment',
   },
   label: {
     name: 'label',
-    description: 'Donne un label au champ, le paramètre @id devient obligatoire avec ce paramètre.',
-    type: { name: 'string', required: false },
-    table: {
-      type: { summary: 'string' },
-      defaultValue: { summary: null },
-    },
+    description: 'Donne un label au champ',
+    type: { name: 'string', required: true },
+    defaultValue: 'Label du champ',
   },
   emptyMessage: {
     name: 'emptyMessage',
@@ -132,13 +140,6 @@ export const argTypes = {
       "Message qui apparaît dans les options quand celles-ci sont en train d'être chargées via onLoadOptions",
     type: { name: 'string', required: false },
     defaultValue: 'Chargement...',
-  },
-  placeholder: {
-    name: 'placeholder',
-    description:
-      'Donner une liste d‘exemple pour la recherche utilisateur dans le cas ``isSearchable`` à ``true``',
-    type: { name: 'string', required: true },
-    defaultValue: 'Curcuma, Thym, ...',
   },
   options: {
     name: 'options',
@@ -165,13 +166,6 @@ export const argTypes = {
     type: { name: 'array', required: false },
     defaultValue: ['1', '4'],
   },
-  showOptionsOnInput: {
-    name: 'showOptionsOnInput',
-    description:
-      'Afficher la liste au focus du champs de saisie lorsque ``isSearchable`` à ``true``',
-    type: { name: 'boolean', required: false },
-    defaultValue: true,
-  },
   isSearchable: {
     name: 'isSearchable',
     description: 'Permet de rajouter une saisie utilisateur pour faciliter la recherche',
@@ -185,15 +179,10 @@ export const argTypes = {
     type: { name: 'boolean', required: false },
     defaultValue: false,
   },
-  size: {
-    name: 'size',
-    description:
-      '⚠️ **Propriété dépréciée** ⚠️ , désormais tous les éléments de formulaires feront 36px de hauteur.',
-    options: ['big', 'small'],
-    type: { name: 'string', required: false },
-    table: {
-      type: { summary: 'string' },
-      defaultValue: { summary: 'small' },
-    },
+  screenReaderOnly: {
+    name: 'screenReaderOnly',
+    description: "Permet de cacher à l'écran le label tout en restant vocalisable",
+    type: { name: 'boolean', required: false },
+    defaultValue: false,
   },
 };

--- a/app/stories/pix-multi-select.stories.mdx
+++ b/app/stories/pix-multi-select.stories.mdx
@@ -40,11 +40,14 @@ Il est possible de donner un message via `loadingMessage` à afficher à la plac
 
 ```html
 <PixMultiSelect
-  @title={{title}}
-  @emptyMessage={{emptyMessage}}
   @id={{id}}
+  @label={{label}}
+  @screenReaderOnly={{screenReaderOnly}}
+  @innerText={{innerText}}
+
   @onSelect={{doSomething}}
   @selected={{selected}}
+  @emptyMessage={{emptyMessage}}
   @options={{options}} as |option|>
   {{option.label}}
 </PixMultiSelect>

--- a/package-lock.json
+++ b/package-lock.json
@@ -39,6 +39,7 @@
         "@storybook/ember-cli-storybook": "^0.4.0",
         "@storybook/storybook-deployer": "^2.8.10",
         "@storybook/theming": "^6.3.7",
+        "@testing-library/user-event": "^14.4.3",
         "axios": "^0.21.1",
         "babel-eslint": "^10.1.0",
         "babel-plugin-ember-modules-api-polyfill": "^2.13.4",
@@ -7344,6 +7345,19 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/@testing-library/user-event": {
+      "version": "14.4.3",
+      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.4.3.tgz",
+      "integrity": "sha512-kCUc5MEwaEMakkO5x7aoD+DLi02ehmEM2QCGWvNqAS1dV/fAvORWEjnjsEIvml59M7Y5kCkWN6fCCyPOe8OL6Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": ">=7.21.4"
       }
     },
     "node_modules/@tootallnate/once": {
@@ -39983,6 +39997,13 @@
           }
         }
       }
+    },
+    "@testing-library/user-event": {
+      "version": "14.4.3",
+      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.4.3.tgz",
+      "integrity": "sha512-kCUc5MEwaEMakkO5x7aoD+DLi02ehmEM2QCGWvNqAS1dV/fAvORWEjnjsEIvml59M7Y5kCkWN6fCCyPOe8OL6Q==",
+      "dev": true,
+      "requires": {}
     },
     "@tootallnate/once": {
       "version": "1.1.2",

--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
     "@storybook/ember-cli-storybook": "^0.4.0",
     "@storybook/storybook-deployer": "^2.8.10",
     "@storybook/theming": "^6.3.7",
+    "@testing-library/user-event": "^14.4.3",
     "axios": "^0.21.1",
     "babel-eslint": "^10.1.0",
     "babel-plugin-ember-modules-api-polyfill": "^2.13.4",

--- a/tests/integration/components/pix-checkbox-test.js
+++ b/tests/integration/components/pix-checkbox-test.js
@@ -11,7 +11,7 @@ module('Integration | Component | checkbox', function (hooks) {
 
   test('it should be possible to check the checkbox', async function (assert) {
     // when
-    await render(hbs`<PixCheckbox @id="checkboxId" @label="Recevoir la newsletter" />`);
+    await render(hbs`<PixCheckbox @id="checkboxId">Recevoir la newsletter</PixCheckbox>`);
     await clickByText('Recevoir la newsletter');
 
     // then
@@ -22,31 +22,28 @@ module('Integration | Component | checkbox', function (hooks) {
   test('it should throw an error if there is no id', async function (assert) {
     // given & when
     const componentParams = { id: '   ', label: 'Super label' };
-    const component = createGlimmerComponent('component:pix-checkbox', componentParams);
+    const renderComponent = function () {
+      createGlimmerComponent('component:pix-checkbox', componentParams);
+    };
 
     // then
     const expectedError = new Error('ERROR in PixCheckbox component, @id param is not provided');
-    assert.throws(function () {
-      component.id;
-    }, expectedError);
+    assert.throws(renderComponent, expectedError);
   });
 
-  test('it should throw an error if pix checkbox has no label param', async function (assert) {
+  test('it should display error message if there no yield', async function (assert) {
     // given & when
-    const componentParams = { id: 'superId', label: null, ariaLabel: null };
+    const screen = await render(hbs`<PixCheckbox @id="checkboxId"/>`);
 
     // then
-    const expectedError = new Error(
-      'ERROR in PixCheckbox component, you must provide @label params'
-    );
-    assert.throws(function () {
-      createGlimmerComponent('component:pix-checkbox', componentParams);
-    }, expectedError);
+    assert
+      .dom(screen.getByLabelText('yield required to give a label for PixCheckBox checkboxId.'))
+      .exists();
   });
 
   test('it should be possible to make label small', async function (assert) {
     // when
-    await render(hbs`<PixCheckbox @id="checkboxId" @label="Mini label" @labelSize="small" />`);
+    await render(hbs`<PixCheckbox @id="checkboxId" @labelSize="small">Mini label</PixCheckbox>`);
 
     // then
     assert.dom('.pix-checkbox__label--small').exists();
@@ -54,9 +51,9 @@ module('Integration | Component | checkbox', function (hooks) {
 
   test('it should be possible to insert html in label', async function (assert) {
     // given & when
-    const labelWithHtml = 'Accepter les cgu, <a href="https://cgu.example.net">voir ici</a>';
-    this.set('label', labelWithHtml);
-    const screen = await render(hbs`<PixCheckbox @id="checkboxId" @label={{label}} />`);
+    const screen = await render(
+      hbs`<PixCheckbox @id="checkboxId">Accepter les cgu, <a href="https://cgu.example.net">voir ici</a></PixCheckbox>`
+    );
 
     // then
     assert.dom(screen.getByLabelText('Accepter les cgu, voir ici')).exists();
@@ -66,7 +63,7 @@ module('Integration | Component | checkbox', function (hooks) {
     // given
     this.set('checked', false);
     await render(
-      hbs`<PixCheckbox @id="checkboxId" @label="Recevoir la newsletter" @checked={{checked}} />`
+      hbs`<PixCheckbox @id="checkboxId" @checked={{checked}}>Recevoir la newsletter</PixCheckbox>`
     );
     const checkbox = this.element.querySelector(CHECKBOX_INPUT_SELECTOR);
     assert.false(checkbox.checked);

--- a/tests/integration/components/pix-multi-select-test.js
+++ b/tests/integration/components/pix-multi-select-test.js
@@ -1,11 +1,9 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import { render, focus, blur } from '@ember/test-helpers';
+import { render, fillByLabel, clickByName } from '@1024pix/ember-testing-library';
 import { hbs } from 'ember-cli-htmlbars';
 import createGlimmerComponent from '../../helpers/create-glimmer-component';
 import sinon from 'sinon';
-import fillInByLabel from '../../helpers/fill-in-by-label';
-import clickByLabel from '../../helpers/click-by-label';
 
 module('Integration | Component | multi-select', function (hooks) {
   setupRenderingTest(hooks);
@@ -31,7 +29,7 @@ module('Integration | Component | multi-select', function (hooks) {
       <PixMultiSelect
         @selected={{this.selected}}
         @onSelect={{this.onSelect}}
-        @title={{this.title}}
+        @innerText={{this.title}}
         @id={{this.id}}
         @emptyMessage={{this.emptyMessage}}
         @options={{this.options}} as |option|>
@@ -59,7 +57,7 @@ module('Integration | Component | multi-select', function (hooks) {
       <PixMultiSelect
         @selected={{this.selected}}
         @onSelect={{this.onSelect}}
-        @title={{this.title}}
+        @innerText={{this.title}}
         @id={{this.id}}
         @label="label"
         @emptyMessage={{this.emptyMessage}}
@@ -69,7 +67,7 @@ module('Integration | Component | multi-select', function (hooks) {
       </PixMultiSelect>
     `);
 
-    await clickByLabel('label');
+    await clickByName('label');
 
     // then
     const listElement = this.element.querySelectorAll('li');
@@ -92,7 +90,7 @@ module('Integration | Component | multi-select', function (hooks) {
     await render(hbs`
       <PixMultiSelect
         @onSelect={{this.onSelect}}
-        @title={{this.title}}
+        @innerText={{this.title}}
         @id={{this.id}}
         @selected={{this.selected}}
         @label="label"
@@ -103,7 +101,7 @@ module('Integration | Component | multi-select', function (hooks) {
       </PixMultiSelect>
     `);
 
-    await clickByLabel('label');
+    await clickByName('label');
 
     // then
     const checkboxElement = this.element.querySelectorAll('input[type=checkbox]');
@@ -123,15 +121,14 @@ module('Integration | Component | multi-select', function (hooks) {
     this.id = 'id-MultiSelectTest';
 
     // when
-    await render(hbs`
+    const screen = await render(hbs`
       <PixMultiSelect
         @onSelect={{this.onSelect}}
-        @title={{this.title}}
+        @innerText={{this.title}}
         @id={{this.id}}
         @selected={{this.selected}}
         @label="label"
         @emptyMessage={{this.emptyMessage}}
-        @placeholder="Yo"
         @isSearchable={{true}}
         @options={{this.options}} as |option|
       >
@@ -140,7 +137,7 @@ module('Integration | Component | multi-select', function (hooks) {
     `);
 
     // then
-    const inputElement = this.element.querySelector('.pix-multi-select-header__search-input');
+    const inputElement = screen.getByLabelText('label');
     assert.equal(inputElement.placeholder, 'Tomate, Oignon');
   });
 
@@ -156,7 +153,7 @@ module('Integration | Component | multi-select', function (hooks) {
     await render(hbs`
       <PixMultiSelect
         @onSelect={{this.onSelect}}
-        @title={{this.title}}
+        @innerText={{this.title}}
         @id={{this.id}}
         @selected={{this.selected}}
         @label="label"
@@ -168,7 +165,7 @@ module('Integration | Component | multi-select', function (hooks) {
 
     // when
     this.set('selected', []);
-    await clickByLabel('label');
+    await clickByName('label');
 
     // then
     const checkboxElement = this.element.querySelectorAll('input[type=checkbox]');
@@ -186,12 +183,11 @@ module('Integration | Component | multi-select', function (hooks) {
     this.id = 'id-MultiSelectTest';
     this.onSelect = sinon.spy();
 
-    await render(hbs`
+    const screen = await render(hbs`
     <PixMultiSelect
       @onSelect={{this.onSelect}}
-      @title={{this.title}}
+      @innerText={{this.title}}
       @id={{this.id}}
-      @label="label"
       @emptyMessage={{this.emptyMessage}}
       @options={{this.options}} as |option|>
       {{option.label}}
@@ -199,12 +195,14 @@ module('Integration | Component | multi-select', function (hooks) {
   `);
 
     // when
-    await clickByLabel('label');
-    await clickByLabel('Salade');
+    await clickByName(this.title);
+
+    await screen.findByRole('menu');
+
+    await clickByName('Salade');
 
     // then
-    const firstCheckbox = this.element.querySelectorAll('input[type=checkbox]').item(0);
-    assert.true(firstCheckbox.checked);
+    assert.true(screen.getByLabelText('Salade').checked);
     assert.ok(this.onSelect.calledOnce, 'the callback should be called once');
     assert.ok(this.onSelect.calledWith, ['1']);
   });
@@ -219,12 +217,11 @@ module('Integration | Component | multi-select', function (hooks) {
     this.id = 'id-MultiSelectTest';
     this.onSelect = sinon.spy();
 
-    await render(hbs`
+    const screen = await render(hbs`
       <PixMultiSelect
         @onSelect={{this.onSelect}}
-        @title={{this.title}}
+        @innerText={{this.title}}
         @id={{this.id}}
-        @label="label"
         @emptyMessage={{this.emptyMessage}}
         @options={{this.options}} as |option|>
         {{option.label}}
@@ -232,433 +229,14 @@ module('Integration | Component | multi-select', function (hooks) {
     `);
 
     // when
-    await clickByLabel('label');
-    await clickByLabel('Salade');
+    await clickByName(this.title);
+
+    await screen.findByRole('menu');
+
+    await clickByName('Salade');
 
     // then
     assert.ok(this.onSelect.calledWith, ['2']);
-  });
-
-  module('When it is a searchable multiselect', function () {
-    test('it should renders searchable PixMultiSelect multi select list', async function (assert) {
-      // given
-      this.options = DEFAULT_OPTIONS;
-      this.selected = [];
-      this.onSelect = (selected) => this.set('selected', selected);
-      this.emptyMessage = 'no result';
-      this.title = 'MultiSelectTest';
-      this.id = 'id-MultiSelectTest';
-      this.isSearchable = true;
-      this.placeholder = 'Placeholder test';
-
-      // when
-      await render(hbs`
-        <PixMultiSelect
-          @isSearchable={{this.isSearchable}}
-          @selected={{this.selected}}
-          @onSelect={{this.onSelect}}
-          @title={{this.title}}
-          @placeholder={{this.placeholder}}
-          @id={{this.id}}
-          @label="label"
-          @emptyMessage={{this.emptyMessage}}
-          @options={{this.options}} as |option|>
-          {{option.label}}
-        </PixMultiSelect>
-      `);
-
-      // then
-      const inputElement = this.element.querySelector('.pix-multi-select-header__search-input');
-      const listElement = this.element.querySelectorAll('li');
-      assert.contains('MultiSelectTest');
-      assert.equal(inputElement.placeholder, this.placeholder);
-      assert.equal(listElement.length, 3);
-    });
-
-    test('it should renders filtered given case insensitive', async function (assert) {
-      // given
-      this.options = DEFAULT_OPTIONS;
-      this.selected = [];
-      this.onSelect = (selected) => this.set('selected', selected);
-      this.emptyMessage = 'no result';
-      this.title = 'MultiSelectTest';
-      this.id = 'id-MultiSelectTest';
-      this.isSearchable = true;
-      this.placeholder = 'Placeholder test';
-
-      await render(hbs`
-        <PixMultiSelect
-          @isSearchable={{this.isSearchable}}
-          @selected={{this.selected}}
-          @onSelect={{this.onSelect}}
-          @title={{this.title}}
-          @placeholder={{this.placeholder}}
-          @id={{this.id}}
-          @label="label"
-          @emptyMessage={{this.emptyMessage}}
-          @label="Mon multi select"
-          @options={{this.options}} as |option|
-        >
-          {{option.label}}
-        </PixMultiSelect>
-      `);
-
-      // when
-      await fillInByLabel('Mon multi select', 'tomate');
-
-      // then
-      const listElement = this.element.querySelectorAll('.pix-multi-select-list__item');
-      assert.equal(listElement.length, 1);
-      assert.contains('Tomate');
-    });
-
-    test('it should renders no result given case sensitive', async function (assert) {
-      // given
-      this.options = DEFAULT_OPTIONS;
-      this.selected = [];
-      this.onSelect = (selected) => this.set('selected', selected);
-      this.emptyMessage = 'no result';
-      this.title = 'MultiSelectTest';
-      this.id = 'id-MultiSelectTest';
-      this.isSearchable = true;
-      this.strictSearch = true;
-      this.placeholder = 'Placeholder test';
-
-      await render(hbs`
-        <PixMultiSelect
-          @isSearchable={{this.isSearchable}}
-          @strictSearch={{this.strictSearch}}
-          @selected={{this.selected}}
-          @onSelect={{this.onSelect}}
-          @title={{this.title}}
-          @placeholder={{this.placeholder}}
-          @id={{this.id}}
-          @emptyMessage={{this.emptyMessage}}
-          @label="Mon multi select"
-          @options={{this.options}} as |option|
-        >
-          {{option.label}}
-        </PixMultiSelect>
-      `);
-
-      // when
-      await fillInByLabel('Mon multi select', 'tomate');
-
-      // then
-      const listElement = this.element.querySelectorAll('.pix-multi-select-list__item');
-      assert.equal(listElement.length, 1);
-      assert.contains('no result');
-    });
-
-    test('it should display list PixMultiSelect on focus', async function (assert) {
-      // given
-      this.options = DEFAULT_OPTIONS;
-      this.selected = [];
-      this.onSelect = (selected) => this.set('selected', selected);
-      this.emptyMessage = 'no result';
-      this.title = 'MultiSelectTest';
-      this.id = 'id-MultiSelectTest';
-      this.isSearchable = true;
-      this.showOptionsOnInput = true;
-      this.placeholder = 'Placeholder test';
-
-      await render(hbs`
-        <PixMultiSelect
-          @isSearchable={{this.isSearchable}}
-          @showOptionsOnInput={{this.showOptionsOnInput}}
-          @selected={{this.selected}}
-          @onSelect={{this.onSelect}}
-          @title={{this.title}}
-          @placeholder={{this.placeholder}}
-          @id={{this.id}}
-          @emptyMessage={{this.emptyMessage}}
-          @options={{this.options}} as |option|>
-          {{option.label}}
-        </PixMultiSelect>
-      `);
-
-      // when
-      await focus('input');
-
-      // then
-      const listElement = this.element.querySelector('ul');
-      assert.equal(listElement.className.trim(), 'pix-multi-select-list');
-    });
-
-    test('it should not display list PixMultiSelect on focus', async function (assert) {
-      // given
-      this.options = DEFAULT_OPTIONS;
-      this.selected = [];
-      this.onSelect = (selected) => this.set('selected', selected);
-      this.emptyMessage = 'no result';
-      this.title = 'MultiSelectTest';
-      this.id = 'id-MultiSelectTest';
-      this.isSearchable = true;
-      this.showOptionsOnInput = false;
-      this.placeholder = 'Placeholder test';
-
-      await render(hbs`
-        <PixMultiSelect
-          @isSearchable={{this.isSearchable}}
-          @showOptionsOnInput={{this.showOptionsOnInput}}
-          @selected={{this.selected}}
-          @onSelect={{this.onSelect}}
-          @title={{this.title}}
-          @placeholder={{this.placeholder}}
-          @id={{this.id}}
-          @emptyMessage={{this.emptyMessage}}
-          @options={{this.options}} as |option|>
-          {{option.label}}
-        </PixMultiSelect>
-      `);
-
-      // when
-      await focus('input');
-
-      // then
-      const listElement = this.element.querySelector('ul');
-      assert.equal(listElement.className, 'pix-multi-select-list pix-multi-select-list--hidden');
-    });
-
-    test('it should sort default selected items when focused', async function (assert) {
-      // given
-      this.options = DEFAULT_OPTIONS;
-      this.selected = [];
-      this.onSelect = (selected) => this.set('selected', selected);
-      this.emptyMessage = 'no result';
-      this.title = 'MultiSelectTest';
-      this.id = 'id-MultiSelectTest';
-      this.isSearchable = true;
-      this.placeholder = 'Placeholder test';
-      this.defaultSelected = ['3'];
-
-      await render(hbs`
-        <PixMultiSelect
-          @isSearchable={{this.isSearchable}}
-          @selected={{this.selected}}
-          @onSelect={{this.onSelect}}
-          @title={{this.title}}
-          @placeholder={{this.placeholder}}
-          @id={{this.id}}
-          @emptyMessage={{this.emptyMessage}}
-          @selected={{defaultSelected}}
-          @options={{this.options}} as |option|>
-          {{option.label}}
-        </PixMultiSelect>
-      `);
-
-      // when
-      await focus('input');
-
-      // then
-      const listElement = this.element.querySelectorAll('.pix-multi-select-list__item');
-      assert.equal(listElement.length, 3);
-      assert.equal(listElement.item(0).textContent.trim(), 'Oignon');
-      assert.equal(listElement.item(1).textContent.trim(), 'Salade');
-      assert.equal(listElement.item(2).textContent.trim(), 'Tomate');
-    });
-
-    test('it should not sort when user select item', async function (assert) {
-      // given
-      this.options = DEFAULT_OPTIONS;
-      this.selected = [];
-      this.onSelect = (selected) => this.set('selected', selected);
-      this.emptyMessage = 'no result';
-      this.title = 'MultiSelectTest';
-      this.id = 'id-MultiSelectTest';
-      this.isSearchable = true;
-      this.placeholder = 'Placeholder test';
-
-      await render(hbs`
-        <PixMultiSelect
-          @isSearchable={{this.isSearchable}}
-          @selected={{this.selected}}
-          @onSelect={{this.onSelect}}
-          @title={{this.title}}
-          @placeholder={{this.placeholder}}
-          @label="label"
-          @id={{this.id}}
-          @emptyMessage={{this.emptyMessage}}
-          @options={{this.options}} as |option|>
-          {{option.label}}
-        </PixMultiSelect>
-      `);
-
-      // when
-      await clickByLabel('label');
-      await clickByLabel(DEFAULT_OPTIONS[1].label);
-
-      // then
-      const listElement = this.element.querySelectorAll('.pix-multi-select-list__item');
-      assert.equal(listElement.length, 3);
-      assert.equal(listElement.item(0).textContent.trim(), 'Salade');
-      assert.equal(listElement.item(1).textContent.trim(), 'Tomate');
-      assert.equal(listElement.item(2).textContent.trim(), 'Oignon');
-    });
-
-    test('it should not sort when user search and select item', async function (assert) {
-      // given
-      this.options = DEFAULT_OPTIONS;
-      this.selected = [];
-      this.onSelect = (selected) => this.set('selected', selected);
-      this.emptyMessage = 'no result';
-      this.title = 'MultiSelectTest';
-      this.id = 'id-MultiSelectTest';
-      this.isSearchable = true;
-      this.placeholder = 'Placeholder test';
-
-      await render(hbs`
-        <PixMultiSelect
-          @isSearchable={{this.isSearchable}}
-          @selected={{this.selected}}
-          @onSelect={{this.onSelect}}
-          @title={{this.title}}
-          @placeholder={{this.placeholder}}
-          @id={{this.id}}
-          @emptyMessage={{this.emptyMessage}}
-          @label="Mon multi select"
-          @options={{this.options}} as |option|
-        >
-          {{option.label}}
-        </PixMultiSelect>
-      `);
-
-      // when
-      await fillInByLabel('Mon multi select', 'Oi');
-      await clickByLabel('Oignon');
-      await fillInByLabel('Mon multi select', 'o');
-
-      // then
-      const listElement = this.element.querySelectorAll('.pix-multi-select-list__item');
-      assert.equal(listElement.length, 2);
-      assert.equal(listElement.item(0).textContent.trim(), 'Tomate');
-      assert.equal(listElement.item(1).textContent.trim(), 'Oignon');
-    });
-
-    test('it should sort items when search is cleaned', async function (assert) {
-      // given
-      this.options = DEFAULT_OPTIONS;
-      this.selected = [];
-      this.onSelect = (selected) => this.set('selected', selected);
-      this.emptyMessage = 'no result';
-      this.title = 'MultiSelectTest';
-      this.id = 'id-MultiSelectTest';
-      this.isSearchable = true;
-      this.placeholder = 'Placeholder test';
-
-      await render(hbs`
-        <PixMultiSelect
-          @isSearchable={{this.isSearchable}}
-          @selected={{this.selected}}
-          @onSelect={{this.onSelect}}
-          @title={{this.title}}
-          @placeholder={{this.placeholder}}
-          @id={{this.id}}
-          @emptyMessage={{this.emptyMessage}}
-          @label="Mon multi select"
-          @options={{this.options}} as |option|
-        >
-          {{option.label}}
-        </PixMultiSelect>
-      `);
-
-      // when
-      await fillInByLabel('Mon multi select', 'Oi');
-      await clickByLabel('Oignon');
-      await fillInByLabel('Mon multi select', '');
-
-      // then
-      const listElement = this.element.querySelectorAll('.pix-multi-select-list__item');
-      assert.equal(listElement.length, 3);
-      assert.equal(listElement.item(0).textContent.trim(), 'Oignon');
-      assert.equal(listElement.item(1).textContent.trim(), 'Salade');
-      assert.equal(listElement.item(2).textContent.trim(), 'Tomate');
-    });
-
-    test('should not sort when there are default items selected and a new selected item', async function (assert) {
-      // given
-      this.options = DEFAULT_OPTIONS;
-      this.selected = ['2'];
-      this.onSelect = (selected) => this.set('selected', selected);
-      this.emptyMessage = 'no result';
-      this.title = 'MultiSelectTest';
-      this.id = 'id-MultiSelectTest';
-      this.isSearchable = true;
-      this.placeholder = 'Placeholder test';
-
-      await render(hbs`
-        <PixMultiSelect
-          @isSearchable={{this.isSearchable}}
-          @selected={{this.selected}}
-          @onSelect={{this.onSelect}}
-          @title={{this.title}}
-          @placeholder={{this.placeholder}}
-          @id={{this.id}}
-          @label="label"
-          @emptyMessage={{this.emptyMessage}}
-          @showOptionsOnInput={{true}}
-          @options={{this.options}} as |option|>
-          {{option.label}}
-        </PixMultiSelect>
-      `);
-
-      // when
-      await clickByLabel('label');
-
-      const listElement = this.element.querySelectorAll('.pix-multi-select-list__item');
-      assert.equal(listElement.item(0).textContent.trim(), 'Tomate');
-
-      await clickByLabel('Oignon');
-
-      // then
-      const listElement2 = this.element.querySelectorAll('.pix-multi-select-list__item');
-      assert.equal(listElement2.item(0).textContent.trim(), 'Tomate');
-      assert.equal(listElement2.item(1).textContent.trim(), 'Salade');
-      assert.equal(listElement2.item(2).textContent.trim(), 'Oignon');
-    });
-
-    test('it should sort items when search is unfocus', async function (assert) {
-      // given
-      this.options = DEFAULT_OPTIONS;
-      this.selected = [];
-      this.onSelect = (selected) => this.set('selected', selected);
-      this.emptyMessage = 'no result';
-      this.title = 'MultiSelectTest';
-      this.id = 'id-MultiSelectTest';
-      this.isSearchable = true;
-      this.placeholder = 'Placeholder test';
-
-      await render(hbs`
-        <PixMultiSelect
-          @isSearchable={{this.isSearchable}}
-          @selected={{this.selected}}
-          @onSelect={{this.onSelect}}
-          @title={{this.title}}
-          @placeholder={{this.placeholder}}
-          @id={{this.id}}
-          @emptyMessage={{this.emptyMessage}}
-          @label="Mon multi select"
-          @options={{this.options}} as |option|
-        >
-          {{option.label}}
-        </PixMultiSelect>
-      `);
-
-      // when
-      await fillInByLabel('Mon multi select', 'Oi');
-      await clickByLabel('Oignon');
-
-      await blur('input');
-
-      await fillInByLabel('Mon multi select', '');
-
-      // then
-      const listElement = this.element.querySelectorAll('.pix-multi-select-list__item');
-      assert.equal(listElement.length, 3);
-      assert.equal(listElement.item(0).textContent.trim(), 'Oignon');
-      assert.equal(listElement.item(1).textContent.trim(), 'Salade');
-      assert.equal(listElement.item(2).textContent.trim(), 'Tomate');
-    });
   });
 
   test('it should be possible to give a label', async function (assert) {
@@ -682,16 +260,14 @@ module('Integration | Component | multi-select', function (hooks) {
 
   test('it should throw an error if no id is provided when there is a label', async function (assert) {
     // given
-    const componentParams = { id: '   ', label: 'Votre choix: ', options: DEFAULT_OPTIONS };
-    const component = createGlimmerComponent('component:pix-multi-select', componentParams);
+    const componentParams = { id: '   ', options: DEFAULT_OPTIONS };
+    const renderComponent = function () {
+      createGlimmerComponent('component:pix-multi-select', componentParams);
+    };
 
     // when & then
-    const expectedError = new Error(
-      'ERROR in PixMultiSelect component, @id param is necessary when giving @label'
-    );
-    assert.throws(function () {
-      component.label;
-    }, expectedError);
+    const expectedError = new Error('ERROR in PixMultiSelect component, @id param is necessary');
+    assert.throws(renderComponent, expectedError);
   });
 
   test('it should asynchronously load options', async function (assert) {
@@ -708,7 +284,7 @@ module('Integration | Component | multi-select', function (hooks) {
       <PixMultiSelect
         @selected={{this.selected}}
         @onSelect={{this.onSelect}}
-        @title={{this.title}}
+        @innerText={{this.title}}
         @id={{this.id}}
         @emptyMessage={{this.emptyMessage}}
         @onLoadOptions={{this.onLoadOptions}} as |option|>
@@ -720,5 +296,367 @@ module('Integration | Component | multi-select', function (hooks) {
     const listElement = this.element.querySelectorAll('li');
     assert.contains('MultiSelectTest');
     assert.equal(listElement.length, 3);
+  });
+
+  module('When it is a searchable multiselect', function () {
+    test('it should renders searchable PixMultiSelect multi select list', async function (assert) {
+      // given
+      // given
+      this.options = DEFAULT_OPTIONS;
+      this.selected = [];
+      this.onSelect = (selected) => this.set('selected', selected);
+      this.emptyMessage = 'no result';
+      this.innerText = 'MultiSelectTest';
+      this.id = 'id-MultiSelectTest';
+      this.isSearchable = true;
+
+      // when
+      const screen = await render(hbs`
+        <PixMultiSelect
+          @isSearchable={{this.isSearchable}}
+          @selected={{this.selected}}
+          @onSelect={{this.onSelect}}
+          @innerText={{this.innerText}}
+          @id={{this.id}}
+          @label="label"
+          @emptyMessage={{this.emptyMessage}}
+          @options={{this.options}} as |option|>
+          {{option.label}}
+        </PixMultiSelect>
+      `);
+
+      await fillByLabel('label', '');
+
+      await screen.findByRole('menu');
+
+      // then
+
+      assert.equal(screen.getByLabelText('label').placeholder, this.innerText);
+      assert.equal(screen.getAllByRole('checkbox').length, 3);
+    });
+
+    test('it should renders filtered given case insensitive', async function (assert) {
+      // given
+      this.options = DEFAULT_OPTIONS;
+      this.selected = [];
+      this.onSelect = (selected) => this.set('selected', selected);
+      this.emptyMessage = 'no result';
+      this.title = 'MultiSelectTest';
+      this.id = 'id-MultiSelectTest';
+      this.isSearchable = true;
+      this.placeholder = 'Placeholder test';
+
+      const screen = await render(hbs`
+        <PixMultiSelect
+          @isSearchable={{this.isSearchable}}
+          @selected={{this.selected}}
+          @onSelect={{this.onSelect}}
+          @innerText={{this.title}}
+          @placeholder={{this.placeholder}}
+          @id={{this.id}}
+          @emptyMessage={{this.emptyMessage}}
+          @label="Mon multi select"
+          @options={{this.options}} as |option|
+        >
+          {{option.label}}
+        </PixMultiSelect>
+      `);
+
+      // when
+      await fillByLabel('Mon multi select', 'tomate');
+
+      await screen.findByRole('menu');
+
+      // then
+
+      assert.equal(screen.getAllByRole('checkbox').length, 1);
+      assert.contains('Tomate');
+    });
+
+    test('it should renders no result given case sensitive', async function (assert) {
+      // given
+      this.options = DEFAULT_OPTIONS;
+      this.selected = [];
+      this.onSelect = (selected) => this.set('selected', selected);
+      this.emptyMessage = 'no result';
+      this.title = 'MultiSelectTest';
+      this.id = 'id-MultiSelectTest';
+      this.isSearchable = true;
+      this.strictSearch = true;
+      this.placeholder = 'Placeholder test';
+
+      const screen = await render(hbs`
+        <PixMultiSelect
+          @isSearchable={{this.isSearchable}}
+          @strictSearch={{this.strictSearch}}
+          @selected={{this.selected}}
+          @onSelect={{this.onSelect}}
+          @innerText={{this.title}}
+          @placeholder={{this.placeholder}}
+          @id={{this.id}}
+          @emptyMessage={{this.emptyMessage}}
+          @label="Mon multi select"
+          @options={{this.options}} as |option|
+        >
+          {{option.label}}
+        </PixMultiSelect>
+      `);
+
+      // when
+      await fillByLabel('Mon multi select', 'tomate');
+
+      await screen.findByRole('menu');
+
+      // then
+      assert.contains('no result');
+    });
+
+    test('it should display list PixMultiSelect on focus', async function (assert) {
+      // given
+      this.options = DEFAULT_OPTIONS;
+      this.selected = [];
+      this.onSelect = (selected) => this.set('selected', selected);
+      this.emptyMessage = 'no result';
+      this.title = 'MultiSelectTest';
+      this.id = 'id-MultiSelectTest';
+      this.label = 'label';
+      this.isSearchable = true;
+      this.placeholder = 'Placeholder test';
+
+      const screen = await render(hbs`
+        <PixMultiSelect
+          @isSearchable={{this.isSearchable}}
+          @selected={{this.selected}}
+          @onSelect={{this.onSelect}}
+          @innerText={{this.title}}
+          @placeholder={{this.placeholder}}
+          @label={{this.label}}
+          @id={{this.id}}
+          @emptyMessage={{this.emptyMessage}}
+          @options={{this.options}} as |option|>
+          {{option.label}}
+        </PixMultiSelect>
+      `);
+
+      // when
+      await fillByLabel('label', '');
+
+      await screen.findByRole('menu');
+
+      // then
+      assert.equal(screen.getByRole('menu').className.trim(), 'pix-multi-select-list');
+    });
+
+    test('it should sort default selected items when focused', async function (assert) {
+      // given
+      this.options = DEFAULT_OPTIONS;
+      this.selected = [];
+      this.onSelect = (selected) => this.set('selected', selected);
+      this.emptyMessage = 'no result';
+      this.title = 'MultiSelectTest';
+      this.id = 'id-MultiSelectTest';
+      this.isSearchable = true;
+      this.placeholder = 'Placeholder test';
+      this.defaultSelected = ['3'];
+
+      const screen = await render(hbs`
+        <PixMultiSelect
+          @isSearchable={{this.isSearchable}}
+          @selected={{this.selected}}
+          @onSelect={{this.onSelect}}
+          @innerText={{this.title}}
+          @placeholder={{this.placeholder}}
+          @id={{this.id}}
+          @label="label"
+          @emptyMessage={{this.emptyMessage}}
+          @selected={{defaultSelected}}
+          @options={{this.options}} as |option|>
+          {{option.label}}
+        </PixMultiSelect>
+      `);
+
+      // when
+      await fillByLabel('label', '');
+
+      await screen.findByRole('menu');
+
+      // then
+      const listElement = screen.getAllByRole('checkbox');
+      assert.equal(listElement.length, 3);
+      assert.equal(listElement[0].labels[0].innerText.trim(), 'Oignon');
+      assert.equal(listElement[1].labels[0].innerText.trim(), 'Salade');
+      assert.equal(listElement[2].labels[0].innerText.trim(), 'Tomate');
+    });
+
+    test('it should not sort when user select item', async function (assert) {
+      // given
+      this.options = DEFAULT_OPTIONS;
+      this.selected = [];
+      this.onSelect = (selected) => this.set('selected', selected);
+      this.emptyMessage = 'no result';
+      this.title = 'MultiSelectTest';
+      this.id = 'id-MultiSelectTest';
+      this.isSearchable = true;
+      this.placeholder = 'Placeholder test';
+
+      const screen = await render(hbs`
+        <PixMultiSelect
+          @isSearchable={{this.isSearchable}}
+          @selected={{this.selected}}
+          @onSelect={{this.onSelect}}
+          @innerText={{this.title}}
+          @placeholder={{this.placeholder}}
+          @label="label"
+          @id={{this.id}}
+          @emptyMessage={{this.emptyMessage}}
+          @options={{this.options}} as |option|>
+          {{option.label}}
+        </PixMultiSelect>
+      `);
+
+      // when
+      await fillByLabel('label', '');
+
+      await screen.findByRole('menu');
+
+      await clickByName(DEFAULT_OPTIONS[1].label);
+
+      // then
+      const listElement = screen.getAllByRole('checkbox');
+      assert.equal(listElement.length, 3);
+      assert.equal(listElement[0].labels[0].innerText.trim(), 'Salade');
+      assert.equal(listElement[1].labels[0].innerText.trim(), 'Tomate');
+      assert.equal(listElement[2].labels[0].innerText.trim(), 'Oignon');
+    });
+
+    test('it should not sort when user search and select item', async function (assert) {
+      // given
+      this.options = DEFAULT_OPTIONS;
+      this.selected = [];
+      this.onSelect = (selected) => this.set('selected', selected);
+      this.emptyMessage = 'no result';
+      this.title = 'MultiSelectTest';
+      this.id = 'id-MultiSelectTest';
+      this.isSearchable = true;
+      this.placeholder = 'Placeholder test';
+
+      const screen = await render(hbs`
+        <PixMultiSelect
+          @isSearchable={{this.isSearchable}}
+          @selected={{this.selected}}
+          @onSelect={{this.onSelect}}
+          @innerText={{this.title}}
+          @placeholder={{this.placeholder}}
+          @id={{this.id}}
+          @emptyMessage={{this.emptyMessage}}
+          @label="Mon multi select"
+          @options={{this.options}} as |option|
+        >
+          {{option.label}}
+        </PixMultiSelect>
+      `);
+
+      // when
+      await fillByLabel('Mon multi select', 'Oi');
+
+      await screen.findByRole('menu');
+
+      await clickByName('Oignon');
+      await fillByLabel('Mon multi select', 'o');
+      // then
+      const listElement = screen.getAllByRole('checkbox');
+      assert.equal(listElement.length, 2);
+      assert.equal(listElement[0].labels[0].innerText.trim(), 'Tomate');
+      assert.equal(listElement[1].labels[0].innerText.trim(), 'Oignon');
+    });
+
+    test('it should sort items when search is cleaned', async function (assert) {
+      // given
+      this.options = DEFAULT_OPTIONS;
+      this.selected = [];
+      this.onSelect = (selected) => this.set('selected', selected);
+      this.emptyMessage = 'no result';
+      this.title = 'MultiSelectTest';
+      this.id = 'id-MultiSelectTest';
+      this.isSearchable = true;
+      this.placeholder = 'Placeholder test';
+
+      const screen = await render(hbs`
+        <PixMultiSelect
+          @isSearchable={{this.isSearchable}}
+          @selected={{this.selected}}
+          @onSelect={{this.onSelect}}
+          @innerText={{this.title}}
+          @placeholder={{this.placeholder}}
+          @id={{this.id}}
+          @emptyMessage={{this.emptyMessage}}
+          @label="Mon multi select"
+          @options={{this.options}} as |option|
+        >
+          {{option.label}}
+        </PixMultiSelect>
+      `);
+
+      // when
+      await fillByLabel('Mon multi select', 'Oi');
+
+      await screen.findByRole('menu');
+
+      await clickByName('Oignon');
+
+      await fillByLabel('Mon multi select', '');
+
+      // then
+      const listElement = screen.getAllByRole('checkbox');
+      assert.equal(listElement.length, 3);
+      assert.equal(listElement[0].labels[0].innerText.trim(), 'Oignon');
+      assert.equal(listElement[1].labels[0].innerText.trim(), 'Salade');
+      assert.equal(listElement[2].labels[0].innerText.trim(), 'Tomate');
+    });
+
+    test('should not sort when there are default items selected and a new selected item', async function (assert) {
+      // given
+      this.options = DEFAULT_OPTIONS;
+      this.selected = ['2'];
+      this.onSelect = (selected) => this.set('selected', selected);
+      this.emptyMessage = 'no result';
+      this.title = 'MultiSelectTest';
+      this.id = 'id-MultiSelectTest';
+      this.isSearchable = true;
+      this.placeholder = 'Placeholder test';
+
+      const screen = await render(hbs`
+        <PixMultiSelect
+          @isSearchable={{this.isSearchable}}
+          @selected={{this.selected}}
+          @onSelect={{this.onSelect}}
+          @innerText={{this.title}}
+          @placeholder={{this.placeholder}}
+          @id={{this.id}}
+          @label="label"
+          @emptyMessage={{this.emptyMessage}}
+          @showOptionsOnInput={{true}}
+          @options={{this.options}} as |option|>
+          {{option.label}}
+        </PixMultiSelect>
+      `);
+
+      // when
+      await fillByLabel('label', '');
+
+      await screen.findByRole('menu');
+
+      const listElement = screen.getAllByRole('checkbox');
+
+      assert.equal(listElement[0].labels[0].innerText.trim(), 'Tomate');
+
+      await clickByName('Oignon');
+
+      // then
+      const listElement2 = screen.getAllByRole('checkbox');
+
+      assert.equal(listElement2[0].labels[0].innerText.trim(), 'Tomate');
+      assert.equal(listElement2[2].labels[0].innerText.trim(), 'Oignon');
+    });
   });
 });


### PR DESCRIPTION
## :boom: BREAKING_CHANGES
Le composant checkbox ne permettait pas d'utiliser des composants en tant que label. Une modification y a été apporté afin qu'il puisse prendre des composant comme label. 

**PixCheckBox** :
* L'argument `label` n'est plus disponible en tant qu'argument, est doit être instancier de cette manière `<PixCheckBox>label</PixCheckBox>`

**PixMultiSelect** :
* L'argument `title` a été supprimé et ne doit plus être utilisé. Utilisez à la place l'argument `label`, ce label est présent pour définir le champ input ou le bouton.
* L'argument `placeholder` a été remplacé. Utilisez à la place l'argument `innerText`, il fait office de placeholder pour le multiselect searchable ou de contenu pour le bouton.
* L'argument `size` a été supprimé. Ce composant a désormais une taille unique (correspondant à l'ancien small).
* L'argument `showOnInput` a été supprimé, pour un comportement non a11y compliant.
* L'argument `screenReaderOnly` a été ajouté afin de caché de manière accessible le `label` à l'écran

## :christmas_tree: Problème

Le composant multi select n'était pas accessible. il avait des comportement différent entre le mode searchable ou non. 

## :gift: Solution
Sur les recommandations de l'équipe a11y, nous avons implémenté le PixMultiSelect en mode `disclosure` avec les utilisations du  `menu button`

https://www.w3.org/WAI/ARIA/apg/patterns/disclosure/

https://www.w3.org/WAI/ARIA/apg/patterns/menubutton/

## :santa: Pour tester
Installer le composants PixMultiSelect sur PixOrga et vérifier que tout fonctionne
