### PR TITLE
[FEATURE] Améliorer de l'accessibilité de Pix-Sidebar.

### DIFF
--- a/addon/components/pix-sidebar.hbs
+++ b/addon/components/pix-sidebar.hbs
@@ -7,13 +7,13 @@
   <div
     class="pix-sidebar {{unless @showSidebar ' pix-sidebar--hidden'}}"
     role="dialog"
-    aria-labelledby="sidebar-title"
-    aria-describedby="sidebar-content"
+    aria-labelledby="sidebar-title--{{this.id}}"
+    aria-describedby="sidebar-content--{{this.id}}"
     aria-modal="true"
     ...attributes
   >
     <header class="pix-sidebar__header">
-      <h1 id="sidebar-title" class="pix-sidebar__title">{{@title}}</h1>
+      <h1 id="sidebar-title--{{this.id}}" class="pix-sidebar__title">{{@title}}</h1>
       <PixIconButton
         @icon="xmark"
         @triggerAction={{@onClose}}
@@ -23,7 +23,7 @@
         class="pix-sidebar__close-button"
       />
     </header>
-    <main id="sidebar-content" class="pix-sidebar__content">
+    <main id="sidebar-content--{{this.id}}" class="pix-sidebar__content">
       {{yield to="content"}}
     </main>
     <footer class="pix-sidebar__footer">

--- a/addon/components/pix-sidebar.js
+++ b/addon/components/pix-sidebar.js
@@ -1,5 +1,6 @@
 import Component from '@glimmer/component';
 import { action } from '@ember/object';
+import uniqueId from '@1024pix/pix-ui/utils/unique-id';
 
 export default class PixSidebar extends Component {
   constructor(...args) {
@@ -19,5 +20,9 @@ export default class PixSidebar extends Component {
 
   isClickOnOverlay(event) {
     return event.target.classList.contains('pix-sidebar__overlay');
+  }
+
+  get id() {
+    return uniqueId();
   }
 }

--- a/addon/styles/_trap-focus.scss
+++ b/addon/styles/_trap-focus.scss
@@ -1,0 +1,3 @@
+.body__trap-focus {
+  overflow: hidden;
+}

--- a/addon/styles/addon.scss
+++ b/addon/styles/addon.scss
@@ -28,6 +28,7 @@
 @import 'pix-dropdown';
 @import 'pix-pagination';
 @import 'pix-checkbox';
+@import 'trap-focus';
 
 html {
   font-size: 16px;

--- a/addon/utils/unique-id.js
+++ b/addon/utils/unique-id.js
@@ -1,0 +1,5 @@
+export default function uniqueId() {
+  return ([3e7] + -1e3 + -4e3 + -2e3 + -1e11).replace(/[0-3]/g, (a) =>
+    ((a * 4) ^ ((Math.random() * 16) >> (a & 2))).toString(16)
+  );
+}

--- a/app/modifiers/trap-focus.js
+++ b/app/modifiers/trap-focus.js
@@ -6,9 +6,11 @@ export default modifier(function trapFocus(element, [isOpen]) {
   const [firstFocusableElement] = findFocusableElements(element);
 
   if (isOpen) {
+    preventPageScrolling();
     sourceActiveElement = document.activeElement;
     focusElement(firstFocusableElement, element);
   } else if (sourceActiveElement) {
+    allowPageScrolling();
     focusElement(sourceActiveElement, element);
   }
 
@@ -56,6 +58,14 @@ function focusElement(elementToFocus, element) {
       element.removeEventListener('animationend', handleTransitionEnd);
     }
   };
+}
+
+function preventPageScrolling() {
+  document.body.classList.add('body__trap-focus');
+}
+
+function allowPageScrolling() {
+  document.body.classList.remove('body__trap-focus');
 }
 
 function hasTransitionDuration(element) {

--- a/app/stories/pix-sidebar.stories.js
+++ b/app/stories/pix-sidebar.stories.js
@@ -17,7 +17,9 @@ export const Template = (args) => {
           </div>
         </:footer>
       </PixSidebar>
-      <PixButton @triggerAction={{fn (mut showSidebar) (not showSidebar)}}>Ouvrir la sidebar</PixButton>
+      <div style="display:flex; justify-content:center; align-items:center; height:105vh;">
+        <PixButton @triggerAction={{fn (mut showSidebar) (not showSidebar)}} style="height:45px">Ouvrir la sidebar</PixButton>
+      </div>
     `,
     context: args,
   };


### PR DESCRIPTION
## :christmas_tree: Problème

- Certains `ids` étaient en dur dans le composant. On ne pouvait pas utiliser plusieurs sidebar dans la même page
- On pouvait encore scroller dans la page alors que la sidebar était ouverte

## :gift: Solution

- Ajouter des ids dynamiques.
- Empêcher le scroll sur la page à l'ouverture de la sidebar.

## :star2: Remarques


## :santa: Pour tester

- Vérifier sur le composant sidebar que la class `body__trap-focus` existe à l'ouverture de la sidebar.
- Vérifier que la sidebar a un id unique dans le dom via la console.
