### PR TITLE
[FEATURE] Améliorer l'accessibilité de Pix-Modal.

### DIFF
--- a/addon/components/pix-modal.hbs
+++ b/addon/components/pix-modal.hbs
@@ -7,13 +7,13 @@
   <div
     class="pix-modal"
     role="dialog"
-    aria-labelledby="modal-title"
-    aria-describedby="modal-content"
+    aria-labelledby="modal-title--{{this.id}}"
+    aria-describedby="modal-content--{{this.id}}"
     aria-modal="true"
     ...attributes
   >
     <header class="pix-modal__header">
-      <h1 id="modal-title" class="pix-modal__title">{{@title}}</h1>
+      <h1 id="modal-title--{{this.id}}" class="pix-modal__title">{{@title}}</h1>
       <PixIconButton
         @icon="xmark"
         @triggerAction={{@onCloseButtonClick}}
@@ -23,7 +23,7 @@
         class="pix-modal__close-button"
       />
     </header>
-    <main id="modal-content" class="pix-modal__content">
+    <main id="modal-content--{{this.id}}" class="pix-modal__content">
       {{yield to="content"}}
     </main>
     <footer class="pix-modal__footer">

--- a/addon/components/pix-modal.js
+++ b/addon/components/pix-modal.js
@@ -1,5 +1,6 @@
 import Component from '@glimmer/component';
 import { action } from '@ember/object';
+import uniqueId from '@1024pix/pix-ui/utils/unique-id';
 
 export default class PixModal extends Component {
   constructor(...args) {
@@ -19,5 +20,9 @@ export default class PixModal extends Component {
 
   isClickOnOverlay(event) {
     return event.target.classList.contains('pix-modal__overlay');
+  }
+
+  get id() {
+    return uniqueId();
   }
 }

--- a/addon/styles/_pix-modal.scss
+++ b/addon/styles/_pix-modal.scss
@@ -7,7 +7,7 @@
   right: 0;
   top: 0;
   z-index: 1000;
-  transition: all .3s ease-in-out;
+  transition: all 0.3s ease-in-out;
 
   &--hidden {
     visibility: hidden;

--- a/app/stories/pix-modal.stories.js
+++ b/app/stories/pix-modal.stories.js
@@ -19,8 +19,9 @@ export const Template = (args) => {
         <PixButton @triggerAction={{fn (mut showModal) (not showModal)}}>Valider</PixButton>
       </:footer>
     </PixModal>
-    <PixButton @triggerAction={{fn (mut showModal) (not showModal)}}>Ouvrir la modale</PixButton>
-    `,
+    <div style="display:flex; justify-content:center; align-items:center; height:105vh;">
+      <PixButton @triggerAction={{fn (mut showModal) (not showModal)}}>Ouvrir la modale</PixButton>
+    </div>`,
     context: args,
   };
 };


### PR DESCRIPTION
## :christmas_tree: Problème
- Certains `ids` étaient en dur dans le composant. On ne pouvait pas utiliser plusieurs `modal` dans la même page

## :gift: Solution
- Ajouter des `ids` dynamiques.

## :santa: Pour tester
- Vérifier que la `modal` a un `id unique `dans le dom via la console.
