### PR TITLE
[BUFGIX] Mettre à jour la page d'utilisation de la PixModal (PIX-5735)

### DIFF
--- a/app/stories/pix-modal.stories.js
+++ b/app/stories/pix-modal.stories.js
@@ -49,7 +49,7 @@ export const argTypes = {
   showModal: {
     name: 'showModal',
     description: "Gérer l'ouverture de la modale",
-    type: { name: 'boolean', required: false },
+    type: { name: 'boolean', required: true },
     control: { type: 'boolean' },
     table: {
       type: { summary: 'boolean' },

--- a/app/stories/pix-modal.stories.mdx
+++ b/app/stories/pix-modal.stories.mdx
@@ -30,6 +30,7 @@ Ce composant possède deux `yield` :
 ```html
 <PixModal
   @title="Qu'est-ce qu'une modale ?"
+  @showModal={{this.showModal}}
   @onCloseButtonClick={{this.closeModal}}
 >
  <:content>


### PR DESCRIPTION
## :boom: BREAKING_CHANGES
RAS

## :christmas_tree: Problème
La manière d'utiliser la PixModal n'a pas été mis à jour lors de son update.

## :gift: Solution
Rajouter la manière d'utiliser correctement la PixModal

## :star2: Remarques
RAS

## :santa: Pour tester
Vérifier que dans la page PixModal nous avons bien le showModal de déclaré et required