### PR TITLE
[FEATURE] Suppression du `padding` de la Sidebar pour permettre de mieux customiser

### DIFF
--- a/addon/styles/_pix-sidebar.scss
+++ b/addon/styles/_pix-sidebar.scss
@@ -69,10 +69,6 @@ $button-margin: 16px;
     }
   }
 
-  &__content {
-    padding: $sidebar-padding 0;
-  }
-
   &__footer {
     padding: $sidebar-padding;
     border-top: 1px solid $pix-neutral-20;


### PR DESCRIPTION
## :christmas_tree: Problème
Dans nos usages actuels, le `padding` en haut et en bas du contenu de la Sidebar nous embête plus qu'autre chose.

<img width="321" alt="image" src="https://user-images.githubusercontent.com/5855339/191964274-ee6f3c8e-7eb0-4c19-a105-e074df8bdb15.png">

<img width="338" alt="image" src="https://user-images.githubusercontent.com/5855339/191964313-4fd71e71-7d37-4a1c-8b96-17b12d6212dc.png">

## :gift: Solution
Retirer ce `padding`.

## :star2: Remarques
Le fait de ne pas avoir de `padding` permet une customisation maximum de la Sidebar. Par contre cela laisse l'ouverture à de l'hétérogénéité.

La `PixModal`, elle, définit un padding dans le contenu.

## :santa: Pour tester
Vérifier sur Storybook qu'il n'y a plus de padding dans le contenu de la Sidebar.