### PR TITLE
[FEATURE] Centre la PixModal en hauteur

### DIFF
--- a/addon/styles/_pix-modal.scss
+++ b/addon/styles/_pix-modal.scss
@@ -40,14 +40,15 @@ $button-margin: 16px;
   vertical-align: middle; // Centered vertically with the .pix-modal__overlay::after which is 100% height
   width: 512px;
   max-width: calc(100% - #{2 * $spacing-xs}); // Horizontal margin sets here to have extra space for the .pix-modal__overlay::after on mobile
-  text-align: initial;
+  text-align: initial; 
+  background-color: $pix-neutral-10;
   box-shadow: 1px 1px 5px rgba(0, 0, 0, 0.1);
+  border-radius: 4px;
+  overflow: hidden;
 
   &__header {
     background: $pix-neutral-0;
     border-bottom: 1px solid $pix-neutral-20;
-    border-top-left-radius: 4px;
-    border-top-right-radius: 4px;
     padding: $modal-padding;
     display: flex;
     align-items: flex-start;
@@ -79,7 +80,6 @@ $button-margin: 16px;
   }
 
   &__content {
-    background-color: $pix-neutral-10;
     padding: $modal-padding;
     font-size: 0.875rem;
     color: $pix-neutral-90;
@@ -93,10 +93,7 @@ $button-margin: 16px;
   }
 
   &__footer {
-    background-color: $pix-neutral-10;
     padding: 0 $modal-padding $modal-padding - $button-margin;
-    border-bottom-left-radius: 4px;
-    border-bottom-right-radius: 4px;
 
     @include device-is('tablet') {
       display: flex;

--- a/addon/styles/_pix-modal.scss
+++ b/addon/styles/_pix-modal.scss
@@ -5,14 +5,22 @@
   bottom: 0;
   left: 0;
   right: 0;
-  overflow-y: scroll;
-  padding: $spacing-xs;
+  overflow-y: auto;
+  text-align: center; // Used to center horizontally the inline-block modal content
+  padding: $spacing-xs 0;
   background-color: rgba(52, 69, 99, 0.7);
   transition: all 0.3s ease-in-out;
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  flex-direction: column;
+
+  // This block is used to center vertically the modal
+  // if the content is less than 100vh
+  // Inspired by https://mui.com/material-ui/react-dialog/#scrolling-long-content
+  &::after {
+    content: "";
+    display: inline-block;
+    vertical-align: middle;
+    height: 100%;
+    width: 0px;
+  }
 
   &--hidden {
     visibility: hidden;
@@ -28,10 +36,12 @@ $button-margin: 16px;
 
 .pix-modal {
   @import 'reset-css';
-  width: 100%;
-  max-width: 512px;
+  display: inline-block;
+  vertical-align: middle; // Centered vertically with the .pix-modal__overlay::after which is 100% height
+  width: 512px;
+  max-width: calc(100% - #{2 * $spacing-xs}); // Horizontal margin sets here to have extra space for the .pix-modal__overlay::after on mobile
+  text-align: initial;
   box-shadow: 1px 1px 5px rgba(0, 0, 0, 0.1);
-  min-height: 0;
 
   &__header {
     background: $pix-neutral-0;

--- a/addon/styles/_pix-modal.scss
+++ b/addon/styles/_pix-modal.scss
@@ -1,13 +1,18 @@
 .pix-modal__overlay {
-  background-color: rgba(52, 69, 99, 0.7);
+  position: fixed;
+  z-index: 1000;
+  top: 0;
   bottom: 0;
   left: 0;
-  overflow-y: scroll;
-  position: fixed;
   right: 0;
-  top: 0;
-  z-index: 1000;
+  overflow-y: scroll;
+  padding: $spacing-xs;
+  background-color: rgba(52, 69, 99, 0.7);
   transition: all 0.3s ease-in-out;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  flex-direction: column;
 
   &--hidden {
     visibility: hidden;
@@ -23,10 +28,10 @@ $button-margin: 16px;
 
 .pix-modal {
   @import 'reset-css';
-  box-shadow: 1px 1px 5px rgba(0, 0, 0, 0.1);
-  margin: 20vh auto;
+  width: 100%;
   max-width: 512px;
-  width: calc(100% - 24px);
+  box-shadow: 1px 1px 5px rgba(0, 0, 0, 0.1);
+  min-height: 0;
 
   &__header {
     background: $pix-neutral-0;


### PR DESCRIPTION
## :christmas_tree: Problème
La `PixSidebar` a un margin de `20vh` en haut en bas. Ca fait bizarre quand la modale contient beaucoup de contenu.

## :gift: Solution
Centrer la modale verticalement.

Si il y a trop de contenu, lui appliquer un espacement minimum similaire à celui qu'on a en mobile.

## :star2: Remarques
~J'ai ajouté un `min-height: 0;` pour éviter que la modale déborde en haut. C'est un peu mystérieux pour moi, la modale ne prend pas toute la hauteur qu'elle occupe réellement (même avec `height: 100%`) donc l'espacement en bas de la modale ne s'affiche pas quand le contenu est trop grand.~

Inspiré du [Dialog de Material-ui](https://mui.com/material-ui/react-dialog/#scrolling-long-content), et pour mieux gérer le padding du bas, le manière de faire a été revue.
Nous utilisons maintenant l'alignement vertical d'éléments en inline-block.

- Si, le contenu est plus grand que 100vh, alors, le scroll est automatique, et donc on a pas besoin de centrer verticalement la modale.
- Si, le contenu est plus petit que 100vh, alors, on utilise un élément "caché" créé via un `::after`, qui fait une hauteur de 100%, et qui sert de référence à notre modale pour se centrer verticalement avec elle.

## :santa: Pour tester
Checker les stories dans la RA pour vérifier que c'est mieux qu'avant.
