### PR TITLE
[BREAKING CHANGES][FEATURE] Suppression du padding dans le composant `PixBlock` (PIX-5971).

### DIFF
--- a/addon/components/pix-background-header.hbs
+++ b/addon/components/pix-background-header.hbs
@@ -1,7 +1,7 @@
 <div class="pix-background-header" ...attributes>
-
   <div class="pix-background-header__background"></div>
 
-  {{yield}}
-
+  <div class="pix-background-header__content">
+    {{yield}}
+  </div>
 </div>

--- a/addon/styles/_pix-background-header.scss
+++ b/addon/styles/_pix-background-header.scss
@@ -1,6 +1,4 @@
 .pix-background-header {
-  @import 'reset-css';
-
   position: relative;
   display: flex;
   flex-direction: column;
@@ -17,5 +15,10 @@
     background: $pix-primary-app-gradient;
     box-shadow: 0 2px 8px 0 rgba(0, 0, 0, 0.1);
     color: $pix-neutral-0;
+  }
+
+  &__content {
+    max-width: 980px;
+    margin: 0 auto;
   }
 }

--- a/addon/styles/_pix-block.scss
+++ b/addon/styles/_pix-block.scss
@@ -4,9 +4,9 @@
   border-radius: 5px;
 
   &--shadow-light {
-    box-shadow: 0px 4px 8px 0px hsla(220, 74%, 10%, 0.08);
+    box-shadow: 0px 4px 8px 0px $pix-neutral-110;
   }
-  
+
   &--shadow-heavy {
     box-shadow: 0 50px 54px -40px rgba($pix-neutral-110, 0.4),
       0 7px 14px 0 rgba($pix-neutral-100, 0.1);

--- a/addon/styles/_pix-block.scss
+++ b/addon/styles/_pix-block.scss
@@ -1,9 +1,6 @@
 .pix-block {
   position: relative;
   width: 100%;
-  max-width: 980px;
-  padding: 14px 24px;
-  margin-bottom: 32px;
   background-color: $pix-neutral-0;
   border-radius: 5px;
 
@@ -13,17 +10,5 @@
   &--shadow-heavy {
     box-shadow: 0 50px 54px -40px rgba($pix-neutral-110, 0.4),
       0 7px 14px 0 rgba($pix-neutral-100, 0.1);
-  }
-}
-
-.pix-background-header {
-  &__background + .pix-block {
-    margin-top: 68px;
-  }
-}
-
-@include device-is('mobile') {
-  .pix-block {
-    padding: 16px;
   }
 }

--- a/addon/styles/_pix-block.scss
+++ b/addon/styles/_pix-block.scss
@@ -1,12 +1,12 @@
 .pix-block {
   position: relative;
-  width: 100%;
   background-color: $pix-neutral-0;
   border-radius: 5px;
 
   &--shadow-light {
-    box-shadow: 0 10px 20px 0 rgba($pix-primary, 0.06);
+    box-shadow: 0px 4px 8px 0px hsla(220, 74%, 10%, 0.08);
   }
+  
   &--shadow-heavy {
     box-shadow: 0 50px 54px -40px rgba($pix-neutral-110, 0.4),
       0 7px 14px 0 rgba($pix-neutral-100, 0.1);

--- a/app/stories/pix-background-header.stories.js
+++ b/app/stories/pix-background-header.stories.js
@@ -5,9 +5,9 @@ export const backgroundHeader = (args) => {
     template: hbs`
       <PixBackgroundHeader>
 
-        <PixBlock>Un panel avec du text</PixBlock>
+        <PixBlock style="margin: 68px 0 32px; padding: 14px 24px;">Un panel avec du text</PixBlock>
 
-        <PixBlock>
+        <PixBlock style="padding: 14px 24px;">
           Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis a interdum mauris. Morbi ac diam varius, maximus massa id, venenatis lectus. Fusce interdum tincidunt mattis. Nullam porta sollicitudin lorem, sodales cursus arcu finibus in. Nam pretium congue diam sollicitudin faucibus. Aliquam nec augue massa. Pellentesque eleifend nec arcu eu tincidunt. Pellentesque at quam dignissim, lacinia sem et, pharetra magna. Etiam venenatis felis augue, id sollicitudin sapien interdum at. Cras bibendum fermentum eros, rutrum varius turpis venenatis vitae. Suspendisse aliquet iaculis sem in blandit. Mauris vitae erat lobortis est volutpat bibendum non molestie purus.
           Orci varius natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Sed consequat porttitor metus a imperdiet. Duis quis enim fermentum, sodales massa sit amet, blandit elit. Aliquam felis purus, dictum sed pretium vel, aliquam sit amet felis. Nunc convallis pellentesque convallis. Suspendisse potenti. Aenean iaculis, nunc placerat aliquam posuere, tellus enim facilisis metus, non egestas sapien arcu et leo.
         </PixBlock>

--- a/app/stories/pix-block.stories.mdx
+++ b/app/stories/pix-block.stories.mdx
@@ -13,8 +13,6 @@ import * as stories from './pix-block.stories.js';
 
 Un \`Block\` est un bloc de fond blanc dont les bords sont arrondis et ayant une ombre projetée.
 
-> Les marges intérieures du bloc sont de 14px (haut et bas) et 24px (droite et gauche), sauf pour la version mobile où c'est 16px (partout).
-
 > Un \`Block\` prendra toute la largeur de son parent, dans la limite maximale de 980px.
 
 > Donnez donc un parent de la taille que vous souhaitez, votre bloc prendra la même taille.

--- a/tests/integration/components/pix-background-header-test.js
+++ b/tests/integration/components/pix-background-header-test.js
@@ -8,6 +8,7 @@ module('Integration | Component | pix-background-header', function (hooks) {
 
   const BACKGROUND_HEADER_SELECTOR = '.pix-background-header';
   const BACKGROUND_SELECTOR = `${BACKGROUND_HEADER_SELECTOR} .pix-background-header__background`;
+  const BACKGROUND_CONTENT_SELECTOR = `${BACKGROUND_HEADER_SELECTOR} .pix-background-header__content`;
 
   test('it renders the default PixBackgroundHeader', async function (assert) {
     // when
@@ -37,8 +38,8 @@ module('Integration | Component | pix-background-header', function (hooks) {
           <PixBlock>Je suis un deuxième bloc</PixBlock>
         </PixBackgroundHeader>
       `);
-      const firstBlockElement = this.element.querySelector(BACKGROUND_HEADER_SELECTOR).children[1];
-      const lastBlockElement = this.element.querySelector(BACKGROUND_HEADER_SELECTOR).children[2];
+      const firstBlockElement = this.element.querySelector(BACKGROUND_CONTENT_SELECTOR).children[0];
+      const lastBlockElement = this.element.querySelector(BACKGROUND_CONTENT_SELECTOR).children[1];
 
       // then
       assert.equal(firstBlockElement.className, 'pix-block pix-block--shadow-heavy');


### PR DESCRIPTION
## :boom: BREAKING_CHANGES
La suppression du padding, fait qu'il doit désormais être géré par les composants utilisant `<PixBlock>`.
Pour gérer les cas nominaux, il faut ajouter : 
```scss
	padding: 14px 24px; 
	margin-bottom: 32px;
	
	@include device-is('mobile') {
		  .pix-block {
		    padding: 16px;
		  }
	}
``` 

## :christmas_tree: Problème
Le composant `PixBlock` manque de généricité due au padding que son style par défaut contient. 
Le composant : 
	- doit uniquement permettre d'avoir un encadré avec une ombre sur un fond blanc.
	- ne doit pas se préoccuper du positionnement des choses qu'il contient
	- ne doit pas se préoccuper des choses qui l'entourent. 

## :gift: Solution
- Retirer le padding du composant `PixBlock` ainsi que le `margin`.

## :star2: Remarques
- Des réflexions sont en cours :
  * la possibilité de créer un composant PixCard, basé sur PixBlock.
  * gérer plusieurs intensités d'ombrage

## :santa: Pour tester
- Vérifier la story `PixBlock` ainsi que la story `PixBackgroundHeader`
