### PR TITLE
[BUGFIX] suppression d'un display flex inutile sur le conteneur principal de PixBackgroundHeader

### DIFF
--- a/addon/styles/_pix-background-header.scss
+++ b/addon/styles/_pix-background-header.scss
@@ -1,9 +1,6 @@
 .pix-background-header {
   position: relative;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  padding: 0 24px;
+  padding: 68px 24px 0;
 
   &__background {
     position: absolute;

--- a/app/stories/pix-background-header.stories.js
+++ b/app/stories/pix-background-header.stories.js
@@ -5,7 +5,7 @@ export const backgroundHeader = (args) => {
     template: hbs`
       <PixBackgroundHeader>
 
-        <PixBlock style="margin: 68px 0 32px; padding: 14px 24px;">Un panel avec du text</PixBlock>
+        <PixBlock style="margin: 0 0 32px; padding: 14px 24px;">Un panel avec du text</PixBlock>
 
         <PixBlock style="padding: 14px 24px;">
           Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis a interdum mauris. Morbi ac diam varius, maximus massa id, venenatis lectus. Fusce interdum tincidunt mattis. Nullam porta sollicitudin lorem, sodales cursus arcu finibus in. Nam pretium congue diam sollicitudin faucibus. Aliquam nec augue massa. Pellentesque eleifend nec arcu eu tincidunt. Pellentesque at quam dignissim, lacinia sem et, pharetra magna. Etiam venenatis felis augue, id sollicitudin sapien interdum at. Cras bibendum fermentum eros, rutrum varius turpis venenatis vitae. Suspendisse aliquet iaculis sem in blandit. Mauris vitae erat lobortis est volutpat bibendum non molestie purus.


### PR DESCRIPTION
## :christmas_tree: Problème
Trop de gros changements à gérer côté mon-pix à cause d'un flex inutile sur le composant PixBackgroundHeader.

## :gift: Solution
Supprimer la propriété `display: flex`.

## :star2: Remarques
L'espacement entre le background et le contenu est maintenant tout le temps géré par le composant.

## :santa: Pour tester
Vérifier la story du composant
