### PR TITLE
[BUGFIX] Permettre le scroll quand la modale est détruite

### DIFF
--- a/app/modifiers/trap-focus.js
+++ b/app/modifiers/trap-focus.js
@@ -22,6 +22,7 @@ export default modifier(function trapFocus(element, [isOpen]) {
     element.removeEventListener('keydown', (event) => {
       handleKeyDown(event, element);
     });
+    allowPageScrolling();
   };
 });
 


### PR DESCRIPTION
## :boom: BREAKING_CHANGES
> _Décrivez ici les changements cassant (voir la doc associée)[https://github.com/1024pix/pix-ui/blob/dev/docs/breaking-changes.stories.mdx], s'il n'y en a pas indiquez le aussi.

## :christmas_tree: Problème
Lorsqu'on fait un changement de page à l'aide d'un <LinkTo> dans la <PixModal>, nous n'enlevons pas le trap-focus qui permet de ne pas scroller sur la page.

## :gift: Solution
Enlever le trap-focus quand le composant est détruit (cf: https://guides.emberjs.com/release/components/template-lifecycle-dom-and-modifiers/#toc_out-of-component-modifications) 
<img width="786" alt="image" src="https://user-images.githubusercontent.com/26384707/195335411-8b7b13ba-0e8f-452a-9733-0761638109d1.png">


## :star2: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :santa: Pour tester
- Utiliser un LinkTo dans une modale 
- Constater que la classe `body__trap-focus` n'est plus présente sur l'élément `body `après la rédirection 