### PR TITLE
[BUGFIX] Réparer l'ombre du compsant Pix Block.

### DIFF
--- a/addon/styles/_pix-block.scss
+++ b/addon/styles/_pix-block.scss
@@ -4,11 +4,10 @@
   border-radius: 5px;
 
   &--shadow-light {
-    box-shadow: 0px 4px 8px 0px $pix-neutral-110;
+    box-shadow: 0px 4px 8px rgba($pix-neutral-110, 0.08);
   }
 
   &--shadow-heavy {
-    box-shadow: 0 50px 54px -40px rgba($pix-neutral-110, 0.4),
-      0 7px 14px 0 rgba($pix-neutral-100, 0.1);
+    box-shadow: 0px 12px 24px rgba($pix-neutral-110, 0.08);
   }
 }


### PR DESCRIPTION
## :christmas_tree: Problème
L'ombre actuelle du composant `Pix-Block` n'est pas la bonne.

## :gift: Solution
Mettre la bonne ombre du design system

## :star2: Remarques
N/A

## :santa: Pour tester
Comparer l'ombre du composant `Pix-Block` de pix-ui avec celle du design system : https://www.figma.com/file/8RJ3aCSfdeQ8AZZVBBYKS8/Design-System-Pix?node-id=54%3A5134