### PR TITLE
[FEATURE] Gérer l'échappement de la tooltip (PIX-6114)

### DIFF
--- a/addon/components/pix-tooltip.hbs
+++ b/addon/components/pix-tooltip.hbs
@@ -1,4 +1,12 @@
-<span class="pix-tooltip" ...attributes>
+<span
+  class="pix-tooltip"
+  {{on-escape-action this.hideTooltip}}
+  {{on "mouseover" this.showTooltip}}
+  {{on "mouseout" this.hideTooltipOnMouseOut}}
+  {{on "focusin" this.showTooltip}}
+  {{on "focusout" this.hideTooltip}}
+  ...attributes
+>
   {{#if (has-block "triggerElement")}}
     {{yield to="triggerElement"}}
   {{/if}}

--- a/addon/components/pix-tooltip.js
+++ b/addon/components/pix-tooltip.js
@@ -1,4 +1,5 @@
 import Component from '@glimmer/component';
+import { action } from '@ember/object';
 
 export default class PixTooltip extends Component {
   get position() {
@@ -17,5 +18,26 @@ export default class PixTooltip extends Component {
 
   get display() {
     return typeof this.args.hide === 'undefined' || !this.args.hide;
+  }
+
+  @action
+  showTooltip(event) {
+    event.target.classList.add('pix-tooltip--visible');
+  }
+
+  @action
+  hideTooltip(event) {
+    event.target.classList.remove('pix-tooltip--visible');
+  }
+
+  @action
+  hideTooltipOnMouseOut(event) {
+    const isFocused = document.activeElement === event.target;
+
+    if (isFocused) {
+      return;
+    }
+
+    this.hideTooltip(event);
   }
 }

--- a/addon/styles/_pix-tooltip.scss
+++ b/addon/styles/_pix-tooltip.scss
@@ -5,9 +5,10 @@
   display: flex;
   justify-content: center;
   align-items: center;
+}
 
-  & > *:first-child:hover + .pix-tooltip__content,
-  & > *:first-child:focus + .pix-tooltip__content {
+.pix-tooltip--visible {
+  + .pix-tooltip__content {
     display: block;
     opacity: 1;
   }

--- a/tests/integration/components/pix-tooltip-test.js
+++ b/tests/integration/components/pix-tooltip-test.js
@@ -1,7 +1,8 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import { render } from '@ember/test-helpers';
+import { render } from '@1024pix/ember-testing-library';
 import { hbs } from 'ember-cli-htmlbars';
+import userEvent from '@testing-library/user-event';
 
 module('Integration | Component | pix-tooltip', function (hooks) {
   setupRenderingTest(hooks);
@@ -61,6 +62,27 @@ module('Integration | Component | pix-tooltip', function (hooks) {
     const tooltipContentElement = this.element.querySelector(TOOLTIP_SELECTOR);
     assert.contains('template block text');
     assert.notOk(tooltipContentElement);
+  });
+
+  test('it dismissed tooltip on escape keyup', async function (assert) {
+    // given
+    const screen = await render(hbs`
+      <PixTooltip>
+        <:triggerElement>
+          template block text
+        </:triggerElement>
+        <:tooltip></:tooltip>
+      </PixTooltip>
+    `);
+
+    // when
+    await screen.getByText('template block text').focus();
+
+    await userEvent.keyboard('[Escape]');
+
+    // then
+    assert.contains('template block text');
+    assert.dom('.pix-tooltip__content').isNotVisible();
   });
 
   module('tooltip position', function () {


### PR DESCRIPTION
## :christmas_tree: Problème
La tooltip n'était pas masquée lors de l'échappement.

## :gift: Solution
Utilisation du modifier `on-escape-action`.

## :santa: Pour tester
Aller sur la storie et tester que la tooltip est masquée lors de l'échappement