### PR TITLE
[FEATURE] Revue du design des boutons (PIX-6218)

### DIFF
--- a/addon/styles/_colors.scss
+++ b/addon/styles/_colors.scss
@@ -88,6 +88,7 @@ $pix-error-50: #ef4444;
 $pix-error-60: #dc2626;
 $pix-error-70: #b91c1c;
 $pix-error-80: #991b1b;
+$pix-error-90: #861212;
 
 // Neutral
 $pix-neutral-0: #ffffff;

--- a/addon/styles/_pix-banner.scss
+++ b/addon/styles/_pix-banner.scss
@@ -38,6 +38,10 @@
         background-color: $pix-primary-10;
         color: $pix-primary-70;
       }
+
+      &:focus:enabled {
+        outline-color: $pix-primary-70;
+      }
     }
   }
 
@@ -53,6 +57,10 @@
         background-color: $pix-warning-10;
         color: $pix-warning-70;
       }
+
+      &:focus:enabled {
+        outline-color: $pix-warning-70;
+      }
     }
   }
 
@@ -67,6 +75,10 @@
       &:active:enabled {
         background-color: $pix-error-10;
         color: $pix-error-70;
+      }
+
+      &:focus:enabled {
+        outline-color: $pix-error-70;
       }
     }
   }

--- a/addon/styles/_pix-button-base.scss
+++ b/addon/styles/_pix-button-base.scss
@@ -54,8 +54,8 @@
       &:focus,
       &:focus-visible {
         background-color: $pix-primary-60;
-        box-shadow: 0 0 0 2px $pix-primary-60;
-        border: 2px solid $pix-neutral-0;
+        box-shadow: inset 0 0 0 2px $pix-neutral-0;
+        border: 2px solid $pix-primary-60;
       }
 
       &:active {
@@ -79,8 +79,8 @@
       &:focus,
       &:focus-visible {
         background-color: $pix-success-70;
-        box-shadow: 0 0 0 2px $pix-success-70;
-        border: 2px solid $pix-neutral-0;
+        box-shadow: inset 0 0 0 2px $pix-neutral-0;
+        border: 2px solid $pix-success-70;
       }
 
       &:active {
@@ -106,8 +106,8 @@
       &:focus,
       &:focus-visible {
         background-color: $pix-warning-50;
-        box-shadow: 0 0 0 2px $pix-warning-50;
-        border: 2px solid $pix-neutral-0;
+        box-shadow: inset 0 0 0 2px $pix-neutral-0;
+        border: 2px solid $pix-warning-50;
       }
 
       &:active {
@@ -133,8 +133,8 @@
       &:focus,
       &:focus-visible {
         background-color: $pix-error-70;
-        box-shadow: 0 0 0 2px $pix-error-70;
-        border: 2px solid $pix-neutral-0;
+        box-shadow: inset 0 0 0 2px $pix-neutral-0;
+        border: 2px solid $pix-error-70;
       }
 
       &:active {

--- a/addon/styles/_pix-button-base.scss
+++ b/addon/styles/_pix-button-base.scss
@@ -10,6 +10,7 @@
   cursor: pointer;
   background-color: $pix-primary;
   border: 2px solid transparent;
+  outline: none;
   display: flex;
   justify-content: center;
   align-items: center;
@@ -42,52 +43,50 @@
 
   &--background-blue {
     background-color: $pix-primary;
-    border-color: $pix-primary;
 
     &:not(.pix-button--disabled) {
       &:hover {
-        background-color: darken($pix-primary, 8%);
-        box-shadow: 0 0 0 2px darken($pix-primary, 8%);
-        border-color: $pix-neutral-0;
-        outline: none;
+        background-color: $pix-primary-60;
+        box-shadow: none;
+        border: 2px solid transparent;
       }
 
       &:focus,
       &:focus-visible {
-        background-color: darken($pix-primary, 8%);
-        box-shadow: 0 0 0 2px darken($pix-primary, 8%);
-        border-color: $pix-neutral-0;
-        outline: none;
+        background-color: $pix-primary-60;
+        box-shadow: 0 0 0 2px $pix-primary-60;
+        border: 2px solid $pix-neutral-0;
       }
 
       &:active {
-        background-color: darken($pix-primary, 12%);
+        background-color: $pix-primary-70;
+        box-shadow: none;
+        border: 2px solid transparent;
       }
     }
   }
 
   &--background-green {
-    background-color: $green;
-    border-color: $green;
+    background-color: $pix-success-60;
 
     &:not(.pix-button--disabled) {
       &:hover {
-        background-color: darken($green, 8%);
-        box-shadow: 0 0 0 2px darken($green, 8%);
-        border-color: $pix-neutral-0;
-        outline: none;
+        background-color: $pix-success-70;
+        box-shadow: none;
+        border: 2px solid transparent;
       }
 
       &:focus,
       &:focus-visible {
-        background-color: darken($green, 8%);
-        box-shadow: 0 0 0 2px darken($green, 8%);
-        border-color: $pix-neutral-0;
-        outline: none;
+        background-color: $pix-success-70;
+        box-shadow: 0 0 0 2px $pix-success-70;
+        border: 2px solid $pix-neutral-0;
       }
 
       &:active {
-        background-color: darken($green, 12%);
+        background-color: $pix-success-80;
+        box-shadow: none;
+        border: 2px solid transparent;
       }
     }
   }
@@ -95,26 +94,26 @@
   &--background-yellow {
     color: $pix-neutral-100;
     background-color: $pix-warning-40;
-    border-color: $pix-warning-40;
+    border: 2px solid transparent;
 
     &:not(.pix-button--disabled) {
       &:hover {
-        background-color: darken($pix-warning-40, 8%);
-        box-shadow: 0 0 0 2px darken($pix-warning-40, 8%);
-        border-color: $pix-neutral-0;
-        outline: none;
+        background-color: $pix-warning-50;
+        box-shadow: none;
+        border: 2px solid transparent;
       }
 
       &:focus,
       &:focus-visible {
-        background-color: darken($pix-warning-40, 8%);
-        box-shadow: 0 0 0 2px darken($pix-warning-40, 8%);
-        border-color: $pix-neutral-0;
-        outline: none;
+        background-color: $pix-warning-50;
+        box-shadow: 0 0 0 2px $pix-warning-50;
+        border: 2px solid $pix-neutral-0;
       }
 
       &:active {
-        background-color: darken($pix-warning-40, 12%);
+        background-color: $pix-warning-60;
+        box-shadow: none;
+        border: 2px solid transparent;
       }
     }
   }
@@ -122,33 +121,33 @@
   &--background-red {
     color: $pix-neutral-0;
     background-color: $pix-error-70;
-    border-color: $pix-error-70;
+    border: 2px solid transparent;
 
     &:not(.pix-button--disabled) {
       &:hover {
-        background-color: darken($pix-error-70, 8%);
-        box-shadow: 0 0 0 2px darken($pix-error-70, 8%);
-        border-color: $pix-neutral-0;
-        outline: none;
+        background-color: $pix-error-80;
+        box-shadow: none;
+        border: 2px solid transparent;
       }
 
       &:focus,
       &:focus-visible {
-        background-color: darken($pix-error-70, 8%);
-        box-shadow: 0 0 0 2px darken($pix-error-70, 8%);
-        border-color: $pix-neutral-0;
-        outline: none;
+        background-color: $pix-error-70;
+        box-shadow: 0 0 0 2px $pix-error-70;
+        border: 2px solid $pix-neutral-0;
       }
 
       &:active {
-        background-color: darken($pix-error-70, 12%);
+        background-color: #861212;
+        box-shadow: none;
+        border: 2px solid transparent;
       }
     }
   }
 
   &--background-grey {
     background-color: $pix-neutral-60;
-    border-color: $pix-neutral-60;
+    border: 2px solid transparent;
 
     &:not(.pix-button--disabled) {
       &:hover {

--- a/addon/styles/_pix-button-base.scss
+++ b/addon/styles/_pix-button-base.scss
@@ -167,63 +167,64 @@
   }
 
   &--background-transparent-light {
-    background-color: transparent;
-    border-color: transparent;
     color: $pix-neutral-90;
+    background-color: transparent;
+    border: 2px solid transparent;
+
+    &.pix-button--border {
+      border: 2px solid $pix-neutral-50;
+    }
 
     &:not(.pix-button--disabled) {
       &:hover {
-        background-color: rgba($pix-neutral-110, 0.1);
-        outline: none;
+        background-color: $pix-neutral-60;
+        color: $pix-neutral-0;
+        border: 2px solid transparent;
       }
 
       &:focus,
       &:focus-visible {
-        background-color: rgba($pix-neutral-110, 0.1);
-        outline: none;
+        background-color: $pix-neutral-90;
+        color: $pix-neutral-0;
+        outline: 2px solid $pix-neutral-0;
+        outline-offset: -4px;
       }
 
       &:active {
-        background-color: rgba($pix-neutral-110, 0.2);
-      }
-    }
-
-    &.pix-button--border {
-      border-color: $pix-neutral-50;
-
-      &:not(.pix-button--disabled) {
-        &:hover,
-        &:active {
-          border-color: $pix-neutral-80;
-        }
+        background-color: $pix-neutral-70;
+        outline: none;
       }
     }
   }
 
   &--background-transparent-dark {
-    background-color: transparent;
-    border-color: transparent;
     color: $pix-neutral-0;
+    background-color: transparent;
+    border: 2px solid transparent;
+
+    &.pix-button--border {
+      border: 2px solid $pix-neutral-0;
+    }
 
     &:not(.pix-button--disabled) {
       &:hover {
-        background-color: rgba($pix-neutral-110, 0.1);
-        outline: none;
+        background-color: $pix-neutral-10;
+        color: $pix-neutral-90;
+        border: 2px solid transparent;
       }
 
       &:focus,
       &:focus-visible {
-        background-color: rgba($pix-neutral-110, 0.1);
-        outline: none;
+        background-color: $pix-neutral-10;
+        color: $pix-neutral-90;
+        outline: 2px solid $pix-neutral-90;
+        outline-offset: -4px;
       }
 
       &:active {
-        background-color: rgba($pix-neutral-110, 0.2);
+        background-color: $pix-neutral-20;
+        outline: none;
       }
-    }
-
-    &.pix-button--border {
-      border-color: $pix-neutral-0;
     }
   }
 }

--- a/addon/styles/_pix-button-base.scss
+++ b/addon/styles/_pix-button-base.scss
@@ -45,7 +45,13 @@
     border-color: $pix-primary;
 
     &:not(.pix-button--disabled) {
-      &:hover,
+      &:hover {
+        background-color: darken($pix-primary, 8%);
+        box-shadow: 0 0 0 2px darken($pix-primary, 8%);
+        border-color: $pix-neutral-0;
+        outline: none;
+      }
+
       &:focus,
       &:focus-visible {
         background-color: darken($pix-primary, 8%);
@@ -65,7 +71,13 @@
     border-color: $green;
 
     &:not(.pix-button--disabled) {
-      &:hover,
+      &:hover {
+        background-color: darken($green, 8%);
+        box-shadow: 0 0 0 2px darken($green, 8%);
+        border-color: $pix-neutral-0;
+        outline: none;
+      }
+
       &:focus,
       &:focus-visible {
         background-color: darken($green, 8%);
@@ -86,7 +98,13 @@
     border-color: $pix-warning-40;
 
     &:not(.pix-button--disabled) {
-      &:hover,
+      &:hover {
+        background-color: darken($pix-warning-40, 8%);
+        box-shadow: 0 0 0 2px darken($pix-warning-40, 8%);
+        border-color: $pix-neutral-0;
+        outline: none;
+      }
+
       &:focus,
       &:focus-visible {
         background-color: darken($pix-warning-40, 8%);
@@ -107,7 +125,13 @@
     border-color: $pix-error-70;
 
     &:not(.pix-button--disabled) {
-      &:hover,
+      &:hover {
+        background-color: darken($pix-error-70, 8%);
+        box-shadow: 0 0 0 2px darken($pix-error-70, 8%);
+        border-color: $pix-neutral-0;
+        outline: none;
+      }
+
       &:focus,
       &:focus-visible {
         background-color: darken($pix-error-70, 8%);
@@ -127,7 +151,13 @@
     border-color: $pix-neutral-60;
 
     &:not(.pix-button--disabled) {
-      &:hover,
+      &:hover {
+        background-color: darken($pix-neutral-60, 8%);
+        box-shadow: 0 0 0 2px darken($pix-neutral-60, 8%);
+        border-color: $pix-neutral-0;
+        outline: none;
+      }
+
       &:focus,
       &:focus-visible {
         background-color: darken($pix-neutral-60, 8%);
@@ -155,7 +185,11 @@
     color: $pix-neutral-90;
 
     &:not(.pix-button--disabled) {
-      &:hover,
+      &:hover {
+        background-color: rgba($pix-neutral-110, 0.1);
+        outline: none;
+      }
+
       &:focus,
       &:focus-visible {
         background-color: rgba($pix-neutral-110, 0.1);
@@ -185,7 +219,11 @@
     color: $pix-neutral-0;
 
     &:not(.pix-button--disabled) {
-      &:hover,
+      &:hover {
+        background-color: rgba($pix-neutral-110, 0.1);
+        outline: none;
+      }
+
       &:focus,
       &:focus-visible {
         background-color: rgba($pix-neutral-110, 0.1);

--- a/addon/styles/_pix-button-base.scss
+++ b/addon/styles/_pix-button-base.scss
@@ -9,7 +9,7 @@
   letter-spacing: 0.028rem;
   cursor: pointer;
   background-color: $pix-primary;
-  border: 2px solid transparent;
+  border: 1px solid transparent;
   outline: none;
   display: flex;
   justify-content: center;
@@ -52,7 +52,7 @@
       &:focus,
       &:focus-visible {
         background-color: $pix-primary-60;
-        outline: 2px solid $pix-neutral-0;
+        outline: 1px solid $pix-neutral-0;
         outline-offset: -4px;
       }
 
@@ -74,7 +74,7 @@
       &:focus,
       &:focus-visible {
         background-color: $pix-success-70;
-        outline: 2px solid $pix-neutral-0;
+        outline: 1px solid $pix-neutral-0;
         outline-offset: -4px;
       }
 
@@ -88,7 +88,6 @@
   &--background-yellow {
     color: $pix-neutral-100;
     background-color: $pix-warning-40;
-    border: 2px solid transparent;
 
     &:not(.pix-button--disabled) {
       &:hover {
@@ -98,7 +97,7 @@
       &:focus,
       &:focus-visible {
         background-color: $pix-warning-50;
-        outline: 2px solid $pix-neutral-0;
+        outline: 1px solid $pix-neutral-0;
         outline-offset: -4px;
       }
 
@@ -112,7 +111,6 @@
   &--background-red {
     color: $pix-neutral-0;
     background-color: $pix-error-70;
-    border: 2px solid transparent;
 
     &:not(.pix-button--disabled) {
       &:hover {
@@ -122,7 +120,7 @@
       &:focus,
       &:focus-visible {
         background-color: $pix-error-70;
-        outline: 2px solid $pix-neutral-0;
+        outline: 1px solid $pix-neutral-0;
         outline-offset: -4px;
       }
 
@@ -136,7 +134,6 @@
   &--background-grey {
     color: $pix-neutral-90;
     background-color: $pix-neutral-20;
-    border: 2px solid transparent;
 
     &:not(.pix-button--disabled) {
       &:hover {
@@ -147,7 +144,7 @@
       &:focus-visible {
         background-color: $pix-neutral-90;
         color: $pix-neutral-0;
-        outline: 2px solid $pix-neutral-0;
+        outline: 1px solid $pix-neutral-0;
         outline-offset: -4px;
       }
 
@@ -163,30 +160,29 @@
   &--background-transparent {
     background-color: transparent;
     color: $pix-neutral-50;
-    border: 2px solid $pix-neutral-50;
+    border: 1px solid $pix-neutral-50;
   }
 
   &--background-transparent-light {
     color: $pix-neutral-90;
     background-color: transparent;
-    border: 2px solid transparent;
 
     &.pix-button--border {
-      border: 2px solid $pix-neutral-50;
+      border: 1px solid $pix-neutral-50;
     }
 
     &:not(.pix-button--disabled) {
       &:hover {
         background-color: $pix-neutral-60;
         color: $pix-neutral-0;
-        border: 2px solid transparent;
+        border: 1px solid transparent;
       }
 
       &:focus,
       &:focus-visible {
         background-color: $pix-neutral-90;
         color: $pix-neutral-0;
-        outline: 2px solid $pix-neutral-0;
+        outline: 1px solid $pix-neutral-0;
         outline-offset: -4px;
       }
 
@@ -200,24 +196,23 @@
   &--background-transparent-dark {
     color: $pix-neutral-0;
     background-color: transparent;
-    border: 2px solid transparent;
 
     &.pix-button--border {
-      border: 2px solid $pix-neutral-0;
+      border: 1px solid $pix-neutral-0;
     }
 
     &:not(.pix-button--disabled) {
       &:hover {
         background-color: $pix-neutral-10;
         color: $pix-neutral-90;
-        border: 2px solid transparent;
+        border: 1px solid transparent;
       }
 
       &:focus,
       &:focus-visible {
         background-color: $pix-neutral-10;
         color: $pix-neutral-90;
-        outline: 2px solid $pix-neutral-90;
+        outline: 1px solid $pix-neutral-90;
         outline-offset: -4px;
       }
 

--- a/addon/styles/_pix-button-base.scss
+++ b/addon/styles/_pix-button-base.scss
@@ -125,7 +125,7 @@
       }
 
       &:active {
-        background-color: #861212;
+        background-color: $pix-error-90;
         outline: none;
       }
     }

--- a/addon/styles/_pix-button-base.scss
+++ b/addon/styles/_pix-button-base.scss
@@ -134,27 +134,27 @@
   }
 
   &--background-grey {
-    background-color: $pix-neutral-60;
+    color: $pix-neutral-90;
+    background-color: $pix-neutral-20;
     border: 2px solid transparent;
 
     &:not(.pix-button--disabled) {
       &:hover {
-        background-color: darken($pix-neutral-60, 8%);
-        box-shadow: 0 0 0 2px darken($pix-neutral-60, 8%);
-        border-color: $pix-neutral-0;
-        outline: none;
+        background-color: $pix-neutral-22;
       }
 
       &:focus,
       &:focus-visible {
-        background-color: darken($pix-neutral-60, 8%);
-        box-shadow: 0 0 0 2px darken($pix-neutral-60, 8%);
-        border-color: $pix-neutral-0;
-        outline: none;
+        background-color: $pix-neutral-90;
+        color: $pix-neutral-0;
+        outline: 2px solid $pix-neutral-0;
+        outline-offset: -4px;
       }
 
       &:active {
-        background-color: darken($pix-neutral-60, 12%);
+        background-color: $pix-neutral-25;
+        color: $pix-neutral-90;
+        outline: none;
       }
     }
   }

--- a/addon/styles/_pix-button-base.scss
+++ b/addon/styles/_pix-button-base.scss
@@ -47,21 +47,18 @@
     &:not(.pix-button--disabled) {
       &:hover {
         background-color: $pix-primary-60;
-        box-shadow: none;
-        border: 2px solid transparent;
       }
 
       &:focus,
       &:focus-visible {
         background-color: $pix-primary-60;
-        box-shadow: inset 0 0 0 2px $pix-neutral-0;
-        border: 2px solid $pix-primary-60;
+        outline: 2px solid $pix-neutral-0;
+        outline-offset: -4px;
       }
 
       &:active {
         background-color: $pix-primary-70;
-        box-shadow: none;
-        border: 2px solid transparent;
+        outline: none;
       }
     }
   }
@@ -72,21 +69,18 @@
     &:not(.pix-button--disabled) {
       &:hover {
         background-color: $pix-success-70;
-        box-shadow: none;
-        border: 2px solid transparent;
       }
 
       &:focus,
       &:focus-visible {
         background-color: $pix-success-70;
-        box-shadow: inset 0 0 0 2px $pix-neutral-0;
-        border: 2px solid $pix-success-70;
+        outline: 2px solid $pix-neutral-0;
+        outline-offset: -4px;
       }
 
       &:active {
         background-color: $pix-success-80;
-        box-shadow: none;
-        border: 2px solid transparent;
+        outline: none;
       }
     }
   }
@@ -99,21 +93,18 @@
     &:not(.pix-button--disabled) {
       &:hover {
         background-color: $pix-warning-50;
-        box-shadow: none;
-        border: 2px solid transparent;
       }
 
       &:focus,
       &:focus-visible {
         background-color: $pix-warning-50;
-        box-shadow: inset 0 0 0 2px $pix-neutral-0;
-        border: 2px solid $pix-warning-50;
+        outline: 2px solid $pix-neutral-0;
+        outline-offset: -4px;
       }
 
       &:active {
         background-color: $pix-warning-60;
-        box-shadow: none;
-        border: 2px solid transparent;
+        outline: none;
       }
     }
   }
@@ -126,21 +117,18 @@
     &:not(.pix-button--disabled) {
       &:hover {
         background-color: $pix-error-80;
-        box-shadow: none;
-        border: 2px solid transparent;
       }
 
       &:focus,
       &:focus-visible {
         background-color: $pix-error-70;
-        box-shadow: inset 0 0 0 2px $pix-neutral-0;
-        border: 2px solid $pix-error-70;
+        outline: 2px solid $pix-neutral-0;
+        outline-offset: -4px;
       }
 
       &:active {
         background-color: #861212;
-        box-shadow: none;
-        border: 2px solid transparent;
+        outline: none;
       }
     }
   }

--- a/addon/styles/_pix-button-base.scss
+++ b/addon/styles/_pix-button-base.scss
@@ -40,46 +40,106 @@
     cursor: not-allowed;
   }
 
-  @mixin colorizeBackground($backgroundColor, $outlineColor) {
-    background-color: $backgroundColor;
-    border-color: $backgroundColor;
+  &--background-blue {
+    background-color: $pix-primary;
+    border-color: $pix-primary;
 
     &:not(.pix-button--disabled) {
       &:hover,
       &:focus,
       &:focus-visible {
-        background-color: darken($backgroundColor, 8%);
-        box-shadow: 0 0 0 2px darken($outlineColor, 8%);
+        background-color: darken($pix-primary, 8%);
+        box-shadow: 0 0 0 2px darken($pix-primary, 8%);
         border-color: $pix-neutral-0;
         outline: none;
       }
 
       &:active {
-        background-color: darken($backgroundColor, 12%);
+        background-color: darken($pix-primary, 12%);
       }
     }
   }
 
-  &--background-blue {
-    @include colorizeBackground($pix-primary, $pix-primary);
-  }
-
   &--background-green {
-    @include colorizeBackground($green, $green);
+    background-color: $green;
+    border-color: $green;
+
+    &:not(.pix-button--disabled) {
+      &:hover,
+      &:focus,
+      &:focus-visible {
+        background-color: darken($green, 8%);
+        box-shadow: 0 0 0 2px darken($green, 8%);
+        border-color: $pix-neutral-0;
+        outline: none;
+      }
+
+      &:active {
+        background-color: darken($green, 12%);
+      }
+    }
   }
 
   &--background-yellow {
     color: $pix-neutral-100;
-    @include colorizeBackground($pix-warning-40, $pix-warning-40);
+    background-color: $pix-warning-40;
+    border-color: $pix-warning-40;
+
+    &:not(.pix-button--disabled) {
+      &:hover,
+      &:focus,
+      &:focus-visible {
+        background-color: darken($pix-warning-40, 8%);
+        box-shadow: 0 0 0 2px darken($pix-warning-40, 8%);
+        border-color: $pix-neutral-0;
+        outline: none;
+      }
+
+      &:active {
+        background-color: darken($pix-warning-40, 12%);
+      }
+    }
   }
 
   &--background-red {
     color: $pix-neutral-0;
-    @include colorizeBackground($pix-error-70, $pix-error-70);
+    background-color: $pix-error-70;
+    border-color: $pix-error-70;
+
+    &:not(.pix-button--disabled) {
+      &:hover,
+      &:focus,
+      &:focus-visible {
+        background-color: darken($pix-error-70, 8%);
+        box-shadow: 0 0 0 2px darken($pix-error-70, 8%);
+        border-color: $pix-neutral-0;
+        outline: none;
+      }
+
+      &:active {
+        background-color: darken($pix-error-70, 12%);
+      }
+    }
   }
 
   &--background-grey {
-    @include colorizeBackground($pix-neutral-60, $pix-neutral-60);
+    background-color: $pix-neutral-60;
+    border-color: $pix-neutral-60;
+
+    &:not(.pix-button--disabled) {
+      &:hover,
+      &:focus,
+      &:focus-visible {
+        background-color: darken($pix-neutral-60, 8%);
+        box-shadow: 0 0 0 2px darken($pix-neutral-60, 8%);
+        border-color: $pix-neutral-0;
+        outline: none;
+      }
+
+      &:active {
+        background-color: darken($pix-neutral-60, 12%);
+      }
+    }
   }
 
   /* deprecated in favor of --background-transparent-light + --border */

--- a/addon/styles/_pix-icon-button.scss
+++ b/addon/styles/_pix-icon-button.scss
@@ -19,22 +19,20 @@
 
   &:hover:enabled {
     background-color: $pix-neutral-20;
-    box-shadow: none;
-    border: 0;
+    outline: 0;
     color: $pix-neutral-60;
   }
 
   &:focus:enabled {
     background-color: $pix-neutral-60;
-    box-shadow: 0 0 0 2px $pix-neutral-60;
-    border: 2px solid $pix-neutral-0;
+    outline: 1px solid $pix-neutral-0;
+    outline-offset: -3px;
     color: $pix-neutral-0;
   }
 
   &:active:enabled {
     background-color: $pix-neutral-22;
-    box-shadow: none;
-    border: 0;
+    outline: 0;
     color: $pix-neutral-60;
   }
 


### PR DESCRIPTION
## :boom: BREAKING_CHANGES
Aucun.

## :christmas_tree: Problème
Nos boutons ne respectent plus les styles du ~Design System~ [Kit UI](https://www.figma.com/file/8RJ3aCSfdeQ8AZZVBBYKS8/Design-System-Pix?node-id=55%3A19).

## :gift: Proposition
Revoir le design de nos boutons pour se rapprocher au maximum du design. Le contrat d'interface ne change pas mais le design varie légèrement.

Voilà comment le design diffère dans plusieurs contextes.

### État hover/active
Changement le plus important de la PR : **la bordure intérieure est supprimée**. Les couleurs évoluent pour une meilleure visibilité.

<table>
<tr>
	<td></td>
	<td>Avant</td>
	<td>Après</td>
</tr>
<tr>
	<td>Hover</td>
	<td><img src="https://user-images.githubusercontent.com/5855339/199748717-5a16f15a-f644-4f8d-a9b9-e9d01cdca6fd.png" /></td>
	<td><img src="https://user-images.githubusercontent.com/5855339/199748754-cb07bc27-981d-47fc-9705-bafe15b1300b.png" /></td>
</tr>
<tr>
	<td>Active</td>
	<td><img src="https://user-images.githubusercontent.com/5855339/199751339-b6056b8f-0297-4b21-9e55-9e77a13829d0.png" /></td>
	<td><img src="https://user-images.githubusercontent.com/5855339/199751368-5ea6dc61-227a-41b9-af47-1f92e0ab5a26.png" /></td>
</tr>
</table>

### État focus
La bordure intérieure ne fait plus qu'1px d'épaisseur contre 2px. Un petit impact sur l'arrondi selon le navigateur est à prévoir (voir les remarques techniques plus bas).

<table>
<tr>
	<td>Avant</td>
	<td>Après</td>
</tr>
<tr>
	<td><img src="https://user-images.githubusercontent.com/5855339/199749747-80467147-bea7-473d-a353-c3ae36ed4361.png" /></td>
	<td><img src="https://user-images.githubusercontent.com/5855339/199749784-404c5d7a-75d3-4bf9-9ffb-90439ddf04e3.png" /></td>
</tr>
<tr>
	<td><img src="https://user-images.githubusercontent.com/5855339/199751684-989aa6c8-a6ee-4c47-aef1-83033ba435da.png" /></td>
	<td><img src="https://user-images.githubusercontent.com/5855339/199751752-6d709998-64f5-4c7a-9e6d-024ed1fa240a.png" /></td>
</tr>
</table>

### État neutre
Les couleurs évoluent un petit peu. Les borders ne font plus que 1px donc les boutons sont légèrement plus fins.

<table>
<tr>
	<td>Avant</td>
	<td>Après</td>
</tr>
<tr>
	<td><img src="https://user-images.githubusercontent.com/5855339/199747721-6bc99474-3276-48fb-999e-eb95ee3155f2.png" /></td>
	<td><img src="https://user-images.githubusercontent.com/5855339/199747648-54f12fc4-f2e0-45dc-9c8b-38ebe6fb2d06.png" /></td>
</tr>
</table>

### Complément

Les `PixButtonLink` et `PixButtonUpload` sont impactés car utilisent les mêmes bases de styles SCSS.

Le `PixIconButton` a été revu également (ainsi que la `PixBanner` qui stylise localement le `PixIconButton` de fermeture).

## :star2: Remarques
J'ai volontairement laissé des commits de travail pour garder la transparence sur les choses qui me sont passé en tête lors du développement. Cette proposition n'est qu'une étape intermédiaire, je pense qu'il y a du potentiel de simplification flagrant sur la multitude de paramètres que nous avons à disposition.

Lors du redesign, j'ai essayé de simplifier le code pour qu'il soit plus facilement modifiable par la suite. Notamment pour pouvoir par la suite introduire des breaking changes car nos paramètres ne sont pas du tout ISO avec ceux proposés sur Figma. Plus on sera proche, plus il sera facile d'intégrer nos maquettes. Je détaille ici quelques changements :

### Utilisation d'`outline` plutôt que `border`+`box-shadow`
Le besoin du design est d'ajouter une bordure intérieure à nos boutons lorsque l'utilisateur y prend le focus. Avant ce chantier, on créait une `border` de 2px avant d'ajouter autour un `box-shadow` au hover. On jouait ensuite sur la `border-color` pour la faire passer de "transparent" à du blanc la plupart du temps.

Les [`outline`](https://developer.mozilla.org/fr/docs/Web/CSS/outline) permettent de répondre à notre besoin sans ajouter de `box-shadow` car ils viennent se poser par dessus le bouton sans prendre d'espace. On économise donc une propriété en utilisant l'`outline`.

### Suppression de la mixin `colorizeBackground`
Les mixins sont une fonctionnalité SCSS permettant de factoriser du code CSS. La factorisation permet de réduire le code nécessaire pour faire des variantes d'un composant (par exemple les couleurs) mais réduisent la liberté dont nous avons besoin pour affiner les couleurs de notre design. Je trouve aussi que la mixin `colorizeBackground` complique la lecture de la stylisation de nos boutons.

### Difficultés
J'ai eu beaucoup de difficultés à recoller ce qu'est un "secondary" button ou "tertiary" button côté Figma aux noms de nos paramètres. Je pense qu'un chantier suivant serait de faire apparaître ces notions mais nécessitera (au moins) un breaking change.

## :santa: Pour tester
Vérifier que les différents boutons utilisés dans Pix UI fonctionnement toujours correctement.
