### PR TITLE
[TECH] Remplacer l'import d'`htmlSafe` depuis `ember/string` en `ember/template`

### DIFF
--- a/addon/components/pix-progress-gauge.js
+++ b/addon/components/pix-progress-gauge.js
@@ -1,5 +1,5 @@
 import Component from '@glimmer/component';
-import { htmlSafe } from '@ember/string';
+import { htmlSafe } from '@ember/template';
 
 export default class PixProgressGauge extends Component {
   get progressValue() {


### PR DESCRIPTION
## :christmas_tree: Problème
`htmlSafe` pouvait provenir d'`ember/string` et `ember/template`, désormais il n'est possible de l'importer que depuis `ember/template` (cf: [guide](https://deprecations.emberjs.com/v3.x/#toc_ember-string-prototype_extensions))

## :gift: Solution
Changer l'import vers `ember/template`

## :star2: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :santa: Pour tester
- Vérifier le bon fonctionnement du composant <ProgressGauge>