### PR TITLE
[TECH] Utiliser la dernière version mineure de NodeJs automatiquement

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -81,8 +81,8 @@
         "sass": "^1.37.5"
       },
       "engines": {
-        "node": "16.14.0",
-        "npm": ">=8.3.1 <=8.13.2"
+        "node": "16.*.*",
+        "npm": "8.*.*"
       }
     },
     "node_modules/@1024pix/ember-testing-library": {

--- a/package.json
+++ b/package.json
@@ -8,8 +8,8 @@
   "license": "MIT",
   "author": "GIP Pix",
   "engines": {
-    "node": "16.14.0",
-    "npm": ">=8.3.1 <=8.13.2"
+    "node": "16",
+    "npm": ">=8.13.2 <9"
   },
   "ember": {
     "edition": "octane"


### PR DESCRIPTION
## :boom: BREAKING_CHANGES
Pas d'impact UI

## :christmas_tree: Problème
Il y a un équilibre à trouver entre:
- déterminisme d'une version:
- marge de tolérance (disponibilité de l'image docker, des packages managers OS).

## :gift: Solution
Vérifier la version majeure de 
- node
- npm

## :star2: Remarques
PR bloquante pour le monorepo https://github.com/1024pix/pix/pull/5200

## :santa: Pour tester
Vérifier que la CI passe, car elle vérifie les versions automatiquement
