### PR TITLE
[BREAKING CHANGES][TECH] Améliorer le composant PixMultiSelect (Pix-6025)

### DIFF
--- a/addon/components/pix-multi-select.hbs
+++ b/addon/components/pix-multi-select.hbs
@@ -10,7 +10,7 @@
       for={{@id}}
       class="pix-multi-select__label{{if @screenReaderOnly ' screen-reader-only'}}"
     >{{@label}}</label>
-    <span class="pix-multi-select-header">
+    <span class="pix-multi-select-header{{if @className this.className}}">
       <FaIcon @icon="magnifying-glass" class="pix-multi-select-header__search-icon" />
 
       <input
@@ -41,7 +41,7 @@
       aria-expanded={{this.isAriaExpanded}}
       aria-controls={{this.listId}}
       aria-haspopup="menu"
-      class="pix-multi-select-header"
+      class="pix-multi-select-header{{if @className this.className}}"
       {{on "click" this.toggleDropDown}}
       ...attributes
     >

--- a/addon/components/pix-multi-select.hbs
+++ b/addon/components/pix-multi-select.hbs
@@ -18,7 +18,7 @@
         id={{@id}}
         type="text"
         name={{@id}}
-        placeholder={{this.innerText}}
+        placeholder={{this.placeholder}}
         autocomplete="off"
         {{on "input" this.updateSearch}}
         {{on "click" this.toggleDropDown}}
@@ -45,7 +45,7 @@
       {{on "click" this.toggleDropDown}}
       ...attributes
     >
-      {{this.innerText}}
+      {{this.placeholder}}
       <FaIcon
         class="pix-multi-select-header__dropdown-icon
           {{if this.isExpanded ' pix-multi-select-header__dropdown-icon--expand'}}"

--- a/addon/components/pix-multi-select.js
+++ b/addon/components/pix-multi-select.js
@@ -162,4 +162,9 @@ export default class PixMultiSelect extends Component {
       this._setDisplayedOptions(this.args.values, true);
     }
   }
+
+  get className() {
+    const { className } = this.args;
+    return ' ' + className;
+  }
 }

--- a/addon/components/pix-multi-select.js
+++ b/addon/components/pix-multi-select.js
@@ -26,18 +26,18 @@ export default class PixMultiSelect extends Component {
 
   constructor(...args) {
     super(...args);
-    const { onLoadOptions, id, label, innerText } = this.args;
+    const { onLoadOptions, id, label, placeholder } = this.args;
 
     const idIsNotDefined = !id || !id.trim();
     const labelIsNotDefined = !label || !label.trim();
-    const innerTextIsNotDefined = !innerText || !innerText.trim();
+    const innerTextIsNotDefined = !placeholder || !placeholder.trim();
 
     if (idIsNotDefined || labelIsNotDefined || innerTextIsNotDefined) {
       const missingParams = [];
 
       if (idIsNotDefined) missingParams.push('@id');
       if (labelIsNotDefined) missingParams.push('@label');
-      if (innerTextIsNotDefined) missingParams.push('@innerText');
+      if (innerTextIsNotDefined) missingParams.push('@placeholder');
 
       throw new Error(
         `ERROR in PixMultiSelect component, ${missingParams.join(', ')} ${
@@ -76,8 +76,8 @@ export default class PixMultiSelect extends Component {
     return this.options;
   }
 
-  get innerText() {
-    const { values, innerText } = this.args;
+  get placeholder() {
+    const { values, placeholder } = this.args;
     if (values?.length > 0) {
       const selectedOptionLabels = this.options
         .filter((option) => {
@@ -88,7 +88,7 @@ export default class PixMultiSelect extends Component {
         .join(', ');
       return selectedOptionLabels;
     }
-    return innerText;
+    return placeholder;
   }
 
   _setDisplayedOptions(selected, shouldSort) {

--- a/addon/components/pix-multi-select.js
+++ b/addon/components/pix-multi-select.js
@@ -77,12 +77,12 @@ export default class PixMultiSelect extends Component {
   }
 
   get innerText() {
-    const { selected, innerText } = this.args;
-    if (selected?.length > 0) {
+    const { values, innerText } = this.args;
+    if (values?.length > 0) {
       const selectedOptionLabels = this.options
-        .filter(({ value, label }) => {
-          const hasOption = selected.includes(value);
-          return hasOption && Boolean(label);
+        .filter((option) => {
+          const hasOption = values.includes(option.value);
+          return hasOption && Boolean(option.label);
         })
         .map(({ label }) => label)
         .join(', ');
@@ -113,7 +113,7 @@ export default class PixMultiSelect extends Component {
 
   @action
   onSelect(event) {
-    let selected = [...(this.args.selected || [])];
+    let selected = [...(this.args.values || [])];
     if (event.target.checked) {
       selected.push(event.target.value);
     } else {
@@ -138,7 +138,7 @@ export default class PixMultiSelect extends Component {
   showDropDown() {
     if (this.isExpanded) return;
     this.isExpanded = true;
-    this._setDisplayedOptions(this.args.selected, true);
+    this._setDisplayedOptions(this.args.values, true);
   }
 
   @action
@@ -159,7 +159,7 @@ export default class PixMultiSelect extends Component {
       : removeCapitalizeAndDiacritics(event.target.value);
     this.isExpanded = true;
     if (!event.target.value) {
-      this._setDisplayedOptions(this.args.selected, true);
+      this._setDisplayedOptions(this.args.values, true);
     }
   }
 }

--- a/addon/components/pix-multi-select.js
+++ b/addon/components/pix-multi-select.js
@@ -120,8 +120,8 @@ export default class PixMultiSelect extends Component {
       selected = selected.filter((value) => value !== event.target.value);
     }
 
-    if (this.args.onSelect) {
-      this.args.onSelect(selected);
+    if (this.args.onChange) {
+      this.args.onChange(selected);
     }
   }
 

--- a/app/stories/pix-multi-select.stories.js
+++ b/app/stories/pix-multi-select.stories.js
@@ -25,7 +25,7 @@ export const multiSelectWithChildComponent = (args) => {
         @innerText={{this.titleStars}}
         @screenReaderOnly={{this.screenReaderOnly}}
         
-        @onSelect={{this.onSelect}}
+        @onChange={{this.onChange}}
         @emptyMessage={{this.emptyMessage}}
         
         @options={{this.options}} as |star|
@@ -66,7 +66,7 @@ export const multiSelectSearchable = (args) => {
         @isSearchable={{this.isSearchable}}
         @strictSearch={{this.strictSearch}}
 
-        @onSelect={{this.doSomething}}
+        @onChange={{this.doSomething}}
         @selected={{this.selected}}
 
         @emptyMessage={{this.emptyMessage}}
@@ -94,7 +94,7 @@ export const multiSelectAsyncOptions = (args) => {
         @isSearchable={{this.isSearchable}}
         @strictSearch={{this.strictSearch}}
 
-        @onSelect={{this.doSomething}}
+        @onChange={{this.doSomething}}
         @selected={{this.selected}}
 
         @emptyMessage={{this.emptyMessage}}
@@ -160,11 +160,11 @@ export const argTypes = {
     type: { name: 'string', required: false },
     defaultValue: 'Chargement...',
   },
-  onSelect: {
-    name: 'onSelect',
+  onChange: {
+    name: 'onChange',
     description: "Une fonction permettant d'effectuer une action à chaque sélection",
     type: { required: true },
-    defaultValue: action('onSelect'),
+    defaultValue: action('onChange'),
   },
   selected: {
     name: 'selected',

--- a/app/stories/pix-multi-select.stories.js
+++ b/app/stories/pix-multi-select.stories.js
@@ -1,6 +1,31 @@
 import { hbs } from 'ember-cli-htmlbars';
 import { action } from '@storybook/addon-actions';
 
+const Template = (args) => ({
+  template: hbs`
+  <style>
+    .custom {
+      border : none;
+    }
+  </style>
+  <h4>⚠️ La sélection des éléments ne fonctionne pas dans Storybook.</h4>
+  <PixMultiSelect
+    @id={{id}}
+    @label={{label}}
+    @placeholder={{placeholder}}
+    @screenReaderOnly={{screenReaderOnly}}
+    @onChange={{onChange}}
+    @emptyMessage={{emptyMessage}}
+    @className={{className}}
+    @isSearchable={{isSearchable}}
+    @strictSearch={{strictSearch}}
+    @values={{values}}
+    @onLoadOptions={{onLoadOptions}} 
+    @options={{options}} as |option|
+  >{{option.label}}</PixMultiSelect>
+ `,
+  context: args,
+});
 const DEFAULT_OPTIONS = [
   { label: 'ANETH HERBE AROMATIQUE', value: '1' },
   { label: 'ANIS VERT HERBE AROMATIQUE', value: '2' },
@@ -15,6 +40,13 @@ const DEFAULT_OPTIONS = [
   { label: 'CERFEUIL HERBE AROMATIQUE', value: '11' },
 ];
 
+export const Default = Template.bind({});
+Default.args = {
+  options: DEFAULT_OPTIONS,
+  onChange: action('onChange'),
+  placeholder: 'placeholder',
+};
+
 export const multiSelectWithChildComponent = (args) => {
   return {
     template: hbs`
@@ -22,17 +54,17 @@ export const multiSelectWithChildComponent = (args) => {
       <PixMultiSelect
         @id={{this.id}}
         @label={{this.label}}
-        @placeholder={{this.titleStars}}
+        @placeholder={{this.placeholder}}
         @screenReaderOnly={{this.screenReaderOnly}}
         @onChange={{this.onChange}}
         @emptyMessage={{this.emptyMessage}}
         @className={{this.className}}
-        @options={{this.options}} as |star|
+        @options={{this.options}} as |option|
       >
         <PixStars
-          @alt={{concat "Étoiles " star.value " sur " star.total}}
-          @count={{star.value}}
-          @total={{star.total}}
+          @alt={{concat "Étoiles " option.value " sur " option.total}}
+          @count={{option.value}}
+          @total={{option.total}}
         />
       </PixMultiSelect>
     `,
@@ -41,7 +73,7 @@ export const multiSelectWithChildComponent = (args) => {
 };
 
 multiSelectWithChildComponent.args = {
-  titleStars: 'Sélectionner le niveau souhaité',
+  placeholder: 'Sélectionner le niveau souhaité',
   label: 'Résultat évaluation',
   options: [
     { value: '0', total: 3 },
@@ -51,86 +83,25 @@ multiSelectWithChildComponent.args = {
   ],
 };
 
-export const multiSelectSearchable = (args) => {
-  return {
-    template: hbs`
-      <h4>⚠️ La sélection des éléments ne fonctionne pas dans Storybook.</h4>
-      <PixMultiSelect
-        style="width:350px"
-        @id={{this.id}}
-        @label={{this.label}}
-        @screenReaderOnly={{this.screenReaderOnly}}
-        @placeholder={{this.placeholder}}
-        @isSearchable={{this.isSearchable}}
-        @strictSearch={{this.strictSearch}}
-        @onChange={{this.doSomething}}
-        @values={{this.values}}
-        @className={{this.className}}
-        @emptyMessage={{this.emptyMessage}}
-        @options={{this.options}} as |option|
-      >
-        {{option.label}}
-      </PixMultiSelect>
-    `,
-    context: args,
-  };
+export const multiSelectSearchable = Template.bind({});
+multiSelectSearchable.args = {
+  ...Default.args,
+  isSearchable: true,
+  strictSearch: true,
+  emptyMessage: 'Aucune option trouvée',
 };
 
-export const multiSelectAsyncOptions = (args) => {
-  args.onLoadOptions = () => Promise.resolve(DEFAULT_OPTIONS);
-  return {
-    template: hbs`
-      <h4>⚠️ La sélection des éléments ne fonctionne pas dans Storybook.</h4>
-      <PixMultiSelect
-        style="width:350px"
-        @id={{this.id}}
-        @label={{this.label}}
-        @screenReaderOnly={{this.screenReaderOnly}}
-        @placeholder={{this.placeholder}}
-        @isSearchable={{this.isSearchable}}
-        @strictSearch={{this.strictSearch}}
-        @onChange={{this.doSomething}}
-        @values={{this.values}}
-        @className={{this.className}}
-        @emptyMessage={{this.emptyMessage}}
-        @onLoadOptions={{this.onLoadOptions}} as |option|
-      >
-        {{option.label}}
-      </PixMultiSelect>
-    `,
-    context: args,
-  };
+export const multiSelectAsyncOptions = Template.bind({});
+multiSelectAsyncOptions.args = {
+  ...Default.args,
+  onLoadOptions: () => Promise.resolve(Default.args.options),
+  loadingMessage: 'Chargement en cours ...',
 };
 
-export const multiSelectWithCustomClass = (args) => {
-  args.onLoadOptions = () => Promise.resolve(DEFAULT_OPTIONS);
-  return {
-    template: hbs`
-      <style>
-        .custom {
-          border : none;
-        }
-      </style>
-      <h4>⚠️ La sélection des éléments ne fonctionne pas dans Storybook.</h4>
-      <PixMultiSelect
-        style="width:350px"
-        @id={{this.id}}
-        @label={{this.label}}
-        @screenReaderOnly={{this.screenReaderOnly}}
-        @placeholder={{this.placeholder}}
-        @isSearchable={{this.isSearchable}}
-        @strictSearch={{this.strictSearch}}
-        @onChange={{this.doSomething}}
-        @values={{this.values}}
-        @className="custom"
-        @emptyMessage={{this.emptyMessage}}
-        @onLoadOptions={{this.onLoadOptions}} as |option|
-      >
-        {{option.label}}
-      </PixMultiSelect>
-    `,
-    context: args,
-  };
+export const multiSelectWithCustomClass = Template.bind({});
+multiSelectWithCustomClass.args = {
+  ...Default.args,
+  className: 'custom',
 };
 
 export const argTypes = {

--- a/app/stories/pix-multi-select.stories.js
+++ b/app/stories/pix-multi-select.stories.js
@@ -67,7 +67,7 @@ export const multiSelectSearchable = (args) => {
         @strictSearch={{this.strictSearch}}
 
         @onChange={{this.doSomething}}
-        @selected={{this.selected}}
+        @values={{this.values}}
 
         @emptyMessage={{this.emptyMessage}}
         @options={{this.options}} as |option|
@@ -95,7 +95,7 @@ export const multiSelectAsyncOptions = (args) => {
         @strictSearch={{this.strictSearch}}
 
         @onChange={{this.doSomething}}
-        @selected={{this.selected}}
+        @values={{this.values}}
 
         @emptyMessage={{this.emptyMessage}}
         @onLoadOptions={{this.onLoadOptions}} as |option|
@@ -166,8 +166,8 @@ export const argTypes = {
     type: { required: true },
     defaultValue: action('onChange'),
   },
-  selected: {
-    name: 'selected',
+  values: {
+    name: 'values',
     description: 'Une pré-sélection peut être donnée au composant',
     type: { name: 'array', required: false },
     defaultValue: ['1', '4'],

--- a/app/stories/pix-multi-select.stories.js
+++ b/app/stories/pix-multi-select.stories.js
@@ -22,7 +22,7 @@ export const multiSelectWithChildComponent = (args) => {
       <PixMultiSelect
         @id={{this.id}}
         @label={{this.label}}
-        @innerText={{this.titleStars}}
+        @placeholder={{this.titleStars}}
         @screenReaderOnly={{this.screenReaderOnly}}
         
         @onChange={{this.onChange}}
@@ -61,7 +61,7 @@ export const multiSelectSearchable = (args) => {
         @id={{this.id}}
         @label={{this.label}}
         @screenReaderOnly={{this.screenReaderOnly}}
-        @innerText={{this.innerText}}
+        @placeholder={{this.placeholder}}
 
         @isSearchable={{this.isSearchable}}
         @strictSearch={{this.strictSearch}}
@@ -89,7 +89,7 @@ export const multiSelectAsyncOptions = (args) => {
         @id={{this.id}}
         @label={{this.label}}
         @screenReaderOnly={{this.screenReaderOnly}}
-        @innerText={{this.innerText}}
+        @placeholder={{this.placeholder}}
 
         @isSearchable={{this.isSearchable}}
         @strictSearch={{this.strictSearch}}
@@ -114,8 +114,8 @@ export const argTypes = {
     type: { name: 'string', required: true },
     defaultValue: 'aromate',
   },
-  innerText: {
-    name: 'innerText',
+  placeholder: {
+    name: 'placeholder',
     description:
       'Rempli le contenu interne du composant, `placeholder` pour `isSearchable` `true`, sinon rawContent du `button`',
     type: { name: 'string', required: true },

--- a/app/stories/pix-multi-select.stories.js
+++ b/app/stories/pix-multi-select.stories.js
@@ -24,10 +24,9 @@ export const multiSelectWithChildComponent = (args) => {
         @label={{this.label}}
         @placeholder={{this.titleStars}}
         @screenReaderOnly={{this.screenReaderOnly}}
-        
         @onChange={{this.onChange}}
         @emptyMessage={{this.emptyMessage}}
-        
+        @className={{this.className}}
         @options={{this.options}} as |star|
       >
         <PixStars
@@ -62,13 +61,11 @@ export const multiSelectSearchable = (args) => {
         @label={{this.label}}
         @screenReaderOnly={{this.screenReaderOnly}}
         @placeholder={{this.placeholder}}
-
         @isSearchable={{this.isSearchable}}
         @strictSearch={{this.strictSearch}}
-
         @onChange={{this.doSomething}}
         @values={{this.values}}
-
+        @className={{this.className}}
         @emptyMessage={{this.emptyMessage}}
         @options={{this.options}} as |option|
       >
@@ -90,13 +87,42 @@ export const multiSelectAsyncOptions = (args) => {
         @label={{this.label}}
         @screenReaderOnly={{this.screenReaderOnly}}
         @placeholder={{this.placeholder}}
-
         @isSearchable={{this.isSearchable}}
         @strictSearch={{this.strictSearch}}
-
         @onChange={{this.doSomething}}
         @values={{this.values}}
+        @className={{this.className}}
+        @emptyMessage={{this.emptyMessage}}
+        @onLoadOptions={{this.onLoadOptions}} as |option|
+      >
+        {{option.label}}
+      </PixMultiSelect>
+    `,
+    context: args,
+  };
+};
 
+export const multiSelectWithCustomClass = (args) => {
+  args.onLoadOptions = () => Promise.resolve(DEFAULT_OPTIONS);
+  return {
+    template: hbs`
+      <style>
+        .custom {
+          border : none;
+        }
+      </style>
+      <h4>⚠️ La sélection des éléments ne fonctionne pas dans Storybook.</h4>
+      <PixMultiSelect
+        style="width:350px"
+        @id={{this.id}}
+        @label={{this.label}}
+        @screenReaderOnly={{this.screenReaderOnly}}
+        @placeholder={{this.placeholder}}
+        @isSearchable={{this.isSearchable}}
+        @strictSearch={{this.strictSearch}}
+        @onChange={{this.doSomething}}
+        @values={{this.values}}
+        @className="custom"
         @emptyMessage={{this.emptyMessage}}
         @onLoadOptions={{this.onLoadOptions}} as |option|
       >
@@ -184,5 +210,13 @@ export const argTypes = {
       'Permet de rendre sensible à la casse et au diacritiques lorsque ``isSearchable`` à ``true``',
     type: { name: 'boolean', required: false },
     defaultValue: false,
+  },
+  className: {
+    name: 'className',
+    description: 'Cette classe css permet de surcharger le css par défaut du composant.',
+    type: { name: 'string', required: false },
+    table: {
+      type: { summary: 'string' },
+    },
   },
 };

--- a/app/stories/pix-multi-select.stories.mdx
+++ b/app/stories/pix-multi-select.stories.mdx
@@ -45,7 +45,7 @@ Il est possible de donner un message via `loadingMessage` à afficher à la plac
   @screenReaderOnly={{screenReaderOnly}}
   @innerText={{innerText}}
 
-  @onSelect={{doSomething}}
+  @onChange={{doSomething}}
   @selected={{selected}}
   @emptyMessage={{emptyMessage}}
   @options={{options}} as |option|>

--- a/app/stories/pix-multi-select.stories.mdx
+++ b/app/stories/pix-multi-select.stories.mdx
@@ -43,7 +43,7 @@ Il est possible de donner un message via `loadingMessage` à afficher à la plac
   @id={{id}}
   @label={{label}}
   @screenReaderOnly={{screenReaderOnly}}
-  @innerText={{innerText}}
+  @placeholder={{placeholder}}
 
   @onChange={{doSomething}}
   @values={{values}}

--- a/app/stories/pix-multi-select.stories.mdx
+++ b/app/stories/pix-multi-select.stories.mdx
@@ -25,6 +25,11 @@ L'ajout de ``class`` et d'autres attributs comme ``aria-label`` sont possibles.
   <Story name="Searchable" story={stories.multiSelectSearchable} height={330}/>
 </Canvas>
 
+## withCustomClass
+<Canvas>
+  <Story name="withCustomClass" story={stories.multiSelectWithCustomClass} height={330}/>
+</Canvas>
+
 ## With async options
 
 Via la propriété `onLoadOptions`, le composant peut charger lui-même les options de manière asynchrone.
@@ -48,6 +53,7 @@ Il est possible de donner un message via `loadingMessage` à afficher à la plac
   @onChange={{doSomething}}
   @values={{values}}
   @emptyMessage={{emptyMessage}}
+  @className={{className}}
   @options={{options}} as |option|>
   {{option.label}}
 </PixMultiSelect>

--- a/app/stories/pix-multi-select.stories.mdx
+++ b/app/stories/pix-multi-select.stories.mdx
@@ -46,7 +46,7 @@ Il est possible de donner un message via `loadingMessage` à afficher à la plac
   @innerText={{innerText}}
 
   @onChange={{doSomething}}
-  @selected={{selected}}
+  @values={{values}}
   @emptyMessage={{emptyMessage}}
   @options={{options}} as |option|>
   {{option.label}}

--- a/tests/integration/components/pix-multi-select-test.js
+++ b/tests/integration/components/pix-multi-select-test.js
@@ -20,8 +20,8 @@ module('Integration | Component | multi-select', function (hooks) {
     test('it renders PixMultiSelect with hidden list', async function (assert) {
       // given
       this.options = DEFAULT_OPTIONS;
-      this.selected = [];
-      this.onChange = (selected) => this.set('selected', selected);
+      this.values = [];
+      this.onChange = () => {};
       this.emptyMessage = 'no result';
       this.innerText = 'MultiSelectTest';
       this.id = 'id-MultiSelectTest';
@@ -29,7 +29,7 @@ module('Integration | Component | multi-select', function (hooks) {
       // when
       const screen = await render(hbs`
         <PixMultiSelect
-          @selected={{this.selected}}
+          @values={{this.values}}
           @onChange={{this.onChange}}
           @innerText={{this.innerText}}
           @id={{this.id}}
@@ -47,8 +47,8 @@ module('Integration | Component | multi-select', function (hooks) {
     test('it should asynchronously load options', async function (assert) {
       // given
       this.onLoadOptions = () => Promise.resolve(DEFAULT_OPTIONS);
-      this.selected = [];
-      this.onChange = (selected) => this.set('selected', selected);
+      this.values = [];
+      this.onChange = () => {};
       this.emptyMessage = 'no result';
       this.innerText = 'MultiSelectTest';
       this.id = 'id-MultiSelectTest';
@@ -56,7 +56,7 @@ module('Integration | Component | multi-select', function (hooks) {
       // when
       const screen = await render(hbs`
         <PixMultiSelect
-          @selected={{this.selected}}
+          @values={{this.values}}
           @onChange={{this.onChange}}
           @innerText={{this.innerText}}
           @id={{this.id}}
@@ -75,11 +75,11 @@ module('Integration | Component | multi-select', function (hooks) {
       assert.equal(screen.getAllByRole('checkbox').length, 3);
     });
 
-    test('it should updates selected items when @selected is reset', async function (assert) {
+    test('it should updates selected items when @values is reset', async function (assert) {
       // given
       this.options = DEFAULT_OPTIONS;
-      this.selected = ['2'];
-      this.onChange = (selected) => this.set('selected', selected);
+      this.values = ['2'];
+      this.onChange = (values) => this.set('values', values);
       this.emptyMessage = 'no result';
       this.innerText = 'MultiSelectTest';
       this.id = 'id-MultiSelectTest';
@@ -89,7 +89,7 @@ module('Integration | Component | multi-select', function (hooks) {
           @onChange={{this.onChange}}
           @innerText={{this.innerText}}
           @id={{this.id}}
-          @selected={{this.selected}}
+          @values={{this.values}}
           @label="labelMultiSelect"
           @emptyMessage={{this.emptyMessage}}
           @options={{this.options}} as |option|>
@@ -98,7 +98,7 @@ module('Integration | Component | multi-select', function (hooks) {
       `);
 
       // when
-      this.set('selected', []);
+      this.set('values', []);
       await clickByName('labelMultiSelect');
 
       await screen.findByRole('menu');
@@ -113,8 +113,8 @@ module('Integration | Component | multi-select', function (hooks) {
       test('it renders PixMultiSelect list', async function (assert) {
         // given
         this.options = DEFAULT_OPTIONS;
-        this.selected = [];
-        this.onChange = (selected) => this.set('selected', selected);
+        this.values = [];
+        this.onChange = () => {};
         this.emptyMessage = 'no result';
         this.innerText = 'MultiSelectTest';
         this.id = 'id-MultiSelectTest';
@@ -122,7 +122,7 @@ module('Integration | Component | multi-select', function (hooks) {
         // when
         const screen = await render(hbs`
           <PixMultiSelect
-            @selected={{this.selected}}
+            @values={{this.values}}
             @onChange={{this.onChange}}
             @innerText={{this.innerText}}
             @id={{this.id}}
@@ -144,8 +144,8 @@ module('Integration | Component | multi-select', function (hooks) {
       test('it renders the PixMultiSelect with empty message', async function (assert) {
         // given
         this.options = [];
-        this.selected = [];
-        this.onChange = (selected) => this.set('selected', selected);
+        this.values = [];
+        this.onChange = () => {};
         this.emptyMessage = 'no result';
         this.innerText = 'MultiSelectTest';
         this.id = 'id-MultiSelectTest';
@@ -153,7 +153,7 @@ module('Integration | Component | multi-select', function (hooks) {
         // when
         const screen = await render(hbs`
           <PixMultiSelect
-            @selected={{this.selected}}
+            @values={{this.values}}
             @onChange={{this.onChange}}
             @innerText={{this.innerText}}
             @label="labelMultiSelect"
@@ -176,8 +176,8 @@ module('Integration | Component | multi-select', function (hooks) {
       test('it renders the PixMultiSelect with default checked', async function (assert) {
         // given
         this.options = DEFAULT_OPTIONS;
-        this.onChange = (selected) => this.set('selected', selected);
-        this.selected = ['2'];
+        this.onChange = () => {};
+        this.values = ['2'];
         this.emptyMessage = 'no result';
         this.innerText = 'MultiSelectTest';
         this.id = 'id-MultiSelectTest';
@@ -188,7 +188,7 @@ module('Integration | Component | multi-select', function (hooks) {
             @onChange={{this.onChange}}
             @innerText={{this.innerText}}
             @id={{this.id}}
-            @selected={{this.selected}}
+            @values={{this.values}}
             @label="labelMultiSelect"
             @emptyMessage={{this.emptyMessage}}
             @options={{this.options}} as |option|
@@ -216,8 +216,8 @@ module('Integration | Component | multi-select', function (hooks) {
       test('it should display selected labels on MultiSelect', async function (assert) {
         // given
         this.options = DEFAULT_OPTIONS;
-        this.onChange = (selected) => this.set('selected', selected);
-        this.selected = ['2', '3'];
+        this.onChange = () => {};
+        this.values = ['2', '3'];
         this.emptyMessage = 'no result';
         this.innerText = 'MultiSelectTest';
         this.id = 'id-MultiSelectTest';
@@ -228,7 +228,7 @@ module('Integration | Component | multi-select', function (hooks) {
             @onChange={{this.onChange}}
             @innerText={{this.innerText}}
             @id={{this.id}}
-            @selected={{this.selected}}
+            @values={{this.values}}
             @label="labelMultiSelect"
             @emptyMessage={{this.emptyMessage}}
             @isSearchable={{true}}
@@ -237,7 +237,6 @@ module('Integration | Component | multi-select', function (hooks) {
             {{option.label}}
           </PixMultiSelect>
         `);
-
         // then
         const inputElement = screen.getByLabelText('labelMultiSelect');
         assert.equal(inputElement.placeholder, 'Tomate, Oignon');
@@ -363,7 +362,7 @@ module('Integration | Component | multi-select', function (hooks) {
 
         this.innerText = 'MultiSelectTest';
         this.emptyMessage = 'no result';
-        this.selected = ['1', '2'];
+        this.values = ['1', '2'];
         this.id = 'id-MultiSelectTest';
         this.onChange = sinon.spy();
 
@@ -614,8 +613,8 @@ module('Integration | Component | multi-select', function (hooks) {
     test('it should renders searchable PixMultiSelect multi select list', async function (assert) {
       // given
       this.options = DEFAULT_OPTIONS;
-      this.selected = [];
-      this.onChange = (selected) => this.set('selected', selected);
+      this.values = [];
+      this.onChange = () => {};
       this.emptyMessage = 'no result';
       this.innerText = 'MultiSelectTest';
       this.id = 'id-MultiSelectTest';
@@ -625,7 +624,7 @@ module('Integration | Component | multi-select', function (hooks) {
       const screen = await render(hbs`
         <PixMultiSelect
           @isSearchable={{this.isSearchable}}
-          @selected={{this.selected}}
+          @values={{this.values}}
           @onChange={{this.onChange}}
           @innerText={{this.innerText}}
           @id={{this.id}}
@@ -649,8 +648,8 @@ module('Integration | Component | multi-select', function (hooks) {
     test('it should renders filtered given case insensitive', async function (assert) {
       // given
       this.options = DEFAULT_OPTIONS;
-      this.selected = [];
-      this.onChange = (selected) => this.set('selected', selected);
+      this.values = [];
+      this.onChange = () => {};
       this.emptyMessage = 'no result';
       this.innerText = 'MultiSelectTest';
       this.id = 'id-MultiSelectTest';
@@ -660,7 +659,7 @@ module('Integration | Component | multi-select', function (hooks) {
       const screen = await render(hbs`
         <PixMultiSelect
           @isSearchable={{this.isSearchable}}
-          @selected={{this.selected}}
+          @values={{this.values}}
           @onChange={{this.onChange}}
           @innerText={{this.innerText}}
           @placeholder={{this.placeholder}}
@@ -687,8 +686,8 @@ module('Integration | Component | multi-select', function (hooks) {
     test('it should renders no result given case sensitive', async function (assert) {
       // given
       this.options = DEFAULT_OPTIONS;
-      this.selected = [];
-      this.onChange = (selected) => this.set('selected', selected);
+      this.values = [];
+      this.onChange = () => {};
       this.emptyMessage = 'no result';
       this.innerText = 'MultiSelectTest';
       this.id = 'id-MultiSelectTest';
@@ -700,7 +699,7 @@ module('Integration | Component | multi-select', function (hooks) {
         <PixMultiSelect
           @isSearchable={{this.isSearchable}}
           @strictSearch={{this.strictSearch}}
-          @selected={{this.selected}}
+          @values={{this.values}}
           @onChange={{this.onChange}}
           @innerText={{this.innerText}}
           @placeholder={{this.placeholder}}
@@ -725,8 +724,8 @@ module('Integration | Component | multi-select', function (hooks) {
     test('it should display list PixMultiSelect on focus', async function (assert) {
       // given
       this.options = DEFAULT_OPTIONS;
-      this.selected = [];
-      this.onChange = (selected) => this.set('selected', selected);
+      this.values = [];
+      this.onChange = () => {};
       this.emptyMessage = 'no result';
       this.innerText = 'MultiSelectTest';
       this.id = 'id-MultiSelectTest';
@@ -737,7 +736,7 @@ module('Integration | Component | multi-select', function (hooks) {
       const screen = await render(hbs`
         <PixMultiSelect
           @isSearchable={{this.isSearchable}}
-          @selected={{this.selected}}
+          @values={{this.values}}
           @onChange={{this.onChange}}
           @innerText={{this.innerText}}
           @placeholder={{this.placeholder}}
@@ -761,26 +760,24 @@ module('Integration | Component | multi-select', function (hooks) {
     test('it should sort default selected items when focused', async function (assert) {
       // given
       this.options = DEFAULT_OPTIONS;
-      this.selected = [];
-      this.onChange = (selected) => this.set('selected', selected);
+      this.values = ['3'];
+      this.onChange = () => {};
       this.emptyMessage = 'no result';
       this.innerText = 'MultiSelectTest';
       this.id = 'id-MultiSelectTest';
       this.isSearchable = true;
       this.placeholder = 'Placeholder test';
-      this.defaultSelected = ['3'];
 
       const screen = await render(hbs`
         <PixMultiSelect
           @isSearchable={{this.isSearchable}}
-          @selected={{this.selected}}
+          @values={{this.values}}
           @onChange={{this.onChange}}
           @innerText={{this.innerText}}
           @placeholder={{this.placeholder}}
           @id={{this.id}}
           @label="label"
           @emptyMessage={{this.emptyMessage}}
-          @selected={{defaultSelected}}
           @options={{this.options}} as |option|>
           {{option.label}}
         </PixMultiSelect>
@@ -802,8 +799,8 @@ module('Integration | Component | multi-select', function (hooks) {
     test('it should not sort when user select item', async function (assert) {
       // given
       this.options = DEFAULT_OPTIONS;
-      this.selected = [];
-      this.onChange = (selected) => this.set('selected', selected);
+      this.values = [];
+      this.onChange = () => {};
       this.emptyMessage = 'no result';
       this.innerText = 'MultiSelectTest';
       this.id = 'id-MultiSelectTest';
@@ -813,7 +810,7 @@ module('Integration | Component | multi-select', function (hooks) {
       const screen = await render(hbs`
         <PixMultiSelect
           @isSearchable={{this.isSearchable}}
-          @selected={{this.selected}}
+          @values={{this.values}}
           @onChange={{this.onChange}}
           @innerText={{this.innerText}}
           @placeholder={{this.placeholder}}
@@ -843,8 +840,8 @@ module('Integration | Component | multi-select', function (hooks) {
     test('it should not sort when user search and select item', async function (assert) {
       // given
       this.options = DEFAULT_OPTIONS;
-      this.selected = [];
-      this.onChange = (selected) => this.set('selected', selected);
+      this.values = [];
+      this.onChange = () => {};
       this.emptyMessage = 'no result';
       this.innerText = 'MultiSelectTest';
       this.id = 'id-MultiSelectTest';
@@ -854,7 +851,7 @@ module('Integration | Component | multi-select', function (hooks) {
       const screen = await render(hbs`
         <PixMultiSelect
           @isSearchable={{this.isSearchable}}
-          @selected={{this.selected}}
+          @values={{this.values}}
           @onChange={{this.onChange}}
           @innerText={{this.innerText}}
           @placeholder={{this.placeholder}}
@@ -884,8 +881,8 @@ module('Integration | Component | multi-select', function (hooks) {
     test('it should sort items when search is cleaned', async function (assert) {
       // given
       this.options = DEFAULT_OPTIONS;
-      this.selected = [];
-      this.onChange = (selected) => this.set('selected', selected);
+      this.values = [];
+      this.onChange = (values) => this.set('values', values);
       this.emptyMessage = 'no result';
       this.innerText = 'MultiSelectTest';
       this.id = 'id-MultiSelectTest';
@@ -895,7 +892,7 @@ module('Integration | Component | multi-select', function (hooks) {
       const screen = await render(hbs`
         <PixMultiSelect
           @isSearchable={{this.isSearchable}}
-          @selected={{this.selected}}
+          @values={{this.values}}
           @onChange={{this.onChange}}
           @innerText={{this.innerText}}
           @placeholder={{this.placeholder}}
@@ -928,8 +925,8 @@ module('Integration | Component | multi-select', function (hooks) {
     test('should not sort when there are default items selected and a new selected item', async function (assert) {
       // given
       this.options = DEFAULT_OPTIONS;
-      this.selected = ['2'];
-      this.onChange = (selected) => this.set('selected', selected);
+      this.values = ['2'];
+      this.onChange = () => {};
       this.emptyMessage = 'no result';
       this.innerText = 'MultiSelectTest';
       this.id = 'id-MultiSelectTest';
@@ -939,7 +936,7 @@ module('Integration | Component | multi-select', function (hooks) {
       const screen = await render(hbs`
         <PixMultiSelect
           @isSearchable={{this.isSearchable}}
-          @selected={{this.selected}}
+          @values={{this.values}}
           @onChange={{this.onChange}}
           @innerText={{this.innerText}}
           @placeholder={{this.placeholder}}

--- a/tests/integration/components/pix-multi-select-test.js
+++ b/tests/integration/components/pix-multi-select-test.js
@@ -21,7 +21,7 @@ module('Integration | Component | multi-select', function (hooks) {
       // given
       this.options = DEFAULT_OPTIONS;
       this.selected = [];
-      this.onSelect = (selected) => this.set('selected', selected);
+      this.onChange = (selected) => this.set('selected', selected);
       this.emptyMessage = 'no result';
       this.innerText = 'MultiSelectTest';
       this.id = 'id-MultiSelectTest';
@@ -30,7 +30,7 @@ module('Integration | Component | multi-select', function (hooks) {
       const screen = await render(hbs`
         <PixMultiSelect
           @selected={{this.selected}}
-          @onSelect={{this.onSelect}}
+          @onChange={{this.onChange}}
           @innerText={{this.innerText}}
           @id={{this.id}}
           @label="multiSelectLabel"
@@ -48,7 +48,7 @@ module('Integration | Component | multi-select', function (hooks) {
       // given
       this.onLoadOptions = () => Promise.resolve(DEFAULT_OPTIONS);
       this.selected = [];
-      this.onSelect = (selected) => this.set('selected', selected);
+      this.onChange = (selected) => this.set('selected', selected);
       this.emptyMessage = 'no result';
       this.innerText = 'MultiSelectTest';
       this.id = 'id-MultiSelectTest';
@@ -57,7 +57,7 @@ module('Integration | Component | multi-select', function (hooks) {
       const screen = await render(hbs`
         <PixMultiSelect
           @selected={{this.selected}}
-          @onSelect={{this.onSelect}}
+          @onChange={{this.onChange}}
           @innerText={{this.innerText}}
           @id={{this.id}}
           @label="labelMultiSelect"
@@ -79,14 +79,14 @@ module('Integration | Component | multi-select', function (hooks) {
       // given
       this.options = DEFAULT_OPTIONS;
       this.selected = ['2'];
-      this.onSelect = (selected) => this.set('selected', selected);
+      this.onChange = (selected) => this.set('selected', selected);
       this.emptyMessage = 'no result';
       this.innerText = 'MultiSelectTest';
       this.id = 'id-MultiSelectTest';
 
       const screen = await render(hbs`
         <PixMultiSelect
-          @onSelect={{this.onSelect}}
+          @onChange={{this.onChange}}
           @innerText={{this.innerText}}
           @id={{this.id}}
           @selected={{this.selected}}
@@ -114,7 +114,7 @@ module('Integration | Component | multi-select', function (hooks) {
         // given
         this.options = DEFAULT_OPTIONS;
         this.selected = [];
-        this.onSelect = (selected) => this.set('selected', selected);
+        this.onChange = (selected) => this.set('selected', selected);
         this.emptyMessage = 'no result';
         this.innerText = 'MultiSelectTest';
         this.id = 'id-MultiSelectTest';
@@ -123,7 +123,7 @@ module('Integration | Component | multi-select', function (hooks) {
         const screen = await render(hbs`
           <PixMultiSelect
             @selected={{this.selected}}
-            @onSelect={{this.onSelect}}
+            @onChange={{this.onChange}}
             @innerText={{this.innerText}}
             @id={{this.id}}
             @label="labelMultiSelect"
@@ -145,7 +145,7 @@ module('Integration | Component | multi-select', function (hooks) {
         // given
         this.options = [];
         this.selected = [];
-        this.onSelect = (selected) => this.set('selected', selected);
+        this.onChange = (selected) => this.set('selected', selected);
         this.emptyMessage = 'no result';
         this.innerText = 'MultiSelectTest';
         this.id = 'id-MultiSelectTest';
@@ -154,7 +154,7 @@ module('Integration | Component | multi-select', function (hooks) {
         const screen = await render(hbs`
           <PixMultiSelect
             @selected={{this.selected}}
-            @onSelect={{this.onSelect}}
+            @onChange={{this.onChange}}
             @innerText={{this.innerText}}
             @label="labelMultiSelect"
             @id={{this.id}}
@@ -176,7 +176,7 @@ module('Integration | Component | multi-select', function (hooks) {
       test('it renders the PixMultiSelect with default checked', async function (assert) {
         // given
         this.options = DEFAULT_OPTIONS;
-        this.onSelect = (selected) => this.set('selected', selected);
+        this.onChange = (selected) => this.set('selected', selected);
         this.selected = ['2'];
         this.emptyMessage = 'no result';
         this.innerText = 'MultiSelectTest';
@@ -185,7 +185,7 @@ module('Integration | Component | multi-select', function (hooks) {
         // when
         const screen = await render(hbs`
           <PixMultiSelect
-            @onSelect={{this.onSelect}}
+            @onChange={{this.onChange}}
             @innerText={{this.innerText}}
             @id={{this.id}}
             @selected={{this.selected}}
@@ -216,7 +216,7 @@ module('Integration | Component | multi-select', function (hooks) {
       test('it should display selected labels on MultiSelect', async function (assert) {
         // given
         this.options = DEFAULT_OPTIONS;
-        this.onSelect = (selected) => this.set('selected', selected);
+        this.onChange = (selected) => this.set('selected', selected);
         this.selected = ['2', '3'];
         this.emptyMessage = 'no result';
         this.innerText = 'MultiSelectTest';
@@ -225,7 +225,7 @@ module('Integration | Component | multi-select', function (hooks) {
         // when
         const screen = await render(hbs`
           <PixMultiSelect
-            @onSelect={{this.onSelect}}
+            @onChange={{this.onChange}}
             @innerText={{this.innerText}}
             @id={{this.id}}
             @selected={{this.selected}}
@@ -322,19 +322,19 @@ module('Integration | Component | multi-select', function (hooks) {
       });
     });
 
-    module('onSelect', function () {
-      test('it should trigger onSelect function when an item is selected', async function (assert) {
+    module('onChange', function () {
+      test('it should trigger onChange function when an item is selected', async function (assert) {
         // given
         this.options = DEFAULT_OPTIONS;
 
         this.innerText = 'MultiSelectTest';
         this.emptyMessage = 'no result';
         this.id = 'id-MultiSelectTest';
-        this.onSelect = sinon.spy();
+        this.onChange = sinon.spy();
 
         const screen = await render(hbs`
         <PixMultiSelect
-          @onSelect={{this.onSelect}}
+          @onChange={{this.onChange}}
           @innerText={{this.innerText}}
           @id={{this.id}}
           @label="labelMultiSelect"
@@ -353,8 +353,8 @@ module('Integration | Component | multi-select', function (hooks) {
 
         // then
         assert.true(screen.getByLabelText('Salade').checked);
-        assert.ok(this.onSelect.calledOnce, 'the callback should be called once');
-        sinon.assert.calledWithMatch(this.onSelect, ['1']);
+        assert.ok(this.onChange.calledOnce, 'the callback should be called once');
+        sinon.assert.calledWithMatch(this.onChange, ['1']);
       });
 
       test('it should unselect item and return selected item of the updated list', async function (assert) {
@@ -365,11 +365,11 @@ module('Integration | Component | multi-select', function (hooks) {
         this.emptyMessage = 'no result';
         this.selected = ['1', '2'];
         this.id = 'id-MultiSelectTest';
-        this.onSelect = sinon.spy();
+        this.onChange = sinon.spy();
 
         const screen = await render(hbs`
           <PixMultiSelect
-            @onSelect={{this.onSelect}}
+            @onChange={{this.onChange}}
             @innerText={{this.innerText}}
             @id={{this.id}}
             @label="labelMultiSelect"
@@ -387,7 +387,7 @@ module('Integration | Component | multi-select', function (hooks) {
         await clickByName('Salade');
 
         // then
-        sinon.assert.calledWithMatch(this.onSelect, ['1']);
+        sinon.assert.calledWithMatch(this.onChange, ['1']);
         assert.ok(true);
       });
     });
@@ -400,11 +400,11 @@ module('Integration | Component | multi-select', function (hooks) {
         this.innerText = 'MultiSelectTest';
         this.emptyMessage = 'no result';
         this.id = 'id-MultiSelectTest';
-        this.onSelect = sinon.spy();
+        this.onChange = sinon.spy();
 
         const screen = await render(hbs`
         <PixMultiSelect
-          @onSelect={{this.onSelect}}
+          @onChange={{this.onChange}}
           @innerText={{this.innerText}}
           @id={{this.id}}
           @label="labelMultiSelect"
@@ -436,11 +436,11 @@ module('Integration | Component | multi-select', function (hooks) {
         this.innerText = 'MultiSelectTest';
         this.emptyMessage = 'no result';
         this.id = 'id-MultiSelectTest';
-        this.onSelect = sinon.spy();
+        this.onChange = sinon.spy();
 
         const screen = await render(hbs`
         <PixMultiSelect
-          @onSelect={{this.onSelect}}
+          @onChange={{this.onChange}}
           @innerText={{this.innerText}}
           @id={{this.id}}
           @label="labelMultiSelect"
@@ -472,11 +472,11 @@ module('Integration | Component | multi-select', function (hooks) {
         this.innerText = 'MultiSelectTest';
         this.emptyMessage = 'no result';
         this.id = 'id-MultiSelectTest';
-        this.onSelect = sinon.spy();
+        this.onChange = sinon.spy();
 
         const screen = await render(hbs`
         <PixMultiSelect
-          @onSelect={{this.onSelect}}
+          @onChange={{this.onChange}}
           @innerText={{this.innerText}}
           @id={{this.id}}
           @label="labelMultiSelect"
@@ -507,11 +507,11 @@ module('Integration | Component | multi-select', function (hooks) {
         this.innerText = 'MultiSelectTest';
         this.emptyMessage = 'no result';
         this.id = 'id-MultiSelectTest';
-        this.onSelect = sinon.spy();
+        this.onChange = sinon.spy();
 
         const screen = await render(hbs`
         <PixMultiSelect
-          @onSelect={{this.onSelect}}
+          @onChange={{this.onChange}}
           @innerText={{this.innerText}}
           @id={{this.id}}
           @label="labelMultiSelect"
@@ -542,11 +542,11 @@ module('Integration | Component | multi-select', function (hooks) {
         this.innerText = 'MultiSelectTest';
         this.emptyMessage = 'no result';
         this.id = 'id-MultiSelectTest';
-        this.onSelect = sinon.spy();
+        this.onChange = sinon.spy();
 
         const screen = await render(hbs`
         <PixMultiSelect
-          @onSelect={{this.onSelect}}
+          @onChange={{this.onChange}}
           @innerText={{this.innerText}}
           @id={{this.id}}
           @label="labelMultiSelect"
@@ -569,7 +569,7 @@ module('Integration | Component | multi-select', function (hooks) {
 
         // then
         assert.throws(screen.getByRole('menu'));
-        assert.ok(this.onSelect.calledOnce, 'the callback should be called once');
+        assert.ok(this.onChange.calledOnce, 'the callback should be called once');
         assert.equal(document.activeElement, screen.getByLabelText('labelMultiSelect'));
       });
 
@@ -580,11 +580,11 @@ module('Integration | Component | multi-select', function (hooks) {
         this.innerText = 'MultiSelectTest';
         this.emptyMessage = 'no result';
         this.id = 'id-MultiSelectTest';
-        this.onSelect = sinon.spy();
+        this.onChange = sinon.spy();
 
         const screen = await render(hbs`
         <PixMultiSelect
-          @onSelect={{this.onSelect}}
+          @onChange={{this.onChange}}
           @innerText={{this.innerText}}
           @id={{this.id}}
           @label="labelMultiSelect"
@@ -615,7 +615,7 @@ module('Integration | Component | multi-select', function (hooks) {
       // given
       this.options = DEFAULT_OPTIONS;
       this.selected = [];
-      this.onSelect = (selected) => this.set('selected', selected);
+      this.onChange = (selected) => this.set('selected', selected);
       this.emptyMessage = 'no result';
       this.innerText = 'MultiSelectTest';
       this.id = 'id-MultiSelectTest';
@@ -626,7 +626,7 @@ module('Integration | Component | multi-select', function (hooks) {
         <PixMultiSelect
           @isSearchable={{this.isSearchable}}
           @selected={{this.selected}}
-          @onSelect={{this.onSelect}}
+          @onChange={{this.onChange}}
           @innerText={{this.innerText}}
           @id={{this.id}}
           @label="label"
@@ -650,7 +650,7 @@ module('Integration | Component | multi-select', function (hooks) {
       // given
       this.options = DEFAULT_OPTIONS;
       this.selected = [];
-      this.onSelect = (selected) => this.set('selected', selected);
+      this.onChange = (selected) => this.set('selected', selected);
       this.emptyMessage = 'no result';
       this.innerText = 'MultiSelectTest';
       this.id = 'id-MultiSelectTest';
@@ -661,7 +661,7 @@ module('Integration | Component | multi-select', function (hooks) {
         <PixMultiSelect
           @isSearchable={{this.isSearchable}}
           @selected={{this.selected}}
-          @onSelect={{this.onSelect}}
+          @onChange={{this.onChange}}
           @innerText={{this.innerText}}
           @placeholder={{this.placeholder}}
           @id={{this.id}}
@@ -688,7 +688,7 @@ module('Integration | Component | multi-select', function (hooks) {
       // given
       this.options = DEFAULT_OPTIONS;
       this.selected = [];
-      this.onSelect = (selected) => this.set('selected', selected);
+      this.onChange = (selected) => this.set('selected', selected);
       this.emptyMessage = 'no result';
       this.innerText = 'MultiSelectTest';
       this.id = 'id-MultiSelectTest';
@@ -701,7 +701,7 @@ module('Integration | Component | multi-select', function (hooks) {
           @isSearchable={{this.isSearchable}}
           @strictSearch={{this.strictSearch}}
           @selected={{this.selected}}
-          @onSelect={{this.onSelect}}
+          @onChange={{this.onChange}}
           @innerText={{this.innerText}}
           @placeholder={{this.placeholder}}
           @id={{this.id}}
@@ -726,7 +726,7 @@ module('Integration | Component | multi-select', function (hooks) {
       // given
       this.options = DEFAULT_OPTIONS;
       this.selected = [];
-      this.onSelect = (selected) => this.set('selected', selected);
+      this.onChange = (selected) => this.set('selected', selected);
       this.emptyMessage = 'no result';
       this.innerText = 'MultiSelectTest';
       this.id = 'id-MultiSelectTest';
@@ -738,7 +738,7 @@ module('Integration | Component | multi-select', function (hooks) {
         <PixMultiSelect
           @isSearchable={{this.isSearchable}}
           @selected={{this.selected}}
-          @onSelect={{this.onSelect}}
+          @onChange={{this.onChange}}
           @innerText={{this.innerText}}
           @placeholder={{this.placeholder}}
           @label={{this.label}}
@@ -762,7 +762,7 @@ module('Integration | Component | multi-select', function (hooks) {
       // given
       this.options = DEFAULT_OPTIONS;
       this.selected = [];
-      this.onSelect = (selected) => this.set('selected', selected);
+      this.onChange = (selected) => this.set('selected', selected);
       this.emptyMessage = 'no result';
       this.innerText = 'MultiSelectTest';
       this.id = 'id-MultiSelectTest';
@@ -774,7 +774,7 @@ module('Integration | Component | multi-select', function (hooks) {
         <PixMultiSelect
           @isSearchable={{this.isSearchable}}
           @selected={{this.selected}}
-          @onSelect={{this.onSelect}}
+          @onChange={{this.onChange}}
           @innerText={{this.innerText}}
           @placeholder={{this.placeholder}}
           @id={{this.id}}
@@ -803,7 +803,7 @@ module('Integration | Component | multi-select', function (hooks) {
       // given
       this.options = DEFAULT_OPTIONS;
       this.selected = [];
-      this.onSelect = (selected) => this.set('selected', selected);
+      this.onChange = (selected) => this.set('selected', selected);
       this.emptyMessage = 'no result';
       this.innerText = 'MultiSelectTest';
       this.id = 'id-MultiSelectTest';
@@ -814,7 +814,7 @@ module('Integration | Component | multi-select', function (hooks) {
         <PixMultiSelect
           @isSearchable={{this.isSearchable}}
           @selected={{this.selected}}
-          @onSelect={{this.onSelect}}
+          @onChange={{this.onChange}}
           @innerText={{this.innerText}}
           @placeholder={{this.placeholder}}
           @label="labelMultiSelect"
@@ -844,7 +844,7 @@ module('Integration | Component | multi-select', function (hooks) {
       // given
       this.options = DEFAULT_OPTIONS;
       this.selected = [];
-      this.onSelect = (selected) => this.set('selected', selected);
+      this.onChange = (selected) => this.set('selected', selected);
       this.emptyMessage = 'no result';
       this.innerText = 'MultiSelectTest';
       this.id = 'id-MultiSelectTest';
@@ -855,7 +855,7 @@ module('Integration | Component | multi-select', function (hooks) {
         <PixMultiSelect
           @isSearchable={{this.isSearchable}}
           @selected={{this.selected}}
-          @onSelect={{this.onSelect}}
+          @onChange={{this.onChange}}
           @innerText={{this.innerText}}
           @placeholder={{this.placeholder}}
           @id={{this.id}}
@@ -885,7 +885,7 @@ module('Integration | Component | multi-select', function (hooks) {
       // given
       this.options = DEFAULT_OPTIONS;
       this.selected = [];
-      this.onSelect = (selected) => this.set('selected', selected);
+      this.onChange = (selected) => this.set('selected', selected);
       this.emptyMessage = 'no result';
       this.innerText = 'MultiSelectTest';
       this.id = 'id-MultiSelectTest';
@@ -896,7 +896,7 @@ module('Integration | Component | multi-select', function (hooks) {
         <PixMultiSelect
           @isSearchable={{this.isSearchable}}
           @selected={{this.selected}}
-          @onSelect={{this.onSelect}}
+          @onChange={{this.onChange}}
           @innerText={{this.innerText}}
           @placeholder={{this.placeholder}}
           @id={{this.id}}
@@ -929,7 +929,7 @@ module('Integration | Component | multi-select', function (hooks) {
       // given
       this.options = DEFAULT_OPTIONS;
       this.selected = ['2'];
-      this.onSelect = (selected) => this.set('selected', selected);
+      this.onChange = (selected) => this.set('selected', selected);
       this.emptyMessage = 'no result';
       this.innerText = 'MultiSelectTest';
       this.id = 'id-MultiSelectTest';
@@ -940,7 +940,7 @@ module('Integration | Component | multi-select', function (hooks) {
         <PixMultiSelect
           @isSearchable={{this.isSearchable}}
           @selected={{this.selected}}
-          @onSelect={{this.onSelect}}
+          @onChange={{this.onChange}}
           @innerText={{this.innerText}}
           @placeholder={{this.placeholder}}
           @id={{this.id}}

--- a/tests/integration/components/pix-multi-select-test.js
+++ b/tests/integration/components/pix-multi-select-test.js
@@ -23,7 +23,7 @@ module('Integration | Component | multi-select', function (hooks) {
       this.values = [];
       this.onChange = () => {};
       this.emptyMessage = 'no result';
-      this.innerText = 'MultiSelectTest';
+      this.placeholder = 'MultiSelectTest';
       this.id = 'id-MultiSelectTest';
 
       // when
@@ -31,7 +31,7 @@ module('Integration | Component | multi-select', function (hooks) {
         <PixMultiSelect
           @values={{this.values}}
           @onChange={{this.onChange}}
-          @innerText={{this.innerText}}
+          @placeholder={{this.placeholder}}
           @id={{this.id}}
           @label="multiSelectLabel"
           @emptyMessage={{this.emptyMessage}}
@@ -50,7 +50,7 @@ module('Integration | Component | multi-select', function (hooks) {
       this.values = [];
       this.onChange = () => {};
       this.emptyMessage = 'no result';
-      this.innerText = 'MultiSelectTest';
+      this.placeholder = 'MultiSelectTest';
       this.id = 'id-MultiSelectTest';
 
       // when
@@ -58,7 +58,7 @@ module('Integration | Component | multi-select', function (hooks) {
         <PixMultiSelect
           @values={{this.values}}
           @onChange={{this.onChange}}
-          @innerText={{this.innerText}}
+          @placeholder={{this.placeholder}}
           @id={{this.id}}
           @label="labelMultiSelect"
           @emptyMessage={{this.emptyMessage}}
@@ -81,13 +81,13 @@ module('Integration | Component | multi-select', function (hooks) {
       this.values = ['2'];
       this.onChange = (values) => this.set('values', values);
       this.emptyMessage = 'no result';
-      this.innerText = 'MultiSelectTest';
+      this.placeholder = 'MultiSelectTest';
       this.id = 'id-MultiSelectTest';
 
       const screen = await render(hbs`
         <PixMultiSelect
           @onChange={{this.onChange}}
-          @innerText={{this.innerText}}
+          @placeholder={{this.placeholder}}
           @id={{this.id}}
           @values={{this.values}}
           @label="labelMultiSelect"
@@ -116,7 +116,7 @@ module('Integration | Component | multi-select', function (hooks) {
         this.values = [];
         this.onChange = () => {};
         this.emptyMessage = 'no result';
-        this.innerText = 'MultiSelectTest';
+        this.placeholder = 'MultiSelectTest';
         this.id = 'id-MultiSelectTest';
 
         // when
@@ -124,7 +124,7 @@ module('Integration | Component | multi-select', function (hooks) {
           <PixMultiSelect
             @values={{this.values}}
             @onChange={{this.onChange}}
-            @innerText={{this.innerText}}
+            @placeholder={{this.placeholder}}
             @id={{this.id}}
             @label="labelMultiSelect"
             @emptyMessage={{this.emptyMessage}}
@@ -147,7 +147,7 @@ module('Integration | Component | multi-select', function (hooks) {
         this.values = [];
         this.onChange = () => {};
         this.emptyMessage = 'no result';
-        this.innerText = 'MultiSelectTest';
+        this.placeholder = 'MultiSelectTest';
         this.id = 'id-MultiSelectTest';
 
         // when
@@ -155,7 +155,7 @@ module('Integration | Component | multi-select', function (hooks) {
           <PixMultiSelect
             @values={{this.values}}
             @onChange={{this.onChange}}
-            @innerText={{this.innerText}}
+            @placeholder={{this.placeholder}}
             @label="labelMultiSelect"
             @id={{this.id}}
             @emptyMessage={{this.emptyMessage}}
@@ -179,14 +179,14 @@ module('Integration | Component | multi-select', function (hooks) {
         this.onChange = () => {};
         this.values = ['2'];
         this.emptyMessage = 'no result';
-        this.innerText = 'MultiSelectTest';
+        this.placeholder = 'MultiSelectTest';
         this.id = 'id-MultiSelectTest';
 
         // when
         const screen = await render(hbs`
           <PixMultiSelect
             @onChange={{this.onChange}}
-            @innerText={{this.innerText}}
+            @placeholder={{this.placeholder}}
             @id={{this.id}}
             @values={{this.values}}
             @label="labelMultiSelect"
@@ -219,14 +219,14 @@ module('Integration | Component | multi-select', function (hooks) {
         this.onChange = () => {};
         this.values = ['2', '3'];
         this.emptyMessage = 'no result';
-        this.innerText = 'MultiSelectTest';
+        this.placeholder = 'MultiSelectTest';
         this.id = 'id-MultiSelectTest';
 
         // when
         const screen = await render(hbs`
           <PixMultiSelect
             @onChange={{this.onChange}}
-            @innerText={{this.innerText}}
+            @placeholder={{this.placeholder}}
             @id={{this.id}}
             @values={{this.values}}
             @label="labelMultiSelect"
@@ -249,7 +249,7 @@ module('Integration | Component | multi-select', function (hooks) {
         const componentParams = {
           id: '   ',
           label: 'toto',
-          innerText: 'coucou',
+          placeholder: 'coucou',
           options: DEFAULT_OPTIONS,
         };
         const renderComponent = function () {
@@ -268,7 +268,7 @@ module('Integration | Component | multi-select', function (hooks) {
         const componentParams = {
           id: 'toto',
           label: ' ',
-          innerText: 'coucou',
+          placeholder: 'coucou',
           options: DEFAULT_OPTIONS,
         };
         const renderComponent = function () {
@@ -282,12 +282,12 @@ module('Integration | Component | multi-select', function (hooks) {
         assert.throws(renderComponent, expectedError);
       });
 
-      test('it should throw an error if no innerText is provided', async function (assert) {
+      test('it should throw an error if no placeholder is provided', async function (assert) {
         // given
         const componentParams = {
           id: 'toto',
           label: 'coucou',
-          innerText: ' ',
+          placeholder: ' ',
           options: DEFAULT_OPTIONS,
         };
         const renderComponent = function () {
@@ -296,17 +296,17 @@ module('Integration | Component | multi-select', function (hooks) {
 
         // when & then
         const expectedError = new Error(
-          'ERROR in PixMultiSelect component, @innerText param is necessary'
+          'ERROR in PixMultiSelect component, @placeholder param is necessary'
         );
         assert.throws(renderComponent, expectedError);
       });
 
-      test('it should throw a combined error if no innerText, label is provided', async function (assert) {
+      test('it should throw a combined error if no placeholder, label is provided', async function (assert) {
         // given
         const componentParams = {
           id: 'toto',
           label: ' ',
-          innerText: ' ',
+          placeholder: ' ',
           options: DEFAULT_OPTIONS,
         };
         const renderComponent = function () {
@@ -315,7 +315,7 @@ module('Integration | Component | multi-select', function (hooks) {
 
         // when & then
         const expectedError = new Error(
-          'ERROR in PixMultiSelect component, @label, @innerText params are necessary'
+          'ERROR in PixMultiSelect component, @label, @placeholder params are necessary'
         );
         assert.throws(renderComponent, expectedError);
       });
@@ -326,7 +326,7 @@ module('Integration | Component | multi-select', function (hooks) {
         // given
         this.options = DEFAULT_OPTIONS;
 
-        this.innerText = 'MultiSelectTest';
+        this.placeholder = 'MultiSelectTest';
         this.emptyMessage = 'no result';
         this.id = 'id-MultiSelectTest';
         this.onChange = sinon.spy();
@@ -334,7 +334,7 @@ module('Integration | Component | multi-select', function (hooks) {
         const screen = await render(hbs`
         <PixMultiSelect
           @onChange={{this.onChange}}
-          @innerText={{this.innerText}}
+          @placeholder={{this.placeholder}}
           @id={{this.id}}
           @label="labelMultiSelect"
           @emptyMessage={{this.emptyMessage}}
@@ -360,7 +360,7 @@ module('Integration | Component | multi-select', function (hooks) {
         // given
         this.options = DEFAULT_OPTIONS;
 
-        this.innerText = 'MultiSelectTest';
+        this.placeholder = 'MultiSelectTest';
         this.emptyMessage = 'no result';
         this.values = ['1', '2'];
         this.id = 'id-MultiSelectTest';
@@ -369,7 +369,7 @@ module('Integration | Component | multi-select', function (hooks) {
         const screen = await render(hbs`
           <PixMultiSelect
             @onChange={{this.onChange}}
-            @innerText={{this.innerText}}
+            @placeholder={{this.placeholder}}
             @id={{this.id}}
             @label="labelMultiSelect"
             @emptyMessage={{this.emptyMessage}}
@@ -396,7 +396,7 @@ module('Integration | Component | multi-select', function (hooks) {
         // given
         this.options = DEFAULT_OPTIONS;
 
-        this.innerText = 'MultiSelectTest';
+        this.placeholder = 'MultiSelectTest';
         this.emptyMessage = 'no result';
         this.id = 'id-MultiSelectTest';
         this.onChange = sinon.spy();
@@ -404,7 +404,7 @@ module('Integration | Component | multi-select', function (hooks) {
         const screen = await render(hbs`
         <PixMultiSelect
           @onChange={{this.onChange}}
-          @innerText={{this.innerText}}
+          @placeholder={{this.placeholder}}
           @id={{this.id}}
           @label="labelMultiSelect"
           @emptyMessage={{this.emptyMessage}}
@@ -432,7 +432,7 @@ module('Integration | Component | multi-select', function (hooks) {
         // given
         this.options = DEFAULT_OPTIONS;
 
-        this.innerText = 'MultiSelectTest';
+        this.placeholder = 'MultiSelectTest';
         this.emptyMessage = 'no result';
         this.id = 'id-MultiSelectTest';
         this.onChange = sinon.spy();
@@ -440,7 +440,7 @@ module('Integration | Component | multi-select', function (hooks) {
         const screen = await render(hbs`
         <PixMultiSelect
           @onChange={{this.onChange}}
-          @innerText={{this.innerText}}
+          @placeholder={{this.placeholder}}
           @id={{this.id}}
           @label="labelMultiSelect"
           @emptyMessage={{this.emptyMessage}}
@@ -468,7 +468,7 @@ module('Integration | Component | multi-select', function (hooks) {
         // given
         this.options = DEFAULT_OPTIONS;
 
-        this.innerText = 'MultiSelectTest';
+        this.placeholder = 'MultiSelectTest';
         this.emptyMessage = 'no result';
         this.id = 'id-MultiSelectTest';
         this.onChange = sinon.spy();
@@ -476,7 +476,7 @@ module('Integration | Component | multi-select', function (hooks) {
         const screen = await render(hbs`
         <PixMultiSelect
           @onChange={{this.onChange}}
-          @innerText={{this.innerText}}
+          @placeholder={{this.placeholder}}
           @id={{this.id}}
           @label="labelMultiSelect"
           @emptyMessage={{this.emptyMessage}}
@@ -503,7 +503,7 @@ module('Integration | Component | multi-select', function (hooks) {
         // given
         this.options = DEFAULT_OPTIONS;
 
-        this.innerText = 'MultiSelectTest';
+        this.placeholder = 'MultiSelectTest';
         this.emptyMessage = 'no result';
         this.id = 'id-MultiSelectTest';
         this.onChange = sinon.spy();
@@ -511,7 +511,7 @@ module('Integration | Component | multi-select', function (hooks) {
         const screen = await render(hbs`
         <PixMultiSelect
           @onChange={{this.onChange}}
-          @innerText={{this.innerText}}
+          @placeholder={{this.placeholder}}
           @id={{this.id}}
           @label="labelMultiSelect"
           @emptyMessage={{this.emptyMessage}}
@@ -538,7 +538,7 @@ module('Integration | Component | multi-select', function (hooks) {
         // given
         this.options = DEFAULT_OPTIONS;
 
-        this.innerText = 'MultiSelectTest';
+        this.placeholder = 'MultiSelectTest';
         this.emptyMessage = 'no result';
         this.id = 'id-MultiSelectTest';
         this.onChange = sinon.spy();
@@ -546,7 +546,7 @@ module('Integration | Component | multi-select', function (hooks) {
         const screen = await render(hbs`
         <PixMultiSelect
           @onChange={{this.onChange}}
-          @innerText={{this.innerText}}
+          @placeholder={{this.placeholder}}
           @id={{this.id}}
           @label="labelMultiSelect"
           @emptyMessage={{this.emptyMessage}}
@@ -576,7 +576,7 @@ module('Integration | Component | multi-select', function (hooks) {
         // given
         this.options = DEFAULT_OPTIONS;
 
-        this.innerText = 'MultiSelectTest';
+        this.placeholder = 'MultiSelectTest';
         this.emptyMessage = 'no result';
         this.id = 'id-MultiSelectTest';
         this.onChange = sinon.spy();
@@ -584,7 +584,7 @@ module('Integration | Component | multi-select', function (hooks) {
         const screen = await render(hbs`
         <PixMultiSelect
           @onChange={{this.onChange}}
-          @innerText={{this.innerText}}
+          @placeholder={{this.placeholder}}
           @id={{this.id}}
           @label="labelMultiSelect"
           @emptyMessage={{this.emptyMessage}}
@@ -616,7 +616,7 @@ module('Integration | Component | multi-select', function (hooks) {
       this.values = [];
       this.onChange = () => {};
       this.emptyMessage = 'no result';
-      this.innerText = 'MultiSelectTest';
+      this.placeholder = 'MultiSelectTest';
       this.id = 'id-MultiSelectTest';
       this.isSearchable = true;
 
@@ -626,7 +626,7 @@ module('Integration | Component | multi-select', function (hooks) {
           @isSearchable={{this.isSearchable}}
           @values={{this.values}}
           @onChange={{this.onChange}}
-          @innerText={{this.innerText}}
+          @placeholder={{this.placeholder}}
           @id={{this.id}}
           @label="label"
           @emptyMessage={{this.emptyMessage}}
@@ -641,7 +641,7 @@ module('Integration | Component | multi-select', function (hooks) {
 
       // then
 
-      assert.equal(screen.getByLabelText('label').placeholder, this.innerText);
+      assert.equal(screen.getByLabelText('label').placeholder, this.placeholder);
       assert.equal(screen.getAllByRole('checkbox').length, 3);
     });
 
@@ -651,7 +651,7 @@ module('Integration | Component | multi-select', function (hooks) {
       this.values = [];
       this.onChange = () => {};
       this.emptyMessage = 'no result';
-      this.innerText = 'MultiSelectTest';
+      this.placeholder = 'MultiSelectTest';
       this.id = 'id-MultiSelectTest';
       this.isSearchable = true;
       this.placeholder = 'Placeholder test';
@@ -661,7 +661,6 @@ module('Integration | Component | multi-select', function (hooks) {
           @isSearchable={{this.isSearchable}}
           @values={{this.values}}
           @onChange={{this.onChange}}
-          @innerText={{this.innerText}}
           @placeholder={{this.placeholder}}
           @id={{this.id}}
           @emptyMessage={{this.emptyMessage}}
@@ -689,7 +688,7 @@ module('Integration | Component | multi-select', function (hooks) {
       this.values = [];
       this.onChange = () => {};
       this.emptyMessage = 'no result';
-      this.innerText = 'MultiSelectTest';
+      this.placeholder = 'MultiSelectTest';
       this.id = 'id-MultiSelectTest';
       this.isSearchable = true;
       this.strictSearch = true;
@@ -701,7 +700,6 @@ module('Integration | Component | multi-select', function (hooks) {
           @strictSearch={{this.strictSearch}}
           @values={{this.values}}
           @onChange={{this.onChange}}
-          @innerText={{this.innerText}}
           @placeholder={{this.placeholder}}
           @id={{this.id}}
           @emptyMessage={{this.emptyMessage}}
@@ -727,7 +725,7 @@ module('Integration | Component | multi-select', function (hooks) {
       this.values = [];
       this.onChange = () => {};
       this.emptyMessage = 'no result';
-      this.innerText = 'MultiSelectTest';
+      this.placeholder = 'MultiSelectTest';
       this.id = 'id-MultiSelectTest';
       this.label = 'label';
       this.isSearchable = true;
@@ -738,7 +736,6 @@ module('Integration | Component | multi-select', function (hooks) {
           @isSearchable={{this.isSearchable}}
           @values={{this.values}}
           @onChange={{this.onChange}}
-          @innerText={{this.innerText}}
           @placeholder={{this.placeholder}}
           @label={{this.label}}
           @id={{this.id}}
@@ -763,7 +760,7 @@ module('Integration | Component | multi-select', function (hooks) {
       this.values = ['3'];
       this.onChange = () => {};
       this.emptyMessage = 'no result';
-      this.innerText = 'MultiSelectTest';
+      this.placeholder = 'MultiSelectTest';
       this.id = 'id-MultiSelectTest';
       this.isSearchable = true;
       this.placeholder = 'Placeholder test';
@@ -773,7 +770,6 @@ module('Integration | Component | multi-select', function (hooks) {
           @isSearchable={{this.isSearchable}}
           @values={{this.values}}
           @onChange={{this.onChange}}
-          @innerText={{this.innerText}}
           @placeholder={{this.placeholder}}
           @id={{this.id}}
           @label="label"
@@ -802,7 +798,7 @@ module('Integration | Component | multi-select', function (hooks) {
       this.values = [];
       this.onChange = () => {};
       this.emptyMessage = 'no result';
-      this.innerText = 'MultiSelectTest';
+      this.placeholder = 'MultiSelectTest';
       this.id = 'id-MultiSelectTest';
       this.isSearchable = true;
       this.placeholder = 'Placeholder test';
@@ -812,7 +808,6 @@ module('Integration | Component | multi-select', function (hooks) {
           @isSearchable={{this.isSearchable}}
           @values={{this.values}}
           @onChange={{this.onChange}}
-          @innerText={{this.innerText}}
           @placeholder={{this.placeholder}}
           @label="labelMultiSelect"
           @id={{this.id}}
@@ -843,7 +838,7 @@ module('Integration | Component | multi-select', function (hooks) {
       this.values = [];
       this.onChange = () => {};
       this.emptyMessage = 'no result';
-      this.innerText = 'MultiSelectTest';
+      this.placeholder = 'MultiSelectTest';
       this.id = 'id-MultiSelectTest';
       this.isSearchable = true;
       this.placeholder = 'Placeholder test';
@@ -853,7 +848,6 @@ module('Integration | Component | multi-select', function (hooks) {
           @isSearchable={{this.isSearchable}}
           @values={{this.values}}
           @onChange={{this.onChange}}
-          @innerText={{this.innerText}}
           @placeholder={{this.placeholder}}
           @id={{this.id}}
           @emptyMessage={{this.emptyMessage}}
@@ -884,7 +878,7 @@ module('Integration | Component | multi-select', function (hooks) {
       this.values = [];
       this.onChange = (values) => this.set('values', values);
       this.emptyMessage = 'no result';
-      this.innerText = 'MultiSelectTest';
+      this.placeholder = 'MultiSelectTest';
       this.id = 'id-MultiSelectTest';
       this.isSearchable = true;
       this.placeholder = 'Placeholder test';
@@ -894,7 +888,6 @@ module('Integration | Component | multi-select', function (hooks) {
           @isSearchable={{this.isSearchable}}
           @values={{this.values}}
           @onChange={{this.onChange}}
-          @innerText={{this.innerText}}
           @placeholder={{this.placeholder}}
           @id={{this.id}}
           @emptyMessage={{this.emptyMessage}}
@@ -928,7 +921,7 @@ module('Integration | Component | multi-select', function (hooks) {
       this.values = ['2'];
       this.onChange = () => {};
       this.emptyMessage = 'no result';
-      this.innerText = 'MultiSelectTest';
+      this.placeholder = 'MultiSelectTest';
       this.id = 'id-MultiSelectTest';
       this.isSearchable = true;
       this.placeholder = 'Placeholder test';
@@ -938,7 +931,6 @@ module('Integration | Component | multi-select', function (hooks) {
           @isSearchable={{this.isSearchable}}
           @values={{this.values}}
           @onChange={{this.onChange}}
-          @innerText={{this.innerText}}
           @placeholder={{this.placeholder}}
           @id={{this.id}}
           @label="labelMultiSelect"

--- a/tests/integration/components/pix-multi-select-test.js
+++ b/tests/integration/components/pix-multi-select-test.js
@@ -959,4 +959,36 @@ module('Integration | Component | multi-select', function (hooks) {
       assert.equal(listElement2[2].labels[0].innerText.trim(), 'Oignon');
     });
   });
+
+  module('custom class name', function () {
+    test('it should use the added class name', async function (assert) {
+      // given
+      this.options = DEFAULT_OPTIONS;
+      this.onChange = () => {};
+      this.values = ['2', '3'];
+      this.emptyMessage = 'no result';
+      this.placeholder = 'MultiSelectTest';
+      this.id = 'id-MultiSelectTest';
+      this.className = 'custom';
+
+      // when
+      await render(hbs`
+        <PixMultiSelect
+          @onChange={{this.onChange}}
+          @placeholder={{this.placeholder}}
+          @id={{this.id}}
+          @values={{this.values}}
+          @label="labelMultiSelect"
+          @emptyMessage={{this.emptyMessage}}
+          @isSearchable={{true}}
+          @className = {{this.className}}
+          @options={{this.options}} as |option|
+        >
+          {{option.label}}
+        </PixMultiSelect>
+      `);
+      // then
+      assert.dom('.custom').exists();
+    });
+  });
 });


### PR DESCRIPTION
## :boom: BREAKING_CHANGES
OUI 
Il y a des attributs qui ont changé:
- `onChange` qui remplace onSelect
- `placeholder` qui remplace innerText
- `values` qui remplace selected

## :christmas_tree: Problème
Dans le cadre de notre épix, on souhaite modifier le composant qui permet de choisir un parcours personnalisé. Pour ce faire, on doit modifier le composant existant PixMultiSelect.

## :gift: Solution


## :star2: Remarques

## :santa: Pour tester
Se connecter sur PixUi et vérifier que le composant soit raccord avec Figma