### PR TITLE
[BUG] Empêche le composant PixSelect de capturer le focus à chaque click sur la page (PIX-6397)

### DIFF
--- a/addon/components/pix-select.js
+++ b/addon/components/pix-select.js
@@ -105,11 +105,13 @@ export default class PixSelect extends Component {
 
   @action
   hideDropdown(event) {
-    event.stopPropagation();
-    event.preventDefault();
+    if (this.isExpanded) {
+      event.stopPropagation();
+      event.preventDefault();
 
-    this.isExpanded = false;
-    document.getElementById(this.selectId).focus();
+      this.isExpanded = false;
+      document.getElementById(this.selectId).focus();
+    }
   }
 
   @action
@@ -117,7 +119,6 @@ export default class PixSelect extends Component {
     this.args.onChange(option.value);
 
     this.hideDropdown(event);
-    document.getElementById(this.selectId).focus();
   }
 
   @action


### PR DESCRIPTION
## :boom: BREAKING_CHANGES
> _Décrivez ici les changements cassant (voir la doc associée)[https://github.com/1024pix/pix-ui/blob/dev/docs/breaking-changes.stories.mdx], s'il n'y en a pas indiquez le aussi.

## :christmas_tree: Problème

Le composant Select attache un comportement au click en dehors du composant pour refermer la liste de ses options. Cependant nous avons oublié de conditionner ce comportement au fait que la liste des options est effectivement ouverte. La conséquence est que à chaque click de l'utilisateur dans la page le focus passe automatiquement un PixSelect.

## :gift: Solution

Nous rajoutons la condition qui permet de vérifier que la liste des options est ouverte.

## :star2: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :santa: Pour tester
> _Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc._
