### PR TITLE
[BUGFIX] Autorise d'autres événements de la page à avoir lieu lors de l'ouverture/fermeture du select (PIX-6399)

### DIFF
--- a/addon/components/pix-select.js
+++ b/addon/components/pix-select.js
@@ -97,7 +97,6 @@ export default class PixSelect extends Component {
 
   @action
   showDropdown(event) {
-    event.stopPropagation();
     event.preventDefault();
 
     this.isExpanded = true;
@@ -106,7 +105,6 @@ export default class PixSelect extends Component {
   @action
   hideDropdown(event) {
     if (this.isExpanded) {
-      event.stopPropagation();
       event.preventDefault();
 
       this.isExpanded = false;


### PR DESCRIPTION
## :christmas_tree: Problème
À l'ouverture/fermeture du select, on empêchait d'autres événements de la page d'avoir lieu.

## :gift: Solution
Suppression du `stopPropagation` a l'ouverture et fermeture de la liste des options.

## :star2: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :santa: Pour tester
Dans un contexte avec un bouton à côté du select, si nous ouvrons les options et que nous cliquons sur le bouton il faut que l'action du bouton soit bien appelée.