### PR TITLE
[TECH] Eviter le `no-audit` en demandant la version minimum de `npm` 8.13.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "author": "GIP Pix",
   "engines": {
     "node": "16.14.0",
-    "npm": ">=8.3.1 <=8.13.2"
+    "npm": ">=8.13.2"
   },
   "ember": {
     "edition": "octane"


### PR DESCRIPTION
## :christmas_tree: Problème
Avec les versions < 8.13.2 de npm nous avons besoin de lancer le `npm ci` avec le param `--no-audit`.

Voir https://github.com/storybookjs/ember-cli-storybook/pull/125.

## :gift: Solution
Monter la version minimum de npm à la 8.13.2 pour éviter ce soucis.

## :star2: Remarques
On ne fixe plus de version haute pour ne pas limiter les montées de version de npm. En espérant que les nouvelles versions de npm restent compatibles.

## :santa: Pour tester
- En local, demande de lancer `npm install --global npm@latest` pour mettre à jour sa version de `npm`.
- Lancer le `npm ci` en local sans `--no-audit`.
