### PR TITLE
[BREAKING CHANGES][TECH] Supprime la propriété onLoadOptions sur le composant PixMultiSelect (PIX-6418)

### DIFF
--- a/addon/components/pix-multi-select.hbs
+++ b/addon/components/pix-multi-select.hbs
@@ -75,10 +75,6 @@
           </PixCheckbox>
         </li>
       {{/each}}
-    {{else if this.isLoadingOptions}}
-      <li
-        class="pix-multi-select-list__item pix-multi-select-list__item--no-result"
-      >{{@loadingMessage}}</li>
     {{else}}
       <li
         class="pix-multi-select-list__item pix-multi-select-list__item--no-result"

--- a/addon/components/pix-multi-select.js
+++ b/addon/components/pix-multi-select.js
@@ -22,11 +22,10 @@ export default class PixMultiSelect extends Component {
   @tracked searchData;
 
   @tracked options = [];
-  @tracked isLoadingOptions = false;
 
   constructor(...args) {
     super(...args);
-    const { onLoadOptions, id, label, placeholder } = this.args;
+    const { id, label, placeholder } = this.args;
 
     const idIsNotDefined = !id || !id.trim();
     const labelIsNotDefined = !label || !label.trim();
@@ -46,15 +45,7 @@ export default class PixMultiSelect extends Component {
       );
     }
 
-    if (onLoadOptions) {
-      this.isLoadingOptions = true;
-      onLoadOptions().then((options = []) => {
-        this.options = options;
-        this.isLoadingOptions = false;
-      });
-    } else {
-      this.options = [...(this.args.options || [])];
-    }
+    this.options = [...(this.args.options || [])];
   }
 
   get listId() {

--- a/app/stories/pix-multi-select.stories.js
+++ b/app/stories/pix-multi-select.stories.js
@@ -20,7 +20,6 @@ const Template = (args) => ({
     @isSearchable={{isSearchable}}
     @strictSearch={{strictSearch}}
     @values={{values}}
-    @onLoadOptions={{onLoadOptions}} 
     @options={{options}} as |option|
   >{{option.label}}</PixMultiSelect>
  `,
@@ -91,13 +90,6 @@ multiSelectSearchable.args = {
   emptyMessage: 'Aucune option trouvée',
 };
 
-export const multiSelectAsyncOptions = Template.bind({});
-multiSelectAsyncOptions.args = {
-  ...Default.args,
-  onLoadOptions: () => Promise.resolve(Default.args.options),
-  loadingMessage: 'Chargement en cours ...',
-};
-
 export const multiSelectWithCustomClass = Template.bind({});
 multiSelectWithCustomClass.args = {
   ...Default.args,
@@ -143,19 +135,6 @@ export const argTypes = {
       'Les options sont représentées par un tableau d‘objet contenant les propriétés ``value`` et ``label``. ``value`` doit être de type ``String`` pour être conforme au traitement des input value.',
     type: { name: 'array', required: false },
     defaultValue: DEFAULT_OPTIONS,
-  },
-  onLoadOptions: {
-    name: 'onLoadOptions',
-    description:
-      'Charge de manière asynchrone les options. Doit renvoyer une promesse avec la liste des options. Les options sont représentées par un tableau d‘objet contenant les propriétés ``value`` et ``label``. ``value`` doit être de type ``String`` pour être conforme au traitement des input value.',
-    type: { required: false },
-  },
-  loadingMessage: {
-    name: 'loadingMessage',
-    description:
-      "Message qui apparaît dans les options quand celles-ci sont en train d'être chargées via onLoadOptions",
-    type: { name: 'string', required: false },
-    defaultValue: 'Chargement...',
   },
   onChange: {
     name: 'onChange',

--- a/app/stories/pix-multi-select.stories.mdx
+++ b/app/stories/pix-multi-select.stories.mdx
@@ -30,17 +30,6 @@ L'ajout de ``class`` et d'autres attributs comme ``aria-label`` sont possibles.
   <Story name="withCustomClass" story={stories.multiSelectWithCustomClass} height={330}/>
 </Canvas>
 
-## With async options
-
-Via la propriété `onLoadOptions`, le composant peut charger lui-même les options de manière asynchrone.
-Le callback `onLoadOptions` est une promesse renvoyant la liste des options. (eg. `[{ label: 'A', value: '1' }]`).
-
-Il est possible de donner un message via `loadingMessage` à afficher à la place des options pendant que celles-ci soient chargées.
-
-<Canvas>
-  <Story name="With async options" story={stories.multiSelectAsyncOptions} height={330}/>
-</Canvas>
-
 ## Usage
 
 ```html

--- a/tests/integration/components/pix-multi-select-test.js
+++ b/tests/integration/components/pix-multi-select-test.js
@@ -44,37 +44,6 @@ module('Integration | Component | multi-select', function (hooks) {
       assert.equal(screen.queryAllByRole('checkbox').length, 0);
     });
 
-    test('it should asynchronously load options', async function (assert) {
-      // given
-      this.onLoadOptions = () => Promise.resolve(DEFAULT_OPTIONS);
-      this.values = [];
-      this.onChange = () => {};
-      this.emptyMessage = 'no result';
-      this.placeholder = 'MultiSelectTest';
-      this.id = 'id-MultiSelectTest';
-
-      // when
-      const screen = await render(hbs`
-        <PixMultiSelect
-          @values={{this.values}}
-          @onChange={{this.onChange}}
-          @placeholder={{this.placeholder}}
-          @id={{this.id}}
-          @label="labelMultiSelect"
-          @emptyMessage={{this.emptyMessage}}
-          @onLoadOptions={{this.onLoadOptions}} as |option|>
-          {{option.label}}
-        </PixMultiSelect>
-      `);
-
-      await clickByName('labelMultiSelect');
-
-      await screen.findByRole('menu');
-
-      // then
-      assert.equal(screen.getAllByRole('checkbox').length, 3);
-    });
-
     test('it should updates selected items when @values is reset', async function (assert) {
       // given
       this.options = DEFAULT_OPTIONS;


### PR DESCRIPTION
## :boom: BREAKING_CHANGES

Cette PR supprime les propriétés `onLoadOptions` et `loadingMessage`. Leurs usages ont été supprimés des applications dans la PR suivante : https://github.com/1024pix/pix/pull/5264#event-7900509521 

Il n'y a donc normalement rien à faire lors de la mise à jour de PixUI qui embarquera ces changes.

## :christmas_tree: Problème

Rappel du contexte décrit dans la PR : https://github.com/1024pix/pix/pull/5264#event-7900509521 

Le fonctionnement de la propriété onLoadOptions sur le composant PixMultiSelect est problématique car il sort de nos standards en terme d'interface de composant.

Pour passer de l'information à un composant on utilise des types comme string, object, number, ...
Pour communiquer de l'information en dehors d'un composant, on utilise des callbacks. Le composant se charge d'appeler la fonction au moment opportuns avec les données à communiquer en paramètre mais ne se soucie pas d'attendre un retour de la fonction.

Ici la propriété onLoadOptions attend une fonction qui retourne en promesse. Le composant pourra ensuite accéder aux options à afficher lorsque la promesse sera résolu. Cela permet notamment au composant de décider tout seul si il doit afficher ou non un état de chargement.

Je pense que le composant ne devrait pas avoir cette responsabilité. Le code qui appelle le composant à la charge de gérer comment la donnée est chargée et la passer au composant. Cependant le composant peut fournir la possibilité d'afficher un état de chargement (par exemple au travers d'une propriété isLoading). Il incombe alors à l'appelant de dire au composant quand afficher cet état ou non.

## :gift: Solution

Supprimer la propriété `onLoadOptions`

## :star2: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :santa: Pour tester
> _Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc._
