### PR TITLE
[FEATURE] Améliorer l'accessibilité de PixModal (PIX-6265)

### DIFF
--- a/addon/components/pix-modal.hbs
+++ b/addon/components/pix-modal.hbs
@@ -12,7 +12,7 @@
     aria-modal="true"
     ...attributes
   >
-    <header class="pix-modal__header">
+    <div class="pix-modal__header">
       <h1 id="modal-title--{{this.id}}" class="pix-modal__title">{{@title}}</h1>
       <PixIconButton
         @icon="xmark"
@@ -22,12 +22,12 @@
         @withBackground={{true}}
         class="pix-modal__close-button"
       />
-    </header>
-    <main id="modal-content--{{this.id}}" class="pix-modal__content">
+    </div>
+    <div id="modal-content--{{this.id}}" class="pix-modal__content">
       {{yield to="content"}}
-    </main>
-    <footer class="pix-modal__footer">
+    </div>
+    <div class="pix-modal__footer">
       {{yield to="footer"}}
-    </footer>
+    </div>
   </div>
 </div>

--- a/addon/styles/_pix-modal.scss
+++ b/addon/styles/_pix-modal.scss
@@ -15,7 +15,7 @@
   // if the content is less than 100vh
   // Inspired by https://mui.com/material-ui/react-dialog/#scrolling-long-content
   &::after {
-    content: "";
+    content: '';
     display: inline-block;
     vertical-align: middle;
     height: 100%;
@@ -39,8 +39,10 @@ $button-margin: 16px;
   display: inline-block;
   vertical-align: middle; // Centered vertically with the .pix-modal__overlay::after which is 100% height
   width: 512px;
-  max-width: calc(100% - #{2 * $spacing-xs}); // Horizontal margin sets here to have extra space for the .pix-modal__overlay::after on mobile
-  text-align: initial; 
+  max-width: calc(
+    100% - #{2 * $spacing-xs}
+  ); // Horizontal margin sets here to have extra space for the .pix-modal__overlay::after on mobile
+  text-align: initial;
   background-color: $pix-neutral-10;
   box-shadow: 1px 1px 5px rgba(0, 0, 0, 0.1);
   border-radius: 4px;
@@ -94,21 +96,5 @@ $button-margin: 16px;
 
   &__footer {
     padding: 0 $modal-padding $modal-padding - $button-margin;
-
-    @include device-is('tablet') {
-      display: flex;
-      justify-content: flex-end;
-      flex-wrap: wrap;
-    }
-
-    .pix-button {
-      margin-bottom: $button-margin;
-      width: 100%;
-
-      @include device-is('tablet') {
-        margin: 0 0 $button-margin $button-margin;
-        width: auto;
-      }
-    }
   }
 }

--- a/app/stories/pix-modal.stories.js
+++ b/app/stories/pix-modal.stories.js
@@ -18,12 +18,10 @@ export const Template = (args) => {
     </p>
   </:content>
   <:footer>
-    <PixButton
-      @backgroundColor='transparent-light'
-      @isBorderVisible='true'
-      @triggerAction={{fn (mut this.showModal) (not this.showModal)}}
-    >Annuler</PixButton>
-    <PixButton @triggerAction={{fn (mut this.showModal) (not this.showModal)}}>Valider</PixButton>
+    <div style="display:flex; justify-content: flex-end; flex-wrap: wrap;">
+      <PixButton style="margin: 0 0 16px 16px;" @backgroundColor='transparent-light' @isBorderVisible='true' @triggerAction={{fn (mut this.showModal) (not this.showModal)}}>Annuler</PixButton>
+      <PixButton style="margin: 0 0 16px 16px;" @triggerAction={{fn (mut this.showModal) (not this.showModal)}}>Valider</PixButton>
+    </div>
   </:footer>
 </PixModal>
 <div style='display:flex; justify-content:center; align-items:center; height:105vh;'>


### PR DESCRIPTION
## :christmas_tree: Problèmes
La présence de balises dupliquées `header`,`main` et `footer` sur la page de mon-pix**
- dans la `Pix-Modal` qui est dans le dom.
- dans la page d'accueil de Pix app.

**problème 3 : Du css inclu dans le composant Pix-Modal entrave sa généricité**

## :gift: Solutions
Utiliser des balises `div` plutôt que des balises structurantes telles que `main`, `header`, `footer`, etc.
Supprimer le code css

## :star2: Remarques
Nous avons profité de cette PR pour corriger le problème de l'alignement sur la droite des boutons du `footer` de la modale. Ainsi, pour avoir les boutons d'actions stylisés à droite, il faudra rajouter ce style sur la liste de boutons d'action : 
```
ul {
  display: flex;
  flex-direction: column;
  gap: $spacing-s;
  margin-bottom: $spacing-s;

  @include device-is('tablet') {
    flex-direction: row;
    flex-wrap: wrap;
    justify-content: flex-end;
  }
}
```

## :santa: Pour tester
- regarder la story
- vérifier que rien n'est cassé sur la `Pix-Modal`


