### PR TITLE
[FEATURE] Améliorer l'accessiblité de PixSidebar (PIX-6424)

### DIFF
--- a/addon/components/pix-sidebar.hbs
+++ b/addon/components/pix-sidebar.hbs
@@ -12,7 +12,7 @@
     aria-modal="true"
     ...attributes
   >
-    <header class="pix-sidebar__header">
+    <div class="pix-sidebar__header">
       <h1 id="sidebar-title--{{this.id}}" class="pix-sidebar__title">{{@title}}</h1>
       <PixIconButton
         @icon="xmark"
@@ -22,12 +22,12 @@
         @withBackground={{true}}
         class="pix-sidebar__close-button"
       />
-    </header>
-    <main id="sidebar-content--{{this.id}}" class="pix-sidebar__content">
+    </div>
+    <div id="sidebar-content--{{this.id}}" class="pix-sidebar__content">
       {{yield to="content"}}
-    </main>
-    <footer class="pix-sidebar__footer">
+    </div>
+    <div class="pix-sidebar__footer">
       {{yield to="footer"}}
-    </footer>
+    </div>
   </div>
 </div>

--- a/app/stories/pix-sidebar.stories.js
+++ b/app/stories/pix-sidebar.stories.js
@@ -34,8 +34,8 @@ export const Template = (args) => {
 
 export const Default = Template.bind({});
 Default.args = {
-  showSidebar: true,
   title: 'Filtrer',
+  showSidebar: true,
   onClose: () => {},
 };
 

--- a/app/stories/pix-sidebar.stories.js
+++ b/app/stories/pix-sidebar.stories.js
@@ -34,8 +34,8 @@ export const Template = (args) => {
 
 export const Default = Template.bind({});
 Default.args = {
-  title: 'Filtrer',
   showSidebar: true,
+  title: 'Filtrer',
   onClose: () => {},
 };
 

--- a/tests/integration/components/pix-sidebar-test.js
+++ b/tests/integration/components/pix-sidebar-test.js
@@ -15,14 +15,16 @@ module('Integration | Component | Sidebar', function (hooks) {
       this.showSidebar = true;
 
       // when
-      await render(hbs`<PixSidebar @title={{this.title}} @showSidebar={{this.showSidebar}}>
-  <:content>
-    content
-  </:content>
-  <:footer>
-    footer
-  </:footer>
-</PixSidebar>`);
+      await render(hbs`
+        <PixSidebar @title={{this.title}} @showSidebar={{this.showSidebar}}>
+          <:content>
+            content
+          </:content>
+          <:footer>
+            footer
+          </:footer>
+        </PixSidebar>
+      `);
 
       // then
       assert.contains("It's a sidebar!");
@@ -40,9 +42,17 @@ module('Integration | Component | Sidebar', function (hooks) {
         this.onClose = sinon.stub();
 
         // when
-        await render(hbs`<PixSidebar @title={{this.title}} @onClose={{this.onClose}} @showSidebar={{this.showSidebar}}>
-  content
-</PixSidebar>`);
+        await render(hbs`
+          <PixSidebar
+            @title={{this.title}}
+            @onClose={{this.onClose}}
+            @showSidebar={{this.showSidebar}}
+          >
+          <:content>
+            content
+          </:content>
+          </PixSidebar>
+        `);
         await click('[aria-label="Fermer"]');
 
         // then
@@ -58,9 +68,17 @@ module('Integration | Component | Sidebar', function (hooks) {
         this.onClose = sinon.stub();
 
         // when
-        await render(hbs`<PixSidebar @title={{this.title}} @onClose={{this.onClose}} @showSidebar={{this.showSidebar}}>
-  content
-</PixSidebar>`);
+        await render(hbs`
+          <PixSidebar
+            @title={{this.title}}
+            @onClose={{this.onClose}}
+            @showSidebar={{this.showSidebar}}
+          >
+          <:content>
+            content
+          </:content>
+          </PixSidebar>
+        `);
         await triggerKeyEvent('.pix-sidebar__overlay', 'keyup', 'Escape');
 
         // then
@@ -76,14 +94,16 @@ module('Integration | Component | Sidebar', function (hooks) {
       this.showSidebar = false;
 
       // when
-      await render(hbs`<PixSidebar @title={{this.title}} @showSidebar={{this.showSidebar}}>
-  <:content>
-    content
-  </:content>
-  <:footer>
-    footer
-  </:footer>
-</PixSidebar>`);
+      await render(hbs`
+        <PixSidebar @title={{this.title}} @showSidebar={{this.showSidebar}}>
+          <:content>
+            content
+          </:content>
+          <:footer>
+            footer
+          </:footer>
+        </PixSidebar>
+      `);
 
       // then
       assert.dom('.pix-sidebar--hidden').exists();


### PR DESCRIPTION
## :christmas_tree: Problèmes
 La présence de balises dupliquées `header`,`main` et `footer` sur la page de mon-pix**
- dans la `Pix-Sidebar` qui est dans le dom.
- dans la page d'accueil de Pix app.

## :gift: Solutions
Utiliser des balises `div` plutôt que des balises structurantes telles que `main`, `header`, `footer`, etc.

## :santa: Pour tester
- regarder la story
- vérifier que rien n'est cassé sur la `Pix-Sidebar`


