### PR TITLE
[FEATURE] Ajout le composant PixToggle (PIX-6427)

### DIFF
--- a/addon/components/pix-toggle.hbs
+++ b/addon/components/pix-toggle.hbs
@@ -1,0 +1,1 @@
+<span>Hello</span>

--- a/addon/components/pix-toggle.hbs
+++ b/addon/components/pix-toggle.hbs
@@ -1,1 +1,24 @@
-<span>Hello</span>
+<label class={{this.className}}>
+  <span class="pix-toggle__label{{if @screenReaderOnly ' screen-reader-only'}}">{{@label}}</span>
+  <button
+    class="pix-toggle__button"
+    aria-pressed={{if @toggled "true" "false"}}
+    type="button"
+    {{on "click" this.onToggle}}
+  >
+    <span class="pix-toggle__on">
+      {{#if @onLabel}}
+        {{@onLabel}}
+      {{else}}
+        {{yield to="on"}}
+      {{/if}}
+    </span>
+    <span class="pix-toggle__off">
+      {{#if @offLabel}}
+        {{@offLabel}}
+      {{else}}
+        {{yield to="off"}}
+      {{/if}}
+    </span>
+  </button>
+</label>

--- a/addon/components/pix-toggle.js
+++ b/addon/components/pix-toggle.js
@@ -1,0 +1,23 @@
+import Component from '@glimmer/component';
+import { action } from '@ember/object';
+
+export default class PixToggle extends Component {
+  get className() {
+    const classes = ['pix-toggle'];
+    if (this.args.inline) {
+      classes.push('pix-toggle--inline');
+    }
+    if (this.args.toggled) {
+      classes.push('pix-toggle--pressed');
+    }
+    if (this.args.screenReaderOnly) {
+      classes.push('pix-toggle--screen-reader-only');
+    }
+    return classes.join(' ');
+  }
+
+  @action
+  onToggle() {
+    this.args.onChange(!this.args.toggled);
+  }
+}

--- a/addon/styles/_pix-toggle.scss
+++ b/addon/styles/_pix-toggle.scss
@@ -1,0 +1,63 @@
+.pix-toggle {
+  display: flex;
+  flex-direction: column;
+
+  &__label {
+    color: $pix-neutral-90;
+
+    @include text;
+  }
+
+  &__button {
+    width: fit-content;
+    background-color: transparent;
+    border: 1px solid $pix-neutral-30;
+    border-radius: 4px;
+    padding: $spacing-xxs;
+    margin-top: $spacing-xxs;
+  }
+
+  &__on,
+  &__off {
+    display: inline-block;
+    border-radius: 4px;
+    padding: $spacing-xs;
+    color: $pix-neutral-70;
+
+    @include text-small;
+  }
+
+  &__off {
+    background-color: $pix-neutral-45;
+    color: $white;
+  }
+
+  &--inline {
+    flex-direction: row;
+    align-items: center;
+    gap: $spacing-xxs;
+  }
+
+  &--inline,
+  &--screen-reader-only {
+    .pix-toggle {
+      &__button {
+        margin-top: 0;
+      }
+    }
+  }
+
+  &--pressed {
+    .pix-toggle {
+      &__on {
+        background-color: $pix-neutral-45;
+        color: $white;
+      }
+
+      &__off {
+        background-color: transparent;
+        color: inherit;
+      }
+    }
+  }
+}

--- a/addon/styles/addon.scss
+++ b/addon/styles/addon.scss
@@ -29,6 +29,7 @@
 @import 'pix-dropdown';
 @import 'pix-pagination';
 @import 'pix-checkbox';
+@import 'pix-toggle';
 @import 'trap-focus';
 
 // at the end so it can override it's children scss

--- a/app/components/pix-toggle.js
+++ b/app/components/pix-toggle.js
@@ -1,0 +1,1 @@
+export { default } from '@1024pix/pix-ui/components/pix-toggle';

--- a/app/stories/pix-toggle.stories.js
+++ b/app/stories/pix-toggle.stories.js
@@ -1,0 +1,13 @@
+import { hbs } from 'ember-cli-htmlbars';
+
+export const Template = (args) => {
+  return {
+    template: hbs`
+        <PixToggle />
+    `,
+    context: args,
+  };
+};
+
+export const Default = Template.bind({});
+Default.args = {};

--- a/app/stories/pix-toggle.stories.js
+++ b/app/stories/pix-toggle.stories.js
@@ -1,13 +1,120 @@
 import { hbs } from 'ember-cli-htmlbars';
+import { action } from '@storybook/addon-actions';
 
 export const Template = (args) => {
   return {
     template: hbs`
-        <PixToggle />
+      <PixToggle
+        @label={{this.label}}
+        @onLabel={{this.onLabel}}
+        @offLabel={{this.offLabel}}
+        @toggled={{this.toggled}}
+        @onChange={{this.onChange}}
+        @inline={{this.inline}}
+        @screenReaderOnly={{this.screenReaderOnly}}
+      />
+    `,
+    context: args,
+  };
+};
+
+export const TemplateWithYields = (args) => {
+  return {
+    template: hbs`
+      <PixToggle
+        @label={{this.label}}
+        @toggled={{this.toggled}}
+        @onChange={{this.onChange}}
+      >
+        <:on><FaIcon @icon="sun" /></:on>
+        <:off><FaIcon @icon="moon" /></:off>
+      </PixToggle>
     `,
     context: args,
   };
 };
 
 export const Default = Template.bind({});
-Default.args = {};
+Default.args = {
+  label: 'Mon toggle',
+  onLabel: 'Oui',
+  offLabel: 'Non',
+  toggled: false,
+  onChange: action('onChange'),
+};
+
+export const Inline = Template.bind({});
+Inline.args = {
+  inline: true,
+  label: 'Mon toggle',
+  onLabel: 'Oui',
+  offLabel: 'Non',
+  toggled: false,
+  onChange: action('onChange'),
+};
+
+export const ScreenReaderOnly = Template.bind({});
+ScreenReaderOnly.args = {
+  screenReaderOnly: true,
+  label: 'Mon toggle',
+  onLabel: 'Oui',
+  offLabel: 'Non',
+  toggled: false,
+  onChange: action('onChange'),
+};
+
+export const WithYields = TemplateWithYields.bind({});
+WithYields.args = {
+  label: 'Mon toggle',
+  toggled: false,
+  onChange: action('onChange'),
+};
+
+export const argTypes = {
+  label: {
+    name: 'label',
+    description: 'Le label du PixToggle',
+    type: { name: 'string', required: true },
+  },
+  onLabel: {
+    name: 'onLabel',
+    description: "Le label de l'état actif du PixToggle",
+    type: { name: 'string', required: false },
+  },
+  offLabel: {
+    name: 'offLabel',
+    description: "Le label de l'état non actif du PixToggle",
+    type: { name: 'string', required: false },
+  },
+  toggled: {
+    name: 'toggled',
+    description: 'Détermine si le PixToggle est activé',
+    type: { name: 'boolean', required: true },
+  },
+  onChange: {
+    name: 'onChange',
+    description: "Fonction à appeler quand le PixToggle change d'état.",
+    type: { required: true },
+    control: { disable: true },
+  },
+  inline: {
+    name: 'inline',
+    description: "Permet d'afficher le PixToggle sur une seule ligne",
+    control: { type: 'boolean' },
+    type: { name: 'boolean', required: false },
+    table: {
+      type: { summary: 'boolean' },
+      defaultValue: { summary: false },
+    },
+  },
+  screenReaderOnly: {
+    name: 'screenReaderOnly',
+    description: "Permet de rendre le label lisible uniquement par les lecteurs d'écran",
+    control: { type: 'boolean' },
+    type: { name: 'boolean', required: false },
+    table: {
+      type: { summary: 'boolean' },
+      defaultValue: { summary: false },
+    },
+  },
+};

--- a/app/stories/pix-toggle.stories.mdx
+++ b/app/stories/pix-toggle.stories.mdx
@@ -10,11 +10,29 @@ import * as stories from './pix-toggle.stories.js';
 
 # Pix Select
 
-Affiche un bouton à états.
+Affiche un bouton à deux états.
 
 ## Default
 
 <Canvas>
   <Story name='Default' story={stories.Default} height={200} />
+</Canvas>
+
+## Inline
+
+<Canvas>
+  <Story name='Inline' story={stories.Inline} height={200} />
+</Canvas>
+
+## ScreenReaderOnly
+
+<Canvas>
+  <Story name='ScreenReaderOnly' story={stories.ScreenReaderOnly} height={200} />
+</Canvas>
+
+## WithYields
+
+<Canvas>
+  <Story name='WithYields' story={stories.WithYields} height={200} />
 </Canvas>
 

--- a/app/stories/pix-toggle.stories.mdx
+++ b/app/stories/pix-toggle.stories.mdx
@@ -1,0 +1,20 @@
+import { Meta, Story, Canvas, ArgsTable } from '@storybook/addon-docs/blocks';
+import centered from '@storybook/addon-centered/ember';
+import * as stories from './pix-toggle.stories.js';
+
+<Meta
+  title='Form/Toggle'
+  component='PixToggle'
+  argTypes={stories.argTypes}
+/>
+
+# Pix Select
+
+Affiche un bouton à états.
+
+## Default
+
+<Canvas>
+  <Story name='Default' story={stories.Default} height={200} />
+</Canvas>
+

--- a/tests/integration/components/pix-toggle-test.js
+++ b/tests/integration/components/pix-toggle-test.js
@@ -1,0 +1,159 @@
+import { module, test } from 'qunit';
+import { click } from '@ember/test-helpers';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@1024pix/ember-testing-library';
+import { hbs } from 'ember-cli-htmlbars';
+import sinon from 'sinon';
+import userEvent from '@testing-library/user-event';
+
+module('Integration | Component | PixToggle', function (hooks) {
+  setupRenderingTest(hooks);
+
+  this.label = 'Mon bouton toggle';
+  this.onLabel = 'Oui';
+  this.offLabel = 'Non';
+
+  test('it renders PixToggle', async function (assert) {
+    // given & when
+    const screen = await render(hbs`
+    <PixToggle
+      @label={{this.label}}
+      @onLabel={{this.onLabel}}
+      @offLabel={{this.offLabel}}
+    />
+  `);
+
+    // then
+    assert.dom(screen.getByText(this.label)).exists();
+    assert.dom(screen.getByText(this.onLabel)).exists();
+    assert.dom(screen.getByText(this.offLabel)).exists();
+  });
+
+  test('it renders PixToggle with labels yielded', async function (assert) {
+    // given & when
+    const screen = await render(hbs`
+    <PixToggle
+      @label={{this.label}}
+    >
+      <:on>{{this.onLabel}}</:on>
+      <:off>{{this.offLabel}}</:off>
+    </PixToggle>
+  `);
+
+    assert.dom(screen.getByText(this.label)).exists();
+    assert.dom(screen.getByText(this.onLabel)).exists();
+    assert.dom(screen.getByText(this.offLabel)).exists();
+  });
+
+  test('it pressed PixToggle', async function (assert) {
+    // given & when
+    const screen = await render(hbs`
+    <PixToggle
+      @label={{this.label}}
+      @onLabel={{this.onLabel}}
+      @offLabel={{this.offLabel}}
+      @toggled={{true}}
+    />
+  `);
+
+    // then
+    assert.dom(screen.getByRole('button', { pressed: true })).exists();
+  });
+
+  test('it does not press PixToggle', async function (assert) {
+    // given & when
+    const screen = await render(hbs`
+    <PixToggle
+      @label={{this.label}}
+      @onLabel={{this.onLabel}}
+      @offLabel={{this.offLabel}}
+      @toggled={{false}}
+    />
+  `);
+
+    // then
+    assert.dom(screen.getByRole('button', { pressed: false })).exists();
+  });
+
+  test('it calls onChange when PixToggle is not pressed with value true', async function (assert) {
+    // given & when
+    this.onChange = sinon.spy();
+
+    const screen = await render(hbs`
+    <PixToggle
+      @label={{this.label}}
+      @onLabel={{this.onLabel}}
+      @offLabel={{this.offLabel}}
+      @toggled={{false}}
+      @onChange={{this.onChange}}
+    />
+  `);
+
+    await click(screen.getByRole('button'));
+
+    // then
+    sinon.assert.calledWith(this.onChange, true);
+    assert.ok(this.onChange.called);
+  });
+
+  test('it calls onChange when PixToggle is pressed with value false', async function (assert) {
+    // given & when
+    this.onChange = sinon.spy();
+
+    const screen = await render(hbs`
+    <PixToggle
+      @label={{this.label}}
+      @onLabel={{this.onLabel}}
+      @offLabel={{this.offLabel}}
+      @toggled={{true}}
+      @onChange={{this.onChange}}
+    />
+  `);
+
+    await click(screen.getByRole('button'));
+
+    // then
+    sinon.assert.calledWith(this.onChange, false);
+    assert.ok(this.onChange.called);
+  });
+
+  test('it calls onChange when Enter is pressed', async function (assert) {
+    // given & when
+    this.onChange = sinon.spy();
+
+    const screen = await render(hbs`
+    <PixToggle
+      @label={{this.label}}
+      @onLabel={{this.onLabel}}
+      @offLabel={{this.offLabel}}
+      @onChange={{this.onChange}}
+    />
+  `);
+
+    await screen.getByRole('button').focus();
+    await userEvent.keyboard('[Enter]');
+
+    // then
+    assert.ok(this.onChange.called);
+  });
+
+  test('it calls onChange when Space is pressed', async function (assert) {
+    // given & when
+    this.onChange = sinon.spy();
+
+    const screen = await render(hbs`
+    <PixToggle
+      @label={{this.label}}
+      @onLabel={{this.onLabel}}
+      @offLabel={{this.offLabel}}
+      @onChange={{this.onChange}}
+    />
+  `);
+
+    await screen.getByRole('button').focus();
+    await userEvent.keyboard('[Space]');
+
+    // then
+    assert.ok(this.onChange.called);
+  });
+});


### PR DESCRIPTION
## :boom: BREAKING_CHANGES
> _Décrivez ici les changements cassant (voir la doc associée)[https://github.com/1024pix/pix-ui/blob/dev/docs/breaking-changes.stories.mdx], s'il n'y en a pas indiquez le aussi.

## :christmas_tree: Problème
Dans PixAdmin on utilise un le composant XToggle. Il existe un composant PixToggle designer dans le Design System. On a donc une dépendance dont on pourrait se passer dans PixAdmin si le composant PixToggle était implémenté.

## :gift: Solution
On implémente le composant PixToggle

## :star2: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :santa: Pour tester
> _Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc._
