### PR TITLE
[FEATURE] Ajoute une propriété id sur le composant PixSelect (PIX-6440)

### DIFF
--- a/addon/components/pix-select.hbs
+++ b/addon/components/pix-select.hbs
@@ -8,18 +8,20 @@
   {{did-insert this.setSelectWidth}}
   {{on "keydown" this.lockTab}}
 >
-  <div class="{{if @screenReaderOnly 'screen-reader-only'}}">
-    <label for={{this.selectId}} class="pix-select__label">
-      {{#if @requiredText}}
-        <abbr class="mandatory-mark" title="{{@requiredText}}" aria-hidden="true">*</abbr>
-      {{/if}}
-      {{@label}}
-    </label>
+  {{#if @label}}
+    <div class="{{if @screenReaderOnly 'screen-reader-only'}}">
+      <label for={{this.selectId}} class="pix-select__label">
+        {{#if @requiredText}}
+          <abbr class="mandatory-mark" title="{{@requiredText}}" aria-hidden="true">*</abbr>
+        {{/if}}
+        {{@label}}
+      </label>
 
-    {{#if @subLabel}}
-      <span class="pix-select__sub-label">{{@subLabel}}</span>
-    {{/if}}
-  </div>
+      {{#if @subLabel}}
+        <span class="pix-select__sub-label">{{@subLabel}}</span>
+      {{/if}}
+    </div>
+  {{/if}}
 
   <button
     type="button"

--- a/addon/components/pix-select.js
+++ b/addon/components/pix-select.js
@@ -7,12 +7,12 @@ export default class PixSelect extends Component {
   @tracked isExpanded = false;
   @tracked searchValue = null;
   searchId = 'search-input-' + guidFor(this);
-  selectId = 'select-' + guidFor(this);
 
   constructor(...args) {
     super(...args);
 
-    if (!this.args.label) throw new Error('ERROR in PixSelect, a label is required');
+    if (!this.args.label && !this.args.id)
+      throw new Error('ERROR in PixSelect, a @label or an @id was not provided');
 
     const categories = [];
     this.args.options.forEach((element) => {
@@ -22,6 +22,11 @@ export default class PixSelect extends Component {
     });
 
     this.displayCategory = categories.length > 0;
+  }
+
+  get selectId() {
+    if (this.args.id) return this.args.id;
+    return 'select-' + guidFor(this);
   }
 
   get displayDefaultOption() {

--- a/app/stories/pix-select.stories.js
+++ b/app/stories/pix-select.stories.js
@@ -12,7 +12,13 @@ export const Template = (args) => {
           border: 0;
         }
       </style>
+        {{#if this.id}}
+          <div>
+            <label for={{this.id}}>Un label en dehors du composant</label>
+          </div>
+        {{/if}}
         <PixSelect
+          @id={{this.id}}
           @className={{this.className}}
           @options={{this.options}}
           @isSearchable={{this.isSearchable}}
@@ -32,6 +38,25 @@ export const Template = (args) => {
     `,
     context: args,
   };
+};
+
+export const WithId = Template.bind({});
+WithId.args = {
+  id: 'custom',
+  options: [
+    { value: '1', label: 'Figues' },
+    { value: '3', label: 'Fraises' },
+    { value: '2', label: 'Bananes' },
+    { value: '4', label: 'Mangues' },
+    { value: '5', label: 'Kaki' },
+    {
+      value: '6',
+      label: 'Asiminier trilobé oblong vert (à ne pas confondre avec la papaye)',
+    },
+  ],
+  placeholder: 'Mon innerText',
+  isSearchable: false,
+  onChange: action('onChange'),
 };
 
 export const WithCustomClass = Template.bind({});
@@ -184,10 +209,18 @@ export const argTypes = {
       defaultValue: { summary: false },
     },
   },
+  id: {
+    name: 'id',
+    description: 'Un identifiant unique placé sur le composant',
+    type: { name: 'string', required: false },
+    table: {
+      type: { summary: 'string' },
+    },
+  },
   label: {
     name: 'label',
     description: 'Label du menu déroulant',
-    type: { name: 'string', required: true },
+    type: { name: 'string', required: false },
     table: {
       type: { summary: 'string' },
     },

--- a/app/stories/pix-select.stories.mdx
+++ b/app/stories/pix-select.stories.mdx
@@ -26,6 +26,12 @@ Les options sont représentées par un tableau d'objet contenant les propriété
   <Story name='Default' story={stories.Default} height={200} />
 </Canvas>
 
+## WithId
+
+<Canvas>
+  <Story name='WithId' story={stories.WithId} height={200} />
+</Canvas>
+
 ## WithCustomClass
 
 <Canvas>

--- a/tests/integration/components/pix-select-test.js
+++ b/tests/integration/components/pix-select-test.js
@@ -39,6 +39,24 @@ module('Integration | Component | PixSelect', function (hooks) {
     assert.equal(screen.getByLabelText('Mon menu déroulant').innerText, 'Choisissez une option');
   });
 
+  module('#id', function () {
+    test('it puts a custom id on pix-select', async function (assert) {
+      // given & when
+      await render(hbs`
+        <PixSelect
+          @id="custom"
+          @options={{this.options}}
+          @label={{this.label}}
+          @subLabel={{this.subLabel}}
+          @placeholder={{this.placeholder}}
+        />
+      `);
+
+      // then
+      assert.dom('#custom').exists();
+    });
+  });
+
   module('listbox', function () {
     test('it hides the dropdown unless there is a click on the button', async function (assert) {
       // given & when

--- a/tests/unit/components/pix-select-test.js
+++ b/tests/unit/components/pix-select-test.js
@@ -5,6 +5,18 @@ import createGlimmerComponent from '../../helpers/create-glimmer-component';
 module('Unit | Component | pix-select', function (hooks) {
   setupTest(hooks);
 
+  test('it throws an error if there is no id and no label', function (assert) {
+    // given & when
+    const componentParams = { options: [] };
+    const renderComponent = function () {
+      createGlimmerComponent('component:pix-select', componentParams);
+    };
+
+    // then
+    const expectedError = new Error('ERROR in PixSelect, a @label or an @id was not provided');
+    assert.throws(renderComponent, expectedError);
+  });
+
   test('its should return the default className', function (assert) {
     // given
     const componentParams = { label: 'Un label', options: [] };


### PR DESCRIPTION
## :boom: BREAKING_CHANGES
> _Décrivez ici les changements cassant (voir la doc associée)[https://github.com/1024pix/pix-ui/blob/dev/docs/breaking-changes.stories.mdx], s'il n'y en a pas indiquez le aussi.

## :christmas_tree: Problème
Le composant PixSelect ne permet pas d'avoir un label positionné en dehors du composant comme c'est le cas dans la page de création de campagne sur PixOrga.

## :gift: Solution
On ajoute un propriété id qui va permettre de lié le PixSelect à un label que gère le développeur ou la développeuse qui utilise le composant.

## :star2: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :santa: Pour tester
- Regarder que la story WithId lie bien le PixSelect au label qui est situé au dessus.
