### PR TITLE
[FEATURE] Ajoute la possibilité d'utiliser un block à la place du placeholder (PIX-6443)

### DIFF
--- a/addon/components/pix-multi-select.hbs
+++ b/addon/components/pix-multi-select.hbs
@@ -6,10 +6,12 @@
 >
 
   {{#if @isSearchable}}
-    <label
-      for={{this.multiSelectId}}
-      class="pix-multi-select__label{{if @screenReaderOnly ' screen-reader-only'}}"
-    >{{@label}}</label>
+    {{#if @label}}
+      <label
+        for={{this.multiSelectId}}
+        class="pix-multi-select__label{{if @screenReaderOnly ' screen-reader-only'}}"
+      >{{@label}}</label>
+    {{/if}}
     <span class="pix-multi-select-header{{if @className this.className}}">
       <FaIcon @icon="magnifying-glass" class="pix-multi-select-header__search-icon" />
 
@@ -29,11 +31,12 @@
       />
     </span>
   {{else}}
-    <span
-      id={{this.labelId}}
-      class="pix-multi-select__label{{if @screenReaderOnly ' screen-reader-only'}}"
-    >{{@label}}</span>
-
+    {{#if @label}}
+      <span
+        id={{this.labelId}}
+        class="pix-multi-select__label{{if @screenReaderOnly ' screen-reader-only'}}"
+      >{{@label}}</span>
+    {{/if}}
     <button
       aria-labelledby={{this.labelId}}
       id={{this.multiSelectId}}

--- a/addon/components/pix-multi-select.hbs
+++ b/addon/components/pix-multi-select.hbs
@@ -48,7 +48,11 @@
       {{on "click" this.toggleDropDown}}
       ...attributes
     >
-      {{this.placeholder}}
+      {{#if (has-block "placeholder")}}
+        {{yield to="placeholder"}}
+      {{else if @placeholder}}
+        {{this.placeholder}}
+      {{/if}}
       <FaIcon
         class="pix-multi-select-header__dropdown-icon
           {{if this.isExpanded ' pix-multi-select-header__dropdown-icon--expand'}}"
@@ -74,7 +78,7 @@
             {{on-enter-action this.hideDropDown this.multiSelectId}}
             tabindex={{if this.isExpanded "0" "-1"}}
           >
-            {{yield option}}
+            {{yield option to="default"}}
           </PixCheckbox>
         </li>
       {{/each}}

--- a/addon/components/pix-multi-select.hbs
+++ b/addon/components/pix-multi-select.hbs
@@ -2,12 +2,12 @@
   class="pix-multi-select"
   {{on-click-outside this.hideDropDown}}
   {{on-arrow-down-up-action this.listId this.showDropDown this.isExpanded}}
-  {{on-escape-action this.hideDropDown @id}}
+  {{on-escape-action this.hideDropDown this.multiSelectId}}
 >
 
   {{#if @isSearchable}}
     <label
-      for={{@id}}
+      for={{this.multiSelectId}}
       class="pix-multi-select__label{{if @screenReaderOnly ' screen-reader-only'}}"
     >{{@label}}</label>
     <span class="pix-multi-select-header{{if @className this.className}}">
@@ -15,9 +15,9 @@
 
       <input
         class="pix-multi-select-header__search-input"
-        id={{@id}}
+        id={{this.multiSelectId}}
         type="text"
-        name={{@id}}
+        name={{this.multiSelectId}}
         placeholder={{this.placeholder}}
         autocomplete="off"
         {{on "input" this.updateSearch}}
@@ -36,7 +36,7 @@
 
     <button
       aria-labelledby={{this.labelId}}
-      id={{@id}}
+      id={{this.multiSelectId}}
       type="button"
       aria-expanded={{this.isAriaExpanded}}
       aria-controls={{this.listId}}
@@ -64,11 +64,11 @@
       {{#each this.results as |option|}}
         <li class="pix-multi-select-list__item" role="menuitem">
           <PixCheckbox
-            @id={{concat @id "-" option.value}}
+            @id={{concat this.multiSelectId "-" option.value}}
             @checked={{option.checked}}
             value={{option.value}}
             {{on "change" this.onSelect}}
-            {{on-enter-action this.hideDropDown @id}}
+            {{on-enter-action this.hideDropDown this.multiSelectId}}
             tabindex={{if this.isExpanded "0" "-1"}}
           >
             {{yield option}}

--- a/addon/components/pix-multi-select.js
+++ b/addon/components/pix-multi-select.js
@@ -30,9 +30,6 @@ export default class PixMultiSelect extends Component {
     if (!this.args.label && !this.args.id)
       throw new Error('ERROR in PixMultiSelect, a @label or an @id was not provided');
 
-    if (!this.args.placeholder)
-      throw new Error('ERROR in PixMultiSelect, a @placeholder was not provided');
-
     this.options = [...(this.args.options || [])];
   }
 

--- a/addon/components/pix-multi-select.js
+++ b/addon/components/pix-multi-select.js
@@ -2,6 +2,7 @@ import Component from '@glimmer/component';
 
 import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
+import { guidFor } from '@ember/object/internals';
 
 function sortOptionsByCheckedFirst(a, b) {
   if (a.checked && b.checked) return 0;
@@ -25,27 +26,19 @@ export default class PixMultiSelect extends Component {
 
   constructor(...args) {
     super(...args);
-    const { id, label, placeholder } = this.args;
 
-    const idIsNotDefined = !id || !id.trim();
-    const labelIsNotDefined = !label || !label.trim();
-    const innerTextIsNotDefined = !placeholder || !placeholder.trim();
+    if (!this.args.label && !this.args.id)
+      throw new Error('ERROR in PixMultiSelect, a @label or an @id was not provided');
 
-    if (idIsNotDefined || labelIsNotDefined || innerTextIsNotDefined) {
-      const missingParams = [];
-
-      if (idIsNotDefined) missingParams.push('@id');
-      if (labelIsNotDefined) missingParams.push('@label');
-      if (innerTextIsNotDefined) missingParams.push('@placeholder');
-
-      throw new Error(
-        `ERROR in PixMultiSelect component, ${missingParams.join(', ')} ${
-          missingParams.length > 1 ? 'params are' : 'param is'
-        } necessary`
-      );
-    }
+    if (!this.args.placeholder)
+      throw new Error('ERROR in PixMultiSelect, a @placeholder was not provided');
 
     this.options = [...(this.args.options || [])];
+  }
+
+  get multiSelectId() {
+    if (this.args.id) return this.args.id;
+    return 'select-' + guidFor(this);
   }
 
   get listId() {

--- a/addon/styles/_pix-multi-select.scss
+++ b/addon/styles/_pix-multi-select.scss
@@ -56,16 +56,13 @@
   }
 
   &__dropdown-icon {
-    font-size: 11px;
-    color: $pix-neutral-30;
+    @include text-small();
+    color: $pix-neutral-60;
+    font-weight: $font-heavy;
     right: 10px;
     top: calc(50% - 6px);
     position: absolute;
     pointer-events: none;
-
-    &--expand {
-      color: $pix-primary;
-    }
   }
 }
 
@@ -82,7 +79,7 @@
   list-style-type: none;
   padding: 0;
   box-shadow: 0px 8px 24px 0px rgba(23, 43, 77, 0.1);
-  transition: all .1s ease-in-out;
+  transition: all 0.1s ease-in-out;
 
   &--hidden {
     visibility: hidden;
@@ -114,7 +111,7 @@
     padding: 8px;
 
     @include hoverFormElement();
-    
+
     &--no-result {
       text-align: center;
       padding: 12px 0;

--- a/app/stories/pix-multi-select.stories.js
+++ b/app/stories/pix-multi-select.stories.js
@@ -98,6 +98,7 @@ export const multiSelectWithCustomClass = Template.bind({});
 multiSelectWithCustomClass.args = {
   ...Default.args,
   className: 'custom',
+  isSearchable: false,
 };
 
 export const multiSelectWithId = Template.bind({});
@@ -105,6 +106,35 @@ multiSelectWithId.args = {
   ...Default.args,
   label: undefined,
   id: 'custom',
+  isSearchable: false,
+};
+
+const TemplateWithYield = (args) => ({
+  template: hbs`
+  <PixMultiSelect
+    @id={{this.id}}
+    @label={{this.label}}
+    @screenReaderOnly={{this.screenReaderOnly}}
+    @onChange={{this.onChange}}
+    @emptyMessage={{this.emptyMessage}}
+    @className={{this.className}}
+    @isSearchable={{this.isSearchable}}
+    @strictSearch={{this.strictSearch}}
+    @values={{this.values}}
+    @options={{this.options}}
+  >
+    <:placeholder>filtres (2)</:placeholder>
+    <:default as |option|>{{option.label}}</:default>
+  </PixMultiSelect>
+ `,
+  context: args,
+});
+
+export const multiSelectWithYield = TemplateWithYield.bind({});
+multiSelectWithYield.args = {
+  ...Default.args,
+  placeholder: undefined,
+  isSearchable: false,
 };
 
 export const argTypes = {
@@ -112,7 +142,6 @@ export const argTypes = {
     name: 'id',
     description: 'Permet l‘accessibilité du composant attribuant des ``for`` pour chaque entité',
     type: { name: 'string' },
-    defaultValue: 'aromate',
   },
   placeholder: {
     name: 'placeholder',

--- a/app/stories/pix-multi-select.stories.js
+++ b/app/stories/pix-multi-select.stories.js
@@ -9,18 +9,23 @@ const Template = (args) => ({
     }
   </style>
   <h4>⚠️ La sélection des éléments ne fonctionne pas dans Storybook.</h4>
+  {{#if this.id}}
+    <div>
+      <label for={{this.id}}>Un label en dehors du composant</label>
+    </div>
+  {{/if}}
   <PixMultiSelect
-    @id={{id}}
-    @label={{label}}
-    @placeholder={{placeholder}}
-    @screenReaderOnly={{screenReaderOnly}}
-    @onChange={{onChange}}
-    @emptyMessage={{emptyMessage}}
-    @className={{className}}
-    @isSearchable={{isSearchable}}
-    @strictSearch={{strictSearch}}
-    @values={{values}}
-    @options={{options}} as |option|
+    @id={{this.id}}
+    @label={{this.label}}
+    @placeholder={{this.placeholder}}
+    @screenReaderOnly={{this.screenReaderOnly}}
+    @onChange={{this.onChange}}
+    @emptyMessage={{this.emptyMessage}}
+    @className={{this.className}}
+    @isSearchable={{this.isSearchable}}
+    @strictSearch={{this.strictSearch}}
+    @values={{this.values}}
+    @options={{this.options}} as |option|
   >{{option.label}}</PixMultiSelect>
  `,
   context: args,
@@ -51,7 +56,6 @@ export const multiSelectWithChildComponent = (args) => {
     template: hbs`
       <h4>⚠️ La sélection des éléments ne fonctionne pas dans Storybook.</h4>
       <PixMultiSelect
-        @id={{this.id}}
         @label={{this.label}}
         @placeholder={{this.placeholder}}
         @screenReaderOnly={{this.screenReaderOnly}}
@@ -96,6 +100,13 @@ multiSelectWithCustomClass.args = {
   className: 'custom',
 };
 
+export const multiSelectWithId = Template.bind({});
+multiSelectWithId.args = {
+  ...Default.args,
+  label: undefined,
+  id: 'custom',
+};
+
 export const argTypes = {
   id: {
     name: 'id',
@@ -113,7 +124,7 @@ export const argTypes = {
   label: {
     name: 'label',
     description: "Donne un label au champ qui sera celui vocalisé par le lecteur d'écran",
-    type: { name: 'string', required: true },
+    type: { name: 'string' },
     defaultValue: 'Label du champ',
   },
   screenReaderOnly: {

--- a/app/stories/pix-multi-select.stories.js
+++ b/app/stories/pix-multi-select.stories.js
@@ -100,7 +100,7 @@ export const argTypes = {
   id: {
     name: 'id',
     description: 'Permet l‘accessibilité du composant attribuant des ``for`` pour chaque entité',
-    type: { name: 'string', required: true },
+    type: { name: 'string' },
     defaultValue: 'aromate',
   },
   placeholder: {

--- a/app/stories/pix-multi-select.stories.mdx
+++ b/app/stories/pix-multi-select.stories.mdx
@@ -35,6 +35,11 @@ L'ajout de ``class`` et d'autres attributs comme ``aria-label`` sont possibles.
   <Story name="withId" story={stories.multiSelectWithId} height={330}/>
 </Canvas>
 
+## withYield
+<Canvas>
+  <Story name="withYield" story={stories.multiSelectWithYield} height={330}/>
+</Canvas>
+
 ## Usage
 
 ```html

--- a/app/stories/pix-multi-select.stories.mdx
+++ b/app/stories/pix-multi-select.stories.mdx
@@ -30,6 +30,11 @@ L'ajout de ``class`` et d'autres attributs comme ``aria-label`` sont possibles.
   <Story name="withCustomClass" story={stories.multiSelectWithCustomClass} height={330}/>
 </Canvas>
 
+## withId
+<Canvas>
+  <Story name="withId" story={stories.multiSelectWithId} height={330}/>
+</Canvas>
+
 ## Usage
 
 ```html

--- a/tests/integration/components/pix-multi-select-test.js
+++ b/tests/integration/components/pix-multi-select-test.js
@@ -4,7 +4,6 @@ import { render, fillByLabel, clickByName } from '@1024pix/ember-testing-library
 import userEvent from '@testing-library/user-event';
 import { fireEvent } from '@testing-library/dom';
 import { hbs } from 'ember-cli-htmlbars';
-import createGlimmerComponent from '../../helpers/create-glimmer-component';
 import sinon from 'sinon';
 
 module('Integration | Component | multi-select', function (hooks) {
@@ -209,84 +208,6 @@ module('Integration | Component | multi-select', function (hooks) {
         // then
         const inputElement = screen.getByLabelText('labelMultiSelect');
         assert.equal(inputElement.placeholder, 'Tomate, Oignon');
-      });
-    });
-
-    module('mandatory element', function () {
-      test('it should throw an error if no id is provided', async function (assert) {
-        // given
-        const componentParams = {
-          id: '   ',
-          label: 'toto',
-          placeholder: 'coucou',
-          options: DEFAULT_OPTIONS,
-        };
-        const renderComponent = function () {
-          createGlimmerComponent('component:pix-multi-select', componentParams);
-        };
-
-        // when & then
-        const expectedError = new Error(
-          'ERROR in PixMultiSelect component, @id param is necessary'
-        );
-        assert.throws(renderComponent, expectedError);
-      });
-
-      test('it should throw an error if no label is provided', async function (assert) {
-        // given
-        const componentParams = {
-          id: 'toto',
-          label: ' ',
-          placeholder: 'coucou',
-          options: DEFAULT_OPTIONS,
-        };
-        const renderComponent = function () {
-          createGlimmerComponent('component:pix-multi-select', componentParams);
-        };
-
-        // when & then
-        const expectedError = new Error(
-          'ERROR in PixMultiSelect component, @label param is necessary'
-        );
-        assert.throws(renderComponent, expectedError);
-      });
-
-      test('it should throw an error if no placeholder is provided', async function (assert) {
-        // given
-        const componentParams = {
-          id: 'toto',
-          label: 'coucou',
-          placeholder: ' ',
-          options: DEFAULT_OPTIONS,
-        };
-        const renderComponent = function () {
-          createGlimmerComponent('component:pix-multi-select', componentParams);
-        };
-
-        // when & then
-        const expectedError = new Error(
-          'ERROR in PixMultiSelect component, @placeholder param is necessary'
-        );
-        assert.throws(renderComponent, expectedError);
-      });
-
-      test('it should throw a combined error if no placeholder, label is provided', async function (assert) {
-        // given
-        const componentParams = {
-          id: 'toto',
-          label: ' ',
-          placeholder: ' ',
-          options: DEFAULT_OPTIONS,
-        };
-        const renderComponent = function () {
-          createGlimmerComponent('component:pix-multi-select', componentParams);
-        };
-
-        // when & then
-        const expectedError = new Error(
-          'ERROR in PixMultiSelect component, @label, @placeholder params are necessary'
-        );
-        assert.throws(renderComponent, expectedError);
       });
     });
 

--- a/tests/unit/components/pix-multi-select-test.js
+++ b/tests/unit/components/pix-multi-select-test.js
@@ -16,16 +16,4 @@ module('Unit | Component | PixMultiSelect', function (hooks) {
     const expectedError = new Error('ERROR in PixMultiSelect, a @label or an @id was not provided');
     assert.throws(renderComponent, expectedError);
   });
-
-  test('it throws an error if there is no placeholder', function (assert) {
-    // given & when
-    const componentParams = { id: 'id', options: [] };
-    const renderComponent = function () {
-      createGlimmerComponent('component:pix-multi-select', componentParams);
-    };
-
-    // then
-    const expectedError = new Error('ERROR in PixMultiSelect, a @placeholder was not provided');
-    assert.throws(renderComponent, expectedError);
-  });
 });

--- a/tests/unit/components/pix-multi-select-test.js
+++ b/tests/unit/components/pix-multi-select-test.js
@@ -1,0 +1,31 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+import createGlimmerComponent from '../../helpers/create-glimmer-component';
+
+module('Unit | Component | PixMultiSelect', function (hooks) {
+  setupTest(hooks);
+
+  test('it throws an error if there is no id and no label', function (assert) {
+    // given & when
+    const componentParams = { options: [] };
+    const renderComponent = function () {
+      createGlimmerComponent('component:pix-multi-select', componentParams);
+    };
+
+    // then
+    const expectedError = new Error('ERROR in PixMultiSelect, a @label or an @id was not provided');
+    assert.throws(renderComponent, expectedError);
+  });
+
+  test('it throws an error if there is no placeholder', function (assert) {
+    // given & when
+    const componentParams = { id: 'id', options: [] };
+    const renderComponent = function () {
+      createGlimmerComponent('component:pix-multi-select', componentParams);
+    };
+
+    // then
+    const expectedError = new Error('ERROR in PixMultiSelect, a @placeholder was not provided');
+    assert.throws(renderComponent, expectedError);
+  });
+});


### PR DESCRIPTION
## :boom: BREAKING_CHANGES
> _Décrivez ici les changements cassant (voir la doc associée)[https://github.com/1024pix/pix-ui/blob/dev/docs/breaking-changes.stories.mdx], s'il n'y en a pas indiquez le aussi.

## :christmas_tree: Problème
Dans la composant PixSearchableAndFilterableSelect on a besoin d'afficher "filtres([un nombre])". Il est impossible de personnaliser l'affichage de la valeur sélectionnée. Actuellement on affiche la propriété placeholder ou les valeurs sélectionnées. 

## :gift: Solution
Cette PR ajoute un yieldable named block appelé placeholder pour donner la possibilité au développeur ou la développeuse qui utilise le composant d'afficher ce qu'il ou elle souhaite en lieu et place de ce que propose le composant.

## :star2: Remarques
Cette fonctionnalité n'est pas accessible si isSearchable est à false.

Cette PR rend aussi le PixMultiSelect plus cohérent avec le composant PixSelect :
- l'id devient optionnel
- Corrige le style de l'icône de dropdown

## :santa: Pour tester
> _Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc._
