### PR TITLE
[BUGFIX] Le select ne prend pas le focus quand on clique sur son label (PIX-6476).

### DIFF
--- a/addon/components/pix-multi-select.hbs
+++ b/addon/components/pix-multi-select.hbs
@@ -5,13 +5,13 @@
   {{on-escape-action this.hideDropDown this.multiSelectId}}
 >
 
+  {{#if @label}}
+    <label
+      for={{this.multiSelectId}}
+      class="pix-multi-select__label{{if @screenReaderOnly ' screen-reader-only'}}"
+    >{{@label}}</label>
+  {{/if}}
   {{#if @isSearchable}}
-    {{#if @label}}
-      <label
-        for={{this.multiSelectId}}
-        class="pix-multi-select__label{{if @screenReaderOnly ' screen-reader-only'}}"
-      >{{@label}}</label>
-    {{/if}}
     <span class="pix-multi-select-header{{if @className this.className}}">
       <FaIcon @icon="magnifying-glass" class="pix-multi-select-header__search-icon" />
 
@@ -31,14 +31,7 @@
       />
     </span>
   {{else}}
-    {{#if @label}}
-      <span
-        id={{this.labelId}}
-        class="pix-multi-select__label{{if @screenReaderOnly ' screen-reader-only'}}"
-      >{{@label}}</span>
-    {{/if}}
     <button
-      aria-labelledby={{this.labelId}}
       id={{this.multiSelectId}}
       type="button"
       aria-expanded={{this.isAriaExpanded}}

--- a/addon/components/pix-multi-select.js
+++ b/addon/components/pix-multi-select.js
@@ -39,11 +39,7 @@ export default class PixMultiSelect extends Component {
   }
 
   get listId() {
-    return `list-${this.args.id}`;
-  }
-
-  get labelId() {
-    return `label-${this.args.id}`;
+    return `list-${this.multiSelectId}`;
   }
 
   get isAriaExpanded() {

--- a/tests/integration/components/pix-multi-select-test.js
+++ b/tests/integration/components/pix-multi-select-test.js
@@ -943,4 +943,33 @@ module('Integration | Component | multi-select', function (hooks) {
       assert.dom('.custom').exists();
     });
   });
+
+  module('label', function () {
+    test('it focus the input on click on the label', async function (assert) {
+      // given
+      this.options = DEFAULT_OPTIONS;
+      this.onChange = () => {};
+      this.values = [];
+      this.placeholder = 'MultiSelectTest';
+
+      // when
+      const screen = await render(hbs`<PixMultiSelect
+        @onChange={{this.onChange}}
+        @placeholder={{this.placeholder}}
+        @id={{this.id}}
+        @values={{this.values}}
+        @label='labelMultiSelect'
+        @isSearchable={{false}}
+        @options={{this.options}}
+        as |option|
+      >
+        {{option.label}}
+      </PixMultiSelect>`);
+
+      await clickByName('labelMultiSelect');
+
+      // then
+      assert.dom(screen.getByLabelText('labelMultiSelect')).isFocused();
+    });
+  });
 });


### PR DESCRIPTION
## :boom: BREAKING_CHANGES
Le select ne prend pas le focus quand on clique sur son label.


## :gift: Solution
Associer le label au bouton en passant par son id

## :star2: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :santa: Pour tester
Au clique sur le label le focus doit être sur le select.