### PR TITLE
[BUGFIX] Rétrograder la version  d'ember click outside à la 4.0.0 (PIX-6482)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "ember-cli-htmlbars": "^6.1.1",
         "ember-cli-sass": "^11.0.1",
         "ember-cli-string-utils": "^1.1.0",
-        "ember-click-outside": "^5.0.1",
+        "ember-click-outside": "^4.0.0",
         "ember-prop-modifier": "^1.0.1",
         "ember-truth-helpers": "^3.1.1"
       },
@@ -80,8 +80,8 @@
         "sass": "^1.56.1"
       },
       "engines": {
-        "node": "16.*.*",
-        "npm": "8.*.*"
+        "node": "16",
+        "npm": ">=8.13.2 <9"
       }
     },
     "node_modules/@1024pix/ember-testing-library": {
@@ -18616,13 +18616,13 @@
       "dev": true
     },
     "node_modules/ember-click-outside": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/ember-click-outside/-/ember-click-outside-5.0.1.tgz",
-      "integrity": "sha512-RilHTCQvD/5d9pZf6H7MbmBWlVl68nhvn1BPLtfpt9iCNyhtnh5SgwIWGHkJRuTz+DooN6hqTe4Wmq8Zk6kYDw==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/ember-click-outside/-/ember-click-outside-4.0.0.tgz",
+      "integrity": "sha512-3SstFhDWu3K5PQzo0FZwk66Ehe1l6QFU/R+WjAt8yOXw2sHzJHOdx2N+fNWJHZsJ97BSqdL7L0qotJEMX46u6Q==",
       "dependencies": {
         "ember-cli-babel": "^7.26.6",
         "ember-cli-htmlbars": "^5.7.1",
-        "ember-modifier": "^3.2.0"
+        "ember-modifier": "^2.1.0 || ^3.0.0"
       },
       "engines": {
         "node": "12.* || 14.* || >= 16"
@@ -50837,13 +50837,13 @@
       }
     },
     "ember-click-outside": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/ember-click-outside/-/ember-click-outside-5.0.1.tgz",
-      "integrity": "sha512-RilHTCQvD/5d9pZf6H7MbmBWlVl68nhvn1BPLtfpt9iCNyhtnh5SgwIWGHkJRuTz+DooN6hqTe4Wmq8Zk6kYDw==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/ember-click-outside/-/ember-click-outside-4.0.0.tgz",
+      "integrity": "sha512-3SstFhDWu3K5PQzo0FZwk66Ehe1l6QFU/R+WjAt8yOXw2sHzJHOdx2N+fNWJHZsJ97BSqdL7L0qotJEMX46u6Q==",
       "requires": {
         "ember-cli-babel": "^7.26.6",
         "ember-cli-htmlbars": "^5.7.1",
-        "ember-modifier": "^3.2.0"
+        "ember-modifier": "^2.1.0 || ^3.0.0"
       },
       "dependencies": {
         "async-disk-cache": {

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "ember-cli-htmlbars": "^6.1.1",
     "ember-cli-sass": "^11.0.1",
     "ember-cli-string-utils": "^1.1.0",
-    "ember-click-outside": "^5.0.1",
+    "ember-click-outside": "^4.0.0",
     "ember-prop-modifier": "^1.0.1",
     "ember-truth-helpers": "^3.1.1"
   },


### PR DESCRIPTION
## :boom: BREAKING_CHANGES
NO

## :christmas_tree: Problème
Après la montée de version, le click outside d'ember ne fonctionnait plus

## :gift: Solution
On retrouve un comportement normal en repassant à la version 4.0.0 d'ember click-outside

## :star2: Remarques


## :santa: Pour tester
Aller sur les composante Select ou MultiSelect, cliquer dessus et cliquer en dehors pour voir les options disparaitre
