### PR TITLE
[BREAKING CHANGES][FEATURE] Modal: le callback de fermeture passe l'élément HTML en argument (PIX-6503)

### DIFF
--- a/addon/components/pix-modal.hbs
+++ b/addon/components/pix-modal.hbs
@@ -1,29 +1,31 @@
 <div
+  id="{{this.modalId}}"
   class="pix-modal__overlay {{unless @showModal ' pix-modal__overlay--hidden'}}"
   {{on "click" this.closeAction}}
   {{trap-focus @showModal}}
-  {{on-escape-action @onCloseButtonClick}}
+  {{on-escape-action this.closeAction}}
 >
   <div
     class="pix-modal"
     role="dialog"
-    aria-labelledby="modal-title--{{this.id}}"
-    aria-describedby="modal-content--{{this.id}}"
+    aria-labelledby="modal-title--{{this.modalId}}"
+    aria-describedby="modal-content--{{this.modalId}}"
     aria-modal="true"
+    {{on "click" this.stopPropagation}}
     ...attributes
   >
     <div class="pix-modal__header">
-      <h1 id="modal-title--{{this.id}}" class="pix-modal__title">{{@title}}</h1>
+      <h1 id="modal-title--{{this.modalId}}" class="pix-modal__title">{{@title}}</h1>
       <PixIconButton
         @icon="xmark"
-        @triggerAction={{@onCloseButtonClick}}
+        @triggerAction={{this.closeAction}}
         @ariaLabel="Fermer"
         @size="small"
         @withBackground={{true}}
         class="pix-modal__close-button"
       />
     </div>
-    <div id="modal-content--{{this.id}}" class="pix-modal__content">
+    <div id="modal-content--{{this.modalId}}" class="pix-modal__content">
       {{yield to="content"}}
     </div>
     <div class="pix-modal__footer">

--- a/addon/components/pix-modal.js
+++ b/addon/components/pix-modal.js
@@ -1,6 +1,6 @@
 import Component from '@glimmer/component';
 import { action } from '@ember/object';
-import uniqueId from '@1024pix/pix-ui/utils/unique-id';
+import { guidFor } from '@ember/object/internals';
 
 export default class PixModal extends Component {
   constructor(...args) {
@@ -13,16 +13,19 @@ export default class PixModal extends Component {
 
   @action
   closeAction(event) {
-    if (this.args.onCloseButtonClick && this.isClickOnOverlay(event)) {
-      this.args.onCloseButtonClick(event);
+    if (this.args.onClose) {
+      const currentElement = document.getElementById(this.modalId);
+      this.args.onClose(event, currentElement);
     }
   }
 
-  isClickOnOverlay(event) {
-    return event.target.classList.contains('pix-modal__overlay');
+  @action
+  stopPropagation(event) {
+    event.stopPropagation();
   }
 
-  get id() {
-    return uniqueId();
+  get modalId() {
+    if (this.args.id) return this.args.id;
+    return guidFor(this);
   }
 }

--- a/app/stories/pix-modal.stories.js
+++ b/app/stories/pix-modal.stories.js
@@ -5,7 +5,7 @@ export const Template = (args) => {
     template: hbs`<PixModal
   @showModal={{this.showModal}}
   @title={{this.title}}
-  @onCloseButtonClick={{fn (mut this.showModal) (not this.showModal)}}
+  @onClose={{fn (mut this.showModal) (not this.showModal)}}
 >
   <:content>
     <p>
@@ -35,7 +35,7 @@ export const Default = Template.bind({});
 Default.args = {
   showModal: true,
   title: "Qu'est-ce qu'une modale ?",
-  onCloseButtonClick: () => {},
+  onClose: () => {},
 };
 
 export const argTypes = {
@@ -45,9 +45,14 @@ export const argTypes = {
     type: { name: 'string', required: true },
     defaultValue: null,
   },
-  onCloseButtonClick: {
-    name: 'onCloseButtonClick',
-    description: 'Fonction à exécuter à la fermeture de la modale',
+  onClose: {
+    name: 'onClose',
+    description: `
+Fonction à exécuter à la fermeture de la modale.
+Paramètres de callback :
+  1. **event**: Event
+  2. **modalElement**: HTMLElement
+`,
     type: { name: 'function', required: true },
     defaultValue: null,
   },

--- a/app/stories/pix-modal.stories.mdx
+++ b/app/stories/pix-modal.stories.mdx
@@ -29,7 +29,7 @@ Ce composant possède deux `yield` :
 <PixModal
   @title="Qu'est-ce qu'une modale ?"
   @showModal={{this.showModal}}
-  @onCloseButtonClick={{this.closeModal}}
+  @onClose={{this.closeModal}}
 >
  <:content>
   <p>

--- a/tests/dummy/app/controllers/modal-page.js
+++ b/tests/dummy/app/controllers/modal-page.js
@@ -7,5 +7,5 @@ export default class ModalPage extends Controller {
   title = "Qu'est-ce qu'une modale ?";
 
   @action
-  onCloseButtonClick() {}
+  onClose() {}
 }

--- a/tests/dummy/app/controllers/modal-page.js
+++ b/tests/dummy/app/controllers/modal-page.js
@@ -7,5 +7,12 @@ export default class ModalPage extends Controller {
   title = "Qu'est-ce qu'une modale ?";
 
   @action
-  onClose() {}
+  onClose(event) {
+    this.showModal = !this.showModal;
+
+    const currentModal = event.target.closest('.pix-modal');
+    if (currentModal.querySelector('form').length) {
+      currentModal.querySelector('form').reset();
+    }
+  }
 }

--- a/tests/dummy/app/templates/modal-page.hbs
+++ b/tests/dummy/app/templates/modal-page.hbs
@@ -1,16 +1,25 @@
 <PixModal
   @showModal={{this.showModal}}
   @title={{this.title}}
-  @onClose={{fn (mut this.showModal) (not this.showModal)}}
+  @onClose={{this.onClose}}
 >
   <:content>
-    <LinkTo @route="hello" class="internal-link">My link</LinkTo>
+    <form>
+      <p>
+        <label for="test">Input 1</label>
+        <input type="text" name="test" id="test">
+      </p>
+      <p>
+        <label for="test2">Input 2</label>
+        <input type="checkbox" name="test2" id="test2">
+      </p>
+    </form>
   </:content>
   <:footer>
     <PixButton
       @backgroundColor="transparent-light"
       @isBorderVisible="true"
-      @triggerAction={{fn (mut this.showModal) (not this.showModal)}}
+      @triggerAction={{this.onClose}}
     >Annuler</PixButton>
     <PixButton @triggerAction={{fn (mut this.showModal) (not this.showModal)}}>Valider</PixButton>
   </:footer>

--- a/tests/dummy/app/templates/modal-page.hbs
+++ b/tests/dummy/app/templates/modal-page.hbs
@@ -1,7 +1,7 @@
 <PixModal
   @showModal={{this.showModal}}
   @title={{this.title}}
-  @onCloseButtonClick={{fn (mut this.showModal) (not this.showModal)}}
+  @onClose={{fn (mut this.showModal) (not this.showModal)}}
 >
   <:content>
     <LinkTo @route="hello" class="internal-link">My link</LinkTo>

--- a/tests/integration/components/pix-modal-test.js
+++ b/tests/integration/components/pix-modal-test.js
@@ -36,12 +36,12 @@ module('Integration | Component | modal', function (hooks) {
         // given
         this.title = 'Close me baby one more time';
         this.showModal = true;
-        this.onCloseButtonClick = sinon.stub();
+        this.onClose = sinon.stub();
 
         // when
         await render(hbs`<PixModal
   @title={{this.title}}
-  @onCloseButtonClick={{this.onCloseButtonClick}}
+  @onClose={{this.onClose}}
   @showModal={{this.showModal}}
 >
   content
@@ -49,7 +49,7 @@ module('Integration | Component | modal', function (hooks) {
         await click('[aria-label="Fermer"]');
 
         // then
-        assert.ok(this.onCloseButtonClick.calledOnce);
+        assert.ok(this.onClose.calledOnce);
       });
     });
 
@@ -58,12 +58,12 @@ module('Integration | Component | modal', function (hooks) {
         // given
         this.title = 'Close me baby one more time';
         this.showModal = true;
-        this.onCloseButtonClick = sinon.stub();
+        this.onClose = sinon.stub();
 
         // when
         await render(hbs`<PixModal
   @title={{this.title}}
-  @onCloseButtonClick={{this.onCloseButtonClick}}
+  @onClose={{this.onClose}}
   @showModal={{this.showModal}}
 >
   content
@@ -71,7 +71,7 @@ module('Integration | Component | modal', function (hooks) {
         await triggerKeyEvent('.pix-modal__overlay', 'keyup', 'Escape');
 
         // then
-        assert.ok(this.onCloseButtonClick.calledOnce);
+        assert.ok(this.onClose.calledOnce);
       });
     });
   });

--- a/tests/integration/modifiers/on-escape-action-test.js
+++ b/tests/integration/modifiers/on-escape-action-test.js
@@ -10,13 +10,13 @@ module('Integration | Modifier | on-escape-action', function (hooks) {
   test('it fires action on escape keyup', async function (assert) {
     // given
     this.title = 'Close me baby one more time';
-    this.onCloseButtonClick = sinon.stub();
+    this.onClose = sinon.stub();
 
     // when
     await render(hbs`<PixModal
   @title={{this.title}}
-  @onCloseButtonClick={{this.onCloseButtonClick}}
-  {{on-escape-action this.onCloseButtonClick}}
+  @onClose={{this.onClose}}
+  {{on-escape-action this.onClose}}
   {{trap-focus}}
 >
   content
@@ -24,6 +24,6 @@ module('Integration | Modifier | on-escape-action', function (hooks) {
     await triggerKeyEvent('.pix-modal__overlay', 'keyup', 'Escape');
 
     // then
-    assert.ok(this.onCloseButtonClick.calledOnce);
+    assert.ok(this.onClose.calledOnce);
   });
 });


### PR DESCRIPTION
## :boom: BREAKING_CHANGES

La callback `onButtonCloseClick` est renommée `onClose`.

## :christmas_tree: Problème
Depuis le refacto, la modale est tout le temps présente dans le DOM.
Avant, on se servait du mount / unmount pour reset un possible formulaire présent dans la modale. Aujourd'hui, vu qu'on ne fait que cacher / afficher, on ne reset pas les données de form.
Ce qui créée des breakings changes chez la team Certif 😰

> [...] certaines infos de la modale n'étaient pas vidées du DOM à sa fermeture.
> Ça créait des effets de bord un peu chiants quand on rouvrait la même modale, certaines infos apparaissaient encore à l'écran mais ne "portaient" pas réellement d'info (leur valeur était vide pour le controller)

## :gift: Solution
Un callback `onButtonCloseClick` existait, mais n'était pas très explicite.
Il est renommé `onClose`.
On lui passe en nouvel deuxième argument l'élément du DOM de la modale pour que l'utilisateur puisse avoir la liberté de faire des actions dessus.

Exemple: 
```js
const handleClose = (_, modalElement) => {
	// Reset les inputs du form à la fermeture
	modalElement.querySelector('form').reset();
}
```
## :santa: Pour tester
- Lancer Pix UI en local
- Modifier la story pour ajouter un callback et tester qu'on reçoit bien le deuxième paramètre de la callback `onClose`