### PR TITLE
[OLD] Enlever le reset-css et ajouter attributes dans PixSelect

### DIFF
--- a/addon/components/pix-select.hbs
+++ b/addon/components/pix-select.hbs
@@ -7,6 +7,7 @@
   {{on-escape-action this.hideDropdown this.selectId}}
   {{did-insert this.setSelectWidth}}
   {{on "keydown" this.lockTab}}
+  ...attributes
 >
   {{#if @label}}
     <div class="{{if @screenReaderOnly 'screen-reader-only'}}">

--- a/addon/styles/_pix-filter-banner.scss
+++ b/addon/styles/_pix-filter-banner.scss
@@ -1,5 +1,4 @@
 .pix-filter-banner {
-  @import 'reset-css';
   display: flex;
   flex-direction: column;
   position: relative;

--- a/addon/styles/_pix-select.scss
+++ b/addon/styles/_pix-select.scss
@@ -105,6 +105,7 @@
 
   &__dropdown-icon {
     @include text-small();
+    margin-left: $spacing-xs;
     color: $pix-neutral-60;
     font-weight: $font-heavy;
     pointer-events: none;

--- a/app/stories/pix-filter-banner.stories.js
+++ b/app/stories/pix-filter-banner.stories.js
@@ -9,10 +9,10 @@ export const filterBanner = (args) => {
   @clearFiltersLabel={{this.clearFiltersLabel}}
   @onClearFilters={{this.onClearFilters}}
 >
-  <PixSelect @options={{this.options}} @onChange={{this.onChange}} />
-  <PixSelect @options={{this.options}} @onChange={{this.onChange}} />
-  <PixSelect @options={{this.options}} @onChange={{this.onChange}} />
-  <PixSelect @options={{this.options}} @onChange={{this.onChange}} />
+  <PixRadioButton
+    @value='small'
+    @label='Acceptez-vous de vous faire spammer de PUB ?'
+  />
 </PixFilterBanner>`,
     context: args,
   };

--- a/app/stories/pix-filterable-and-searchable-select.stories.js
+++ b/app/stories/pix-filterable-and-searchable-select.stories.js
@@ -155,7 +155,7 @@ export const argTypes = {
   searchLabel: {
     name: 'searchLabel',
     description:
-      'Label de la recherche dans le menu déroulant du select. Obligatoire uniquement si le isSearchable est à true.',
+      'Label de la recherche dans le menu déroulant du select. **⚠️ Obligatoire uniquement si le `isSearchable` est à true. ⚠️**',
     type: { name: 'string', required: false },
     table: {
       type: { summary: 'string' },
@@ -164,7 +164,7 @@ export const argTypes = {
   searchPlaceholder: {
     name: 'searchPlaceholder',
     description:
-      'Placeholder de la recherche dans le menu déroulant du select.  Obligatoire uniquement si le isSearchable est à true.',
+      'Placeholder de la recherche dans le menu déroulant du select.  **⚠️ Obligatoire uniquement si le `isSearchable` est à true. ⚠️**',
     type: { name: 'string', required: false },
     table: {
       type: { summary: 'string' },
@@ -173,7 +173,7 @@ export const argTypes = {
   emptySearchMessage: {
     name: 'emptySearchMessage',
     description:
-      "Message affiché si la recherche dans le select ne retourne pas d'options.  Obligatoire uniquement si le isSearchable est à true.",
+      "Message affiché si la recherche dans le select ne retourne pas d'options.  **⚠️ Obligatoire uniquement si le `isSearchable` est à true. ⚠️**",
     type: { name: 'string', required: false },
     table: {
       type: { summary: 'string' },

--- a/app/stories/pix-multi-select.stories.js
+++ b/app/stories/pix-multi-select.stories.js
@@ -140,7 +140,8 @@ multiSelectWithYield.args = {
 export const argTypes = {
   id: {
     name: 'id',
-    description: 'Permet l‘accessibilité du composant attribuant des ``for`` pour chaque entité',
+    description:
+      "Permet l'accessibilité du composant attribuant des ``for`` pour chaque entité. **⚠️ L'`id` est obligatoire que si le `label` n'est pas donné. ⚠️**",
     type: { name: 'string' },
   },
   placeholder: {
@@ -152,7 +153,8 @@ export const argTypes = {
   },
   label: {
     name: 'label',
-    description: "Donne un label au champ qui sera celui vocalisé par le lecteur d'écran",
+    description:
+      "Donne un label au champ qui sera celui vocalisé par le lecteur d'écran. **⚠️ Le`label` est obligatoire que si l'`id` n'est pas donné. ⚠️**",
     type: { name: 'string' },
     defaultValue: 'Label du champ',
   },

--- a/app/stories/pix-select.stories.js
+++ b/app/stories/pix-select.stories.js
@@ -211,7 +211,8 @@ export const argTypes = {
   },
   id: {
     name: 'id',
-    description: 'Un identifiant unique placé sur le composant',
+    description:
+      "Un identifiant unique placé sur le composant. **⚠️ L'`id` est obligatoire que si le `label` n'est pas donné. ⚠️**",
     type: { name: 'string', required: false },
     table: {
       type: { summary: 'string' },
@@ -219,7 +220,8 @@ export const argTypes = {
   },
   label: {
     name: 'label',
-    description: 'Label du menu déroulant',
+    description:
+      "Label du menu déroulant. ** ⚠️ Le `label` est obligatoire que si l'`id` n'est pas donné. ⚠️ **",
     type: { name: 'string', required: false },
     table: {
       type: { summary: 'string' },
@@ -260,24 +262,27 @@ export const argTypes = {
   },
   searchLabel: {
     name: 'searchLabel',
-    description: 'Label de la recherche dans le menu déroulant',
-    type: { name: 'string', required: true },
+    description:
+      'Label de la recherche dans le menu déroulant. **⚠️ Le `searchLabel` est obligatoire que si le `isSearchable` à `true`. ⚠️**',
+    type: { name: 'string', required: false },
     table: {
       type: { summary: 'string' },
     },
   },
   searchPlaceholder: {
     name: 'searchPlaceholder',
-    description: 'Placeholder de la recherche dans le menu déroulant',
-    type: { name: 'string', required: true },
+    description:
+      'Placeholder de la recherche dans le menu déroulant. **⚠️ Le `searchPlaceholder` est obligatoire que si le `isSearchable` à `true`. ⚠️**',
+    type: { name: 'string', required: false },
     table: {
       type: { summary: 'string' },
     },
   },
   emptySearchMessage: {
     name: 'emptySearchMessage',
-    description: "Message affiché si la recherche ne retourne pas d'options",
-    type: { name: 'string', required: true },
+    description:
+      "Message affiché si la recherche ne retourne pas d'options. **⚠️ Le `emptySearchMessage` est obligatoire que si le `isSearchable` à `true`. ⚠️**",
+    type: { name: 'string', required: false },
     table: {
       type: { summary: 'string' },
     },

--- a/app/stories/pix-toggle.stories.mdx
+++ b/app/stories/pix-toggle.stories.mdx
@@ -8,7 +8,7 @@ import * as stories from './pix-toggle.stories.js';
   argTypes={stories.argTypes}
 />
 
-# Pix Select
+# Pix Toggle
 
 Affiche un bouton à deux états.
 
@@ -36,3 +36,6 @@ Affiche un bouton à deux états.
   <Story name='WithYields' story={stories.WithYields} height={200} />
 </Canvas>
 
+## Arguments
+
+<ArgsTable story="Default" />


### PR DESCRIPTION
## :boom: BREAKING_CHANGES
Non :-)

## :christmas_tree: Problème
Les options du pixSelect dans le FilterBanner n'avaient pas le bon CSS. C'est du au reset-filter du PixFilterBanner qui ajoute un padding aux options du PixSelect.
De plus il manquait le `...attributes` dans le PixSelect.

## :gift: Solution
Enlever le reset-css
Ajouter le `...attributes`

## :star2: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :santa: Pour tester
> _Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc._
