### PR TITLE
[DOCS] Modifie l'exemple de la Modal pour utiliser `gap`

### DIFF
--- a/app/stories/pix-modal.stories.js
+++ b/app/stories/pix-modal.stories.js
@@ -18,9 +18,9 @@ export const Template = (args) => {
     </p>
   </:content>
   <:footer>
-    <div style="display:flex; justify-content: flex-end; flex-wrap: wrap;">
-      <PixButton style="margin: 0 0 16px 16px;" @backgroundColor='transparent-light' @isBorderVisible='true' @triggerAction={{fn (mut this.showModal) (not this.showModal)}}>Annuler</PixButton>
-      <PixButton style="margin: 0 0 16px 16px;" @triggerAction={{fn (mut this.showModal) (not this.showModal)}}>Valider</PixButton>
+    <div style="display: flex; justify-content: flex-end; flex-wrap: wrap; gap: 16px; margin-bottom: 16px">
+      <PixButton @backgroundColor='transparent-light' @isBorderVisible='true' @triggerAction={{fn (mut this.showModal) (not this.showModal)}}>Annuler</PixButton>
+      <PixButton @triggerAction={{fn (mut this.showModal) (not this.showModal)}}>Valider</PixButton>
     </div>
   </:footer>
 </PixModal>


### PR DESCRIPTION
## :christmas_tree: Problème
On a fait évoluer le code de démo permettant de positionner les buttons dans le footer de la Modal : https://github.com/1024pix/pix-ui/pull/285.

## :gift: Solution
Prendre en compte ces modifications pour être cohérents partout.

## :star2: Remarques
RAS

## :santa: Pour tester
Vérifier que les buttons de la PixModal sont bien alignés à droite.
