### PR TITLE
[TECH] Enlever le reset-css et ajouter attributes dans PixSelect(PIX-6504)

### DIFF
--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -1,4 +1,5 @@
 export const parameters = {
+  layout: 'centered',
   a11y: {
     element: '#root',
   },

--- a/addon/components/pix-pagination.hbs
+++ b/addon/components/pix-pagination.hbs
@@ -3,9 +3,11 @@
     <span class="pagination-size__label">{{this.beforeResultsPerPage}}</span>
     <PixSelect
       @label={{this.selectPageSizeLabel}}
+      @placeholder={{this.pageSize}}
       @screenReaderOnly={{true}}
       class="pagination-size__choice"
-      @selectedOption={{this.pageSize}}
+      @value={{this.pageSize}}
+      @hideDefaultOption={{true}}
       @onChange={{this.changePageSize}}
       @options={{this.pageOptions}}
     />

--- a/addon/components/pix-pagination.js
+++ b/addon/components/pix-pagination.js
@@ -105,8 +105,8 @@ export default class PixPagination extends Component {
   }
 
   @action
-  changePageSize(event) {
-    this.router.replaceWith({ queryParams: { pageSize: event.target.value, pageNumber: 1 } });
+  changePageSize(value) {
+    this.router.replaceWith({ queryParams: { pageSize: value, pageNumber: 1 } });
   }
 
   @action

--- a/addon/components/pix-select.hbs
+++ b/addon/components/pix-select.hbs
@@ -7,6 +7,7 @@
   {{on-escape-action this.hideDropdown this.selectId}}
   {{did-insert this.setSelectWidth}}
   {{on "keydown" this.lockTab}}
+  ...attributes
 >
   {{#if @label}}
     <div class="{{if @screenReaderOnly 'screen-reader-only'}}">

--- a/addon/styles/_pix-filter-banner.scss
+++ b/addon/styles/_pix-filter-banner.scss
@@ -1,5 +1,4 @@
 .pix-filter-banner {
-  @import 'reset-css';
   display: flex;
   flex-direction: column;
   position: relative;

--- a/addon/styles/_pix-select.scss
+++ b/addon/styles/_pix-select.scss
@@ -105,6 +105,7 @@
 
   &__dropdown-icon {
     @include text-small();
+    margin-left: $spacing-xs;
     color: $pix-neutral-60;
     font-weight: $font-heavy;
     pointer-events: none;

--- a/app/stories/form.stories.mdx
+++ b/app/stories/form.stories.mdx
@@ -1,10 +1,8 @@
 import { Meta, Story, Canvas } from '@storybook/addon-docs/blocks';
-import centered from '@storybook/addon-centered/ember';
 import * as stories from './form.stories.js';
 
 <Meta
   title='Form/Example'
-  decorators={[centered]}
 />
 
 # Formulaire avec les composants Pix UI

--- a/app/stories/pix-background-header.stories.mdx
+++ b/app/stories/pix-background-header.stories.mdx
@@ -1,11 +1,9 @@
 import { Meta, Story, Canvas, ArgsTable } from '@storybook/addon-docs/blocks';
-import centered from '@storybook/addon-centered/ember';
 import * as stories from './pix-background-header.stories.js';
 
 <Meta
   title='Layout/Background Header'
   component='PixBackgroundHeader'
-  decorators={[centered]}
 />
 
 # Pix Background Header

--- a/app/stories/pix-banner.stories.mdx
+++ b/app/stories/pix-banner.stories.mdx
@@ -1,11 +1,9 @@
 import { Meta, Story, Canvas, ArgsTable } from '@storybook/addon-docs/blocks';
-import centered from '@storybook/addon-centered/ember';
 import * as stories from './pix-banner.stories.js';
 
 <Meta
   title='Notification/Banner'
   component='PixBanner'
-  decorators={[centered]}
   argTypes={stories.argsTypes}
 />
 

--- a/app/stories/pix-block.stories.mdx
+++ b/app/stories/pix-block.stories.mdx
@@ -1,11 +1,9 @@
 import { Meta, Story, Canvas, ArgsTable } from '@storybook/addon-docs/blocks';
-import centered from '@storybook/addon-centered/ember';
 import * as stories from './pix-block.stories.js';
 
 <Meta
   title='Layout/Block'
   component='PixBlock'
-  decorators={[centered]}
   argTypes={stories.argTypes}
 />
 

--- a/app/stories/pix-button-link.stories.mdx
+++ b/app/stories/pix-button-link.stories.mdx
@@ -1,12 +1,10 @@
 import { Meta, Story, Canvas, ArgsTable } from '@storybook/addon-docs/blocks';
-import centered from '@storybook/addon-centered/ember';
 
 import * as stories from './pix-button-link.stories.js';
 
 <Meta
   title='Basics/ButtonLink'
   component='PixButtonLink'
-  decorators={[centered]}
   argTypes={stories.argTypes}
 />
 

--- a/app/stories/pix-button-upload.stories.mdx
+++ b/app/stories/pix-button-upload.stories.mdx
@@ -1,12 +1,10 @@
 import { Meta, Story, Canvas, ArgsTable } from '@storybook/addon-docs/blocks';
-import centered from '@storybook/addon-centered/ember';
 
 import * as stories from './pix-button-upload.stories.js';
 
 <Meta
   title='Basics/ButtonUpload'
   component='PixButtonUpload'
-  decorators={[centered]}
   argTypes={stories.argTypes}
 />
 

--- a/app/stories/pix-button.stories.mdx
+++ b/app/stories/pix-button.stories.mdx
@@ -1,11 +1,9 @@
 import { Meta, Story, Canvas, ArgsTable, SourceContainer } from '@storybook/addon-docs/blocks';
-import centered from '@storybook/addon-centered/ember';
 import * as stories from './pix-button.stories.js';
 
 <Meta
   title='Basics/Button'
   component='PixButton'
-  decorators={[centered]}
   argTypes={stories.argsTypes}
 />
 

--- a/app/stories/pix-checkbox.stories.mdx
+++ b/app/stories/pix-checkbox.stories.mdx
@@ -1,12 +1,10 @@
 import { Meta, Story, Canvas, ArgsTable } from '@storybook/addon-docs/blocks';
-import centered from '@storybook/addon-centered/ember';
 
 import * as stories from './pix-checkbox.stories.js';
 
 <Meta
   title='Form/Checkbox'
   component='PixCheckbox'
-  decorators={[centered]}
   argTypes={stories.argTypes}
 />
 

--- a/app/stories/pix-collapsible.stories.mdx
+++ b/app/stories/pix-collapsible.stories.mdx
@@ -1,5 +1,4 @@
 import { Meta, Story, Canvas, ArgsTable } from '@storybook/addon-docs/blocks';
-import centered from '@storybook/addon-centered/ember';
 
 import * as stories from './pix-collapsible.stories.js';
 

--- a/app/stories/pix-dropdown.stories.mdx
+++ b/app/stories/pix-dropdown.stories.mdx
@@ -1,5 +1,4 @@
 import { Meta, Story, Canvas, ArgsTable } from '@storybook/addon-docs/blocks';
-import centered from '@storybook/addon-centered/ember';
 
 import * as stories from './pix-dropdown.stories.js';
 

--- a/app/stories/pix-filter-banner.stories.js
+++ b/app/stories/pix-filter-banner.stories.js
@@ -9,10 +9,9 @@ export const filterBanner = (args) => {
   @clearFiltersLabel={{this.clearFiltersLabel}}
   @onClearFilters={{this.onClearFilters}}
 >
-  <PixSelect @options={{this.options}} @onChange={{this.onChange}} />
-  <PixSelect @options={{this.options}} @onChange={{this.onChange}} />
-  <PixSelect @options={{this.options}} @onChange={{this.onChange}} />
-  <PixSelect @options={{this.options}} @onChange={{this.onChange}} />
+  <PixSelect @options={{this.options}} @onChange={{this.onChange}} @label="mon label" @screenReaderOnly={{true}} @placeholder="placeholer"/>
+  <PixSelect @options={{this.options}} @onChange={{this.onChange}} @label="mon label" @screenReaderOnly={{true}} @placeholder="placeholer"/>
+  <PixSelect @options={{this.options}} @onChange={{this.onChange}} @label="mon label" @screenReaderOnly={{true}} @placeholder="placeholer"/>
 </PixFilterBanner>`,
     context: args,
   };

--- a/app/stories/pix-filter-banner.stories.mdx
+++ b/app/stories/pix-filter-banner.stories.mdx
@@ -1,11 +1,9 @@
 import { Meta, Story, Canvas, ArgsTable } from '@storybook/addon-docs/blocks';
-import centered from '@storybook/addon-centered/ember';
 import * as stories from './pix-filter-banner.stories.js';
 
 <Meta
   title='Form/Filter banner'
   component='PixFilterBanner'
-  decorators={[centered]}
   argTypes={stories.argTypes}
 />
 

--- a/app/stories/pix-filterable-and-searchable-select.stories.js
+++ b/app/stories/pix-filterable-and-searchable-select.stories.js
@@ -155,7 +155,7 @@ export const argTypes = {
   searchLabel: {
     name: 'searchLabel',
     description:
-      'Label de la recherche dans le menu déroulant du select. Obligatoire uniquement si le isSearchable est à true.',
+      'Label de la recherche dans le menu déroulant du select. **⚠️ Obligatoire uniquement si le `isSearchable` est à true. ⚠️**',
     type: { name: 'string', required: false },
     table: {
       type: { summary: 'string' },
@@ -164,7 +164,7 @@ export const argTypes = {
   searchPlaceholder: {
     name: 'searchPlaceholder',
     description:
-      'Placeholder de la recherche dans le menu déroulant du select.  Obligatoire uniquement si le isSearchable est à true.',
+      'Placeholder de la recherche dans le menu déroulant du select.  **⚠️ Obligatoire uniquement si le `isSearchable` est à true. ⚠️**',
     type: { name: 'string', required: false },
     table: {
       type: { summary: 'string' },
@@ -173,7 +173,7 @@ export const argTypes = {
   emptySearchMessage: {
     name: 'emptySearchMessage',
     description:
-      "Message affiché si la recherche dans le select ne retourne pas d'options.  Obligatoire uniquement si le isSearchable est à true.",
+      "Message affiché si la recherche dans le select ne retourne pas d'options.  **⚠️ Obligatoire uniquement si le `isSearchable` est à true. ⚠️**",
     type: { name: 'string', required: false },
     table: {
       type: { summary: 'string' },

--- a/app/stories/pix-icon-button.stories.mdx
+++ b/app/stories/pix-icon-button.stories.mdx
@@ -1,11 +1,9 @@
 import { Meta, Story, Canvas, ArgsTable } from '@storybook/addon-docs/blocks';
-import centered from '@storybook/addon-centered/ember';
 import * as stories from './pix-icon-button.stories.js';
 
 <Meta
   title="Basics/Icon button"
   component="PixIconButton"
-  decorators={[centered]}
   argTypes={stories.argTypes}
 />
 

--- a/app/stories/pix-input-code.stories.mdx
+++ b/app/stories/pix-input-code.stories.mdx
@@ -1,12 +1,10 @@
 import { Meta, Story, Canvas, ArgsTable } from '@storybook/addon-docs/blocks';
-import centered from '@storybook/addon-centered/ember';
 
 import * as stories from './pix-input-code.stories.js';
 
 <Meta
   title='Form/Inputs/Code'
   component='PixInputCode'
-  decorators={[centered]}
   argTypes={stories.argTypes}
 />
 

--- a/app/stories/pix-input-password.stories.mdx
+++ b/app/stories/pix-input-password.stories.mdx
@@ -1,12 +1,10 @@
 import { Meta, Story, Canvas, ArgsTable } from '@storybook/addon-docs/blocks';
-import centered from '@storybook/addon-centered/ember';
 
 import * as stories from './pix-input-password.stories.js';
 
 <Meta
   title='Form/Inputs/Password'
   component='PixInputPassword'
-  decorators={[centered]}
   argTypes={stories.argTypes}
 />
 

--- a/app/stories/pix-input.stories.mdx
+++ b/app/stories/pix-input.stories.mdx
@@ -1,12 +1,10 @@
 import { Meta, Story, Canvas, ArgsTable } from '@storybook/addon-docs/blocks';
-import centered from '@storybook/addon-centered/ember';
 
 import * as stories from './pix-input.stories.js';
 
 <Meta
   title='Form/Inputs/Input'
   component='PixInput'
-  decorators={[centered]}
   argTypes={stories.argTypes}
 />
 

--- a/app/stories/pix-message.stories.mdx
+++ b/app/stories/pix-message.stories.mdx
@@ -1,11 +1,9 @@
 import { Meta, Story, Canvas, ArgsTable } from '@storybook/addon-docs/blocks';
-import centered from '@storybook/addon-centered/ember';
 import * as stories from './pix-message.stories.js';
 
 <Meta
   title='Notification/Message'
   component='PixMessage'
-  decorators={[centered]}
   argTypes={stories.argTypes}
 />
 

--- a/app/stories/pix-modal.stories.mdx
+++ b/app/stories/pix-modal.stories.mdx
@@ -1,12 +1,10 @@
 import { Meta, Story, Canvas, ArgsTable } from '@storybook/addon-docs/blocks';
-import centered from '@storybook/addon-centered/ember';
 
 import * as stories from './pix-modal.stories.js';
 
 <Meta
   title="Basics/Modal"
   component="PixModal"
-  decorators={[centered]}
   argTypes={stories.argTypes}
 />
 

--- a/app/stories/pix-multi-select.stories.js
+++ b/app/stories/pix-multi-select.stories.js
@@ -140,7 +140,8 @@ multiSelectWithYield.args = {
 export const argTypes = {
   id: {
     name: 'id',
-    description: 'Permet l‘accessibilité du composant attribuant des ``for`` pour chaque entité',
+    description:
+      "Permet l'accessibilité du composant attribuant des ``for`` pour chaque entité. **⚠️ L'`id` est obligatoire que si le `label` n'est pas donné. ⚠️**",
     type: { name: 'string' },
   },
   placeholder: {
@@ -152,7 +153,8 @@ export const argTypes = {
   },
   label: {
     name: 'label',
-    description: "Donne un label au champ qui sera celui vocalisé par le lecteur d'écran",
+    description:
+      "Donne un label au champ qui sera celui vocalisé par le lecteur d'écran. **⚠️ Le`label` est obligatoire que si l'`id` n'est pas donné. ⚠️**",
     type: { name: 'string' },
     defaultValue: 'Label du champ',
   },

--- a/app/stories/pix-multi-select.stories.mdx
+++ b/app/stories/pix-multi-select.stories.mdx
@@ -1,5 +1,4 @@
 import { Meta, Story, Canvas, ArgsTable } from '@storybook/addon-docs/blocks';
-import centered from '@storybook/addon-centered/ember';
 import * as stories from './pix-multi-select.stories.js';
 
 <Meta

--- a/app/stories/pix-pagination.stories.mdx
+++ b/app/stories/pix-pagination.stories.mdx
@@ -1,5 +1,4 @@
 import { Meta, Story, Canvas, ArgsTable } from '@storybook/addon-docs/blocks';
-import centered from '@storybook/addon-centered/ember';
 
 import * as stories from './pix-pagination.stories.js';
 

--- a/app/stories/pix-pagination.stories.mdx
+++ b/app/stories/pix-pagination.stories.mdx
@@ -54,8 +54,8 @@ Sur mobile, le select qui permet de choisir le nombre d'élément à afficher su
 <PixPagination
    @pagination={{pagination}}
    @locale = {{locale}}
-   @pageOptions = {{pageOptions}
-   @isCondensed = {{isCondensed}
+   @pageOptions = {{pageOptions}}
+   @isCondensed = {{isCondensed}}
 />
 ```
 

--- a/app/stories/pix-progress-gauge.stories.mdx
+++ b/app/stories/pix-progress-gauge.stories.mdx
@@ -1,11 +1,9 @@
 import { Meta, Story, Canvas, ArgsTable } from '@storybook/addon-docs/blocks';
-import centered from '@storybook/addon-centered/ember';
 import * as stories from './pix-progress-gauge.stories.js';
 
 <Meta
   title='Others/Progress Gauge'
   component='PixProgressGauge'
-  decorators={[centered]}
   argTypes={stories.argTypes}
 />
 

--- a/app/stories/pix-radio-button.stories.mdx
+++ b/app/stories/pix-radio-button.stories.mdx
@@ -1,12 +1,10 @@
 import { Meta, Story, Canvas, ArgsTable } from '@storybook/addon-docs/blocks';
-import centered from '@storybook/addon-centered/ember';
 
 import * as stories from './pix-radio-button.stories.js';
 
 <Meta
   title='Form/Radio Button'
   component='PixRadioButton'
-  decorators={[centered]}
   argTypes={stories.argTypes}
 />
 

--- a/app/stories/pix-return-to.stories.mdx
+++ b/app/stories/pix-return-to.stories.mdx
@@ -1,11 +1,9 @@
 import { Meta, Story, Canvas, ArgsTable } from '@storybook/addon-docs/blocks';
-import centered from '@storybook/addon-centered/ember';
 import * as stories from './pix-return-to.stories.js';
 
 <Meta
   title='Basics/Return To'
   component='PixReturnTo'
-  decorators={[centered]}
   argTypes={stories.argTypes}
 />
 

--- a/app/stories/pix-select.stories.js
+++ b/app/stories/pix-select.stories.js
@@ -211,7 +211,8 @@ export const argTypes = {
   },
   id: {
     name: 'id',
-    description: 'Un identifiant unique placé sur le composant',
+    description:
+      "Un identifiant unique placé sur le composant. **⚠️ L'`id` est obligatoire que si le `label` n'est pas donné. ⚠️**",
     type: { name: 'string', required: false },
     table: {
       type: { summary: 'string' },
@@ -219,7 +220,8 @@ export const argTypes = {
   },
   label: {
     name: 'label',
-    description: 'Label du menu déroulant',
+    description:
+      "Label du menu déroulant. ** ⚠️ Le `label` est obligatoire que si l'`id` n'est pas donné. ⚠️ **",
     type: { name: 'string', required: false },
     table: {
       type: { summary: 'string' },
@@ -260,24 +262,27 @@ export const argTypes = {
   },
   searchLabel: {
     name: 'searchLabel',
-    description: 'Label de la recherche dans le menu déroulant',
-    type: { name: 'string', required: true },
+    description:
+      'Label de la recherche dans le menu déroulant. **⚠️ Le `searchLabel` est obligatoire que si le `isSearchable` à `true`. ⚠️**',
+    type: { name: 'string', required: false },
     table: {
       type: { summary: 'string' },
     },
   },
   searchPlaceholder: {
     name: 'searchPlaceholder',
-    description: 'Placeholder de la recherche dans le menu déroulant',
-    type: { name: 'string', required: true },
+    description:
+      'Placeholder de la recherche dans le menu déroulant. **⚠️ Le `searchPlaceholder` est obligatoire que si le `isSearchable` à `true`. ⚠️**',
+    type: { name: 'string', required: false },
     table: {
       type: { summary: 'string' },
     },
   },
   emptySearchMessage: {
     name: 'emptySearchMessage',
-    description: "Message affiché si la recherche ne retourne pas d'options",
-    type: { name: 'string', required: true },
+    description:
+      "Message affiché si la recherche ne retourne pas d'options. **⚠️ Le `emptySearchMessage` est obligatoire que si le `isSearchable` à `true`. ⚠️**",
+    type: { name: 'string', required: false },
     table: {
       type: { summary: 'string' },
     },

--- a/app/stories/pix-select.stories.mdx
+++ b/app/stories/pix-select.stories.mdx
@@ -1,5 +1,4 @@
 import { Meta, Story, Canvas, ArgsTable } from '@storybook/addon-docs/blocks';
-import centered from '@storybook/addon-centered/ember';
 import * as stories from './pix-select.stories.js';
 
 <Meta

--- a/app/stories/pix-selectable-tag.stories.mdx
+++ b/app/stories/pix-selectable-tag.stories.mdx
@@ -1,12 +1,10 @@
 import { Meta, Story, Canvas, ArgsTable } from '@storybook/addon-docs/blocks';
-import centered from '@storybook/addon-centered/ember';
 
 import * as stories from './pix-selectable-tag.stories.js';
 
 <Meta
   title='basics/Tag/Selectable Tag'
   component='PixSelectableTag'
-  decorators={[centered]}
   argTypes={stories.argTypes}
 />
 

--- a/app/stories/pix-sidebar.stories.mdx
+++ b/app/stories/pix-sidebar.stories.mdx
@@ -1,12 +1,10 @@
 import { Meta, Story, Canvas, ArgsTable } from '@storybook/addon-docs/blocks';
-import centered from '@storybook/addon-centered/ember';
 
 import * as stories from './pix-sidebar.stories.js';
 
 <Meta
   title="Basics/Sidebar"
   component="PixSidebar"
-  decorators={[centered]}
   argTypes={stories.argTypes}
 />
 

--- a/app/stories/pix-stars.stories.mdx
+++ b/app/stories/pix-stars.stories.mdx
@@ -1,11 +1,9 @@
 import { Meta, Story, Canvas, ArgsTable } from '@storybook/addon-docs/blocks';
-import centered from '@storybook/addon-centered/ember';
 import * as stories from './pix-stars.stories.js';
 
 <Meta
   title='Others/PixStars'
   component='PixStars'
-  decorators={[centered]}
   argTypes={stories.argTypes}
 />
 

--- a/app/stories/pix-tag.stories.mdx
+++ b/app/stories/pix-tag.stories.mdx
@@ -1,11 +1,9 @@
 import { Meta, Story, Canvas, ArgsTable } from '@storybook/addon-docs/blocks';
-import centered from '@storybook/addon-centered/ember';
 import * as stories from './pix-tag.stories.js';
 
 <Meta
   title='Basics/Tag'
   component='PixTag'
-  decorators={[centered]}
   argTypes={stories.argTypes}
 />
 

--- a/app/stories/pix-textarea.stories.mdx
+++ b/app/stories/pix-textarea.stories.mdx
@@ -1,11 +1,9 @@
 import { Meta, Story, Canvas, ArgsTable } from '@storybook/addon-docs/blocks';
-import centered from '@storybook/addon-centered/ember';
 import * as stories from './pix-textarea.stories.js';
 
 <Meta
   title='Form/Textarea'
   component='PixTextarea'
-  decorators={[centered]}
   argTypes={stories.argTypes}
 />
 

--- a/app/stories/pix-toggle.stories.mdx
+++ b/app/stories/pix-toggle.stories.mdx
@@ -7,7 +7,7 @@ import * as stories from './pix-toggle.stories.js';
   argTypes={stories.argTypes}
 />
 
-# Pix Select
+# Pix Toggle
 
 Affiche un bouton à deux états.
 
@@ -35,3 +35,6 @@ Affiche un bouton à deux états.
   <Story name='WithYields' story={stories.WithYields} height={200} />
 </Canvas>
 
+## Arguments
+
+<ArgsTable story="Default" />

--- a/app/stories/pix-toggle.stories.mdx
+++ b/app/stories/pix-toggle.stories.mdx
@@ -1,5 +1,4 @@
 import { Meta, Story, Canvas, ArgsTable } from '@storybook/addon-docs/blocks';
-import centered from '@storybook/addon-centered/ember';
 import * as stories from './pix-toggle.stories.js';
 
 <Meta

--- a/app/stories/pix-tooltip.stories.mdx
+++ b/app/stories/pix-tooltip.stories.mdx
@@ -1,11 +1,9 @@
 import { Meta, Story, Canvas, ArgsTable } from '@storybook/addon-docs/blocks';
-import centered from '@storybook/addon-centered/ember';
 import * as stories from './pix-tooltip.stories.js';
 
 <Meta
   title='Basics/Tooltip'
   component='PixTooltip'
-  decorators={[centered]}
   argTypes={stories.argTypes}
 />
 

--- a/blueprints/pix-component/files/app/stories/pix-__name__.stories.mdx
+++ b/blueprints/pix-component/files/app/stories/pix-__name__.stories.mdx
@@ -1,12 +1,10 @@
 import { Meta, Story, Canvas, ArgsTable } from '@storybook/addon-docs/blocks';
-import centered from '@storybook/addon-centered/ember';
 
 import * as stories from './pix-<%= dasherizedModuleName %>.stories.js';
 
 <Meta
   title='<%= classifiedModuleName %>'
   component='Pix<%= classifiedModuleName %>'
-  decorators={[centered]}
   argTypes={stories.argTypes}
 />
 

--- a/docs/create-component.stories.mdx
+++ b/docs/create-component.stories.mdx
@@ -77,7 +77,6 @@ export const argTypes = {
 ```markdown
 {/* pix-message.stories.mdx */}
 import { Meta, Story, Canvas, ArgsTable } from '@storybook/addon-docs/blocks';
-import centered from '@storybook/addon-centered/ember';
 import * as stories from './pix-message.stories.js';
 
 {/* Titre de la section affichée dans le menu de storybook */}
@@ -85,7 +84,6 @@ import * as stories from './pix-message.stories.js';
 <Meta
   title='Notification/Message'
   component='PixMessage'
-  decorators={[centered]}
   argTypes={stories.argTypes}
 />
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -33,7 +33,6 @@
         "@glimmer/component": "^1.1.2",
         "@glimmer/tracking": "^1.1.2",
         "@storybook/addon-a11y": "^6.5.13",
-        "@storybook/addon-centered": "^5.3.21",
         "@storybook/addon-controls": "^6.5.13",
         "@storybook/addon-docs": "^6.5.13",
         "@storybook/addon-essentials": "^6.5.13",
@@ -3776,146 +3775,6 @@
         "node": "8.* || >= 10.*"
       }
     },
-    "node_modules/@emotion/cache": {
-      "version": "10.0.29",
-      "resolved": "https://registry.npmjs.org/@emotion/cache/-/cache-10.0.29.tgz",
-      "integrity": "sha512-fU2VtSVlHiF27empSbxi1O2JFdNWZO+2NFHfwO0pxgTep6Xa3uGb+3pVKfLww2l/IBGLNEZl5Xf/++A4wAYDYQ==",
-      "dev": true,
-      "dependencies": {
-        "@emotion/sheet": "0.9.4",
-        "@emotion/stylis": "0.8.5",
-        "@emotion/utils": "0.11.3",
-        "@emotion/weak-memoize": "0.2.5"
-      }
-    },
-    "node_modules/@emotion/core": {
-      "version": "10.1.1",
-      "resolved": "https://registry.npmjs.org/@emotion/core/-/core-10.1.1.tgz",
-      "integrity": "sha512-ZMLG6qpXR8x031NXD8HJqugy/AZSkAuMxxqB46pmAR7ze47MhNJ56cdoX243QPZdGctrdfo+s08yZTiwaUcRKA==",
-      "dev": true,
-      "dependencies": {
-        "@babel/runtime": "^7.5.5",
-        "@emotion/cache": "^10.0.27",
-        "@emotion/css": "^10.0.27",
-        "@emotion/serialize": "^0.11.15",
-        "@emotion/sheet": "0.9.4",
-        "@emotion/utils": "0.11.3"
-      },
-      "peerDependencies": {
-        "react": ">=16.3.0"
-      }
-    },
-    "node_modules/@emotion/css": {
-      "version": "10.0.27",
-      "resolved": "https://registry.npmjs.org/@emotion/css/-/css-10.0.27.tgz",
-      "integrity": "sha512-6wZjsvYeBhyZQYNrGoR5yPMYbMBNEnanDrqmsqS1mzDm1cOTu12shvl2j4QHNS36UaTE0USIJawCH9C8oW34Zw==",
-      "dev": true,
-      "dependencies": {
-        "@emotion/serialize": "^0.11.15",
-        "@emotion/utils": "0.11.3",
-        "babel-plugin-emotion": "^10.0.27"
-      }
-    },
-    "node_modules/@emotion/hash": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/@emotion/hash/-/hash-0.8.0.tgz",
-      "integrity": "sha512-kBJtf7PH6aWwZ6fka3zQ0p6SBYzx4fl1LoZXE2RrnYST9Xljm7WfKJrU4g/Xr3Beg72MLrp1AWNUmuYJTL7Cow==",
-      "dev": true
-    },
-    "node_modules/@emotion/is-prop-valid": {
-      "version": "0.8.8",
-      "resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-0.8.8.tgz",
-      "integrity": "sha512-u5WtneEAr5IDG2Wv65yhunPSMLIpuKsbuOktRojfrEiEvRyC85LgPMZI63cr7NUqT8ZIGdSVg8ZKGxIug4lXcA==",
-      "dev": true,
-      "dependencies": {
-        "@emotion/memoize": "0.7.4"
-      }
-    },
-    "node_modules/@emotion/memoize": {
-      "version": "0.7.4",
-      "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.7.4.tgz",
-      "integrity": "sha512-Ja/Vfqe3HpuzRsG1oBtWTHk2PGZ7GR+2Vz5iYGelAw8dx32K0y7PjVuxK6z1nMpZOqAFsRUPCkK1YjJ56qJlgw==",
-      "dev": true
-    },
-    "node_modules/@emotion/serialize": {
-      "version": "0.11.16",
-      "resolved": "https://registry.npmjs.org/@emotion/serialize/-/serialize-0.11.16.tgz",
-      "integrity": "sha512-G3J4o8by0VRrO+PFeSc3js2myYNOXVJ3Ya+RGVxnshRYgsvErfAOglKAiy1Eo1vhzxqtUvjCyS5gtewzkmvSSg==",
-      "dev": true,
-      "dependencies": {
-        "@emotion/hash": "0.8.0",
-        "@emotion/memoize": "0.7.4",
-        "@emotion/unitless": "0.7.5",
-        "@emotion/utils": "0.11.3",
-        "csstype": "^2.5.7"
-      }
-    },
-    "node_modules/@emotion/serialize/node_modules/csstype": {
-      "version": "2.6.17",
-      "resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.17.tgz",
-      "integrity": "sha512-u1wmTI1jJGzCJzWndZo8mk4wnPTZd1eOIYTYvuEyOQGfmDl3TrabCCfKnOC86FZwW/9djqTl933UF/cS425i9A==",
-      "dev": true
-    },
-    "node_modules/@emotion/sheet": {
-      "version": "0.9.4",
-      "resolved": "https://registry.npmjs.org/@emotion/sheet/-/sheet-0.9.4.tgz",
-      "integrity": "sha512-zM9PFmgVSqBw4zL101Q0HrBVTGmpAxFZH/pYx/cjJT5advXguvcgjHFTCaIO3enL/xr89vK2bh0Mfyj9aa0ANA==",
-      "dev": true
-    },
-    "node_modules/@emotion/styled": {
-      "version": "10.0.27",
-      "resolved": "https://registry.npmjs.org/@emotion/styled/-/styled-10.0.27.tgz",
-      "integrity": "sha512-iK/8Sh7+NLJzyp9a5+vIQIXTYxfT4yB/OJbjzQanB2RZpvmzBQOHZWhpAMZWYEKRNNbsD6WfBw5sVWkb6WzS/Q==",
-      "dev": true,
-      "dependencies": {
-        "@emotion/styled-base": "^10.0.27",
-        "babel-plugin-emotion": "^10.0.27"
-      },
-      "peerDependencies": {
-        "@emotion/core": "^10.0.27",
-        "react": ">=16.3.0"
-      }
-    },
-    "node_modules/@emotion/styled-base": {
-      "version": "10.0.31",
-      "resolved": "https://registry.npmjs.org/@emotion/styled-base/-/styled-base-10.0.31.tgz",
-      "integrity": "sha512-wTOE1NcXmqMWlyrtwdkqg87Mu6Rj1MaukEoEmEkHirO5IoHDJ8LgCQL4MjJODgxWxXibGR3opGp1p7YvkNEdXQ==",
-      "dev": true,
-      "dependencies": {
-        "@babel/runtime": "^7.5.5",
-        "@emotion/is-prop-valid": "0.8.8",
-        "@emotion/serialize": "^0.11.15",
-        "@emotion/utils": "0.11.3"
-      },
-      "peerDependencies": {
-        "@emotion/core": "^10.0.28",
-        "react": ">=16.3.0"
-      }
-    },
-    "node_modules/@emotion/stylis": {
-      "version": "0.8.5",
-      "resolved": "https://registry.npmjs.org/@emotion/stylis/-/stylis-0.8.5.tgz",
-      "integrity": "sha512-h6KtPihKFn3T9fuIrwvXXUOwlx3rfUvfZIcP5a6rh8Y7zjE3O06hT5Ss4S/YI1AYhuZ1kjaE/5EaOOI2NqSylQ==",
-      "dev": true
-    },
-    "node_modules/@emotion/unitless": {
-      "version": "0.7.5",
-      "resolved": "https://registry.npmjs.org/@emotion/unitless/-/unitless-0.7.5.tgz",
-      "integrity": "sha512-OWORNpfjMsSSUBVrRBVGECkhWcULOAJz9ZW8uK9qgxD+87M7jHRcvh/A96XXNhXTLmKcoYSQtBEX7lHMO7YRwg==",
-      "dev": true
-    },
-    "node_modules/@emotion/utils": {
-      "version": "0.11.3",
-      "resolved": "https://registry.npmjs.org/@emotion/utils/-/utils-0.11.3.tgz",
-      "integrity": "sha512-0o4l6pZC+hI88+bzuaX/6BgOvQVhbt2PfmxauVaYOGgbsAw14wdKyvMCZXnsnsHys94iadcF+RG/wZyx6+ZZBw==",
-      "dev": true
-    },
-    "node_modules/@emotion/weak-memoize": {
-      "version": "0.2.5",
-      "resolved": "https://registry.npmjs.org/@emotion/weak-memoize/-/weak-memoize-0.2.5.tgz",
-      "integrity": "sha512-6U71C2Wp7r5XtFtQzYrW5iKFT67OixrSxjI4MptCHzdSVlgabczzqLe0ZSgnub/5Kp4hSbpDB1tMytZY9pwxxA==",
-      "dev": true
-    },
     "node_modules/@eslint/eslintrc": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.3.3.tgz",
@@ -5520,22 +5379,6 @@
         "node": ">=10"
       }
     },
-    "node_modules/@reach/router": {
-      "version": "1.3.4",
-      "resolved": "https://registry.npmjs.org/@reach/router/-/router-1.3.4.tgz",
-      "integrity": "sha512-+mtn9wjlB9NN2CNnnC/BRYtwdKBfSyyasPYraNAyvaV1occr/5NnB4CVzjEZipNHwYebQwcndGUmpFzxAUoqSA==",
-      "dev": true,
-      "dependencies": {
-        "create-react-context": "0.3.0",
-        "invariant": "^2.2.3",
-        "prop-types": "^15.6.1",
-        "react-lifecycles-compat": "^3.0.4"
-      },
-      "peerDependencies": {
-        "react": "15.x || 16.x || 16.4.0-alpha.0911da3",
-        "react-dom": "15.x || 16.x || 16.4.0-alpha.0911da3"
-      }
-    },
     "node_modules/@simple-dom/interface": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/@simple-dom/interface/-/interface-1.4.0.tgz",
@@ -5737,201 +5580,6 @@
       "dev": true,
       "dependencies": {
         "lodash": "^4.17.15"
-      }
-    },
-    "node_modules/@storybook/addon-centered": {
-      "version": "5.3.21",
-      "resolved": "https://registry.npmjs.org/@storybook/addon-centered/-/addon-centered-5.3.21.tgz",
-      "integrity": "sha512-noWVIfN1jeCpMubiS43N2wFTUKEbo2MPR46+YeiYn1wOASyZjnkdV7gl63FCNRgFOz55jQGsrJVz+JJ7xz+rdQ==",
-      "dev": true,
-      "dependencies": {
-        "@storybook/addons": "5.3.21",
-        "core-js": "^3.0.1",
-        "global": "^4.3.2",
-        "util-deprecate": "^1.0.2"
-      },
-      "peerDependencies": {
-        "react-dom": "*",
-        "regenerator-runtime": "*"
-      }
-    },
-    "node_modules/@storybook/addon-centered/node_modules/@storybook/addons": {
-      "version": "5.3.21",
-      "resolved": "https://registry.npmjs.org/@storybook/addons/-/addons-5.3.21.tgz",
-      "integrity": "sha512-Ji/21WADTLVbTbiKcZ64BcL0Es+h1Afxx3kNmGJqPSTUYroCwIFCT9mUzCqU6G+YyWaISAmTii5UJkTwMkChwA==",
-      "dev": true,
-      "dependencies": {
-        "@storybook/api": "5.3.21",
-        "@storybook/channels": "5.3.21",
-        "@storybook/client-logger": "5.3.21",
-        "@storybook/core-events": "5.3.21",
-        "core-js": "^3.0.1",
-        "global": "^4.3.2",
-        "util-deprecate": "^1.0.2"
-      }
-    },
-    "node_modules/@storybook/addon-centered/node_modules/@storybook/api": {
-      "version": "5.3.21",
-      "resolved": "https://registry.npmjs.org/@storybook/api/-/api-5.3.21.tgz",
-      "integrity": "sha512-K1o4an/Rx8daKRDooks6qzN6ZGyqizeacZZbair3F8CsSfTgrr2zCcf9pgKojLQa9koEmMHlcdb2KnS+GwPEgA==",
-      "dev": true,
-      "dependencies": {
-        "@reach/router": "^1.2.1",
-        "@storybook/channels": "5.3.21",
-        "@storybook/client-logger": "5.3.21",
-        "@storybook/core-events": "5.3.21",
-        "@storybook/csf": "0.0.1",
-        "@storybook/router": "5.3.21",
-        "@storybook/theming": "5.3.21",
-        "@types/reach__router": "^1.2.3",
-        "core-js": "^3.0.1",
-        "fast-deep-equal": "^2.0.1",
-        "global": "^4.3.2",
-        "lodash": "^4.17.15",
-        "memoizerific": "^1.11.3",
-        "prop-types": "^15.6.2",
-        "react": "^16.8.3",
-        "semver": "^6.0.0",
-        "shallow-equal": "^1.1.0",
-        "store2": "^2.7.1",
-        "telejson": "^3.2.0",
-        "util-deprecate": "^1.0.2"
-      },
-      "peerDependencies": {
-        "regenerator-runtime": "*"
-      }
-    },
-    "node_modules/@storybook/addon-centered/node_modules/@storybook/channels": {
-      "version": "5.3.21",
-      "resolved": "https://registry.npmjs.org/@storybook/channels/-/channels-5.3.21.tgz",
-      "integrity": "sha512-OXoFs9XtBVg/cCk6lYMrxkzaNlJRf54ABdorp7YAAj7S9tRL1JxOZHxmjNQwEoiRvssmem2rAWtEAxfuEANsAA==",
-      "dev": true,
-      "dependencies": {
-        "core-js": "^3.0.1"
-      }
-    },
-    "node_modules/@storybook/addon-centered/node_modules/@storybook/client-logger": {
-      "version": "5.3.21",
-      "resolved": "https://registry.npmjs.org/@storybook/client-logger/-/client-logger-5.3.21.tgz",
-      "integrity": "sha512-OzQkwpZ5SK9cXD9Mv6lxPGPot+hSZvnkEW12kpt1AHfJz4ET26YTDOI3oetPsjfRJo6qYLeQX8+wF7rklfXbzA==",
-      "dev": true,
-      "dependencies": {
-        "core-js": "^3.0.1"
-      }
-    },
-    "node_modules/@storybook/addon-centered/node_modules/@storybook/core-events": {
-      "version": "5.3.21",
-      "resolved": "https://registry.npmjs.org/@storybook/core-events/-/core-events-5.3.21.tgz",
-      "integrity": "sha512-/Zsm1sKAh6pzQv8jQUmuhM7nuM01ZljIRKy8p2HjPNlMjDB5yaRkBfyeAUXUg+qXNI6aHVWa4jGdPEdwwY4oLA==",
-      "dev": true,
-      "dependencies": {
-        "core-js": "^3.0.1"
-      }
-    },
-    "node_modules/@storybook/addon-centered/node_modules/@storybook/router": {
-      "version": "5.3.21",
-      "resolved": "https://registry.npmjs.org/@storybook/router/-/router-5.3.21.tgz",
-      "integrity": "sha512-c29m5UikK5Q1lyd6FltOGFhIcpd6PIb855YS3OUNe3F6ZA1tfJ+aNKrCBc65d1c+fvCGG76dYYYv0RvwEmKXXg==",
-      "dev": true,
-      "dependencies": {
-        "@reach/router": "^1.2.1",
-        "@storybook/csf": "0.0.1",
-        "@types/reach__router": "^1.2.3",
-        "core-js": "^3.0.1",
-        "global": "^4.3.2",
-        "lodash": "^4.17.15",
-        "memoizerific": "^1.11.3",
-        "qs": "^6.6.0",
-        "util-deprecate": "^1.0.2"
-      },
-      "peerDependencies": {
-        "react": "*",
-        "react-dom": "*"
-      }
-    },
-    "node_modules/@storybook/addon-centered/node_modules/@storybook/theming": {
-      "version": "5.3.21",
-      "resolved": "https://registry.npmjs.org/@storybook/theming/-/theming-5.3.21.tgz",
-      "integrity": "sha512-FZbxjizqdO9lV5LUixPio/7+6UdPiswCzTJn8Hcot9uwwgfnrViRdN7xyjmSYRqv9nHP3OlYbtdeCAgZ4aPq8g==",
-      "dev": true,
-      "dependencies": {
-        "@emotion/core": "^10.0.20",
-        "@emotion/styled": "^10.0.17",
-        "@storybook/client-logger": "5.3.21",
-        "core-js": "^3.0.1",
-        "deep-object-diff": "^1.1.0",
-        "emotion-theming": "^10.0.19",
-        "global": "^4.3.2",
-        "memoizerific": "^1.11.3",
-        "polished": "^3.3.1",
-        "prop-types": "^15.7.2",
-        "resolve-from": "^5.0.0",
-        "ts-dedent": "^1.1.0"
-      },
-      "peerDependencies": {
-        "react": "*",
-        "react-dom": "*"
-      }
-    },
-    "node_modules/@storybook/addon-centered/node_modules/fast-deep-equal": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
-      "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=",
-      "dev": true
-    },
-    "node_modules/@storybook/addon-centered/node_modules/isobject": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/isobject/-/isobject-4.0.0.tgz",
-      "integrity": "sha512-S/2fF5wH8SJA/kmwr6HYhK/RI/OkhD84k8ntalo0iJjZikgq1XFvR5M8NPT1x5F7fBwCG3qHfnzeP/Vh/ZxCUA==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/@storybook/addon-centered/node_modules/polished": {
-      "version": "3.7.2",
-      "resolved": "https://registry.npmjs.org/polished/-/polished-3.7.2.tgz",
-      "integrity": "sha512-pQKtpZGmsZrW8UUpQMAnR7s3ppHeMQVNyMDKtUyKwuvDmklzcEyM5Kllb3JyE/sE/x7arDmyd35i+4vp99H6sQ==",
-      "dev": true,
-      "dependencies": {
-        "@babel/runtime": "^7.12.5"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/@storybook/addon-centered/node_modules/semver": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-      "dev": true,
-      "bin": {
-        "semver": "bin/semver.js"
-      }
-    },
-    "node_modules/@storybook/addon-centered/node_modules/telejson": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/telejson/-/telejson-3.3.0.tgz",
-      "integrity": "sha512-er08AylQ+LEbDLp1GRezORZu5wKOHaBczF6oYJtgC3Idv10qZ8A3p6ffT+J5BzDKkV9MqBvu8HAKiIIOp6KJ2w==",
-      "dev": true,
-      "dependencies": {
-        "@types/is-function": "^1.0.0",
-        "global": "^4.4.0",
-        "is-function": "^1.0.1",
-        "is-regex": "^1.0.4",
-        "is-symbol": "^1.0.3",
-        "isobject": "^4.0.0",
-        "lodash": "^4.17.15",
-        "memoizerific": "^1.11.3"
-      }
-    },
-    "node_modules/@storybook/addon-centered/node_modules/ts-dedent": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/ts-dedent/-/ts-dedent-1.2.0.tgz",
-      "integrity": "sha512-6zSJp23uQI+Txyz5LlXMXAHpUhY4Hi0oluXny0OgIR7g/Cromq4vDBnhtbBdyIV34g0pgwxUvnvg+jLJe4c1NA==",
-      "dev": true,
-      "engines": {
-        "node": ">=6.10"
       }
     },
     "node_modules/@storybook/addon-controls": {
@@ -10376,15 +10024,6 @@
         }
       }
     },
-    "node_modules/@storybook/csf": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/@storybook/csf/-/csf-0.0.1.tgz",
-      "integrity": "sha512-USTLkZze5gkel8MYCujSRBVIrUQ3YPBrLOx7GNk/0wttvVtlzWXAq9eLbQ4p/NicGxP+3T7KPEMVV//g+yubpw==",
-      "dev": true,
-      "dependencies": {
-        "lodash": "^4.17.15"
-      }
-    },
     "node_modules/@storybook/csf-tools": {
       "version": "6.5.13",
       "resolved": "https://registry.npmjs.org/@storybook/csf-tools/-/csf-tools-6.5.13.tgz",
@@ -14082,12 +13721,6 @@
       "integrity": "sha512-VjID5MJb1eGKthz2qUerWT8+R4b9N+CHvGCzg9fn4kWZgaF9AhdYikQio3R7wV8YY1NsQKPaCwKz1Yff+aHNUQ==",
       "dev": true
     },
-    "node_modules/@types/prop-types": {
-      "version": "15.7.4",
-      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.4.tgz",
-      "integrity": "sha512-rZ5drC/jWjrArrS8BR6SIr4cWpW09RNTYt9AMZo3Jwwif+iacXAqgVjm0B0Bv/S1jhDXKHqRVNCbACkJ89RAnQ==",
-      "dev": true
-    },
     "node_modules/@types/qs": {
       "version": "6.9.7",
       "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.7.tgz",
@@ -14099,26 +13732,6 @@
       "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.4.tgz",
       "integrity": "sha512-EEhsLsD6UsDM1yFhAvy0Cjr6VwmpMWqFBCb9w07wVugF7w9nfajxLuVmngTIpgS6svCnm6Vaw+MZhoDCKnOfsw==",
       "dev": true
-    },
-    "node_modules/@types/reach__router": {
-      "version": "1.3.9",
-      "resolved": "https://registry.npmjs.org/@types/reach__router/-/reach__router-1.3.9.tgz",
-      "integrity": "sha512-N6rqQqTTAV/zKLfK3iq9Ww3wqCEhTZvsilhl0zI09zETdVq1QGmJH6+/xnj8AFUWIrle2Cqo+PGM/Ltr1vBb9w==",
-      "dev": true,
-      "dependencies": {
-        "@types/react": "*"
-      }
-    },
-    "node_modules/@types/react": {
-      "version": "17.0.18",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.18.tgz",
-      "integrity": "sha512-YTLgu7oS5zvSqq49X5Iue5oAbVGhgPc5Au29SJC4VeE17V6gASoOxVkUDy9pXFMRFxCWCD9fLeweNFizo3UzOg==",
-      "dev": true,
-      "dependencies": {
-        "@types/prop-types": "*",
-        "@types/scheduler": "*",
-        "csstype": "^3.0.2"
-      }
     },
     "node_modules/@types/resolve": {
       "version": "0.0.8",
@@ -14137,12 +13750,6 @@
         "@types/glob": "*",
         "@types/node": "*"
       }
-    },
-    "node_modules/@types/scheduler": {
-      "version": "0.16.2",
-      "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.2.tgz",
-      "integrity": "sha512-hppQEBDmlwhFAXKJX2KnWLYu5yMfi91yazPb2l+lbJiwW+wdo1gNeRA+3RgNSO39WYX2euey41KEwnqesU2Jew==",
-      "dev": true
     },
     "node_modules/@types/serve-static": {
       "version": "1.13.10",
@@ -15945,24 +15552,6 @@
         "node": ">=12"
       }
     },
-    "node_modules/babel-plugin-emotion": {
-      "version": "10.2.2",
-      "resolved": "https://registry.npmjs.org/babel-plugin-emotion/-/babel-plugin-emotion-10.2.2.tgz",
-      "integrity": "sha512-SMSkGoqTbTyUTDeuVuPIWifPdUGkTk1Kf9BWRiXIOIcuyMfsdp2EjeiiFvOzX8NOBvEh/ypKYvUh2rkgAJMCLA==",
-      "dev": true,
-      "dependencies": {
-        "@babel/helper-module-imports": "^7.0.0",
-        "@emotion/hash": "0.8.0",
-        "@emotion/memoize": "0.7.4",
-        "@emotion/serialize": "^0.11.16",
-        "babel-plugin-macros": "^2.0.0",
-        "babel-plugin-syntax-jsx": "^6.18.0",
-        "convert-source-map": "^1.5.0",
-        "escape-string-regexp": "^1.0.5",
-        "find-root": "^1.1.0",
-        "source-map": "^0.5.7"
-      }
-    },
     "node_modules/babel-plugin-extract-import-names": {
       "version": "1.6.22",
       "resolved": "https://registry.npmjs.org/babel-plugin-extract-import-names/-/babel-plugin-extract-import-names-1.6.22.tgz",
@@ -16019,17 +15608,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/babel-plugin-macros": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-macros/-/babel-plugin-macros-2.8.0.tgz",
-      "integrity": "sha512-SEP5kJpfGYqYKpBrj5XU3ahw5p5GOHJ0U5ssOSQ/WBVdwkD2Dzlce95exQTs3jOVWPPKLBN2rlEWkCK7dSmLvg==",
-      "dev": true,
-      "dependencies": {
-        "@babel/runtime": "^7.7.2",
-        "cosmiconfig": "^6.0.0",
-        "resolve": "^1.12.0"
       }
     },
     "node_modules/babel-plugin-module-resolver": {
@@ -16113,12 +15691,6 @@
       "version": "6.13.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-syntax-exponentiation-operator/-/babel-plugin-syntax-exponentiation-operator-6.13.0.tgz",
       "integrity": "sha1-nufoM3KQ2pUoggGmpX9BcDF4MN4=",
-      "dev": true
-    },
-    "node_modules/babel-plugin-syntax-jsx": {
-      "version": "6.18.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-jsx/-/babel-plugin-syntax-jsx-6.18.0.tgz",
-      "integrity": "sha1-CvMqmm4Tyno/1QaeYtew9Y0NiUY=",
       "dev": true
     },
     "node_modules/babel-plugin-syntax-trailing-function-commas": {
@@ -20506,20 +20078,6 @@
         "sha.js": "^2.4.8"
       }
     },
-    "node_modules/create-react-context": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/create-react-context/-/create-react-context-0.3.0.tgz",
-      "integrity": "sha512-dNldIoSuNSvlTJ7slIKC/ZFGKexBMBrrcc+TTe1NdmROnaASuLPvqpwj9v4XS4uXZ8+YPu0sNmShX2rXI5LNsw==",
-      "dev": true,
-      "dependencies": {
-        "gud": "^1.0.0",
-        "warning": "^4.0.3"
-      },
-      "peerDependencies": {
-        "prop-types": "^15.0.0",
-        "react": "^0.14.0 || ^15.0.0 || ^16.0.0"
-      }
-    },
     "node_modules/cross-spawn": {
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
@@ -20698,12 +20256,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/csstype": {
-      "version": "3.0.8",
-      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.0.8.tgz",
-      "integrity": "sha512-jXKhWqXPmlUeoQnF/EhTtTl4C9SnrxSH/jZUih3jmO6lBKr99rP3/+FmrMj4EFpOXzMtXHAZkd3x0E6h6Fgflw==",
-      "dev": true
-    },
     "node_modules/ctype": {
       "version": "0.5.3",
       "resolved": "https://registry.npmjs.org/ctype/-/ctype-0.5.3.tgz",
@@ -20843,12 +20395,6 @@
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
       "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
-      "dev": true
-    },
-    "node_modules/deep-object-diff": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/deep-object-diff/-/deep-object-diff-1.1.0.tgz",
-      "integrity": "sha512-b+QLs5vHgS+IoSNcUE4n9HP2NwcHj7aqnJWsjPtuG75Rh5TOaGt0OjAYInh77d5T16V5cRDC+Pw/6ZZZiETBGw==",
       "dev": true
     },
     "node_modules/deepmerge": {
@@ -26261,21 +25807,6 @@
         "node": ">= 4"
       }
     },
-    "node_modules/emotion-theming": {
-      "version": "10.0.27",
-      "resolved": "https://registry.npmjs.org/emotion-theming/-/emotion-theming-10.0.27.tgz",
-      "integrity": "sha512-MlF1yu/gYh8u+sLUqA0YuA9JX0P4Hb69WlKc/9OLo+WCXuX6sy/KoIa+qJimgmr2dWqnypYKYPX37esjDBbhdw==",
-      "dev": true,
-      "dependencies": {
-        "@babel/runtime": "^7.5.5",
-        "@emotion/weak-memoize": "0.2.5",
-        "hoist-non-react-statics": "^3.3.0"
-      },
-      "peerDependencies": {
-        "@emotion/core": "^10.0.27",
-        "react": ">=16.3.0"
-      }
-    },
     "node_modules/encodeurl": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
@@ -28102,12 +27633,6 @@
       "integrity": "sha512-XYKutXMrIK99YMUPf91KX5QVJoG31/OsgftD6YoTPAObfQIxM4ziA9f0J1AsqKhJmo+IeaIPP0CFopTD4bdUBw==",
       "dev": true
     },
-    "node_modules/find-root": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/find-root/-/find-root-1.1.0.tgz",
-      "integrity": "sha512-NKfW6bec6GfKc0SGx1e07QZY9PE99u0Bft/0rzSD5k3sO/vwkVUpDUKVm5Gpp5Ue3YfShPFTX2070tDs5kB9Ng==",
-      "dev": true
-    },
     "node_modules/find-up": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
@@ -29108,12 +28633,6 @@
       "integrity": "sha512-+xGQY0YyAWCnqy7Cd++hc2JqMYzlm0dG30Jd0beaA64sROr8C4nt8Yc9V5Ro3avlSUDTN0ulqP/VBKi1/lLygw==",
       "dev": true
     },
-    "node_modules/gud": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/gud/-/gud-1.0.0.tgz",
-      "integrity": "sha512-zGEOVKFM5sVPPrYs7J5/hYEw2Pof8KCyOwyhG8sAF26mCAeUFAcYPu1mwB7hhpIP29zOIBaDqwuHdLp0jvZXjw==",
-      "dev": true
-    },
     "node_modules/handlebars": {
       "version": "4.7.7",
       "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.7.tgz",
@@ -29616,15 +29135,6 @@
       "optional": true,
       "engines": {
         "node": ">=0.8.0"
-      }
-    },
-    "node_modules/hoist-non-react-statics": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
-      "integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
-      "dev": true,
-      "dependencies": {
-        "react-is": "^16.7.0"
       }
     },
     "node_modules/home-or-tmp": {
@@ -35432,12 +34942,6 @@
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
       "dev": true
     },
-    "node_modules/react-lifecycles-compat": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz",
-      "integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA==",
-      "dev": true
-    },
     "node_modules/react-sizeme": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/react-sizeme/-/react-sizeme-3.0.1.tgz",
@@ -37108,12 +36612,6 @@
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/shallow-equal": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/shallow-equal/-/shallow-equal-1.2.1.tgz",
-      "integrity": "sha512-S4vJDjHHMBaiZuT9NPb616CSmLf618jawtv3sufLl6ivK8WocjAo58cXwbRV1cgqxH0Qbv+iUt6m05eqEa2IRA==",
-      "dev": true
     },
     "node_modules/shallowequal": {
       "version": "1.1.0",
@@ -39966,15 +39464,6 @@
       "dev": true,
       "dependencies": {
         "makeerror": "1.0.x"
-      }
-    },
-    "node_modules/warning": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/warning/-/warning-4.0.3.tgz",
-      "integrity": "sha512-rpJyN222KWIvHJ/F53XSZv0Zl/accqHR8et1kpaMTD/fLCRxtV8iX8czMzY7sVZupTI3zcUTg8eycS2kNF9l6w==",
-      "dev": true,
-      "dependencies": {
-        "loose-envify": "^1.0.0"
       }
     },
     "node_modules/watch-detector": {
@@ -43812,137 +43301,6 @@
         }
       }
     },
-    "@emotion/cache": {
-      "version": "10.0.29",
-      "resolved": "https://registry.npmjs.org/@emotion/cache/-/cache-10.0.29.tgz",
-      "integrity": "sha512-fU2VtSVlHiF27empSbxi1O2JFdNWZO+2NFHfwO0pxgTep6Xa3uGb+3pVKfLww2l/IBGLNEZl5Xf/++A4wAYDYQ==",
-      "dev": true,
-      "requires": {
-        "@emotion/sheet": "0.9.4",
-        "@emotion/stylis": "0.8.5",
-        "@emotion/utils": "0.11.3",
-        "@emotion/weak-memoize": "0.2.5"
-      }
-    },
-    "@emotion/core": {
-      "version": "10.1.1",
-      "resolved": "https://registry.npmjs.org/@emotion/core/-/core-10.1.1.tgz",
-      "integrity": "sha512-ZMLG6qpXR8x031NXD8HJqugy/AZSkAuMxxqB46pmAR7ze47MhNJ56cdoX243QPZdGctrdfo+s08yZTiwaUcRKA==",
-      "dev": true,
-      "requires": {
-        "@babel/runtime": "^7.5.5",
-        "@emotion/cache": "^10.0.27",
-        "@emotion/css": "^10.0.27",
-        "@emotion/serialize": "^0.11.15",
-        "@emotion/sheet": "0.9.4",
-        "@emotion/utils": "0.11.3"
-      }
-    },
-    "@emotion/css": {
-      "version": "10.0.27",
-      "resolved": "https://registry.npmjs.org/@emotion/css/-/css-10.0.27.tgz",
-      "integrity": "sha512-6wZjsvYeBhyZQYNrGoR5yPMYbMBNEnanDrqmsqS1mzDm1cOTu12shvl2j4QHNS36UaTE0USIJawCH9C8oW34Zw==",
-      "dev": true,
-      "requires": {
-        "@emotion/serialize": "^0.11.15",
-        "@emotion/utils": "0.11.3",
-        "babel-plugin-emotion": "^10.0.27"
-      }
-    },
-    "@emotion/hash": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/@emotion/hash/-/hash-0.8.0.tgz",
-      "integrity": "sha512-kBJtf7PH6aWwZ6fka3zQ0p6SBYzx4fl1LoZXE2RrnYST9Xljm7WfKJrU4g/Xr3Beg72MLrp1AWNUmuYJTL7Cow==",
-      "dev": true
-    },
-    "@emotion/is-prop-valid": {
-      "version": "0.8.8",
-      "resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-0.8.8.tgz",
-      "integrity": "sha512-u5WtneEAr5IDG2Wv65yhunPSMLIpuKsbuOktRojfrEiEvRyC85LgPMZI63cr7NUqT8ZIGdSVg8ZKGxIug4lXcA==",
-      "dev": true,
-      "requires": {
-        "@emotion/memoize": "0.7.4"
-      }
-    },
-    "@emotion/memoize": {
-      "version": "0.7.4",
-      "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.7.4.tgz",
-      "integrity": "sha512-Ja/Vfqe3HpuzRsG1oBtWTHk2PGZ7GR+2Vz5iYGelAw8dx32K0y7PjVuxK6z1nMpZOqAFsRUPCkK1YjJ56qJlgw==",
-      "dev": true
-    },
-    "@emotion/serialize": {
-      "version": "0.11.16",
-      "resolved": "https://registry.npmjs.org/@emotion/serialize/-/serialize-0.11.16.tgz",
-      "integrity": "sha512-G3J4o8by0VRrO+PFeSc3js2myYNOXVJ3Ya+RGVxnshRYgsvErfAOglKAiy1Eo1vhzxqtUvjCyS5gtewzkmvSSg==",
-      "dev": true,
-      "requires": {
-        "@emotion/hash": "0.8.0",
-        "@emotion/memoize": "0.7.4",
-        "@emotion/unitless": "0.7.5",
-        "@emotion/utils": "0.11.3",
-        "csstype": "^2.5.7"
-      },
-      "dependencies": {
-        "csstype": {
-          "version": "2.6.17",
-          "resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.17.tgz",
-          "integrity": "sha512-u1wmTI1jJGzCJzWndZo8mk4wnPTZd1eOIYTYvuEyOQGfmDl3TrabCCfKnOC86FZwW/9djqTl933UF/cS425i9A==",
-          "dev": true
-        }
-      }
-    },
-    "@emotion/sheet": {
-      "version": "0.9.4",
-      "resolved": "https://registry.npmjs.org/@emotion/sheet/-/sheet-0.9.4.tgz",
-      "integrity": "sha512-zM9PFmgVSqBw4zL101Q0HrBVTGmpAxFZH/pYx/cjJT5advXguvcgjHFTCaIO3enL/xr89vK2bh0Mfyj9aa0ANA==",
-      "dev": true
-    },
-    "@emotion/styled": {
-      "version": "10.0.27",
-      "resolved": "https://registry.npmjs.org/@emotion/styled/-/styled-10.0.27.tgz",
-      "integrity": "sha512-iK/8Sh7+NLJzyp9a5+vIQIXTYxfT4yB/OJbjzQanB2RZpvmzBQOHZWhpAMZWYEKRNNbsD6WfBw5sVWkb6WzS/Q==",
-      "dev": true,
-      "requires": {
-        "@emotion/styled-base": "^10.0.27",
-        "babel-plugin-emotion": "^10.0.27"
-      }
-    },
-    "@emotion/styled-base": {
-      "version": "10.0.31",
-      "resolved": "https://registry.npmjs.org/@emotion/styled-base/-/styled-base-10.0.31.tgz",
-      "integrity": "sha512-wTOE1NcXmqMWlyrtwdkqg87Mu6Rj1MaukEoEmEkHirO5IoHDJ8LgCQL4MjJODgxWxXibGR3opGp1p7YvkNEdXQ==",
-      "dev": true,
-      "requires": {
-        "@babel/runtime": "^7.5.5",
-        "@emotion/is-prop-valid": "0.8.8",
-        "@emotion/serialize": "^0.11.15",
-        "@emotion/utils": "0.11.3"
-      }
-    },
-    "@emotion/stylis": {
-      "version": "0.8.5",
-      "resolved": "https://registry.npmjs.org/@emotion/stylis/-/stylis-0.8.5.tgz",
-      "integrity": "sha512-h6KtPihKFn3T9fuIrwvXXUOwlx3rfUvfZIcP5a6rh8Y7zjE3O06hT5Ss4S/YI1AYhuZ1kjaE/5EaOOI2NqSylQ==",
-      "dev": true
-    },
-    "@emotion/unitless": {
-      "version": "0.7.5",
-      "resolved": "https://registry.npmjs.org/@emotion/unitless/-/unitless-0.7.5.tgz",
-      "integrity": "sha512-OWORNpfjMsSSUBVrRBVGECkhWcULOAJz9ZW8uK9qgxD+87M7jHRcvh/A96XXNhXTLmKcoYSQtBEX7lHMO7YRwg==",
-      "dev": true
-    },
-    "@emotion/utils": {
-      "version": "0.11.3",
-      "resolved": "https://registry.npmjs.org/@emotion/utils/-/utils-0.11.3.tgz",
-      "integrity": "sha512-0o4l6pZC+hI88+bzuaX/6BgOvQVhbt2PfmxauVaYOGgbsAw14wdKyvMCZXnsnsHys94iadcF+RG/wZyx6+ZZBw==",
-      "dev": true
-    },
-    "@emotion/weak-memoize": {
-      "version": "0.2.5",
-      "resolved": "https://registry.npmjs.org/@emotion/weak-memoize/-/weak-memoize-0.2.5.tgz",
-      "integrity": "sha512-6U71C2Wp7r5XtFtQzYrW5iKFT67OixrSxjI4MptCHzdSVlgabczzqLe0ZSgnub/5Kp4hSbpDB1tMytZY9pwxxA==",
-      "dev": true
-    },
     "@eslint/eslintrc": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.3.3.tgz",
@@ -45247,18 +44605,6 @@
         }
       }
     },
-    "@reach/router": {
-      "version": "1.3.4",
-      "resolved": "https://registry.npmjs.org/@reach/router/-/router-1.3.4.tgz",
-      "integrity": "sha512-+mtn9wjlB9NN2CNnnC/BRYtwdKBfSyyasPYraNAyvaV1occr/5NnB4CVzjEZipNHwYebQwcndGUmpFzxAUoqSA==",
-      "dev": true,
-      "requires": {
-        "create-react-context": "0.3.0",
-        "invariant": "^2.2.3",
-        "prop-types": "^15.6.1",
-        "react-lifecycles-compat": "^3.0.4"
-      }
-    },
     "@simple-dom/interface": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/@simple-dom/interface/-/interface-1.4.0.tgz",
@@ -45414,176 +44760,6 @@
           "requires": {
             "lodash": "^4.17.15"
           }
-        }
-      }
-    },
-    "@storybook/addon-centered": {
-      "version": "5.3.21",
-      "resolved": "https://registry.npmjs.org/@storybook/addon-centered/-/addon-centered-5.3.21.tgz",
-      "integrity": "sha512-noWVIfN1jeCpMubiS43N2wFTUKEbo2MPR46+YeiYn1wOASyZjnkdV7gl63FCNRgFOz55jQGsrJVz+JJ7xz+rdQ==",
-      "dev": true,
-      "requires": {
-        "@storybook/addons": "5.3.21",
-        "core-js": "^3.0.1",
-        "global": "^4.3.2",
-        "util-deprecate": "^1.0.2"
-      },
-      "dependencies": {
-        "@storybook/addons": {
-          "version": "5.3.21",
-          "resolved": "https://registry.npmjs.org/@storybook/addons/-/addons-5.3.21.tgz",
-          "integrity": "sha512-Ji/21WADTLVbTbiKcZ64BcL0Es+h1Afxx3kNmGJqPSTUYroCwIFCT9mUzCqU6G+YyWaISAmTii5UJkTwMkChwA==",
-          "dev": true,
-          "requires": {
-            "@storybook/api": "5.3.21",
-            "@storybook/channels": "5.3.21",
-            "@storybook/client-logger": "5.3.21",
-            "@storybook/core-events": "5.3.21",
-            "core-js": "^3.0.1",
-            "global": "^4.3.2",
-            "util-deprecate": "^1.0.2"
-          }
-        },
-        "@storybook/api": {
-          "version": "5.3.21",
-          "resolved": "https://registry.npmjs.org/@storybook/api/-/api-5.3.21.tgz",
-          "integrity": "sha512-K1o4an/Rx8daKRDooks6qzN6ZGyqizeacZZbair3F8CsSfTgrr2zCcf9pgKojLQa9koEmMHlcdb2KnS+GwPEgA==",
-          "dev": true,
-          "requires": {
-            "@reach/router": "^1.2.1",
-            "@storybook/channels": "5.3.21",
-            "@storybook/client-logger": "5.3.21",
-            "@storybook/core-events": "5.3.21",
-            "@storybook/csf": "0.0.1",
-            "@storybook/router": "5.3.21",
-            "@storybook/theming": "5.3.21",
-            "@types/reach__router": "^1.2.3",
-            "core-js": "^3.0.1",
-            "fast-deep-equal": "^2.0.1",
-            "global": "^4.3.2",
-            "lodash": "^4.17.15",
-            "memoizerific": "^1.11.3",
-            "prop-types": "^15.6.2",
-            "react": "^16.8.3",
-            "semver": "^6.0.0",
-            "shallow-equal": "^1.1.0",
-            "store2": "^2.7.1",
-            "telejson": "^3.2.0",
-            "util-deprecate": "^1.0.2"
-          }
-        },
-        "@storybook/channels": {
-          "version": "5.3.21",
-          "resolved": "https://registry.npmjs.org/@storybook/channels/-/channels-5.3.21.tgz",
-          "integrity": "sha512-OXoFs9XtBVg/cCk6lYMrxkzaNlJRf54ABdorp7YAAj7S9tRL1JxOZHxmjNQwEoiRvssmem2rAWtEAxfuEANsAA==",
-          "dev": true,
-          "requires": {
-            "core-js": "^3.0.1"
-          }
-        },
-        "@storybook/client-logger": {
-          "version": "5.3.21",
-          "resolved": "https://registry.npmjs.org/@storybook/client-logger/-/client-logger-5.3.21.tgz",
-          "integrity": "sha512-OzQkwpZ5SK9cXD9Mv6lxPGPot+hSZvnkEW12kpt1AHfJz4ET26YTDOI3oetPsjfRJo6qYLeQX8+wF7rklfXbzA==",
-          "dev": true,
-          "requires": {
-            "core-js": "^3.0.1"
-          }
-        },
-        "@storybook/core-events": {
-          "version": "5.3.21",
-          "resolved": "https://registry.npmjs.org/@storybook/core-events/-/core-events-5.3.21.tgz",
-          "integrity": "sha512-/Zsm1sKAh6pzQv8jQUmuhM7nuM01ZljIRKy8p2HjPNlMjDB5yaRkBfyeAUXUg+qXNI6aHVWa4jGdPEdwwY4oLA==",
-          "dev": true,
-          "requires": {
-            "core-js": "^3.0.1"
-          }
-        },
-        "@storybook/router": {
-          "version": "5.3.21",
-          "resolved": "https://registry.npmjs.org/@storybook/router/-/router-5.3.21.tgz",
-          "integrity": "sha512-c29m5UikK5Q1lyd6FltOGFhIcpd6PIb855YS3OUNe3F6ZA1tfJ+aNKrCBc65d1c+fvCGG76dYYYv0RvwEmKXXg==",
-          "dev": true,
-          "requires": {
-            "@reach/router": "^1.2.1",
-            "@storybook/csf": "0.0.1",
-            "@types/reach__router": "^1.2.3",
-            "core-js": "^3.0.1",
-            "global": "^4.3.2",
-            "lodash": "^4.17.15",
-            "memoizerific": "^1.11.3",
-            "qs": "^6.6.0",
-            "util-deprecate": "^1.0.2"
-          }
-        },
-        "@storybook/theming": {
-          "version": "5.3.21",
-          "resolved": "https://registry.npmjs.org/@storybook/theming/-/theming-5.3.21.tgz",
-          "integrity": "sha512-FZbxjizqdO9lV5LUixPio/7+6UdPiswCzTJn8Hcot9uwwgfnrViRdN7xyjmSYRqv9nHP3OlYbtdeCAgZ4aPq8g==",
-          "dev": true,
-          "requires": {
-            "@emotion/core": "^10.0.20",
-            "@emotion/styled": "^10.0.17",
-            "@storybook/client-logger": "5.3.21",
-            "core-js": "^3.0.1",
-            "deep-object-diff": "^1.1.0",
-            "emotion-theming": "^10.0.19",
-            "global": "^4.3.2",
-            "memoizerific": "^1.11.3",
-            "polished": "^3.3.1",
-            "prop-types": "^15.7.2",
-            "resolve-from": "^5.0.0",
-            "ts-dedent": "^1.1.0"
-          }
-        },
-        "fast-deep-equal": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
-          "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=",
-          "dev": true
-        },
-        "isobject": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/isobject/-/isobject-4.0.0.tgz",
-          "integrity": "sha512-S/2fF5wH8SJA/kmwr6HYhK/RI/OkhD84k8ntalo0iJjZikgq1XFvR5M8NPT1x5F7fBwCG3qHfnzeP/Vh/ZxCUA==",
-          "dev": true
-        },
-        "polished": {
-          "version": "3.7.2",
-          "resolved": "https://registry.npmjs.org/polished/-/polished-3.7.2.tgz",
-          "integrity": "sha512-pQKtpZGmsZrW8UUpQMAnR7s3ppHeMQVNyMDKtUyKwuvDmklzcEyM5Kllb3JyE/sE/x7arDmyd35i+4vp99H6sQ==",
-          "dev": true,
-          "requires": {
-            "@babel/runtime": "^7.12.5"
-          }
-        },
-        "semver": {
-          "version": "6.3.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-          "dev": true
-        },
-        "telejson": {
-          "version": "3.3.0",
-          "resolved": "https://registry.npmjs.org/telejson/-/telejson-3.3.0.tgz",
-          "integrity": "sha512-er08AylQ+LEbDLp1GRezORZu5wKOHaBczF6oYJtgC3Idv10qZ8A3p6ffT+J5BzDKkV9MqBvu8HAKiIIOp6KJ2w==",
-          "dev": true,
-          "requires": {
-            "@types/is-function": "^1.0.0",
-            "global": "^4.4.0",
-            "is-function": "^1.0.1",
-            "is-regex": "^1.0.4",
-            "is-symbol": "^1.0.3",
-            "isobject": "^4.0.0",
-            "lodash": "^4.17.15",
-            "memoizerific": "^1.11.3"
-          }
-        },
-        "ts-dedent": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/ts-dedent/-/ts-dedent-1.2.0.tgz",
-          "integrity": "sha512-6zSJp23uQI+Txyz5LlXMXAHpUhY4Hi0oluXny0OgIR7g/Cromq4vDBnhtbBdyIV34g0pgwxUvnvg+jLJe4c1NA==",
-          "dev": true
         }
       }
     },
@@ -48975,15 +48151,6 @@
         }
       }
     },
-    "@storybook/csf": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/@storybook/csf/-/csf-0.0.1.tgz",
-      "integrity": "sha512-USTLkZze5gkel8MYCujSRBVIrUQ3YPBrLOx7GNk/0wttvVtlzWXAq9eLbQ4p/NicGxP+3T7KPEMVV//g+yubpw==",
-      "dev": true,
-      "requires": {
-        "lodash": "^4.17.15"
-      }
-    },
     "@storybook/csf-tools": {
       "version": "6.5.13",
       "resolved": "https://registry.npmjs.org/@storybook/csf-tools/-/csf-tools-6.5.13.tgz",
@@ -51869,12 +51036,6 @@
       "integrity": "sha512-VjID5MJb1eGKthz2qUerWT8+R4b9N+CHvGCzg9fn4kWZgaF9AhdYikQio3R7wV8YY1NsQKPaCwKz1Yff+aHNUQ==",
       "dev": true
     },
-    "@types/prop-types": {
-      "version": "15.7.4",
-      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.4.tgz",
-      "integrity": "sha512-rZ5drC/jWjrArrS8BR6SIr4cWpW09RNTYt9AMZo3Jwwif+iacXAqgVjm0B0Bv/S1jhDXKHqRVNCbACkJ89RAnQ==",
-      "dev": true
-    },
     "@types/qs": {
       "version": "6.9.7",
       "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.7.tgz",
@@ -51886,26 +51047,6 @@
       "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.4.tgz",
       "integrity": "sha512-EEhsLsD6UsDM1yFhAvy0Cjr6VwmpMWqFBCb9w07wVugF7w9nfajxLuVmngTIpgS6svCnm6Vaw+MZhoDCKnOfsw==",
       "dev": true
-    },
-    "@types/reach__router": {
-      "version": "1.3.9",
-      "resolved": "https://registry.npmjs.org/@types/reach__router/-/reach__router-1.3.9.tgz",
-      "integrity": "sha512-N6rqQqTTAV/zKLfK3iq9Ww3wqCEhTZvsilhl0zI09zETdVq1QGmJH6+/xnj8AFUWIrle2Cqo+PGM/Ltr1vBb9w==",
-      "dev": true,
-      "requires": {
-        "@types/react": "*"
-      }
-    },
-    "@types/react": {
-      "version": "17.0.18",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.18.tgz",
-      "integrity": "sha512-YTLgu7oS5zvSqq49X5Iue5oAbVGhgPc5Au29SJC4VeE17V6gASoOxVkUDy9pXFMRFxCWCD9fLeweNFizo3UzOg==",
-      "dev": true,
-      "requires": {
-        "@types/prop-types": "*",
-        "@types/scheduler": "*",
-        "csstype": "^3.0.2"
-      }
     },
     "@types/resolve": {
       "version": "0.0.8",
@@ -51924,12 +51065,6 @@
         "@types/glob": "*",
         "@types/node": "*"
       }
-    },
-    "@types/scheduler": {
-      "version": "0.16.2",
-      "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.2.tgz",
-      "integrity": "sha512-hppQEBDmlwhFAXKJX2KnWLYu5yMfi91yazPb2l+lbJiwW+wdo1gNeRA+3RgNSO39WYX2euey41KEwnqesU2Jew==",
-      "dev": true
     },
     "@types/serve-static": {
       "version": "1.13.10",
@@ -53470,24 +52605,6 @@
         }
       }
     },
-    "babel-plugin-emotion": {
-      "version": "10.2.2",
-      "resolved": "https://registry.npmjs.org/babel-plugin-emotion/-/babel-plugin-emotion-10.2.2.tgz",
-      "integrity": "sha512-SMSkGoqTbTyUTDeuVuPIWifPdUGkTk1Kf9BWRiXIOIcuyMfsdp2EjeiiFvOzX8NOBvEh/ypKYvUh2rkgAJMCLA==",
-      "dev": true,
-      "requires": {
-        "@babel/helper-module-imports": "^7.0.0",
-        "@emotion/hash": "0.8.0",
-        "@emotion/memoize": "0.7.4",
-        "@emotion/serialize": "^0.11.16",
-        "babel-plugin-macros": "^2.0.0",
-        "babel-plugin-syntax-jsx": "^6.18.0",
-        "convert-source-map": "^1.5.0",
-        "escape-string-regexp": "^1.0.5",
-        "find-root": "^1.1.0",
-        "source-map": "^0.5.7"
-      }
-    },
     "babel-plugin-extract-import-names": {
       "version": "1.6.22",
       "resolved": "https://registry.npmjs.org/babel-plugin-extract-import-names/-/babel-plugin-extract-import-names-1.6.22.tgz",
@@ -53533,17 +52650,6 @@
         "@istanbuljs/schema": "^0.1.2",
         "istanbul-lib-instrument": "^4.0.0",
         "test-exclude": "^6.0.0"
-      }
-    },
-    "babel-plugin-macros": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-macros/-/babel-plugin-macros-2.8.0.tgz",
-      "integrity": "sha512-SEP5kJpfGYqYKpBrj5XU3ahw5p5GOHJ0U5ssOSQ/WBVdwkD2Dzlce95exQTs3jOVWPPKLBN2rlEWkCK7dSmLvg==",
-      "dev": true,
-      "requires": {
-        "@babel/runtime": "^7.7.2",
-        "cosmiconfig": "^6.0.0",
-        "resolve": "^1.12.0"
       }
     },
     "babel-plugin-module-resolver": {
@@ -53614,12 +52720,6 @@
       "version": "6.13.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-syntax-exponentiation-operator/-/babel-plugin-syntax-exponentiation-operator-6.13.0.tgz",
       "integrity": "sha1-nufoM3KQ2pUoggGmpX9BcDF4MN4=",
-      "dev": true
-    },
-    "babel-plugin-syntax-jsx": {
-      "version": "6.18.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-jsx/-/babel-plugin-syntax-jsx-6.18.0.tgz",
-      "integrity": "sha1-CvMqmm4Tyno/1QaeYtew9Y0NiUY=",
       "dev": true
     },
     "babel-plugin-syntax-trailing-function-commas": {
@@ -57330,16 +56430,6 @@
         "sha.js": "^2.4.8"
       }
     },
-    "create-react-context": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/create-react-context/-/create-react-context-0.3.0.tgz",
-      "integrity": "sha512-dNldIoSuNSvlTJ7slIKC/ZFGKexBMBrrcc+TTe1NdmROnaASuLPvqpwj9v4XS4uXZ8+YPu0sNmShX2rXI5LNsw==",
-      "dev": true,
-      "requires": {
-        "gud": "^1.0.0",
-        "warning": "^4.0.3"
-      }
-    },
     "cross-spawn": {
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
@@ -57469,12 +56559,6 @@
       "integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==",
       "dev": true
     },
-    "csstype": {
-      "version": "3.0.8",
-      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.0.8.tgz",
-      "integrity": "sha512-jXKhWqXPmlUeoQnF/EhTtTl4C9SnrxSH/jZUih3jmO6lBKr99rP3/+FmrMj4EFpOXzMtXHAZkd3x0E6h6Fgflw==",
-      "dev": true
-    },
     "ctype": {
       "version": "0.5.3",
       "resolved": "https://registry.npmjs.org/ctype/-/ctype-0.5.3.tgz",
@@ -57580,12 +56664,6 @@
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
       "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
-      "dev": true
-    },
-    "deep-object-diff": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/deep-object-diff/-/deep-object-diff-1.1.0.tgz",
-      "integrity": "sha512-b+QLs5vHgS+IoSNcUE4n9HP2NwcHj7aqnJWsjPtuG75Rh5TOaGt0OjAYInh77d5T16V5cRDC+Pw/6ZZZiETBGw==",
       "dev": true
     },
     "deepmerge": {
@@ -61826,17 +60904,6 @@
       "integrity": "sha512-/kyM18EfinwXZbno9FyUGeFh87KC8HRQBQGildHZbEuRyWFOmv1U10o9BBp8XVZDVNNuQKyIGIu5ZYAAXJ0V2Q==",
       "dev": true
     },
-    "emotion-theming": {
-      "version": "10.0.27",
-      "resolved": "https://registry.npmjs.org/emotion-theming/-/emotion-theming-10.0.27.tgz",
-      "integrity": "sha512-MlF1yu/gYh8u+sLUqA0YuA9JX0P4Hb69WlKc/9OLo+WCXuX6sy/KoIa+qJimgmr2dWqnypYKYPX37esjDBbhdw==",
-      "dev": true,
-      "requires": {
-        "@babel/runtime": "^7.5.5",
-        "@emotion/weak-memoize": "0.2.5",
-        "hoist-non-react-statics": "^3.3.0"
-      }
-    },
     "encodeurl": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
@@ -63245,12 +62312,6 @@
       "integrity": "sha512-XYKutXMrIK99YMUPf91KX5QVJoG31/OsgftD6YoTPAObfQIxM4ziA9f0J1AsqKhJmo+IeaIPP0CFopTD4bdUBw==",
       "dev": true
     },
-    "find-root": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/find-root/-/find-root-1.1.0.tgz",
-      "integrity": "sha512-NKfW6bec6GfKc0SGx1e07QZY9PE99u0Bft/0rzSD5k3sO/vwkVUpDUKVm5Gpp5Ue3YfShPFTX2070tDs5kB9Ng==",
-      "dev": true
-    },
     "find-up": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
@@ -64030,12 +63091,6 @@
       "integrity": "sha512-+xGQY0YyAWCnqy7Cd++hc2JqMYzlm0dG30Jd0beaA64sROr8C4nt8Yc9V5Ro3avlSUDTN0ulqP/VBKi1/lLygw==",
       "dev": true
     },
-    "gud": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/gud/-/gud-1.0.0.tgz",
-      "integrity": "sha512-zGEOVKFM5sVPPrYs7J5/hYEw2Pof8KCyOwyhG8sAF26mCAeUFAcYPu1mwB7hhpIP29zOIBaDqwuHdLp0jvZXjw==",
-      "dev": true
-    },
     "handlebars": {
       "version": "4.7.7",
       "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.7.tgz",
@@ -64436,15 +63491,6 @@
       "integrity": "sha512-ZZ6eGyzGjyMTmpSPYVECXy9uNfqBR7x5CavhUaLOeD6W0vWK1mp/b7O3f86XE0Mtfo9rZ6Bh3fnuw9Xr8MF9zA==",
       "dev": true,
       "optional": true
-    },
-    "hoist-non-react-statics": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
-      "integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
-      "dev": true,
-      "requires": {
-        "react-is": "^16.7.0"
-      }
     },
     "home-or-tmp": {
       "version": "2.0.0",
@@ -69031,12 +68077,6 @@
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
       "dev": true
     },
-    "react-lifecycles-compat": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz",
-      "integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA==",
-      "dev": true
-    },
     "react-sizeme": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/react-sizeme/-/react-sizeme-3.0.1.tgz",
@@ -70367,12 +69407,6 @@
       "requires": {
         "kind-of": "^6.0.2"
       }
-    },
-    "shallow-equal": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/shallow-equal/-/shallow-equal-1.2.1.tgz",
-      "integrity": "sha512-S4vJDjHHMBaiZuT9NPb616CSmLf618jawtv3sufLl6ivK8WocjAo58cXwbRV1cgqxH0Qbv+iUt6m05eqEa2IRA==",
-      "dev": true
     },
     "shallowequal": {
       "version": "1.1.0",
@@ -72599,15 +71633,6 @@
       "dev": true,
       "requires": {
         "makeerror": "1.0.x"
-      }
-    },
-    "warning": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/warning/-/warning-4.0.3.tgz",
-      "integrity": "sha512-rpJyN222KWIvHJ/F53XSZv0Zl/accqHR8et1kpaMTD/fLCRxtV8iX8czMzY7sVZupTI3zcUTg8eycS2kNF9l6w==",
-      "dev": true,
-      "requires": {
-        "loose-envify": "^1.0.0"
       }
     },
     "watch-detector": {

--- a/package.json
+++ b/package.json
@@ -66,7 +66,6 @@
     "@glimmer/component": "^1.1.2",
     "@glimmer/tracking": "^1.1.2",
     "@storybook/addon-a11y": "^6.5.13",
-    "@storybook/addon-centered": "^5.3.21",
     "@storybook/addon-controls": "^6.5.13",
     "@storybook/addon-docs": "^6.5.13",
     "@storybook/addon-essentials": "^6.5.13",


### PR DESCRIPTION
## :boom: BREAKING_CHANGES
Non :-)

## :christmas_tree: Problème
Plusieurs soucis:
- Les options du pixSelect dans le FilterBanner n'avaient pas le bon CSS. C'est du au reset-filter du PixFilterBanner qui ajoute un padding aux options du PixSelect.
- il manquait le `...attributes` dans le PixSelect.
- PixToggle n'avait pas le bon titre et les arguments n'étaient pas visibles.
- Update des arguments sur PixSelect et MultiSelect pour  préciser si c'est obligatoire ou pas.
- le PixSelect n'affichait pas dans le FilterBanner ou dans le FormExample. C'était du à l'addon `@storybook/addon-centered` qui empéchait l'affichage (on ne sait pas trop pourquoi). De plus, il est déprécié.

## :gift: Solution
- Enlever le reset-css
- Ajouter le `...attributes`
- Ajouter les infos manquantes
- Retirer l'addons et ajouter la propriété `layout` dans le fichier preview.js

## :star2: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :santa: Pour tester
Faire un tour sur l'appli, pour check que rien n'est cassé.
