### PR TITLE
[FEATURE] Permettre l'appel d'une fonction lors de la fermeture d'une Pix Banner (PIX-6513).

### DIFF
--- a/addon/components/pix-banner.js
+++ b/addon/components/pix-banner.js
@@ -53,7 +53,10 @@ export default class PixBanner extends Component {
   }
 
   @action
-  closeBanner() {
+  async closeBanner(params) {
+    if (this.args.onCloseBannerTriggerAction) {
+      await this.args.onCloseBannerTriggerAction(params);
+    }
     this.isBannerVisible = false;
   }
 }

--- a/app/stories/pix-banner.stories.js
+++ b/app/stories/pix-banner.stories.js
@@ -101,4 +101,11 @@ export const argsTypes = {
       defaultValue: { summary: false },
     },
   },
+  onCloseBannerTriggerAction: {
+    name: 'onCloseBannerTriggerAction',
+    description:
+      'Fonction à appeler lors de la fermeture de la bannière. Doit être utilisé avec le paramètre canCloseBanner',
+    type: { required: false },
+    control: { disable: true },
+  },
 };

--- a/app/stories/pix-banner.stories.mdx
+++ b/app/stories/pix-banner.stories.mdx
@@ -110,7 +110,7 @@ Bannière Info par défaut
   @type='warning'
   @canCloseBanner=true
 >
-  Bannière posséndant un bouton de fermeture
+  Bannière possédant un bouton de fermeture
 </PixBanner>
 
 ```

--- a/tests/unit/components/pix-banner-test.js
+++ b/tests/unit/components/pix-banner-test.js
@@ -1,0 +1,27 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+import createGlimmerComponent from '../../helpers/create-glimmer-component';
+import sinon from 'sinon';
+
+module('Unit | Component | PixBanner', function (hooks) {
+  setupTest(hooks);
+
+  module('#closeBanner', function () {
+    module('when onCloseBannerTriggerAction is set', function () {
+      test('it should call the custom action', async function (assert) {
+        // given
+        const params = Symbol();
+        const onCloseBannerTriggerAction = sinon.stub();
+        const componentParams = { canCloseBanner: true, onCloseBannerTriggerAction };
+        const component = createGlimmerComponent('component:pix-banner', componentParams);
+
+        // when
+        await component.closeBanner(params);
+
+        // then
+        sinon.assert.calledWith(onCloseBannerTriggerAction, params);
+        assert.ok(true);
+      });
+    });
+  });
+});


### PR DESCRIPTION
## :boom: BREAKING_CHANGES
RAS

## :christmas_tree: Problème
Actuellement la fermeture d'une PixBanner ne permet que de la faire disparaître. On ne peut pas déclencher une autre action.

## :gift: Solution
Permettre d'appeler une fonction lors de la fermeture du composant.

## :star2: Remarques
Ce nouveau paramètre, onCloseBannerTriggerAction doit être utilisé avec canCloseBanner.

Besoin de ce nouveau paramètre pour les besoins du ticket suivant : https://1024pix.atlassian.net/jira/software/c/projects/PIX/boards/92?modal=detail&selectedIssue=PIX-6220

## :santa: Pour tester
ci ok
