### PR TITLE
[TECH] Ajout d'un paramètre 'manual' sur PixTooltip (PIX-6437).

### DIFF
--- a/addon/components/pix-tooltip.js
+++ b/addon/components/pix-tooltip.js
@@ -3,7 +3,7 @@ import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
 
 export default class PixTooltip extends Component {
-  @tracked isVisible = false;
+  @tracked automaticVisible = false;
 
   get position() {
     const correctsPosition = [
@@ -25,12 +25,12 @@ export default class PixTooltip extends Component {
 
   @action
   showTooltip() {
-    this.isVisible = true;
+    this.automaticVisible = true;
   }
 
   @action
   hideTooltip() {
-    this.isVisible = false;
+    this.automaticVisible = false;
   }
 
   @action
@@ -42,5 +42,9 @@ export default class PixTooltip extends Component {
     }
 
     this.hideTooltip(event);
+  }
+
+  get isVisible() {
+    return this.automaticVisible || this.args.manual;
   }
 }

--- a/app/stories/pix-tooltip.stories.js
+++ b/app/stories/pix-tooltip.stories.js
@@ -9,6 +9,7 @@ const Template = (args) => {
   @isInline={{this.isInline}}
   @isWide={{this.isWide}}
   @hide={{this.hide}}
+  @manual={{this.manual}}
 >
   <:triggerElement>
     <PixButton aria-describedby={{this.id}}>
@@ -121,6 +122,13 @@ hide.args = {
   hide: true,
 };
 
+export const manual = Template.bind({});
+manual.args = {
+  label: 'Ma tooltip ne se cache plus',
+  text: 'Cachez-moi !',
+  manual: true,
+};
+
 export const WithHTML = TemplateWithHTMLElement.bind({});
 WithHTML.args = {
   label: 'À survoler pour voir la tooltip',
@@ -184,6 +192,12 @@ export const argTypes = {
   hide: {
     name: 'hide',
     description: 'Masquer la tooltip',
+    type: { name: 'boolean', required: false },
+    table: { defaultValue: { summary: false } },
+  },
+  manual: {
+    name: 'manual',
+    description: 'Laisser la gestion du comportement de la tooltip au parent',
     type: { name: 'boolean', required: false },
     table: { defaultValue: { summary: false } },
   },

--- a/app/stories/pix-tooltip.stories.mdx
+++ b/app/stories/pix-tooltip.stories.mdx
@@ -80,7 +80,8 @@ Cache la tooltip (par exemple si le contenu est vide).
 
 ## Manual
 
-Annule le comportement par defaut de la tooltip et permet de le forcer dans le component parent
+Annule le comportement par défaut de la tooltip. Le component parent peut afficher/cacher la tooltip via la propriété
+'hide'.
 
 <Canvas>
   <Story name="Manual" story={stories.manual} height={200} />

--- a/app/stories/pix-tooltip.stories.mdx
+++ b/app/stories/pix-tooltip.stories.mdx
@@ -61,6 +61,15 @@ Les tooltips doivent prendre un `@id` et être référencées par leur élément
 </PixTooltip>
 ```
 
+## Default
+
+Infobulle en position `top`, fond sombre (par défaut).
+
+<Canvas>
+  <Story name="Default" story={stories.Default} height={200} />
+  <Story name="WithIcon" story={stories.WithIcon} height={200} />
+</Canvas>
+
 ## Hide
 
 Cache la tooltip (par exemple si le contenu est vide).
@@ -69,13 +78,12 @@ Cache la tooltip (par exemple si le contenu est vide).
   <Story name="Hide" story={stories.hide} height={200} />
 </Canvas>
 
-## Default
+## Manual
 
-Infobulle en position `top`, fond sombre (par défaut).
+Annule le comportement par defaut de la tooltip et permet de le forcer dans le component parent
 
 <Canvas>
-  <Story name="Default" story={stories.Default} height={200} />
-  <Story name="WithIcon" story={stories.WithIcon} height={200} />
+  <Story name="Manual" story={stories.manual} height={200} />
 </Canvas>
 
 ## Is Light
@@ -196,6 +204,19 @@ Infobulle contenant des éléments HTML
     Hey
   </:tooltip>
 </PixTooltip>
+
+</PixTooltip>
+
+<PixTooltip
+  @manual={{true}}
+  >
+  <:triggerElement>
+    <button>Tooltip ne se cache plus</button>
+  </:triggerElement>
+
+  <:tooltip>
+    Hey
+  </:tooltip>
 ```
 
 ## Arguments

--- a/docs/test-component-without-release.stories.mdx
+++ b/docs/test-component-without-release.stories.mdx
@@ -4,6 +4,8 @@ import { Meta } from '@storybook/addon-docs/blocks';
 
 # Tester un composant en developpement dans une app
 
+## Sur une version de Pix UI
+
 Il est possible de tester l'intégration d'un composant dans une application
 Ember sans nécessairement créer une nouvelle release.
 
@@ -17,3 +19,15 @@ npm install "git://github.com/1024pix/pix-ui#add-modal-component" --save-dev
 
 Une fois l'application Ember redémarrée, il sera possible d'accéder aux
 composants Pix UI tels qu'ils sont dans la branche en cours de développement.
+
+## Sur votre Pix UI en local
+
+Dans la console Pix UI lancer la commande : `npm link`
+Puis dans la console de votre app : `npm link @1024pix/pix-ui`
+
+Les changements faits sur votre Pix UI se répercuteront sur votre app en local mais n'oubliez pas de rebuild l'app à
+chaque changement Pix UI.
+
+Pour unlink vous pouvez relancer un `npm ci` sur votre app.
+
+


### PR DESCRIPTION
## :boom: BREAKING_CHANGES
Aucun

## :christmas_tree: Problème
Sur Pix Certif nous utilisons PixTooltip d'une manière un peu détournée, lorsque l'on clique sur un copyButton on souhaite faire apparaitre une tooltip qui indique que le texte a bien été copié. Au bout de 2 seconde (timeout) on vide le message à afficher et souhaite donc cacher la tooltip.
Mais suite à la montée de version de PixUI sur Certif la tooltip n'apparaissait plus a cause d'un conflit d'evenement (lors du click sur le bouton on a un focusout sur le tooltip ce qui le ferme).

## :gift: Solution
Ajouter un parametre 'manual' qui permet d'annuler le comportement par défaut de la tooltip (comme les détections des focus et mouseout). 
En manual onvaffiche/cache le tooltip via la props @hide (deja existant)

## :star2: Remarques
Ajout d'une doc pour tester en local et en live les modifs de pix-ui sur notre app.

## :santa: Pour tester
- Ajouter l'option @manual={{true}} et voir que la tooltip s'affiche tout le temps.