### PR TITLE
[BUGFIX] Support de l'état `disabled` et correction de la taille de l'élement Pix Select

### DIFF
--- a/addon/components/pix-select.hbs
+++ b/addon/components/pix-select.hbs
@@ -31,6 +31,7 @@
     {{on "click" this.toggleDropdown}}
     aria-expanded={{this.isAriaExpanded}}
     aria-controls={{this.listId}}
+    aria-disabled={{@isDisabled}}
   >
     {{this.placeholder}}
 
@@ -59,22 +60,20 @@
       </div>
     {{/if}}
     <div role="listbox" id={{this.listId}} class="pix-select__options">
-      {{#if this.displayDefaultOption}}
-        <li
-          class="pix-select-options-category__option{{unless
-              @value
-              ' pix-select-options-category__option--selected'
-            }}"
-          role="option"
-          tabindex={{if this.isExpanded "0" "-1"}}
-          aria-selected={{if @value "false" "true"}}
-          {{on "click" (fn this.onChange this.defaultOption)}}
-          {{on-enter-action (fn this.onChange this.defaultOption)}}
-          {{on-space-action (fn this.onChange this.defaultOption)}}
-        >
-          {{@placeholder}}
-        </li>
-      {{/if}}
+      <li
+        class="pix-select-options-category__option{{unless
+            @value
+            ' pix-select-options-category__option--selected'
+          }}{{unless this.displayDefaultOption ' pix-select-options-category__option--hidden'}}"
+        role="option"
+        tabindex={{if this.isExpanded "0" "-1"}}
+        aria-selected={{if @value "false" "true"}}
+        {{on "click" (fn this.onChange this.defaultOption)}}
+        {{on-enter-action (fn this.onChange this.defaultOption)}}
+        {{on-space-action (fn this.onChange this.defaultOption)}}
+      >
+        {{@placeholder}}
+      </li>
       {{#if this.results}}
         {{#if this.displayCategory}}
           {{#each this.results as |element index|}}

--- a/addon/components/pix-select.js
+++ b/addon/components/pix-select.js
@@ -41,6 +41,9 @@ export default class PixSelect extends Component {
     if (this.args.errorMessage) {
       classes.push('pix-select-button--error');
     }
+    if (this.args.isDisabled) {
+      classes.push('pix-select-button--disabled');
+    }
     return classes.join(' ');
   }
 
@@ -103,6 +106,7 @@ export default class PixSelect extends Component {
   @action
   showDropdown(event) {
     event.preventDefault();
+    if (this.args.isDisabled) return;
 
     this.isExpanded = true;
   }
@@ -118,6 +122,8 @@ export default class PixSelect extends Component {
 
   @action
   onChange(option, event) {
+    if (this.args.isDisabled) return;
+
     this.args.onChange(option.value);
 
     this.hideDropdown(event);
@@ -156,6 +162,21 @@ export default class PixSelect extends Component {
     const checkIconWidth = 16;
     const listWidth = document.getElementById(this.listId).getBoundingClientRect().width;
     const selectWidth = (listWidth + checkIconWidth) / baseFontRemRatio;
-    document.getElementById(`container-${this.selectId}`).style.width = `${selectWidth}rem`;
+
+    const className = `sizing-select-${this.selectId}`;
+    this.createClass(`.${className}`, `width: ${selectWidth}rem;`);
+
+    const element = document.getElementById(`container-${this.selectId}`);
+
+    element.className = element.className + ' ' + className;
+  }
+
+  createClass(name, rules) {
+    var style = document.createElement('style');
+    style.type = 'text/css';
+    document.getElementsByTagName('head')[0].appendChild(style);
+
+    if (!(style.sheet || {}).insertRule) (style.styleSheet || style.sheet).addRule(name, rules);
+    else style.sheet.insertRule(name + '{' + rules + '}', 0);
   }
 }

--- a/addon/styles/_form.scss
+++ b/addon/styles/_form.scss
@@ -5,6 +5,17 @@
   }
 }
 
+@mixin hoverFormElementDisabled() {
+  &:hover {
+    box-shadow: inset 0px 0px 0px 0.6px $pix-neutral-70;
+    background-color: $pix-neutral-20;
+  }
+}
+
+@mixin formElementDisabled() {  
+  background-color: $pix-neutral-20;
+}
+
 @mixin focusFormElement() {
   &:focus {
     border-color: $pix-primary;

--- a/addon/styles/_pix-select.scss
+++ b/addon/styles/_pix-select.scss
@@ -99,6 +99,11 @@
   @include hoverFormElement();
   @include focusWithinFormElement();
 
+  &--disabled {
+    @include formElementDisabled();
+    @include hoverFormElementDisabled();
+  }
+
   &--error {
     @include formElementInError();
   }
@@ -155,6 +160,11 @@
         visibility: visible;
         opacity: 1;
       }
+    }
+
+    &--hidden {
+      visibility: hidden;
+      height: 0;
     }
   }
 }

--- a/app/stories/pix-select.stories.js
+++ b/app/stories/pix-select.stories.js
@@ -34,6 +34,7 @@ export const Template = (args) => {
           @emptySearchMessage={{this.emptySearchMessage}}
           @requiredText={{this.requiredText}}
           @errorMessage={{this.errorMessage}}
+          @isDisabled={{this.isDisabled}}
         />
     `,
     context: args,
@@ -301,6 +302,14 @@ export const argTypes = {
     type: { name: 'string', required: false },
     table: {
       type: { summary: 'string' },
+    },
+  },
+  isDisabled: {
+    name: 'isDisabled',
+    description: "Permet de désactiver l'affichage des options possible",
+    type: { name: 'boolean', required: false },
+    table: {
+      type: { summary: false },
     },
   },
 };

--- a/tests/integration/components/pix-select-test.js
+++ b/tests/integration/components/pix-select-test.js
@@ -141,6 +141,25 @@ module('Integration | Component | PixSelect', function (hooks) {
   });
 
   module('a11y', function () {
+    module('disabled dropdown', function () {
+      test('it should not display list on click', async function (assert) {
+        // given
+        const screen = await render(hbs`<PixSelect
+  @options={{this.options}}
+  @label={{this.label}}
+  @subLabel={{this.subLabel}}
+  @placeholder={{this.placeholder}}
+  @isDisabled={{true}}
+/>`);
+
+        // when
+        await click(await screen.getByLabelText('Mon menu déroulant'));
+
+        // then
+        assert.dom(await screen.findByRole('listbox', { hidden: true })).exists();
+      });
+    });
+
     module('closed dropdown', function () {
       test('it should display list, focus selected element on arrow up press', async function (assert) {
         // given


### PR DESCRIPTION
## :boom: BREAKING_CHANGES
RAS

## :christmas_tree: Problème
La taille du composant étant ajouter sur un style width, pose des souci de surcharge. 
Non prise en compte de la taille du placeholder lorsqu'il n'est pas présent dans la liste.
Nous avons aussi oublié la possibilité de mettre en disabled le select

## :gift: Solution
Ajouter une class css à la volée pour définir la width du composant
Prise en compte du placeholder dans la liste pour le calcul de la width
Ajouter un aria-disabled pour que les utilisateurs de screen reader ne perde pas le focus sur l'element mais sache que l'input est désactivé.

## :star2: Remarques
RAS

## :santa: Pour tester
CI ok, vérifier sur la branche en cours que cela règle le souci