### PR TITLE
[BUGFIX] Supprime la zone blanche non clickable dans les options du `PixSelect` (PIX-6591)

### DIFF
--- a/addon/styles/_pix-select.scss
+++ b/addon/styles/_pix-select.scss
@@ -165,6 +165,7 @@
     &--hidden {
       visibility: hidden;
       height: 0;
+      padding: 0;
     }
   }
 }


### PR DESCRIPTION
## :christmas_tree: Problème
En donnant la valeur `true` au paramètre `hideDefaultOption`, on retrouve une zone blanche inutile en haut des options du `PixSelect`.

https://ui.pix.fr/?path=/story/form-select--default&args=hideDefaultOption:true

<img width="166" alt="image" src="https://user-images.githubusercontent.com/5855339/208465090-2ed71cfa-9ac2-4c03-807a-4e6b833faa14.png">

## :gift: Solution
Cette zone est dû au padding qui reste sur ce block qui devrait être caché. La proposition est de supprimer ce padding.

## :star2: Remarques
RAS

## :santa: Pour tester
Vérifier que cette zone blanche n'est plus là lorsqu'on set ce paramètre : https://ui-pr312.review.pix.fr/?path=/story/form-select--default&args=hideDefaultOption:true.