### PR TITLE
[BUGFIX] Améliorer le comportement du PixSelect (PIX-6775)

### DIFF
--- a/addon/components/pix-select.hbs
+++ b/addon/components/pix-select.hbs
@@ -33,7 +33,7 @@
     aria-controls={{this.listId}}
     aria-disabled={{@isDisabled}}
   >
-    {{this.placeholder}}
+    <span class="pix-select-button__text">{{this.placeholder}}</span>
 
     <FaIcon
       class="pix-select-button__dropdown-icon"

--- a/addon/components/pix-select.js
+++ b/addon/components/pix-select.js
@@ -139,7 +139,7 @@ export default class PixSelect extends Component {
   lockTab(event) {
     if (event.code === 'Tab' && this.isExpanded) {
       event.preventDefault();
-      document.getElementById(this.searchId).focus();
+      if (this.args.isSearchable) document.getElementById(this.searchId).focus();
     }
   }
 

--- a/addon/styles/_pix-select.scss
+++ b/addon/styles/_pix-select.scss
@@ -108,6 +108,12 @@
     @include formElementInError();
   }
 
+  &__text {
+    overflow: hidden;
+    white-space: nowrap;
+    text-overflow: ellipsis;
+  }
+
   &__dropdown-icon {
     @include text-small();
     margin-left: $spacing-xs;

--- a/addon/styles/_pix-select.scss
+++ b/addon/styles/_pix-select.scss
@@ -165,7 +165,8 @@
     &--hidden {
       visibility: hidden;
       height: 0;
-      padding: 0;
+      padding-top: 0;
+      padding-bottom: 0;
     }
   }
 }

--- a/app/stories/pix-select.stories.js
+++ b/app/stories/pix-select.stories.js
@@ -7,6 +7,7 @@ export const Template = (args) => {
       <style>
         .custom {
           border: 0;
+          width: 150px;
         }
         .custom:hover {
           border: 0;


### PR DESCRIPTION
## :boom: BREAKING_CHANGES
RAS

## :christmas_tree: Problème
Le PixSelect ne prenait pas correctement la taille du placeholder pour faire son calcul,
Une erreur dans la console était remontée lorsque le champ de recherche n'était pas disponible mais que l'on tentait de faire une tabulation dans la liste

## :gift: Solution
Ajouter le padding manquant pour le calcul de la width
Vérifier que l'on a bien `isSearchable` à true avant de cibler l'élément

## :star2: Remarques
RAS

## :santa: Pour tester
Vérifier les comportements attendus du Pix Select