### PR TITLE
[TECH] Changement du ratio minimal pour la couleur de fond accessible de 4.5 à 3 (PIX-6802)

### DIFF
--- a/addon/utils/accessible-contrasted-color-generator.js
+++ b/addon/utils/accessible-contrasted-color-generator.js
@@ -24,6 +24,6 @@ export default function (hex) {
     contrast = color.contrast(newColor);
 
     // newColor.luminosity() can return 0.9999..99 when newColor is white but reinstanciating Color with the hexacode #FFFFFF returns 1
-  } while (contrast < 4.5 && Color(newColor.hex()).luminosity() < 1);
+  } while (contrast < 3 && Color(newColor.hex()).luminosity() < 1);
   return newColor.hex();
 }

--- a/tests/unit/utils/accessible-contrasted-color-generator-test.js
+++ b/tests/unit/utils/accessible-contrasted-color-generator-test.js
@@ -10,7 +10,7 @@ module('Unit | Utils | Accessible Contrasted Color Generator', function () {
     const newColor = getAccessibleContrastedColor('#176C4D');
     // then
     const contrast = color.contrast(Color(newColor));
-    assert.ok(contrast >= 4.5);
+    assert.ok(contrast >= 3);
   });
 
   test('It return a dark background color from a light foreground color', function (assert) {
@@ -20,7 +20,7 @@ module('Unit | Utils | Accessible Contrasted Color Generator', function () {
     const newColor = getAccessibleContrastedColor('#edfbf6');
     // then
     const contrast = color.contrast(Color(newColor));
-    assert.ok(contrast >= 4.5);
+    assert.ok(contrast >= 3);
   });
 
   // See this link to have explaination about this edge case : https://github.com/Qix-/color/issues/53#issue-57856520
@@ -31,12 +31,12 @@ module('Unit | Utils | Accessible Contrasted Color Generator', function () {
     const newColor = getAccessibleContrastedColor('#000');
     const contrast = color.contrast(Color(newColor));
     // then
-    assert.ok(contrast >= 4.5);
+    assert.ok(contrast >= 3);
   });
 
-  test("It return the white hexadecimal when the contrast of 4.5 can't be reached", function (assert) {
+  test("It return the white hexadecimal when the contrast of 3 can't be reached", function (assert) {
     // when
-    const color = getAccessibleContrastedColor('#808080');
+    const color = getAccessibleContrastedColor('#B5B5B5');
     // then
     assert.strictEqual(color.toLowerCase(), '#ffffff');
   });


### PR DESCRIPTION
## :christmas_tree: Problème
La génération de la couleur de background avec un ratio minimal de 4.5 retournait quasi constamment du blanc

## :gift: Solution
Suite au début de la formation de Tanaguru, on s'est aperçu que pour les éléments graphiques, il suffisait d'un minimum de ratio de 3.
Donc modification de l'algorithme générant la couleur du background pour qu'il retourne une couleur avec un contrast de 3.0 minimum

## :star2: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :santa: Pour tester
Ouvrir StoryBook, 
Aller dans Other -> IndicatorCard
Mettre une couleur d'icon et vérifier que la couleur générée dans le background à bien un ratio de contrast d'au moins 3.0
