### PR TITLE
[FEATURE] Ajouter un argument IconPrefixe au composant IndicatorCard afin d'autoriser l'utilisation d'icônes personnalisées (PIX-6809)

### DIFF
--- a/addon/components/pix-indicator-card.hbs
+++ b/addon/components/pix-indicator-card.hbs
@@ -10,7 +10,7 @@
       aria-hidden="true"
       {{did-insert this.setIconColor}}
     >
-      <FaIcon @icon={{@icon}} />
+      <FaIcon @icon={{@icon}} @prefix={{@iconPrefix}} />
     </div>
     <dl class="indicator-card__content">
       <div class="indicator-card__title">

--- a/app/stories/pix-indicator-card.stories.js
+++ b/app/stories/pix-indicator-card.stories.js
@@ -8,6 +8,7 @@ const Template = (args) => {
         @title={{this.title}}
         @color={{this.color}}
         @icon={{this.icon}}
+        @iconPrefix={{this.iconPrefix}}
         @info={{this.info}}
         @isLoading={{this.isLoading}}
         @loadingMessage={{this.loadingMessage}}
@@ -33,6 +34,12 @@ Default.args = {
   loadingMessage: 'texte de chargement ScreenReader',
 };
 
+export const withIconPrefix = Template.bind({});
+withIconPrefix.args = {
+  ...Default.args,
+  iconPrefix: 'far',
+};
+
 export const argTypes = {
   title: {
     name: 'Title',
@@ -45,6 +52,12 @@ export const argTypes = {
   icon: {
     name: 'Icon',
     description: "Icone dans l'encart",
+  },
+  iconPrefix: {
+    name: 'IconPrefix',
+    description:
+      "Préfixe pour l'icone dans l'encart - permet d'utiliser une variation de l'icone font awesome différente de celle par défaut (fa).",
+    defaultValue: null,
   },
   value: {
     name: 'Value',

--- a/app/stories/pix-indicator-card.stories.mdx
+++ b/app/stories/pix-indicator-card.stories.mdx
@@ -17,6 +17,11 @@ Une carte est un bloc en 2 parties dont les bords sont arrondis et ayant une omb
   <Story name="Default" story={stories.Default} height={200} />
 </Canvas>
 
+## WithIconPrefix
+<Canvas>
+  <Story name="WithIconPrefix" story={stories.withIconPrefix} height={200} />
+</Canvas>
+
 ## Usage
 
 ```html
@@ -24,6 +29,7 @@ Une carte est un bloc en 2 parties dont les bords sont arrondis et ayant une omb
       @title={{this.title}}
       @color={{this.color}}
       @icon={{this.icon}}
+      @iconPrefix={{this.iconPrefix}}
       @info={{this.info}}
       @isLoading={{this.isLoading}}
       @loadingMessage={{this.loadingMessage}}


### PR DESCRIPTION
## :christmas_tree: Problème
> L'utilisation d'icône font awesome custom dans le composant IndicatorCard nécessite de pouvoir spécifier un préfixe. 

## :gift: Solution
Ajouter un argument supplémentaire au composant.

## :santa: Pour tester
> Sur storybook, depuis l'onglet Canevas de la page du composant IndicatorCard, spécifier 2 préfixes différents : fa / far.
↪️ L'affichage de l'icône change conformément au préfixe renseigné.