### PR TITLE
[FEATURE] Déplacer le focus sur le champ lorsque le bouton pour masquer/afficher le mot de passe est cliqué sur PixInputPassword (PIX-6855)

### DIFF
--- a/addon/components/pix-input-password.js
+++ b/addon/components/pix-input-password.js
@@ -25,5 +25,9 @@ export default class PixInputPassword extends PixInput {
   @action
   togglePasswordVisibility() {
     this.isPasswordVisible = !this.isPasswordVisible;
+    const InputElement = document.getElementById(this.args.id);
+    if (InputElement) {
+      InputElement.focus();
+    }
   }
 }

--- a/addon/styles/_pix-input-password.scss
+++ b/addon/styles/_pix-input-password.scss
@@ -38,6 +38,8 @@
   }
 
   &__button {
+    margin-right: $spacing-xxs;
+
     &:hover,
     &:active,
     &:focus {

--- a/addon/styles/_pix-input-password.scss
+++ b/addon/styles/_pix-input-password.scss
@@ -55,7 +55,6 @@
 
   svg.pix-input-password__error-icon {
     position: absolute;
-    bottom: 10px;
     right: 6px;
     color: $pix-neutral-0;
     background: $pix-error-70;

--- a/addon/styles/_pix-input.scss
+++ b/addon/styles/_pix-input.scss
@@ -25,7 +25,7 @@
 
   svg.pix-input__error-icon {
     position: absolute;
-    bottom: 10px;
+    bottom: 7px;
     right: 6px;
     color: $pix-neutral-0;
     background: $pix-error-70;

--- a/tests/integration/components/pix-input-password-test.js
+++ b/tests/integration/components/pix-input-password-test.js
@@ -1,6 +1,7 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { render } from '@1024pix/ember-testing-library';
+import { click } from '@ember/test-helpers';
 
 import { hbs } from 'ember-cli-htmlbars';
 import createGlimmerComponent from '../../helpers/create-glimmer-component';
@@ -120,5 +121,20 @@ module('Integration | Component | pix-input-password', function (hooks) {
     // then
     const requiredPasswordInput = screen.getByLabelText('* Mot de passe');
     assert.dom(requiredPasswordInput).isRequired();
+  });
+
+  module('when the password visibility button is clicked', function () {
+    test('it should focus on input', async function (assert) {
+      // given
+      const screen = await render(
+        hbs`<PixInputPassword @id='password' @label='Mot de passe' @requiredLabel='Champ obligatoire' />`
+      );
+
+      // when
+      await click(screen.getByRole('button', { name: 'Afficher le mot de passe' }));
+
+      // then
+      assert.dom(screen.getByRole('textbox', { name: 'Mot de passe' })).isFocused();
+    });
   });
 });


### PR DESCRIPTION
## :boom: BREAKING_CHANGES
Nope !

## :christmas_tree: Problème
Concernant les champs mot de passe dans nos applications, L'audit de Tanaguru nous informe que lorsque l'utilisateur clique sur le bouton pour masquer/afficher le mot de passe, soit le focus disparaît (comportement actuel sur le vieux composant Textfield) soit il reste sur le bouton, or il est nécessaire de déplacer le focus sur le champ de texte pour faciliter l'expérience utilisateur. Cela permet aussi de garder une certaine cohérence dans l'ordre de tabulation (pas de retour en arrière nécessaire).

## :gift: Solution
Déplacer le focus sur le champ lorsqu'on clique sur le bouton

AVANT 
<img width="296" alt="Capture d’écran 2023-01-17 à 18 43 52" src="https://user-images.githubusercontent.com/58915422/212972989-47deee64-a4a6-4e88-9aa8-d146674b7fb9.png">
<img width="338" alt="Capture d’écran 2023-01-17 à 18 43 40" src="https://user-images.githubusercontent.com/58915422/212972986-efaf2261-f4fd-4a48-8236-776422db2506.png">

APRES

<img width="294" alt="Capture d’écran 2023-01-17 à 18 42 00" src="https://user-images.githubusercontent.com/58915422/212972739-9f49e8ff-150f-43a9-a690-b6e53e0f0b56.png">
<img width="340" alt="Capture d’écran 2023-01-17 à 18 42 17" src="https://user-images.githubusercontent.com/58915422/212972742-b7cf68e9-6628-494e-96c8-c8ccbe9c2406.png">

## :star2: Remarques
Ajout d'un margin entre le bouton et le champ.
Et fix du placement du svg d'erreur dans le champ.

## :santa: Pour tester

- Aller sur le composant PixInputPassword
- Faire une navigation au clavier pour atteindre le bouton pour masquer/afficher le mot de passer
- Faire entrer
- Constater que le focus passe sur le champs et que l'on peut modifier le mot de passe
- Constater l'espace entre le bouton et le champ et le fix du svg et que tout est conforme.
