### PR TITLE
[TECH] Stabilise le premier lancement de Storybook en dev

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,9 @@
   "scripts": {
     "build": "./scripts/build.sh",
     "build-ember": "ember build --environment=production",
+    "serve-ember": "ember serve",
     "build-storybook": "ember build && cp -v CNAME dist && build-storybook -s dist",
+    "serve-storybook": "start-storybook --port 9001 --static-dir dist",
     "clean": "rm -rf dist node_modules",
     "deploy-storybook": "storybook-to-ghpages",
     "lint": "npm run lint:js && npm run lint:hbs",
@@ -36,7 +38,8 @@
     "lint:js:fix": "npm run lint:js -- --fix",
     "preinstall": "npx check-engine",
     "start": "ember serve",
-    "storybook": "ember build && ember serve & start-storybook -p 9001 -s dist",
+    "prestorybook": "ember build",
+    "storybook": "npm-run-all --parallel serve-ember serve-storybook",
     "test": "ember test",
     "test:ember": "ember test",
     "test:ember-compatibility": "ember try:each"


### PR DESCRIPTION
## :christmas_tree: Problème
En dev, au premier lancement de Storybook, ça ne fonctionne jamais car la commande `start-storybook`  requière un dossier `dist` que ne nous n'avons pas encore.

## :gift: Proposition
Rendre bloquant le `ember build` dans un script `prestorybook` pour s'assurer d'avoir ce dossier `dist`. On peut ensuite paralléliser `ember serve` pour recompiler suite à des modifs de code et `start-storybook`.

## :star2: Remarques
Je préfère les noms de paramètres complets, j'ai donc remplacé `-p` par `--port` et `-s` par `--static-dir` pour que ce soit plus clair.

## :santa: Pour tester
Constater que cette suite d'action permet d'avoir un Storybook local fonctionnel :

1. `npm run clean`
2. `npm ci`
3. `npm run storybook` 
