### PR TITLE
[BUGFIX] Ajouter le paramètre permettant de ne pas afficher la valeur par défaut dans le fat composant (PIX-6925)

### DIFF
--- a/addon/components/pix-filterable-and-searchable-select.hbs
+++ b/addon/components/pix-filterable-and-searchable-select.hbs
@@ -36,6 +36,7 @@
       @isSearchable={{@isSearchable}}
       @searchLabel={{@searchLabel}}
       @screenReaderOnly={{true}}
+      @hideDefaultOption={{@hideDefaultOption}}
       @className="pix-filterable-and-searchable-select__pix-select"
     />
   </div>

--- a/app/stories/pix-filterable-and-searchable-select.stories.js
+++ b/app/stories/pix-filterable-and-searchable-select.stories.js
@@ -8,6 +8,7 @@ const Template = (args) => {
         @subLabel={{this.subLabel}}
         @screenReaderOnly={{this.screenReaderOnly}}
         @placeholder={{this.placeholder}}
+        @hideDefaultOption={{this.hideDefaultOption}}
         @options={{this.options}}
         @onChange={{this.onChange}}
         @categoriesLabel={{this.categoriesLabel}}


### PR DESCRIPTION
## :boom: BREAKING_CHANGES
RAS

## :christmas_tree: Problème
Un paramètre n'a pas été ajouté sur le Pix Searchable Filterable Multi Select pour cacher la valeur par défaut

## :gift: Solution
Ajouter ce paramètre ✋ 🎤 

## :star2: Remarques

## :santa: Pour tester
Vérifier que sur le canvas, le hideDefaultOption fait bien son office