### PR TITLE
[FEATURE] utiliser une div comme tag parent de PixTooltip (PIX-6816)

### DIFF
--- a/addon/components/pix-tooltip.hbs
+++ b/addon/components/pix-tooltip.hbs
@@ -1,4 +1,4 @@
-<span
+<div
   class="pix-tooltip"
   {{on-escape-action this.hideTooltip}}
   {{on "mouseover" this.showTooltip}}
@@ -28,4 +28,4 @@
       </span>
     {{/if}}
   {{/if}}
-</span>
+</div>


### PR DESCRIPTION
## :christmas_tree: Problème
Problème d'a11y : une `span` ne devrait pas être parente d'éléments de bloc (e.g. `div`).

MDN : https://developer.mozilla.org/fr/docs/Web/HTML/Element/span

> Le tag span doit uniquement être utilisé lorsqu'aucun autre élément sémantique n'est approprié. <span> est très proche de l'élément div, mais l'élément div est un élément de bloc, alors que span est un élément en ligne.

## :gift: Solution
Utiliser un tag `div` comme élément parent.

## :star2: Remarques
Déjà avant, cette `span` était transformée en élément bloc en CSS.
La classe `.pix-tooltip` lui apportait la propriété CSS `display: flex`. 

## :santa: Pour tester
- [Vérifier sur Storybook ](https://ui-pr326.review.pix.fr/)que tout fonctionne comme avant.
- Essayer PixApp après avoir fait un `npm install "git://github.com/1024pix/pix-ui#pix-6816-change-tooltip-parent-html-tag" --save-dev` (dans le dossier `mon-pix`) et vérifier que le tooltip fonctionne bien (bloc de points Pix).
