### PR TITLE
[TECH] Remplacer les valeurs d'`id` par du kebab case

### DIFF
--- a/app/stories/pix-checkbox.stories.js
+++ b/app/stories/pix-checkbox.stories.js
@@ -17,27 +17,27 @@ export const Template = (args) => {
 
 export const Default = Template.bind({});
 Default.args = {
-  id: 'acceptNewsletter',
+  id: 'accept-newsletter',
   label: 'Recevoir la newsletter',
 };
 
 export const indeterminateCheckbox = Template.bind({});
 indeterminateCheckbox.args = {
-  id: 'acceptNewsletter2',
+  id: 'accept-newsletter-2',
   label: 'Recevoir la newsletter',
   isIndeterminate: true,
 };
 
 export const checkboxWithSmallLabel = Template.bind({});
 checkboxWithSmallLabel.args = {
-  id: 'acceptNewsletter2',
+  id: 'accept-newsletter-2',
   label: 'Recevoir la newsletter',
   labelSize: 'small',
 };
 
 export const checkboxWithLargeLabel = Template.bind({});
 checkboxWithLargeLabel.args = {
-  id: 'acceptNewsletter2',
+  id: 'accept-newsletter-2',
   label: 'Recevoir la newsletter',
   labelSize: 'large',
 };

--- a/app/stories/pix-input-password.stories.js
+++ b/app/stories/pix-input-password.stories.js
@@ -17,7 +17,7 @@ export const Template = (args) => {
 
 export const Default = Template.bind({});
 Default.args = {
-  id: 'firstName',
+  id: 'first-name',
   ariaLabel: 'Mot de passe',
 };
 

--- a/app/stories/pix-input.stories.js
+++ b/app/stories/pix-input.stories.js
@@ -17,20 +17,20 @@ export const Template = (args) => {
 
 export const Default = Template.bind({});
 Default.args = {
-  id: 'firstName',
+  id: 'first-name',
   ariaLabel: 'Prénom',
 };
 
 export const withLabel = Template.bind({});
 withLabel.args = {
-  id: 'firstName',
+  id: 'first-name',
   label: 'Prénom',
   information: 'a small information',
 };
 
 export const withErrorMessage = Template.bind({});
 withErrorMessage.args = {
-  id: 'firstName',
+  id: 'first-name',
   label: 'Prénom',
   information: 'a small information',
   errorMessage: "un message d'erreur",
@@ -38,7 +38,7 @@ withErrorMessage.args = {
 
 export const withRequiredLabel = Template.bind({});
 withRequiredLabel.args = {
-  id: 'firstName',
+  id: 'first-name',
   label: 'Prénom',
   requiredLabel: 'Champ obligatoire',
 };


### PR DESCRIPTION
## :christmas_tree: Problème
Les `id` sont pour le moment en camelCase. Il est privilégié d'utiliser kebab case.

## :gift: Solution
Utiliser kebab case.

## :star2: Remarques
RAS

## :santa: Pour tester
¯\_(ツ)_/¯ 
