### PR TITLE
[FEATURE] Ajout de l'état de succès pour les composants pixInput et pixInputPassword

### DIFF
--- a/addon/components/pix-input-password.hbs
+++ b/addon/components/pix-input-password.hbs
@@ -14,7 +14,7 @@
   {{/if}}
   <div
     class="pix-input-password__container
-      {{if @errorMessage 'pix-input-password__error-container'}}
+      {{this.validationStatusClassName}}
       {{if @prefix 'pix-input-password__with-prefix'}}"
   >
 
@@ -29,24 +29,29 @@
       aria-label={{this.ariaLabel}}
       aria-required="{{if @requiredLabel true false}}"
       required={{if @requiredLabel true false}}
-      aria-describedby={{if @errorMessage "text-input-password-error"}}
+      aria-describedby={{if (eq @validationStatus "error") "text-input-password-error"}}
       ...attributes
     />
 
     <PixIconButton
-      class="pix-input-password__button {{if @errorMessage ' pix-input-password__error-button'}}"
+      class="pix-input-password__button"
       @icon={{if this.isPasswordVisible "eye" "eye-slash"}}
       @ariaLabel={{if this.isPasswordVisible "Masquer le mot de passe" "Afficher le mot de passe"}}
       @triggerAction={{this.togglePasswordVisibility}}
       @size="small"
     />
 
-    {{#if @errorMessage}}
-      <FaIcon @icon="xmark" class="pix-input-password__error-icon" />
+    {{#if (eq @validationStatus "error")}}
+      <FaIcon @icon="xmark" class="pix-input-password__icon pix-input-password__error-icon" />
+    {{/if}}
+    {{#if (eq @validationStatus "success")}}
+      <FaIcon @icon="check" class="pix-input-password__icon pix-input-password__success-icon" />
     {{/if}}
   </div>
 
-  {{#if @errorMessage}}
-    <p id="text-input-password-error" class="pix-input__error-message">{{@errorMessage}}</p>
+  {{#if (and (eq @validationStatus "error") @errorMessage)}}
+    <p id="text-input-password-error" class="pix-input-password__error-message">
+      {{@errorMessage}}
+    </p>
   {{/if}}
 </div>

--- a/addon/components/pix-input-password.js
+++ b/addon/components/pix-input-password.js
@@ -5,6 +5,12 @@ import { tracked } from '@glimmer/tracking';
 const ERROR_MESSAGE =
   'ERROR in PixInputPassword component, you must provide @label or @ariaLabel params';
 
+const INPUT_VALIDATION_STATUS_MAP = {
+  default: '',
+  error: 'pix-input-password__error-container',
+  success: 'pix-input-password__success-container',
+};
+
 export default class PixInputPassword extends PixInput {
   @tracked isPasswordVisible = false;
 
@@ -29,5 +35,9 @@ export default class PixInputPassword extends PixInput {
     if (InputElement) {
       InputElement.focus();
     }
+  }
+
+  get validationStatusClassName() {
+    return INPUT_VALIDATION_STATUS_MAP[this.args.validationStatus] || '';
   }
 }

--- a/addon/components/pix-input.hbs
+++ b/addon/components/pix-input.hbs
@@ -16,21 +16,24 @@
   <div class="pix-input__container">
     <input
       id={{this.id}}
-      class={{if @errorMessage "pix-input__input--error"}}
+      class="pix-input__input--default {{this.validationStatusClassName}}"
       value={{@value}}
       aria-label={{this.ariaLabel}}
       aria-required="{{if @requiredLabel true false}}"
       required={{if @requiredLabel true false}}
-      aria-describedby={{if @errorMessage "text-input-error"}}
+      aria-describedby={{if (eq @validationStatus "error") "text-input-error"}}
       ...attributes
     />
 
-    {{#if @errorMessage}}
+    {{#if (eq @validationStatus "error")}}
       <FaIcon @icon="xmark" class="pix-input__error-icon" />
+    {{/if}}
+    {{#if (eq @validationStatus "success")}}
+      <FaIcon @icon="check" class="pix-input__success-icon" />
     {{/if}}
   </div>
 
-  {{#if @errorMessage}}
+  {{#if (and (eq @validationStatus "error") @errorMessage)}}
     <p id="text-input-error" class="pix-input__error-message">{{@errorMessage}}</p>
   {{/if}}
 </div>

--- a/addon/components/pix-input.js
+++ b/addon/components/pix-input.js
@@ -2,6 +2,12 @@ import Component from '@glimmer/component';
 
 const ERROR_MESSAGE = 'ERROR in PixInput component, you must provide @label or @ariaLabel params';
 
+const INPUT_VALIDATION_STATUS_MAP = {
+  default: '',
+  error: 'pix-input__input--error',
+  success: 'pix-input__input--success',
+};
+
 export default class PixInput extends Component {
   get id() {
     if (!this.args.id || !this.args.id.toString().trim()) {
@@ -22,5 +28,9 @@ export default class PixInput extends Component {
       throw new Error(ERROR_MESSAGE);
     }
     return this.args.label ? null : this.args.ariaLabel;
+  }
+
+  get validationStatusClassName() {
+    return INPUT_VALIDATION_STATUS_MAP[this.args.validationStatus] || '';
   }
 }

--- a/addon/styles/_pix-input-password.scss
+++ b/addon/styles/_pix-input-password.scss
@@ -53,15 +53,31 @@
     @include formElementInError();
   }
 
-  svg.pix-input-password__error-icon {
+  &__success-container {
+    padding-right: $spacing-m;
+    @include formElementInSuccess();
+  }
+
+  &__icon {
     position: absolute;
     right: 6px;
     color: $pix-neutral-0;
-    background: $pix-error-70;
     border-radius: 50%;
     font-size: 0.6rem;
     padding: 2px;
     width: 18px;
     height: 18px;
+  }
+
+  &__error-icon {
+    background: $pix-error-70;
+  }
+
+  &__success-icon {
+    background: $pix-success-60;
+  }
+
+  &__error-message {
+    @include errorMessage();
   }
 }

--- a/addon/styles/_pix-input-password.scss
+++ b/addon/styles/_pix-input-password.scss
@@ -60,13 +60,13 @@
 
   &__icon {
     position: absolute;
-    right: 6px;
     color: $pix-neutral-0;
     border-radius: 50%;
     font-size: 0.6rem;
     padding: 2px;
-    width: 18px;
-    height: 18px;
+    right: 12px;
+    width: 10px;
+    height: 10px
   }
 
   &__error-icon {

--- a/addon/styles/_pix-input.scss
+++ b/addon/styles/_pix-input.scss
@@ -45,12 +45,6 @@
 
   &__error-message {
     @include errorMessage();
-    margin-bottom: 0;
-    bottom: calc(-4px - 1px - 0.75rem);
-
-    &.pix-input__error-message {
-      margin-top: 4px;
-    }
   }
 
   &__input--default {

--- a/addon/styles/_pix-input.scss
+++ b/addon/styles/_pix-input.scss
@@ -25,14 +25,14 @@
 
   svg {
     position: absolute;
-    bottom: 7px;
-    right: 6px;
     color: $pix-neutral-0;
     border-radius: 50%;
     font-size: 0.6rem;
     padding: 2px;
-    width: 18px;
-    height: 18px;
+    bottom: 11px;
+    right: 12px;
+    width: 10px;
+    height: 10px;
 
     &.pix-input__error-icon {
       background: $pix-error-70;

--- a/addon/styles/_pix-input.scss
+++ b/addon/styles/_pix-input.scss
@@ -23,17 +23,24 @@
     position: relative;
   }
 
-  svg.pix-input__error-icon {
+  svg {
     position: absolute;
     bottom: 7px;
     right: 6px;
     color: $pix-neutral-0;
-    background: $pix-error-70;
     border-radius: 50%;
     font-size: 0.6rem;
     padding: 2px;
     width: 18px;
     height: 18px;
+
+    &.pix-input__error-icon {
+      background: $pix-error-70;
+    }
+
+    &.pix-input__success-icon {
+      background: $pix-success-60;
+    }
   }
 
   &__error-message {
@@ -46,7 +53,7 @@
     }
   }
 
-  input {
+  &__input--default {
     width: 100%;
     height: 36px;
     border: 1px solid $pix-neutral-40;
@@ -58,10 +65,15 @@
     &::placeholder {
       color: $pix-neutral-30;
     }
+  }
 
-    &.pix-input__input--error {
-      padding-right: 32px;
-      @include formElementInError();
-    }
+  &__input--error {
+    padding-right: $spacing-l;
+    @include formElementInError();
+  }
+
+  &__input--success {
+    padding-right: $spacing-l;
+    @include formElementInSuccess();
   }
 }

--- a/addon/styles/pix-design-tokens/_form.scss
+++ b/addon/styles/pix-design-tokens/_form.scss
@@ -12,7 +12,7 @@
   }
 }
 
-@mixin formElementDisabled() {  
+@mixin formElementDisabled() {
   background-color: $pix-neutral-20;
 }
 
@@ -61,6 +61,11 @@
 @mixin formElementInError() {
   border-color: $pix-error-70;
   box-shadow: inset 0px 0px 0px 0.6px $pix-error-70;
+}
+
+@mixin formElementInSuccess() {
+  border-color: $pix-success-60;
+  box-shadow: inset 0px 0px 0px 0.6px $pix-success-60;
 }
 
 @mixin input() {

--- a/app/stories/form.stories.js
+++ b/app/stories/form.stories.js
@@ -9,6 +9,7 @@ export const form = (args) => {
     @label='Prénom'
     @errorMessage={{this.genericErrorMessage}}
     @requiredLabel='champ obligatoire'
+    @validationStatus={{this.validationStatus}}
   />
   <br />
   <PixInputPassword @id='password' @label='Mot de passe' @errorMessage={{this.genericErrorMessage}} />

--- a/app/stories/form.stories.js
+++ b/app/stories/form.stories.js
@@ -16,8 +16,8 @@ export const form = (args) => {
 
   <PixMultiSelect
     @innerText='Votre notation en étoiles...'
-    @id='form__pix-mutli-select'
-    @label='A quel point aimez vous Pix UI ?'
+    @id='form__pix-multi-select'
+    @label='A quel point aimez-vous Pix UI ?'
     @onSelect={{this.onSelect}}
     @selected={{this.selected}}
     @options={{this.options}}
@@ -28,8 +28,8 @@ export const form = (args) => {
   <br /><br />
 
   <PixMultiSelect
-    @innerText='Mes condiements'
-    @id='form__pix-mutli-select-searchable'
+    @innerText='Mes condiments'
+    @id='form__pix-multi-select-searchable'
     @label='Choississez vos condiments'
     @onSelect={{this.onSelect}}
     @selected={{this.selected}}

--- a/app/stories/form.stories.js
+++ b/app/stories/form.stories.js
@@ -82,8 +82,9 @@ export const form = (args) => {
   <PixCheckbox
     @id='spam-pub'
     @labelSize='small'
-    @label='Acceptez-vous de vous faire spammer de PUB ?'
-  />
+  >
+    Acceptez-vous de vous faire spammer de PUB ?
+  </PixCheckbox>
 
   <br /><br />
 

--- a/app/stories/pix-input-password.stories.js
+++ b/app/stories/pix-input-password.stories.js
@@ -10,6 +10,7 @@ export const Template = (args) => {
   @errorMessage={{this.errorMessage}}
   @prefix={{this.prefix}}
   @requiredLabel={{this.requiredLabel}}
+  @validationStatus={{this.validationStatus}}
 />`,
     context: args,
   };
@@ -28,11 +29,19 @@ withLabelAndInformation.args = {
   information: 'Une brève information',
 };
 
-export const withErrorMessage = Template.bind({});
-withErrorMessage.args = {
+export const errorState = Template.bind({});
+errorState.args = {
   id: 'password',
   label: 'Mot de passe',
-  errorMessage: "Un message d'erreur.",
+  errorMessage: "un message d'erreur",
+  validationStatus: 'error',
+};
+
+export const successState = Template.bind({});
+successState.args = {
+  id: 'password',
+  label: 'Mot de passe',
+  validationStatus: 'success',
 };
 
 export const withPrefix = Template.bind({});
@@ -75,9 +84,18 @@ export const argTypes = {
     description: 'Un descriptif complétant le label',
     type: { name: 'string', required: false },
   },
+  validationStatus: {
+    name: 'validationStatus',
+    description:
+      "Définit l'état du champ, neutre par défaut, en succès ou erreur selon l'action de l'utilisateur",
+    type: { name: 'string', required: false },
+    options: ['default', 'success', 'error'],
+    control: { type: 'select' },
+  },
   errorMessage: {
     name: 'errorMessage',
-    description: "Affiche le message d'erreur donné et encadre en rouge le champ",
+    description:
+      "Affiche le message d'erreur donné. Doit s'accompagner du paramètre validationStatus en 'error'",
     type: { name: 'string', required: false },
   },
   prefix: {

--- a/app/stories/pix-input-password.stories.mdx
+++ b/app/stories/pix-input-password.stories.mdx
@@ -29,13 +29,19 @@ Si vous utilisez le `PixInputPassword` sans label alors il faut renseigner le pa
 ## With label and information
 
 <Canvas>
-  <Story story={stories.withLabelAndInformation} height={100} />
+  <Story story={stories.withLabelAndInformation} height={110} />
 </Canvas>
 
-## With error message
+## Error state (with error message)
 
 <Canvas>
-  <Story story={stories.withErrorMessage} height={100} />
+  <Story story={stories.errorState} height={110} />
+</Canvas>
+
+## Success state
+
+<Canvas>
+  <Story story={stories.successState} height={100} />
 </Canvas>
 
 ## With prefix
@@ -59,6 +65,7 @@ Si vous utilisez le `PixInputPassword` sans label alors il faut renseigner le pa
   @information="8 caractères dont une majuscule..."
   @value="pix123"
   @errorMessage="Le mot de passe est erroné"
+  @validationStatus="default"
   @prefix="C-"
   @requiredLabel="Champ obligatoire"
 />

--- a/app/stories/pix-input.stories.js
+++ b/app/stories/pix-input.stories.js
@@ -10,6 +10,7 @@ export const Template = (args) => {
   placeholder='Jeanne, Pierre ...'
   @requiredLabel={{this.requiredLabel}}
   @ariaLabel={{this.ariaLabel}}
+  @validationStatus={{this.validationStatus}}
 />`,
     context: args,
   };
@@ -28,12 +29,19 @@ withLabel.args = {
   information: 'a small information',
 };
 
-export const withErrorMessage = Template.bind({});
-withErrorMessage.args = {
+export const errorState = Template.bind({});
+errorState.args = {
   id: 'first-name',
   label: 'Prénom',
-  information: 'a small information',
   errorMessage: "un message d'erreur",
+  validationStatus: 'error',
+};
+
+export const successState = Template.bind({});
+successState.args = {
+  id: 'first-name',
+  label: 'Prénom',
+  validationStatus: 'success',
 };
 
 export const withRequiredLabel = Template.bind({});
@@ -69,9 +77,18 @@ export const argTypes = {
     description: 'Un descriptif complétant le label',
     type: { name: 'string', required: false },
   },
+  validationStatus: {
+    name: 'validationStatus',
+    description:
+      "Définit l'état du champ, neutre par défaut, en succès ou erreur selon l'action de l'utilisateur",
+    type: { name: 'string', required: false },
+    options: ['default', 'success', 'error'],
+    control: { type: 'select' },
+  },
   errorMessage: {
     name: 'errorMessage',
-    description: "Affiche le message d'erreur donné et encadre en rouge le champ",
+    description:
+      "Affiche le message d'erreur donné. Doit s'accompagner du paramètre validationStatus en 'error'",
     type: { name: 'string', required: false },
   },
   requiredLabel: {

--- a/app/stories/pix-input.stories.mdx
+++ b/app/stories/pix-input.stories.mdx
@@ -43,19 +43,25 @@ screen.getByLabelText('Prénom exemple: Barry');
 ## With label and information
 
 <Canvas>
-  <Story story={stories.withLabel} height={100} />
+  <Story story={stories.withLabel} height={110} />
 </Canvas>
 
-## With error message
+## Error state (with error message)
 
 <Canvas>
-  <Story story={stories.withErrorMessage} height={130} />
+  <Story story={stories.errorState} height={110} />
+</Canvas>
+
+## Success state
+
+<Canvas>
+  <Story story={stories.successState} height={100} />
 </Canvas>
 
 ## With required label
 
 <Canvas>
-  <Story story={stories.withRequiredLabel} height={130} />
+  <Story story={stories.withRequiredLabel} height={100} />
 </Canvas>
 
 ## Usage
@@ -66,6 +72,7 @@ screen.getByLabelText('Prénom exemple: Barry');
   @label="Prénom"
   @information="Complément du label"
   @errorMessage="Un message d`erreur"
+  @validationStatus="default"
   @requiredLabel="Champ obligatoire"
 />
 ```

--- a/tests/integration/components/pix-input-password-test.js
+++ b/tests/integration/components/pix-input-password-test.js
@@ -48,12 +48,17 @@ module('Integration | Component | pix-input-password', function (hooks) {
 
   test('it should be possible to associate an error message to input', async function (assert) {
     // given & when
-    await render(
-      hbs`<PixInputPassword @label='Mot de passe' @id='password' @errorMessage="Un message d'erreur." />`
+    const screen = await render(
+      hbs`<PixInputPassword
+        @label='Mot de passe'
+        @id='password'
+        @errorMessage="Un message d'erreur."
+        @validationStatus="error"
+        />`
     );
 
     // then
-    assert.contains("Un message d'erreur.");
+    assert.dom(screen.getByText("Un message d'erreur.")).exists();
   });
 
   test('it should display an input prefix if necessary', async function (assert) {

--- a/tests/integration/components/pix-input-test.js
+++ b/tests/integration/components/pix-input-test.js
@@ -62,16 +62,17 @@ module('Integration | Component | input', function (hooks) {
 
   test('it should be possible to give an error message to input', async function (assert) {
     // given & when
-    await render(
+    const screen = await render(
       hbs`<PixInput
-  @id='firstName'
-  @label='Prénom'
-  @errorMessage='Seul les caractères alphanumériques sont autorisés'
-/>`
+        @id='firstName'
+        @label='Prénom'
+        @errorMessage='Seul les caractères alphanumériques sont autorisés'
+        @validationStatus="error"
+      />`
     );
 
     // then
-    assert.contains('Seul les caractères alphanumériques sont autorisés');
+    assert.dom(screen.getByText('Seul les caractères alphanumériques sont autorisés')).exists();
   });
 
   test('it should be possible to track value from input', async function (assert) {


### PR DESCRIPTION
## :boom: BREAKING_CHANGES
Impacte les composants `PixInput` et `PixInputPassword` déjà en place sur les applications qui affichent des messages d'erreur suite à validation.

Sans le nouveau paramètre `validationStatus`, le message ne s'affichera pas.

Pensez bien à ajouter l'icon 'check' dans icons.js si ce n'est pas déjà fait !

## :christmas_tree: Problème
Nous n'avons pas implémenté l'état de succès présent dans le design system sur nos composants Pix UI

## :gift: Solution
Ajouter cet état sur les composants PixInput et PixInputPassword.

## :star2: Remarques
https://www.figma.com/file/8RJ3aCSfdeQ8AZZVBBYKS8/Design-System-Pix?node-id=380%3A6585&t=Rrp2uEQtGQyUy6MR-0

Changement de la taille des svg en suivant le design system également.

AVANT 

<img width="455" alt="Capture d’écran 2023-02-01 à 09 53 55" src="https://user-images.githubusercontent.com/58915422/216024651-f570cebe-8dde-4cdf-92dd-2c4232050e75.png">



## :santa: Pour tester
Aller voir la doc du PixInput et constater l'ajout de l'état de succès
Pareil pour PixInputPassword

n'hésitez pas à tester le composant sur l'application de votre choix (ex Pix Orga sur la page de connexion) https://ui-pr328.review.pix.fr/?path=/docs/d%C3%A9veloppement-tester-un-composant-en-developpement-dans-une-app--page