### PR TITLE
[TECH] Améliorations techniques diverses

### DIFF
--- a/app/stories/pix-banner.stories.js
+++ b/app/stories/pix-banner.stories.js
@@ -44,21 +44,21 @@ communicationPixCertif.args = {
 
 export const withExternalLink = Template.bind({});
 withExternalLink.args = {
-  type: 'info',
+  type: 'information',
   actionLabel: 'Voir le nouveau site',
   actionUrl: 'www.test.fr/',
 };
 
 export const withInternalLink = Template.bind({});
 withInternalLink.args = {
-  type: 'info',
+  type: 'information',
   actionLabel: 'Voir la liste des participants',
   actionUrl: 'campaign.list',
 };
 
 export const withCloseIcon = Template.bind({});
 withCloseIcon.args = {
-  type: 'info',
+  type: 'information',
   canCloseBanner: true,
 };
 

--- a/app/stories/pix-indicator-card.stories.js
+++ b/app/stories/pix-indicator-card.stories.js
@@ -58,6 +58,8 @@ export const argTypes = {
     description:
       "Préfixe pour l'icone dans l'encart - permet d'utiliser une variation de l'icone font awesome différente de celle par défaut.",
     table: { defaultValue: { summary: 'fas' } },
+    control: { type: 'select' },
+    options: ['far', 'fas'],
   },
   value: {
     name: 'Value',

--- a/app/stories/pix-tooltip.stories.js
+++ b/app/stories/pix-tooltip.stories.js
@@ -114,13 +114,6 @@ bottom.args = {
   position: 'bottom',
 };
 
-export const hide = Template.bind({});
-hide.args = {
-  label: 'À survoler pour voir la tooltip',
-  text: "Ne devrait pas s'afficher",
-  hide: true,
-};
-
 export const WithHTML = TemplateWithHTMLElement.bind({});
 WithHTML.args = {
   label: 'À survoler pour voir la tooltip',
@@ -130,6 +123,13 @@ export const WithIcon = TemplateWithIconElement.bind({});
 WithIcon.args = {
   text: 'Hello World',
   label: 'À survoler pour voir la tooltip',
+};
+
+export const hide = Template.bind({});
+hide.args = {
+  label: "Survoler ici n'affiche pas tooltip",
+  text: "Ne devrait pas s'afficher",
+  hide: true,
 };
 
 export const argTypes = {

--- a/app/stories/pix-tooltip.stories.js
+++ b/app/stories/pix-tooltip.stories.js
@@ -127,7 +127,7 @@ WithHTML.args = {
 };
 
 export const WithIcon = TemplateWithIconElement.bind({});
-Default.args = {
+WithIcon.args = {
   text: 'Hello World',
   label: 'À survoler pour voir la tooltip',
 };

--- a/app/stories/pix-tooltip.stories.mdx
+++ b/app/stories/pix-tooltip.stories.mdx
@@ -55,14 +55,6 @@ Les tooltips doivent prendre un `@id` et être référencées par leur élément
 </PixTooltip>
 ```
 
-## Hide
-
-Cache la tooltip (par exemple si le contenu est vide).
-
-<Canvas>
-  <Story name="Hide" story={stories.hide} height={200} />
-</Canvas>
-
 ## Default
 
 Infobulle en position `top`, fond sombre (par défaut).
@@ -115,6 +107,14 @@ Infobulle contenant des éléments HTML
 
 <Canvas>
   <Story name="WithHTML" story={stories.WithHTML} height={200} />
+</Canvas>
+
+## Hide
+
+Cache la tooltip (par exemple si le contenu est vide).
+
+<Canvas>
+  <Story name="Hide" story={stories.hide} height={200} />
 </Canvas>
 
 ## Usage


### PR DESCRIPTION
## :christmas_tree: Problèmes
1. `PixBanner` : La démo de utilise une valeur inexistante `info`.
2. DX démo `PixIndicatorCard` : On ne peut pas changer la valeur du champ `IconPrefix`
3. `PixTooltip` : On modifie la story de démo par erreur
4. `PixTooltip` : La première démo est un comportement très à la marge qui ne met pas en évidence l'utilité de ce composant

## :gift: Solutions
1. Utiliser la bonne valeur `information`.
2. Permettre de choisir la variante d’icône fontawesome que l'on souhaite utiliser avec une liste prédéfinie.
3. Modifier la démo souhaitée `WithIcon` plutôt que celle de `Default`
4. Déplacer la démo `Hide` en fin de page et remettre par défaut `Default`

## :star2: Remarques
RAS

## :santa: Pour tester
1. Vérifier que les démos de [`PixBanner`](https://ui-pr329.review.pix.fr/?path=/docs/notification-banner--default) fonctionnent toujours en RA.
2. Vérifier qu'on peut interagir avec le champ `IconPrefix` du composant [`PixIndicatorCard`](https://ui-pr329.review.pix.fr/?path=/story/others-indicator-card--default)
3. et 4. Constater que la première démo est plus parlante : https://ui-pr329.review.pix.fr/?path=/docs/basics-tooltip