### PR TITLE
[BREAKING CHANGES] Ajouter une min-width au PixIconButton (PIX-7003)

### DIFF
--- a/addon/styles/_pix-icon-button.scss
+++ b/addon/styles/_pix-icon-button.scss
@@ -39,14 +39,16 @@
   }
 
   &--small {
-    width: 32px;
-    height: 32px;
+    width: 2rem;
+    min-width: 2rem;
+    height: 2rem;
     font-size: 1rem;
   }
 
   &--big {
-    width: 38px;
-    height: 38px;
+    width: 2.375rem;
+    min-width: 2.375rem;
+    height: 2.375rem;
     font-size: 1.25rem;
   }
 }


### PR DESCRIPTION
## :boom: BREAKING_CHANGES
Pour un souci d'accessibilité nous avons passé la taille du bouton en rem. Ce qui pourrait engendrer des modifications sur nos applis Front

## :christmas_tree: Problème
L'icône Button se retrouvait à avoir sa width écrasée dans certains cas.

## :gift: Solution
Ajouter une min-width égale à la width

## :star2: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :santa: Pour tester
Verifier le visuel du pixIconButton