### PR TITLE
[TECH] Ajouter la configuration pour Renovate

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,0 +1,5 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["github>1024pix/renovate-config:default"],
+  "enabled": true
+}


### PR DESCRIPTION
## :christmas_tree: Problème
Les montées de version sont faites manuellement et par conséquent sont oubliées. 

## :gift: Solution
Ajouter comme dans nos autres repository la configuration pour Renovate.
J'ai décidé de mettre la version par défaut car je ne connais pas le couverture de nos tests et notre confiance sur ceux-ci. Ce veut dire qu'il faudra approve les PRs. 

## :star2: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :santa: Pour tester
> _Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc._
