### PR TITLE
[BUGFIX] utiliser la font-size du navigateur pour le calcul de la taille du PixSelect (PIX-7128)

### DIFF
--- a/addon/components/pix-select.js
+++ b/addon/components/pix-select.js
@@ -158,8 +158,10 @@ export default class PixSelect extends Component {
 
   @action
   setSelectWidth() {
-    const baseFontRemRatio = 16;
-    const checkIconWidth = 16;
+    const baseFontRemRatio = Number(
+      getComputedStyle(document.querySelector('html')).fontSize.match(/\d+(\.\d+)?/)[0]
+    );
+    const checkIconWidth = 1.125 * baseFontRemRatio;
     const listWidth = document.getElementById(this.listId).getBoundingClientRect().width;
     const selectWidth = (listWidth + checkIconWidth) / baseFontRemRatio;
 

--- a/addon/styles/_pix-select.scss
+++ b/addon/styles/_pix-select.scss
@@ -13,11 +13,10 @@
   &__dropdown {
     z-index: 200;
     position: absolute;
-    border-top: none;
-    border-radius: 0 0 4px 4px;
-    overflow-y: auto;
     max-height: 200px;
     width: inherit;
+    border-top: none;
+    border-radius: 0 0 4px 4px;
     list-style-type: none;
     padding: 0;
     background-color: $pix-neutral-0;
@@ -69,6 +68,8 @@
   }
 
   &__options {
+    overflow-y: auto;
+    max-height: inherit;
     border-top: 1px solid $pix-neutral-20;
   }
 


### PR DESCRIPTION
## :christmas_tree: Problème

![image](https://user-images.githubusercontent.com/7335131/218762545-93d4896a-b357-4330-bf4d-57b3acaf8c99.png)

Sur Firefox, si l'utilisateur avait en paramétrage un zoom sur le texte spécifique, le calcul de la largeur du PixSelect ne se faisait pas bien car la taille de police de base pour le REM était entrée en dur dans le code.

<img width="223" alt="image" src="https://user-images.githubusercontent.com/7335131/218762090-48566766-5325-40ce-841d-5de7aa555f7d.png">

## :gift: Solution

Corriger en récupérant en JS cette valeur sur la balise HTML

## :santa: Pour tester

- Faire un `npm install "git://github.com/1024pix/pix-ui#pix-7128-fix-select-computed-width" --save-dev` dans `mon-pix` en local
- Lancer Pix App 
- Aller sur Firefox et paramétrer un zoom à 67% avec le checkbox "Agrandir uniquement le texte" cochée ✅
- http://localhost:4200/challenges/rechUXZhn1FiLU28x/preview
- http://localhost:4200/challenges/challenge100CwAWFBUtwf8/preview
- Vérifier que les PixSelect soient bons, et pas comme dans l'image de la partie "Problème"

