### PR TITLE
[FEATURE] Permettre au PixButton d'avoir des icônes avant et après le label (PIX-3038)

### DIFF
--- a/addon/components/pix-button.hbs
+++ b/addon/components/pix-button.hbs
@@ -24,7 +24,13 @@
       </div>
       <span class="loader__not-visible-text">{{yield}}</span>
     {{else}}
+      {{#if @iconBefore}}
+        <FaIcon class="pix-button__icon pix-button__icon--before" @icon={{@iconBefore}} />
+      {{/if}}
       {{yield}}
+      {{#if @iconAfter}}
+        <FaIcon class="pix-button__icon pix-button__icon--after" @icon={{@iconAfter}} />
+      {{/if}}
     {{/if}}
   </button>
 {{/if}}

--- a/addon/styles/_pix-button.scss
+++ b/addon/styles/_pix-button.scss
@@ -1,43 +1,53 @@
-.pix-button {
-  .loader {
-    position: absolute;
+.pix-button__icon {
+  height: 1rem;
 
-    &__not-visible-text {
-      visibility: hidden;
-    }
+  &--before {
+    margin-right: $spacing-xs;
   }
 
-  .loader > div {
-    width: 10px;
-    height: 10px;
-    background-color: $pix-neutral-0;
-    border-radius: 100%;
-    display: inline-block;
-    animation: sk-bouncedelay 1.4s infinite ease-in-out both;
+  &--after {
+    margin-left: $spacing-xs;
   }
+}
 
-  .loader--white > div {
-    background-color: $pix-neutral-0;
-  }
-  .loader--grey > div {
-    background-color: $pix-neutral-80;
-  }
-  .loader .bounce1 {
-    animation-delay: -0.32s;
-  }
+.pix-button .loader {
+  position: absolute;
 
-  .loader .bounce2 {
-    animation-delay: -0.16s;
+  &__not-visible-text {
+    visibility: hidden;
   }
+}
 
-  @keyframes sk-bouncedelay {
-    0%,
-    80%,
-    100% {
-      transform: scale(0);
-    }
-    40% {
-      transform: scale(1);
-    }
+.loader > div {
+  width: 10px;
+  height: 10px;
+  background-color: $pix-neutral-0;
+  border-radius: 100%;
+  display: inline-block;
+  animation: sk-bouncedelay 1.4s infinite ease-in-out both;
+}
+
+.loader--white > div {
+  background-color: $pix-neutral-0;
+}
+.loader--grey > div {
+  background-color: $pix-neutral-80;
+}
+.loader .bounce1 {
+  animation-delay: -0.32s;
+}
+
+.loader .bounce2 {
+  animation-delay: -0.16s;
+}
+
+@keyframes sk-bouncedelay {
+  0%,
+  80%,
+  100% {
+    transform: scale(0);
+  }
+  40% {
+    transform: scale(1);
   }
 }

--- a/app/stories/pix-button.stories.js
+++ b/app/stories/pix-button.stories.js
@@ -11,6 +11,8 @@ const Template = (args) => ({
     @isLoading={{this.isLoading}}
     @size={{this.size}}
     @isBorderVisible={{this.isBorderVisible}}
+    @iconBefore={{this.iconBefore}}
+    @iconAfter={{this.iconAfter}}
   >
     {{this.label}}
   </PixButton>
@@ -26,6 +28,8 @@ const Template = (args) => ({
       @isLoading={{button.isLoading}}
       @size={{button.size}}
       @isBorderVisible={{button.isBorderVisible}}
+      @iconBefore={{button.iconBefore}}
+      @iconAfter={{button.iconAfter}}
     >
       {{button.label}}
     </PixButton>
@@ -101,6 +105,13 @@ colors.args = {
       isBorderVisible: true,
     },
   ],
+};
+
+export const icons = Template.bind({});
+icons.args = {
+  ...Default.args,
+  iconBefore: 'magnifying-glass',
+  iconAfter: 'heart',
 };
 
 export const disabled = Template.bind({});
@@ -194,6 +205,28 @@ export const argsTypes = {
     table: {
       type: { summary: 'string' },
       defaultValue: { summary: 'blue' },
+    },
+  },
+  iconBefore: {
+    name: 'iconBefore',
+    description: `Nom de l'icône font-awesome à afficher **avant** le label`,
+    type: { name: 'string', required: false },
+    control: { type: 'select' },
+    options: ['heart', 'magnifying-glass', 'plus', 'xmark'],
+    table: {
+      type: { summary: 'string' },
+      defaultValue: { summary: null },
+    },
+  },
+  iconAfter: {
+    name: 'iconAfter',
+    description: `Nom de l'icône font-awesome à afficher **après** le label`,
+    type: { name: 'string', required: false },
+    control: { type: 'select' },
+    options: ['heart', 'magnifying-glass', 'plus', 'xmark'],
+    table: {
+      type: { summary: 'string' },
+      defaultValue: { summary: null },
     },
   },
   isDisabled: {

--- a/app/stories/pix-button.stories.mdx
+++ b/app/stories/pix-button.stories.mdx
@@ -29,6 +29,16 @@ Le bouton avec toutes ses variations de couleur
   <Story story={stories.colors} height={500} />
 </Canvas>
 
+## Icons
+
+Le bouton avec des icônes `font-awesome` à afficher avant (`@iconBefore`) ou après (`@iconAfter`) le label.
+
+> ℹ️ Accessibilité : dans le cas où les icônes ont une valeur d'information (ex:&nbsp;un bouton `⬅️ Précédent`), il est important d'apporter un aria-label au bouton (ex:&nbsp;"Retour à la page précédente").
+
+<Canvas isColumn>
+  <Story story={stories.icons} height={75} />
+</Canvas>
+
 ## Disabled
 
 Le bouton désactivé

--- a/tests/integration/components/pix-button-test.js
+++ b/tests/integration/components/pix-button-test.js
@@ -54,6 +54,22 @@ module('Integration | Component | button', function (hooks) {
     assert.true(componentElement.disabled);
   });
 
+  test('it renders the PixButton component with iconBefore and iconAfter attributes', async function (assert) {
+    //when
+    await render(hbs`
+      <PixButton @iconBefore='plus' @iconAfter='plus' aria-label='button label'>
+        Mon bouton
+      </PixButton>
+    `);
+
+    // then
+    const iconBefore = this.element.querySelector('.pix-button__icon--before');
+    assert.ok(iconBefore);
+
+    const iconAfter = this.element.querySelector('.pix-button__icon--after');
+    assert.ok(iconAfter);
+  });
+
   test('it should call the action', async function (assert) {
     // given
     this.set('count', 1);


### PR DESCRIPTION
## :christmas_tree: Problème

Le composant n'a pas de propriété spécifique pour ajouter des icônes avant ou après le label, alors que c'est [prévu dans le Design System](https://www.figma.com/file/8RJ3aCSfdeQ8AZZVBBYKS8/Design-System-Pix?node-id=56%3A23&t=LRMu0Csa8MUqrZjQ-4).

## :gift: Solution

Ajouter les propriétés `@iconBefore` et `iconAfter` qui prennent un nom d'icône de _font-awesome_ en valeur.

## :star2: Remarques

Où trouver une liste des icônes utilisables ?

## :santa: Pour tester

- Aller sur la [RA de Pix UI](https://ui-pr338.review.pix.fr/?path=/docs/basics-button--icons#icons)
- Vérifier la story des icônes dans le PixButton
