### PR TITLE
[FEATURE] Accorder le style du PixCollapsible au Design System (PIX-7164)

### DIFF
--- a/addon/components/pix-collapsible.hbs
+++ b/addon/components/pix-collapsible.hbs
@@ -1,16 +1,16 @@
-<div class="pix-collapsible {{if this.isUnCollapsed 'pix-collapsible--uncollapsed'}}">
+<div class="pix-collapsible">
 
   <button
+    class="pix-collapsible__title"
     type="button"
     {{on "click" this.toggleCollapsible}}
-    class="pix-collapsible__title {{if this.isUnCollapsed 'pix-collapsible__title--uncollapsed'}}"
     aria-controls={{this.contentId}}
     aria-expanded={{if this.isUnCollapsed "true" "false"}}
     ...attributes
   >
-    <span class="pix-collapsible-title__container">
+    <span class="pix-collapsible-title__label">
       {{#if @titleIcon}}
-        <FaIcon @icon={{@titleIcon}} class="pix-collapsible-title__icon" />
+        <FaIcon class="pix-collapsible-title__icon" @icon={{@titleIcon}} />
       {{/if}}
 
       {{#if (has-block "title")}}
@@ -21,19 +21,16 @@
     </span>
 
     <FaIcon
-      @icon="{{if this.isCollapsed 'plus' 'minus'}}"
       class="pix-collapsible-title__toggle-icon"
+      @icon="{{if this.isCollapsed 'chevron-down' 'chevron-up'}}"
     />
   </button>
 
   <div
     id={{this.contentId}}
+    class="pix-collapsible__content"
     aria-hidden={{if this.isCollapsed "true" "false"}}
-    class="pix-collapsible__content
-      {{if this.isUnCollapsed ' pix-collapsible__content--uncollapse'}}"
   >
-    {{#if this.isContentRendered}}
-      {{yield}}
-    {{/if}}
+    {{yield}}
   </div>
 </div>

--- a/addon/components/pix-collapsible.js
+++ b/addon/components/pix-collapsible.js
@@ -14,10 +14,6 @@ export default class PixCollapsible extends Component {
     return !this.isCollapsed;
   }
 
-  get isContentRendered() {
-    return this.hasUnCollapsedOnce;
-  }
-
   get title() {
     if (!this.args.title || !this.args.title.trim()) {
       throw new Error('ERROR in PixCollapsible component, @title param is not provided');

--- a/addon/styles/_pix-collapsible.scss
+++ b/addon/styles/_pix-collapsible.scss
@@ -1,93 +1,78 @@
 .pix-collapsible {
-  width: 100%;
-  display: flex;
-  flex-direction: column;
-  font-family: $font-roboto;
-  font-size: 1rem;
-  padding: 0;
-  cursor: pointer;
   border: 1px solid $pix-neutral-20;
   background-color: $pix-neutral-0;
 
-  &:first-child {
-    border-top: 1px solid $pix-neutral-20;
-    border-top-left-radius: 4px;
-    border-top-right-radius: 4px;
+  &:first-child,
+  &:first-child .pix-collapsible__title {
+    border-top-left-radius: 0.5rem;
+    border-top-right-radius: 0.5rem;
   }
 
-  &:last-child {
-    border-bottom-left-radius: 4px;
-    border-bottom-right-radius: 4px;
+  &:last-child,
+  &:last-child .pix-collapsible__title:not([aria-expanded='true']) {
+    border-bottom-left-radius: 0.5rem;
+    border-bottom-right-radius: 0.5rem;
   }
 
-  &--uncollapsed {
-    box-shadow: 0 2px 5px 0 rgba($pix-neutral-110, 0.05);
-    border-radius: 4px;
-  }
-
-  &--uncollapsed:not(:first-child) {
-    margin-top: 10px;
-  }
-
-  &--uncollapsed:not(:last-child) {
-    margin-bottom: 10px;
+  &:not(:first-child) {
+    border-top: none;
   }
 }
 
 .pix-collapsible__title {
-  padding: 14px 16px;
-  min-width: 100%;
-  cursor: pointer;
   display: flex;
   justify-content: space-between;
-  background: transparent;
-  border: none;
-  color: $pix-neutral-60;
-  font-size: 1rem;
   align-items: center;
+  width: 100%;
+  padding: $spacing-s;
+  border: none;
+  color: $pix-neutral-90;
+  font-size: 1rem;
+  line-height: 1.25;
 
-  &:hover {
+  &:hover,
+  &:focus,
+  &[aria-expanded='true'] {
     background-color: $pix-neutral-10;
   }
 
-  &:focus {
-    background-color: $pix-neutral-10;
-  }
-
-  &--uncollapsed {
-    background-color: $pix-neutral-10;
+  &[aria-expanded='true'] {
+    border-bottom: 1px solid $pix-neutral-20;
   }
 }
 
 .pix-collapsible-title {
   &__container {
-    align-items: center;
     display: flex;
+    align-items: center;
     flex-grow: 1;
   }
 
   &__icon {
-    color: $pix-neutral-45;
-    margin-right: 6px;
+    margin-right: $spacing-xs;
+    color: $pix-neutral-50;
   }
 
   &__toggle-icon {
-    color: $pix-neutral-45;
-    margin-left: 16px;
+    width: 1rem;
+    height: 1rem;
+    padding: 0.5rem;
+    margin-left: $spacing-xs;
+    border-radius: 50%;
   }
+}
+
+.pix-collapsible__title:hover .pix-collapsible-title__toggle-icon {
+  background-color: $pix-neutral-20;
 }
 
 .pix-collapsible__content {
-  padding: 16px 20px;
-  display: none;
+  padding: $spacing-s;
+  font-size: 0.875rem;
+  line-height: 1.25rem;
+  color: $pix-neutral-60;
 
-  &--uncollapse {
-    display: initial;
+  &[aria-hidden='true'] {
+    display: none;
   }
-}
-
-// Pour le deuxième élément d'affilé qui est refermé, on enlève la bordure-top
-.pix-collapsible:not(.pix-collapsible--uncollapsed)
-+ .pix-collapsible:not(.pix-collapsible--uncollapsed) {
-  border-top: none;
 }

--- a/addon/styles/_pix-collapsible.scss
+++ b/addon/styles/_pix-collapsible.scss
@@ -4,88 +4,86 @@
   flex-direction: column;
   font-family: $font-roboto;
   font-size: 1rem;
-  border: 1px solid $pix-neutral-20;
   padding: 0;
   cursor: pointer;
+  border: 1px solid $pix-neutral-20;
   background-color: $pix-neutral-0;
 
-  &__title {
-    padding: 14px 16px;
-    min-width: 100%;
-    cursor: pointer;
-    display: flex;
-    justify-content: space-between;
-    background: transparent;
-    border: none;
-    color: $pix-neutral-60;
-    font-size: 1rem;
+  &:first-child {
+    border-top: 1px solid $pix-neutral-20;
+    border-top-left-radius: 4px;
+    border-top-right-radius: 4px;
+  }
+
+  &:last-child {
+    border-bottom-left-radius: 4px;
+    border-bottom-right-radius: 4px;
+  }
+
+  &--uncollapsed {
+    box-shadow: 0 2px 5px 0 rgba($pix-neutral-110, 0.05);
+    border-radius: 4px;
+  }
+
+  &--uncollapsed:not(:first-child) {
+    margin-top: 10px;
+  }
+
+  &--uncollapsed:not(:last-child) {
+    margin-bottom: 10px;
+  }
+}
+
+.pix-collapsible__title {
+  padding: 14px 16px;
+  min-width: 100%;
+  cursor: pointer;
+  display: flex;
+  justify-content: space-between;
+  background: transparent;
+  border: none;
+  color: $pix-neutral-60;
+  font-size: 1rem;
+  align-items: center;
+
+  &:hover {
+    background-color: $pix-neutral-10;
+  }
+
+  &:focus {
+    background-color: $pix-neutral-10;
+  }
+
+  &--uncollapsed {
+    background-color: $pix-neutral-10;
+  }
+}
+
+.pix-collapsible-title {
+  &__container {
     align-items: center;
-
-    &:hover {
-      background-color: $pix-neutral-10;
-    }
-
-    &:focus {
-      background-color: $pix-neutral-10;
-    }
-
-    &--uncollapsed {
-      background-color: $pix-neutral-10;
-    }
+    display: flex;
+    flex-grow: 1;
   }
 
-  &-title {
-
-    &__container {
-      align-items: center;
-      display: flex;
-      flex-grow: 1;
-    }
-
-    &__icon{
-      color: $pix-neutral-45;
-      margin-right: 6px;
-    }
-
-    &__toggle-icon{
-      color: $pix-neutral-45;
-      margin-left: 16px;
-    }
+  &__icon {
+    color: $pix-neutral-45;
+    margin-right: 6px;
   }
 
-  &__content {
-    padding: 16px 20px;
-    display: none;
-
-    &--uncollapse {
-      display: initial;
-    }
+  &__toggle-icon {
+    color: $pix-neutral-45;
+    margin-left: 16px;
   }
 }
 
-.pix-collapsible:first-child {
-  border-top-left-radius: 4px;
-  border-top-right-radius: 4px;
-}
+.pix-collapsible__content {
+  padding: 16px 20px;
+  display: none;
 
-.pix-collapsible:last-child {
-  border-bottom-left-radius: 4px;
-  border-bottom-right-radius: 4px;
-}
-
-.pix-collapsible--uncollapsed {
-  margin-top: 10px;
-  margin-bottom: 10px;
-  box-shadow: 0 2px 5px 0 rgba($pix-neutral-110, 0.05);
-  border-radius: 4px;
-}
-
-.pix-collapsible--uncollapsed:first-child {
-  margin-top: 0;
-}
-
-.pix-collapsible--uncollapsed:last-child {
-  margin-bottom: 0;
+  &--uncollapse {
+    display: initial;
+  }
 }
 
 // Pour le deuxième élément d'affilé qui est refermé, on enlève la bordure-top

--- a/tests/integration/components/pix-collapsible-test.js
+++ b/tests/integration/components/pix-collapsible-test.js
@@ -15,7 +15,7 @@ module('Integration | Component | collapsible', function (hooks) {
 
     // then
     assert.dom(screen.queryByText('Titre de mon élément déroulable')).isVisible();
-    assert.dom(screen.queryByText('Contenu de mon élément')).doesNotExist();
+    assert.dom(screen.queryByText('Contenu de mon élément')).isNotVisible();
   });
 
   test('it should render and show content on click on PixCollapsible title', async function (assert) {


### PR DESCRIPTION
## :christmas_tree: Problème

Le PixCollapsible avait un style qui n'était pas celui [présent dans le Design System](https://www.figma.com/file/8RJ3aCSfdeQ8AZZVBBYKS8/Design-System-Pix?node-id=484%3A6182&t=ywpjKC2ilkBuD7FK-4).

## :gift: Solution

Adapter le style pour qu'il corresponde à celui souhaité.

## :star2: Remarques

1. Il n'y a maintenant plus d'espace entre les collapsibles lorsqu'ils sont ouverts.
2. Vu avec Quentin, il y a une bordure de 2px entre 2 collapsibles sur Figma, mais il veut en fait 1px.

## :santa: Pour tester

- Comparer le composant de [la RA](https://ui-pr339.review.pix.fr/?path=/story/others-collapsible--collapsible) avec [le Figma](https://www.figma.com/file/8RJ3aCSfdeQ8AZZVBBYKS8/Design-System-Pix?node-id=484%3A6182&t=ywpjKC2ilkBuD7FK-4).
