### PR TITLE
[BUGFIX] Ne pas permettre le focus de l'option par défaut cachée du PixSelect (PIX-7196)

### DIFF
--- a/addon/components/pix-select.hbs
+++ b/addon/components/pix-select.hbs
@@ -66,7 +66,7 @@
             ' pix-select-options-category__option--selected'
           }}{{unless this.displayDefaultOption ' pix-select-options-category__option--hidden'}}"
         role="option"
-        tabindex={{if this.isExpanded "0" "-1"}}
+        tabindex={{if this.isDefaultOptionHidden "-1" "0"}}
         aria-selected={{if @value "false" "true"}}
         {{on "click" (fn this.onChange this.defaultOption)}}
         {{on-enter-action (fn this.onChange this.defaultOption)}}

--- a/addon/components/pix-select.js
+++ b/addon/components/pix-select.js
@@ -33,6 +33,10 @@ export default class PixSelect extends Component {
     return !this.searchValue && !this.args.hideDefaultOption;
   }
 
+  get isDefaultOptionHidden() {
+    return !this.isExpanded || this.args.hideDefaultOption;
+  }
+
   get className() {
     const classes = ['pix-select-button'];
     if (this.args.className) {

--- a/tests/integration/components/pix-select-test.js
+++ b/tests/integration/components/pix-select-test.js
@@ -110,6 +110,7 @@ module('Integration | Component | PixSelect', function (hooks) {
       await screen.findByRole('listbox');
 
       // then
+      assert.strictEqual(screen.queryByText(this.placeholder, { selector: 'li' }).tabIndex, -1);
       assert.strictEqual(screen.queryByRole('option', { name: this.placeholder }), null);
     });
   });


### PR DESCRIPTION
## :christmas_tree: Problème

Jusqu'à présent, l’option par défaut non sélectionnable avait un `tabindex="0"` et était donc focusable et causait des problèmes de navigation au clavier.

## :gift: Solution

Passer ce `tabindex` à `-1`

## :santa: Pour tester

- Aller à [cette URL de story PixSelect](https://ui-pr340.review.pix.fr/?path=/story/form-select--default&args=hideDefaultOption:true)
- Checker le DOM et vérifier que la première option a un `tabindex="-1"`, même quand le Select est ouvert
- Tester la navigation clavier
