### PR TITLE
[TECH] Active la règle de lint SCSS d'ajout d'espace après les `:`

### DIFF
--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -7,7 +7,6 @@
     "comment-empty-line-before": null,
     "declaration-block-no-redundant-longhand-properties": null,
     "declaration-block-single-line-max-declarations": null,
-    "declaration-colon-space-after": null,
     "declaration-empty-line-before": null,
     "font-family-name-quotes": null,
     "font-family-no-duplicate-names": null,

--- a/addon/styles/normalize-reset/_reset.scss
+++ b/addon/styles/normalize-reset/_reset.scss
@@ -8,13 +8,13 @@ body {
 }
 *,
 *::before,
-*::after{box-sizing:border-box;}
-a{text-decoration:none; color:inherit; cursor:pointer;}
-button{background-color:transparent; color:inherit; border-width:0; padding:0; cursor:pointer;}
-figure{margin:0;}
-input::-moz-focus-inner {border:0; padding:0; margin:0;}
-ul, ol, dd{margin:0; padding:0; list-style:none;}
-h1, h2, h3, h4, h5, h6{margin:0; font-size:inherit; font-weight:inherit;}
-p{margin:0;}
-cite {font-style:normal;}
-fieldset{border-width:0; padding:0; margin:0;}
+*::after{box-sizing: border-box;}
+a{text-decoration: none; color: inherit; cursor: pointer;}
+button{background-color: transparent; color: inherit; border-width: 0; padding: 0; cursor: pointer;}
+figure{margin: 0;}
+input::-moz-focus-inner {border: 0; padding: 0; margin: 0;}
+ul, ol, dd{margin: 0; padding: 0; list-style: none;}
+h1, h2, h3, h4, h5, h6{margin: 0; font-size: inherit; font-weight: inherit;}
+p{margin: 0;}
+cite {font-style: normal;}
+fieldset{border-width: 0; padding: 0; margin: 0;}


### PR DESCRIPTION
## :christmas_tree: Problème
On désactive une règle de lint utile.

## :gift: Solution
Réactiver cette règle et corriger les soucis.

## :star2: Remarques
See #336.

## :santa: Pour tester
Vérifier que la CI passe.
