### PR TITLE
[TECH] Active la règle de lint SCSS pour ne pas mettre d'unité derrière les `0`

### DIFF
--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -12,7 +12,6 @@
     "font-family-name-quotes": null,
     "font-family-no-duplicate-names": null,
     "function-url-quotes": null,
-    "length-zero-no-unit": null,
     "no-descending-specificity": null,
     "no-empty-source": null,
     "property-no-vendor-prefix": null,

--- a/addon/styles/_pix-banner.scss
+++ b/addon/styles/_pix-banner.scss
@@ -5,7 +5,7 @@
   display: flex;
   align-items: center;
   font-size: 0.875rem;
-  box-shadow: 0px 4px 8px rgba(7, 20, 46, 0.08);
+  box-shadow: 0 4px 8px rgba(7, 20, 46, 0.08);
 
   &__action {
     text-decoration: underline;

--- a/addon/styles/_pix-block.scss
+++ b/addon/styles/_pix-block.scss
@@ -4,10 +4,10 @@
   border-radius: 5px;
 
   &--shadow-light {
-    box-shadow: 0px 4px 8px rgba($pix-neutral-110, 0.08);
+    box-shadow: 0 4px 8px rgba($pix-neutral-110, 0.08);
   }
 
   &--shadow-heavy {
-    box-shadow: 0px 12px 24px rgba($pix-neutral-110, 0.08);
+    box-shadow: 0 12px 24px rgba($pix-neutral-110, 0.08);
   }
 }

--- a/addon/styles/_pix-filterable-and-searchable-select.scss
+++ b/addon/styles/_pix-filterable-and-searchable-select.scss
@@ -37,7 +37,7 @@
   }
 
   &__pix-multi-select {
-    border-radius: 4px 0px 0px 4px;
+    border-radius: 4px 0 0 4px;
     position: relative;
 
     &:after {
@@ -52,6 +52,6 @@
   }
 
   &__pix-select {
-    border-radius: 0px 4px 4px 0px;
+    border-radius: 0 4px 4px 0;
   }
 }

--- a/addon/styles/_pix-modal.scss
+++ b/addon/styles/_pix-modal.scss
@@ -19,7 +19,7 @@
     display: inline-block;
     vertical-align: middle;
     height: 100%;
-    width: 0px;
+    width: 0;
   }
 
   &--hidden {

--- a/addon/styles/_pix-multi-select.scss
+++ b/addon/styles/_pix-multi-select.scss
@@ -16,7 +16,7 @@
   position: relative;
   border: 1px $pix-neutral-40 solid;
   height: 36px;
-  padding: 0px 32px 0px 16px;
+  padding: 0 32px 0 16px;
   width: 100%;
   background-color: $pix-neutral-0;
   border-radius: 4px;
@@ -78,7 +78,7 @@
   max-height: 200px;
   list-style-type: none;
   padding: 0;
-  box-shadow: 0px 6px 12px rgba(7, 20, 46, 0.08);
+  box-shadow: 0 6px 12px rgba(7, 20, 46, 0.08);
   transition: all 0.1s ease-in-out;
   margin-top: $spacing-xxs;
 

--- a/addon/styles/_pix-select.scss
+++ b/addon/styles/_pix-select.scss
@@ -20,7 +20,7 @@
     list-style-type: none;
     padding: 0;
     background-color: $pix-neutral-0;
-    box-shadow: 0px 6px 12px rgba(7, 20, 46, 0.08);
+    box-shadow: 0 6px 12px rgba(7, 20, 46, 0.08);
     transition: all 0.1s ease-in-out;
     white-space: nowrap;
     margin-top: $spacing-xxs;
@@ -86,7 +86,7 @@
   font-weight: $font-normal;
   position: relative;
   border: 1px $pix-neutral-45 solid;
-  padding: 0px $spacing-s 0px $spacing-s;
+  padding: 0 $spacing-s 0 $spacing-s;
   width: 100%;
   background-color: $pix-neutral-0;
   border-radius: 4px;

--- a/addon/styles/_pix-tooltip.scss
+++ b/addon/styles/_pix-tooltip.scss
@@ -50,10 +50,10 @@
     font-weight: $font-medium;
     background-color: $pix-neutral-0;
     color: $pix-neutral-60;
-    box-shadow: 0px 6px 24px 0px rgba($pix-neutral-70, 0.14);
+    box-shadow: 0 6px 24px 0 rgba($pix-neutral-70, 0.14);
 
     &::before {
-      border-width: 0px;
+      border-width: 0;
       height: 8px;
       width: 8px;
       background-color: $pix-neutral-0;

--- a/addon/styles/pix-design-tokens/_form.scss
+++ b/addon/styles/pix-design-tokens/_form.scss
@@ -1,13 +1,13 @@
 @mixin hoverFormElement() {
   &:hover {
-    box-shadow: inset 0px 0px 0px 0.6px $pix-neutral-70;
+    box-shadow: inset 0 0 0 0.6px $pix-neutral-70;
     background-color: $pix-neutral-5;
   }
 }
 
 @mixin hoverFormElementDisabled() {
   &:hover {
-    box-shadow: inset 0px 0px 0px 0.6px $pix-neutral-70;
+    box-shadow: inset 0 0 0 0.6px $pix-neutral-70;
     background-color: $pix-neutral-20;
   }
 }
@@ -19,7 +19,7 @@
 @mixin focusFormElement() {
   &:focus {
     border-color: $pix-primary;
-    box-shadow: inset 0px 0px 0px 0.6px $pix-primary;
+    box-shadow: inset 0 0 0 0.6px $pix-primary;
     outline: none;
   }
 }
@@ -27,7 +27,7 @@
 @mixin focusWithinFormElement() {
   &:focus-within {
     border-color: $pix-primary;
-    box-shadow: inset 0px 0px 0px 0.6px $pix-primary;
+    box-shadow: inset 0 0 0 0.6px $pix-primary;
     outline: none;
   }
 }
@@ -60,12 +60,12 @@
 
 @mixin formElementInError() {
   border-color: $pix-error-70;
-  box-shadow: inset 0px 0px 0px 0.6px $pix-error-70;
+  box-shadow: inset 0 0 0 0.6px $pix-error-70;
 }
 
 @mixin formElementInSuccess() {
   border-color: $pix-success-60;
-  box-shadow: inset 0px 0px 0px 0.6px $pix-success-60;
+  box-shadow: inset 0 0 0 0.6px $pix-success-60;
 }
 
 @mixin input() {


### PR DESCRIPTION
## :christmas_tree: Problème
On désactive une règle de lint utile.

## :gift: Solution
Réactiver cette règle et corriger les soucis.

## :star2: Remarques
See #336.

## :santa: Pour tester
Vérifier que la CI passe.
