### PR TITLE
[BUGFIX] Rendre la ligne entière d'une option du multiselect cliquable (PIX-6957)

### DIFF
--- a/addon/components/pix-checkbox.hbs
+++ b/addon/components/pix-checkbox.hbs
@@ -1,4 +1,4 @@
-<div class="pix-checkbox">
+<label class="pix-checkbox {{if @screenReaderOnly 'sr-only'}} {{@class}}" for={{@id}}>
   <input
     id={{@id}}
     type="checkbox"
@@ -6,15 +6,11 @@
     checked={{@checked}}
     ...attributes
   />
-  <label
-    class="pix-checkbox__label {{this.labelSizeClass}} {{if @screenReaderOnly 'sr-only'}}"
-    for={{@id}}
-  >
-    {{#if (has-block)}}
-      {{yield}}
-    {{else}}
-      yield required to give a label for PixCheckBox
-      {{@id}}.
-    {{/if}}
-  </label>
-</div>
+
+  {{#if (has-block)}}
+    <span class="pix-checkbox__label {{this.labelSizeClass}}">{{yield}}</span>
+  {{else}}
+    yield required to give a label for PixCheckBox
+    {{@id}}.
+  {{/if}}
+</label>

--- a/addon/components/pix-multi-select.hbs
+++ b/addon/components/pix-multi-select.hbs
@@ -66,6 +66,7 @@
             @id={{concat this.multiSelectId "-" option.value}}
             @checked={{option.checked}}
             @labelSize="small"
+            @class="pix-multi-select-list__item-label"
             value={{option.value}}
             {{on "change" this.onSelect}}
             {{on-enter-action this.hideDropDown this.multiSelectId}}

--- a/addon/styles/_pix-checkbox.scss
+++ b/addon/styles/_pix-checkbox.scss
@@ -1,13 +1,10 @@
 .pix-checkbox {
   align-items: center;
   display: flex;
-
-  label, input {
-    cursor: pointer;
-  }
+  color: $pix-neutral-70;
+  cursor: pointer;
 
   &__label {
-    color: $pix-neutral-70;
     @include text;
 
     &--small {
@@ -23,6 +20,10 @@
     }
   }
 
+  input {
+    cursor: pointer;
+  }
+
   &__input {
     appearance: none;
     margin: 0 10px;
@@ -32,12 +33,13 @@
     border-radius: 2px;
     position: relative;
 
-    &:hover, &:focus {
-      box-shadow: inset 0 1px 3px rgba(0,0,0, .1), 0 0 0 6px $pix-neutral-15;
+    &:hover,
+    &:focus {
+      box-shadow: inset 0 1px 3px rgba(0, 0, 0, 0.1), 0 0 0 6px $pix-neutral-15;
     }
 
     &:active {
-      box-shadow: inset 0 1px 3px rgba(0,0,0, .1), 0 0 0 6px $pix-neutral-22;
+      box-shadow: inset 0 1px 3px rgba(0, 0, 0, 0.1), 0 0 0 6px $pix-neutral-22;
     }
 
     &:checked {
@@ -54,7 +56,6 @@
         position: absolute;
         top: 0;
         left: 0;
-
       }
     }
 

--- a/addon/styles/_pix-multi-select.scss
+++ b/addon/styles/_pix-multi-select.scss
@@ -83,6 +83,10 @@
   transition: all 0.1s ease-in-out;
   margin-top: $spacing-xxs;
 
+  &__item-label {
+    padding: $spacing-xs $spacing-m;
+  }
+
   &--hidden {
     visibility: hidden;
     opacity: 0;
@@ -110,7 +114,6 @@
   li.pix-multi-select-list__item {
     position: relative;
     list-style: none;
-    padding: $spacing-xs $spacing-m;
 
 
     &:hover,

--- a/app/stories/pix-checkbox.stories.js
+++ b/app/stories/pix-checkbox.stories.js
@@ -52,6 +52,11 @@ export const argTypes = {
     name: 'label',
     description: "Le label de l'input",
   },
+  class: {
+    name: 'class',
+    description: "Permet d'ajouter une classe css à la checkbox.",
+    type: { name: 'string' },
+  },
   screenReaderOnly: {
     name: 'screenReaderOnly',
     description:


### PR DESCRIPTION
## :christmas_tree: Problème
Actuellement dans la liste des options d'un multiselect, pour sélectionner celle de notre choix on ne peut cliquer que sur la coche ou le texte, mais pas sur le reste de la ligne (“vide”) de cette option.

C’est problématique, surtout pour les options à texte court qui offrent alors une longue zone non cliquable.

## :gift: Solution
Permettre de cliquer sur toute la longueur de la ligne d’une option d’un multiselect

## :star2: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :santa: Pour tester

- Aller sur StoryBook, 
- Tester les différents MultiSelect en vérifiant qu'ils sont cliquables sur toute la ligne et que la bonne checkbox soit cochée.
