### PR TITLE
[FEATURE] Garder la cohérence sémantique du Pix-pagination (PIX-6812)

### DIFF
--- a/addon/styles/_pix-pagination.scss
+++ b/addon/styles/_pix-pagination.scss
@@ -27,7 +27,7 @@
     align-items: center;
     padding: 0;
     gap: 12px;
-    flex-direction: column-reverse;
+    flex-direction: column;
   }
 }
 


### PR DESCRIPTION
## :boom: BREAKING_CHANGES
L'affichage mobile change (le nombre d'éléments affichés avant le numéro de page) ce qui implique un breaking change visuel.

## :christmas_tree: Problème
Dans le code du Pix-Pagination, le nombre d'éléments affichés sur le total est avant le numéro de page dans le code source. mais l'affichage c'est inversé. Or la tabulation suit la disposition du code source ce qui apporte de la confusion.

## :gift: Solution
Ne pas modifier l'ordre d'affichage via des propriétés CSS pour que l'ordre de tabulation reste logique et compréhensible.

## :star2: Remarques
L'affichage en mobile est alors changé. Pour garder une certiane cohérence, on affiche le nombre d'éléments affichés avant le numéro de page.

## :santa: Pour tester
Vérifier que l'ordre à la tabulation est bien respecté.
