### PR TITLE
[BUGFIX] Améliorer l'accessibilité de PixStar (PIX-7349)

### DIFF
--- a/addon/components/pix-stars.hbs
+++ b/addon/components/pix-stars.hbs
@@ -1,10 +1,10 @@
-<div class={{this.pixStarsClass}} ...attributes aria-label={{@alt}}>
+<div class={{this.pixStarsClass}} ...attributes>
+  <span class="screen-reader-only">{{@alt}}</span>
   {{#each this.stars as |star|}}
     <svg
       class="pix-stars__{{star}}"
       data-test-status={{star}}
       viewBox="0 0 36 36"
-      role="img"
       aria-hidden="true"
     >
       <defs>

--- a/tests/integration/components/pix-stars-test.js
+++ b/tests/integration/components/pix-stars-test.js
@@ -43,11 +43,11 @@ module('Integration | Component | stars', function (hooks) {
     assert.equal(unacquiredStars.length, 2);
   });
 
-  test('it renders aria-label message', async function (assert) {
+  test('it renders message', async function (assert) {
     // when
     const screen = await render(hbs`<PixStars @total={{3}} @alt='message' />`);
     // then
-    assert.dom(screen.getByLabelText('message')).exists();
+    assert.dom(screen.getByText('message')).exists();
   });
 
   test('it renders the acquired start but hide unacquired', async function (assert) {


### PR DESCRIPTION
## :boom: BREAKING_CHANGES
RAS

## :christmas_tree: Problème
un aria label sur une div qui ne porte pas de role n'est pas lu, un svg avec un role img ne devrait pas exister 

## :gift: Solution
mettre le label dans un sr-only, et supprimer le role img inutil

## :star2: Remarques
RAS

## :santa: Pour tester
Aller voir PixStar 