### PR TITLE
[BUG] Corrige le PixCheckbox pour éviter de cacher l'input en utilisant la propriété screenReaderOnly

### DIFF
--- a/addon/components/pix-checkbox.hbs
+++ b/addon/components/pix-checkbox.hbs
@@ -9,7 +9,9 @@
 
   {{#if (has-block)}}
     <span
-      class="pix-checkbox__label {{if @screenReaderOnly 'sr-only'}} {{this.labelSizeClass}}"
+      class="pix-checkbox__label
+        {{if @screenReaderOnly 'screen-reader-only'}}
+        {{this.labelSizeClass}}"
     >{{yield}}</span>
   {{else}}
     yield required to give a label for PixCheckBox

--- a/addon/components/pix-checkbox.hbs
+++ b/addon/components/pix-checkbox.hbs
@@ -1,4 +1,4 @@
-<label class="pix-checkbox {{if @screenReaderOnly 'sr-only'}} {{@class}}" for={{@id}}>
+<label class="pix-checkbox {{@class}}" for={{@id}}>
   <input
     id={{@id}}
     type="checkbox"
@@ -8,7 +8,9 @@
   />
 
   {{#if (has-block)}}
-    <span class="pix-checkbox__label {{this.labelSizeClass}}">{{yield}}</span>
+    <span
+      class="pix-checkbox__label {{if @screenReaderOnly 'sr-only'}} {{this.labelSizeClass}}"
+    >{{yield}}</span>
   {{else}}
     yield required to give a label for PixCheckBox
     {{@id}}.


### PR DESCRIPTION
## :boom: BREAKING_CHANGES
> _Décrivez ici les changements cassant (voir la doc associée)[https://github.com/1024pix/pix-ui/blob/dev/docs/breaking-changes.stories.mdx], s'il n'y en a pas indiquez le aussi.

## :christmas_tree: Problème
Dans la PR https://github.com/1024pix/pix-ui/pull/348 on a corrigé un problème empêchant la ligne entière d'être clickable dans le PixMultiSelect. On a introduit une régression qui rend la checkbox invisible quand on utilise l'option screenReaderOnly.

## :gift: Solution
> _Ajoutez à cet endroit, si nécessaire, des détails concernant la solution technique retenue et mise en oeuvre, des difficultés ou problèmes rencontrés._

## :star2: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :santa: Pour tester
> _Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc._
