### PR TITLE
[CHORE] Utiliser la propriété iconBefore dans le bouton du filterBanner (PIX-7415)

### DIFF
--- a/addon/components/pix-button.hbs
+++ b/addon/components/pix-button.hbs
@@ -25,11 +25,19 @@
       <span class="loader__not-visible-text">{{yield}}</span>
     {{else}}
       {{#if @iconBefore}}
-        <FaIcon class="pix-button__icon pix-button__icon--before" @icon={{@iconBefore}} />
+        <FaIcon
+          class="pix-button__icon pix-button__icon--before"
+          @icon={{@iconBefore}}
+          @prefix={{@prefixIconBefore}}
+        />
       {{/if}}
       {{yield}}
       {{#if @iconAfter}}
-        <FaIcon class="pix-button__icon pix-button__icon--after" @icon={{@iconAfter}} />
+        <FaIcon
+          class="pix-button__icon pix-button__icon--after"
+          @icon={{@iconAfter}}
+          @prefix={{@prefixIconAfter}}
+        />
       {{/if}}
     {{/if}}
   </button>

--- a/addon/components/pix-filter-banner.hbs
+++ b/addon/components/pix-filter-banner.hbs
@@ -22,8 +22,9 @@
             @shape="squircle"
             @size="small"
             @triggerAction={{@onClearFilters}}
+            @iconBefore="trash-can"
+            @prefixIconBefore="far"
           >
-            <FaIcon class="pix-filter-banner-button__icon" @icon="trash-can" @prefix="far" />
             {{@clearFiltersLabel}}
           </PixButton>
         </div>

--- a/app/stories/pix-button.stories.js
+++ b/app/stories/pix-button.stories.js
@@ -13,6 +13,8 @@ const Template = (args) => ({
     @isBorderVisible={{this.isBorderVisible}}
     @iconBefore={{this.iconBefore}}
     @iconAfter={{this.iconAfter}}
+    @prefixIconBefore={{this.prefixIconBefore}}
+    @prefixIconAfter={{this.prefixIconAfter}}
   >
     {{this.label}}
   </PixButton>
@@ -30,6 +32,8 @@ const Template = (args) => ({
       @isBorderVisible={{button.isBorderVisible}}
       @iconBefore={{button.iconBefore}}
       @iconAfter={{button.iconAfter}}
+      @prefixIconBefore={{this.prefixIconBefore}}
+      @prefixIconAfter={{this.prefixIconAfter}}
     >
       {{button.label}}
     </PixButton>
@@ -212,7 +216,7 @@ export const argsTypes = {
     description: `Nom de l'icône font-awesome à afficher **avant** le label`,
     type: { name: 'string', required: false },
     control: { type: 'select' },
-    options: ['heart', 'magnifying-glass', 'plus', 'xmark'],
+    options: ['trash-can', 'heart', 'magnifying-glass', 'plus', 'xmark'],
     table: {
       type: { summary: 'string' },
       defaultValue: { summary: null },
@@ -223,7 +227,29 @@ export const argsTypes = {
     description: `Nom de l'icône font-awesome à afficher **après** le label`,
     type: { name: 'string', required: false },
     control: { type: 'select' },
-    options: ['heart', 'magnifying-glass', 'plus', 'xmark'],
+    options: ['trash-can', 'heart', 'magnifying-glass', 'plus', 'xmark'],
+    table: {
+      type: { summary: 'string' },
+      defaultValue: { summary: null },
+    },
+  },
+  prefixIconBefore: {
+    name: 'prefixIconBefore',
+    description: `Permet d'ajouter un préfix à l'icone devant le label pour appliquer un style particulier`,
+    type: { name: 'string', required: false },
+    control: { type: 'select' },
+    options: ['fas', 'far'],
+    table: {
+      type: { summary: 'string' },
+      defaultValue: { summary: null },
+    },
+  },
+  prefixIconAfter: {
+    name: 'prefixIconAfter',
+    description: `Permet d'ajouter un préfix à l'icone derrière le label pour appliquer un style particulier`,
+    type: { name: 'string', required: false },
+    control: { type: 'select' },
+    options: ['fas', 'far'],
     table: {
       type: { summary: 'string' },
       defaultValue: { summary: null },

--- a/tests/integration/components/pix-button-test.js
+++ b/tests/integration/components/pix-button-test.js
@@ -70,6 +70,19 @@ module('Integration | Component | button', function (hooks) {
     assert.ok(iconAfter);
   });
 
+  test('it renders the PixButton component with prefixIconBefore and prefixIconAfter attributes', async function (assert) {
+    //when
+    await render(hbs`
+      <PixButton @iconBefore='plus' @prefixIconBefore='fas' @iconAfter='plus' @prefixIconAfter='fas' aria-label='button label'>
+        Mon bouton
+      </PixButton>
+    `);
+
+    const prefixes = this.element.querySelectorAll('[data-prefix="fas"]');
+    // then
+    assert.strictEqual(prefixes.length, 2);
+  });
+
   test('it should call the action', async function (assert) {
     // given
     this.set('count', 1);


### PR DESCRIPTION
## :boom: BREAKING_CHANGES
Non

## :christmas_tree: Problème
Une propriété a été ajoutée au bouton qui permet de positionner des icons soit avant ou après le texte du bouton.
Dans le bouton du filter banner, on utilise pas cette propriété.

## :gift: Solution
Utiliser la propriété `iconBefore`

## :star2: Remarques


## :santa: Pour tester
Aller voir le composant Filter Banner
