### PR TITLE
[BUGFIX] Le contenu du `PixCollapsible` ne se rend plus en lazy

### DIFF
--- a/addon/components/pix-collapsible.hbs
+++ b/addon/components/pix-collapsible.hbs
@@ -31,6 +31,8 @@
     class="pix-collapsible__content"
     aria-hidden={{if this.isCollapsed "true" "false"}}
   >
-    {{yield}}
+    {{#if this.isContentRendered}}
+      {{yield}}
+    {{/if}}
   </div>
 </div>

--- a/addon/components/pix-collapsible.js
+++ b/addon/components/pix-collapsible.js
@@ -14,6 +14,10 @@ export default class PixCollapsible extends Component {
     return !this.isCollapsed;
   }
 
+  get isContentRendered() {
+    return this.hasUnCollapsedOnce;
+  }
+
   get title() {
     if (!this.args.title || !this.args.title.trim()) {
       throw new Error('ERROR in PixCollapsible component, @title param is not provided');

--- a/tests/integration/components/pix-collapsible-test.js
+++ b/tests/integration/components/pix-collapsible-test.js
@@ -15,7 +15,7 @@ module('Integration | Component | collapsible', function (hooks) {
 
     // then
     assert.dom(screen.queryByText('Titre de mon élément déroulable')).isVisible();
-    assert.dom(screen.queryByText('Contenu de mon élément')).isNotVisible();
+    assert.dom(screen.queryByText('Contenu de mon élément')).doesNotExist();
   });
 
   test('it should render and show content on click on PixCollapsible title', async function (assert) {


### PR DESCRIPTION
## :christmas_tree: Problème
Depuis #339 (v27.0.0), la totalité du contenu du PixCollapsible est rendu directement. C'était bloqué volontairement dans #225 pour répondre à des problèmes de performance.

## :gift: Solution
Remettre en place ce lazy render.

## :star2: Remarques
RAS

## :santa: Pour tester
Vérifier que le contenu du collapsible n'est pas rendu tant qu'on ne l'a pas ouvert.
