### PR TITLE
[BUGFIX] Corriger la sémantique et l'affichage du scroll sur la dropdown du PixSelect (PIX-7480)

### DIFF
--- a/addon/components/pix-select.hbs
+++ b/addon/components/pix-select.hbs
@@ -59,7 +59,7 @@
         />
       </div>
     {{/if}}
-    <div role="listbox" id={{this.listId}} class="pix-select__options">
+    <ul role="listbox" id={{this.listId}} class="pix-select__options">
       <li
         class="pix-select-options-category__option{{unless
             @value
@@ -135,9 +135,9 @@
           {{/each}}
         {{/if}}
       {{else}}
-        <p class="pix-select__empty-search-message">{{@emptySearchMessage}}</p>
+        <li class="pix-select__empty-search-message">{{@emptySearchMessage}}</li>
       {{/if}}
-    </div>
+    </ul>
   </div>
   {{#if @errorMessage}}
     <p class="pix-select__error-message">{{@errorMessage}}</p>

--- a/addon/styles/_pix-indicator-card.scss
+++ b/addon/styles/_pix-indicator-card.scss
@@ -23,7 +23,6 @@
     justify-content: center;
     color: $pix-neutral-60;
     padding: $pix-spacing-s $pix-spacing-m;
-    margin: 0;
   }
 
   &__title {
@@ -40,7 +39,6 @@
   &__value {
     @extend %pix-title-m;
 
-    margin: 0;
     margin-bottom: $pix-spacing-xxs;
   }
 
@@ -50,7 +48,6 @@
     font-weight: $font-normal;
     display: flex;
     gap: 10px;
-    margin: 0;
   }
 
   &__tooltip {

--- a/addon/styles/_pix-select.scss
+++ b/addon/styles/_pix-select.scss
@@ -13,10 +13,10 @@
   &__dropdown {
     z-index: 200;
     position: absolute;
-    max-height: 200px;
+    max-height: 12.5rem;
     width: inherit;
     border-top: none;
-    border-radius: 0 0 4px 4px;
+    border-radius: 0 0 $pix-spacing-xxs $pix-spacing-xxs;
     list-style-type: none;
     padding: 0;
     background-color: $pix-neutral-0;
@@ -24,19 +24,20 @@
     transition: all 0.1s ease-in-out;
     white-space: nowrap;
     margin-top: $pix-spacing-xxs;
+    overflow-y: auto;
 
     &::-webkit-scrollbar {
       width: 0.5rem;
     }
 
     &::-webkit-scrollbar-track {
-      border-radius: 4px;
+      border-radius: $pix-spacing-xxs;
       border: 1px solid $pix-neutral-20;
       background: $pix-neutral-20;
     }
 
     &::-webkit-scrollbar-thumb {
-      border-radius: 4px;
+      border-radius: $pix-spacing-xxs;
       width: 0.375rem;
       background: $pix-neutral-30;
     }
@@ -63,7 +64,7 @@
     border-bottom: 2px solid $pix-neutral-22;
     margin: $pix-spacing-s $pix-spacing-m;
     color: $pix-neutral-30;
-    border-radius: 4px 4px 0 0;
+    border-radius: $pix-spacing-xxs $pix-spacing-xxs 0 0;
 
     &:focus-within {
       background: $pix-neutral-10;
@@ -72,8 +73,6 @@
   }
 
   &__options {
-    overflow-y: auto;
-    max-height: inherit;
     border-top: 1px solid $pix-neutral-20;
   }
 
@@ -84,14 +83,13 @@
 
 .pix-select-button {
   display: flex;
-  flex-direction: row;
   align-items: center;
   position: relative;
   border: 1px $pix-neutral-45 solid;
   padding: 0 $pix-spacing-s 0 $pix-spacing-s;
   width: 100%;
   background-color: $pix-neutral-0;
-  border-radius: 4px;
+  border-radius: $pix-spacing-xxs;
   outline: none;
   height: 2.25rem;
   cursor: pointer;

--- a/addon/styles/normalize-reset/_normalize.scss
+++ b/addon/styles/normalize-reset/_normalize.scss
@@ -9,7 +9,7 @@
  */
 
 html {
-  line-height: 1.15; /* 1 */
+  line-height: normal; /* 1 */
   -webkit-text-size-adjust: 100%; /* 2 */
 }
   

--- a/addon/styles/normalize-reset/_reset.scss
+++ b/addon/styles/normalize-reset/_reset.scss
@@ -44,11 +44,16 @@ input::-moz-focus-inner {
 }
 
 ul,
-ol,
-dd {
+ol {
   margin: 0;
   padding: 0;
   list-style: none;
+}
+
+dl,
+dt,
+dd {
+  margin: 0;
 }
 
 h1,


### PR DESCRIPTION
## :boom: BREAKING_CHANGES
RAS

## :christmas_tree: Problème
Une incohérence de sémantique li sans ul et un affichage "étonnant" se produit sur l'affichage de la dropdown

## :gift: Solution
Corriger le css / sémantique pour que le PixSelect s'affiche correctement

## :santa: Pour tester
Vérifier le code du PixSelect