### PR TITLE
[BUGFIX] Augmenter l'épaisseur du label de PixInput (PIX-7574).

### DIFF
--- a/addon/styles/_pix-input.scss
+++ b/addon/styles/_pix-input.scss
@@ -4,16 +4,11 @@
   position: relative;
 
   &__label {
-    font-size: 0.875rem;
-    color: $pix-neutral-70;
-    margin-bottom: 4px;
+    @include label();
   }
 
   &__information {
-    font-size: 0.75rem;
-    margin-top: 4px;
-    color: $pix-neutral-60;
-    display: block;
+    @include subLabel();
   }
 
   &__container {

--- a/addon/styles/pix-design-tokens/_form.scss
+++ b/addon/styles/pix-design-tokens/_form.scss
@@ -93,7 +93,8 @@
   }
 }
 
-abbr.mandatory-mark {
+.mandatory-mark,
+.mandatory-mark[title] {
   cursor: help;
   color: $pix-error-70;
   text-decoration: none;


### PR DESCRIPTION
## :christmas_tree: Problème

Seul le label du PixInput a une graisse "normal" : https://ui.pix.fr/?path=/story/form-example--form

## :gift: Solution

Augmenter sa graisse à "medium"

## :star2: Remarques

Le normalize ajoutait un soulignement spécifique sous l'étoile de champ requis.
C'est corrigé.

## :santa: Pour tester

Dans la RA vérifier le style du [formulaire complet ](https://ui-pr372.review.pix.fr/?path=/story/form-example--form)et de [PixInput](https://ui-pr372.review.pix.fr/?path=/docs/form-inputs-input--with-label)
