### PR TITLE
[BUGFIX] Rendre les typographies de la modale cohérentes avec celles des maquettes (PIX-7615) 

### DIFF
--- a/addon/styles/_pix-modal.scss
+++ b/addon/styles/_pix-modal.scss
@@ -68,7 +68,7 @@ $button-margin: 16px;
   }
 
   &__title {
-    @extend %pix-title-s;
+    @extend %pix-title-xs;
 
     margin-bottom: 0;
     color: $pix-neutral-90;
@@ -80,7 +80,7 @@ $button-margin: 16px;
   }
 
   &__content {
-    @extend %pix-body-m;
+    @extend %pix-body-s;
 
     padding: $modal-padding;
     color: $pix-neutral-90;


### PR DESCRIPTION
## :boom: BREAKING_CHANGES
Nop

## :christmas_tree: Problème
Les typo dans la modale ne sont pas ISO avec celles dans la maquette de la modale
## :gift: Solution
Les rendre ISO

## :star2: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :santa: Pour tester
comparer les tags de storybooks à la modale sur l[a maquette](https://www.figma.com/file/8RJ3aCSfdeQ8AZZVBBYKS8/Design-System-Pix?node-id=765-6526&t=Uc2IKYZrgMXfWLeR-0)