### PR TITLE
[TECH] Améliorer l'affichage des éléments en screen-reader-only ayant des sous élements (PIX-7623)

### DIFF
--- a/addon/styles/_a11y.scss
+++ b/addon/styles/_a11y.scss
@@ -1,4 +1,4 @@
-.screen-reader-only {
+.screen-reader-only, .screen-reader-only > * {
   position: absolute;
   width: 1px;
   height: 1px;


### PR DESCRIPTION
## 💥 BREAKING_CHANGES
NOP
## :christmas_tree: Problème
l'utilisation du screen-reader-only sur un tableau, met le tableau "invisible" mais les sous elements qui le compose prennent une taille défini qui peut tendre à agrandir involontairement la window de l'utilisateur.

## :gift: Solution
Ajouter le style du screen reader only sur les sous éléments afin de garantir l'aspect visuel des écrans

## :star2: Remarques
RAS

## :santa: Pour tester
RAS