### PR TITLE
[TECH] Supprimer la transition css du dropdown du Pix Select (PIX-7647).

### DIFF
--- a/addon/styles/_pix-select.scss
+++ b/addon/styles/_pix-select.scss
@@ -21,7 +21,6 @@
     padding: 0;
     background-color: $pix-neutral-0;
     box-shadow: 0 6px 12px rgba(7, 20, 46, 0.08);
-    transition: all 0.1s ease-in-out;
     white-space: nowrap;
     margin-top: $pix-spacing-xxs;
     overflow-y: auto;


### PR DESCRIPTION
## :boom: BREAKING_CHANGES
Pas de Breaking changes ici 

## :christmas_tree: Problème
Lorsque qu’une modale est assez longue (scroll pour aller en bas de celle-ci) et qu’elle comprend des Pix Select, alors lorsqu'on clique sur un Pix Select, on est amené automatiquement tout en haut de la page.  

Ce soucis à été constaté sur une modale de Pix Certif ET de Pix Admin.

## :gift: Solution
On a constaté qu'en retirant la transition `css  transition: all 0.1s ease-in-out;` du `pix-select__dropdown`, le soucis ne se produit plus.

Après plusieurs recherches infructueuses et au peu d’utilité à cette transition de 0.1s (qui ne se voit pas), on souhaite retirer cette dernière pour corriger le problème.

## :star2: Remarques
Si vous avez d'autres pistes, on est preneurs ! 
