### PR TITLE
[TECH] Modification de la valeur du Design Token warning-60 et suppression des placeholders de font-weight (PIX-7666).

### DIFF
--- a/addon/styles/pix-design-tokens/_colors.scss
+++ b/addon/styles/pix-design-tokens/_colors.scss
@@ -74,7 +74,7 @@ $pix-warning-20: #FFE381;
 $pix-warning-30: #FFD235;
 $pix-warning-40: #FFBE00;
 $pix-warning-50: #EAA600;
-$pix-warning-60: #CE8900;
+$pix-warning-60: #D87016;
 $pix-warning-70: #A95800;
 $pix-warning-80: #874D00;
 

--- a/addon/styles/pix-design-tokens/_typography.scss
+++ b/addon/styles/pix-design-tokens/_typography.scss
@@ -114,12 +114,10 @@
   letter-spacing: 0.02em;
 }
 
-%pix-body-weight-medium,
 .pix-body-weight-medium {
   font-weight: 500;
 }
 
-%pix-body-weight-bold,
 .pix-body-weight-bold {
   font-weight: 700;
 }

--- a/docs/colors-palette.stories.mdx
+++ b/docs/colors-palette.stories.mdx
@@ -38,7 +38,7 @@ import { Meta, ColorPalette, ColorItem } from '@storybook/addon-docs';
              Secondary: '#ffd235',
              40: '#ffbe00',
              50: '#eaa600',
-             60: '#ce8900',
+             60: '#d87016',
              70: '#a95800',
              80: '#874d00'}}
   />
@@ -103,7 +103,7 @@ import { Meta, ColorPalette, ColorItem } from '@storybook/addon-docs';
             30: '#ffd235',
             40: '#ffbe00',
             50: '#eaa600',
-            60: '#ce8900',
+            60: '#d87016',
             70: '#a95800',
             80: '#874d00'}}
   />

--- a/docs/typography.stories.mdx
+++ b/docs/typography.stories.mdx
@@ -1,6 +1,6 @@
 <!-- Typography.stories.mdx -->
 
-import { Meta, Typeset } from '@storybook/addon-docs';
+import { Meta, Typeset, Markdown } from '@storybook/addon-docs';
 
 <Meta title="Utiliser Pix UI/Design Tokens/Typographie" />
 
@@ -82,24 +82,6 @@ Des **placeholder SCSS** équivalents aux tokens de Figma sont disponibles. C'es
   fontFamily={'Roboto, Arial, sans-serif'}
 />
 
-#### Variantes de gras
-
-Pour les corps, on peut préciser une graisse différente en complément :
-
-<Typeset
-  fontSizes={[16]}
-  fontWeight={500}
-  sampleText={'@extend %pix-weight-medium;'}
-  fontFamily={'Roboto, Arial, sans-serif'}
-/>
-
-<Typeset
-  fontSizes={[16]}
-  fontWeight={700}
-  sampleText={'@extend %pix-weight-bold;'}
-  fontFamily={'Roboto, Arial, sans-serif'}
-/>
-
 ### Comment utiliser un placeholder SCSS ?
 
 ```css
@@ -139,6 +121,29 @@ Pour chaque placeholder SCSS, une **classe CSS** utilitaire de même nom existe 
 - `pix-body-m`
 - `pix-body-s`
 - `pix-body-xs`
+
+## Design tokens
+
+Des variables SCSS existent pour certaines propriétés de typographie.
+
+### Font-weight
+
+ℹ️ Ces variables ne devraient pas être utilisées pour modifier la graisse d'un titre car les classes utilitaires et les placeholders ci-dessus s'en occupent déjà.
+
+`$font-normal: 400;`
+
+`$font-medium: 500;`
+
+`$font-bold: 700;`
+
+### Font-family
+
+ℹ️ Vous ne devriez pas avoir à les utiliser car elles vont de pair avec d'autres propriétés de typo (font-size, line-height, ...).<br/>
+Pour en savoir plus, voir les classes utilitaires et les placeholders ci-dessus.
+
+`$font-open-sans: 'Open Sans', Arial, sans-serif;`
+
+`$font-roboto: 'Roboto', Arial, sans-serif;`
 
 ## Détails techniques
 


### PR DESCRIPTION
## :boom: BREAKING_CHANGES

- Suppression des placeholders de font-weight

## :christmas_tree: Problème

- La valeur de la couleur `pix-warning-60` a changé dans [le Design System](https://www.figma.com/file/8RJ3aCSfdeQ8AZZVBBYKS8/Design-System-Pix?node-id=16-3&t=uqudPLqTbMkLC3gs-4).
- Aucun placeholder SCSS ne devrait générer qu'une ligne de CSS. Autant avoir une variable.

## :gift: Solution

- Changer la valeur du DT
- Supprimer les placeholders

## :santa: Pour tester

- Vérifier que la valeur du Design Token `pix-warning-60` a bien la même valeur que dans le Figma
