### PR TITLE
[FEATURE] Ajouter une icône avant le label du composant Pix-Select (PIX-7634)

### DIFF
--- a/addon/components/pix-select.hbs
+++ b/addon/components/pix-select.hbs
@@ -34,6 +34,10 @@
       aria-controls={{this.listId}}
       aria-disabled={{@isDisabled}}
     >
+      {{#if @icon}}
+        <FaIcon @icon={{@icon}} />
+      {{/if}}
+
       <span class="pix-select-button__text">{{this.placeholder}}</span>
 
       <FaIcon

--- a/app/stories/pix-select.stories.js
+++ b/app/stories/pix-select.stories.js
@@ -28,6 +28,7 @@ export const Template = (args) => {
           @errorMessage={{this.errorMessage}}
           @isDisabled={{this.isDisabled}}
           @placement={{this.placement}}
+          @icon={{this.icon}}
         />
     `,
     context: args,
@@ -218,6 +219,19 @@ WithDropDownAtTheTop.args = {
   placement: 'top',
 };
 
+export const WithIcon = Template.bind({});
+WithIcon.args = {
+  icon: 'earth-europe',
+  isSearchable: false,
+  label: 'With icon',
+  onChange: action('onChange'),
+  options: [
+    { value: 'en', label: 'English' },
+    { value: 'fr', label: 'Français' },
+  ],
+  value: 'fr',
+};
+
 export const argTypes = {
   options: {
     name: 'options',
@@ -369,6 +383,16 @@ export const argTypes = {
       "Permet de placer la dropdown du select par rapport à son bouton. Par défaut, cela s'adapte tout seul.",
     type: { name: 'string', required: false },
     options: ['bottom', 'top', 'left', 'right'],
+    table: {
+      type: { summary: 'string' },
+      defaultValue: { summary: null },
+    },
+  },
+  icon: {
+    name: 'icon',
+    description:
+      "Permet l'affichage d'une icône FontAwesome avant le placeholder ou le label de l'option sélectionnée.",
+    type: { name: 'string', required: false },
     table: {
       type: { summary: 'string' },
       defaultValue: { summary: null },

--- a/app/stories/pix-select.stories.mdx
+++ b/app/stories/pix-select.stories.mdx
@@ -61,6 +61,12 @@ Ici nous avons forcé le placement de la dropdown en haut du select mais sachez 
   <Story name="WithDropDownAtTheTop" story={stories.WithDropDownAtTheTop} />
 </Canvas>
 
+## WithIcon
+
+<Canvas>
+  <Story name="WithIcon" story={stories.WithIcon} />
+</Canvas>
+
 ## Usage
 
 ```html
@@ -80,6 +86,7 @@ Ici nous avons forcé le placement de la dropdown en haut du select mais sachez 
   @requiredText="{{requiredText}}"
   @errorMessage="{{errorMessage}}"
   @placement="{{placement}}"
+  @icon="{{icon}}"
 />
 ```
 

--- a/tests/integration/components/pix-select-test.js
+++ b/tests/integration/components/pix-select-test.js
@@ -702,4 +702,28 @@ module('Integration | Component | PixSelect', function (hooks) {
       assert.dom('.some-custom-class').exists();
     });
   });
+
+  module('#icon', function () {
+    module('when no icon name is provided', function () {
+      test('does not display any icon', async function (assert) {
+        // given & when
+        await render(hbs`<PixSelect @options={{this.options}} @label={{this.label}} />`);
+
+        // then
+        assert.dom('.fa-earth-europe').doesNotExist();
+      });
+    });
+
+    module('when an icon name is provided', function () {
+      test('displays an icon', async function (assert) {
+        // given & when
+        await render(
+          hbs`<PixSelect @icon='earth-europe' @options={{this.options}} @label={{this.label}} />`
+        );
+
+        // then
+        assert.dom('.fa-earth-europe').exists();
+      });
+    });
+  });
 });


### PR DESCRIPTION
## :christmas_tree: Problème

Dans le cadre de l'internationalisation, nous avons besoin d'afficher un sélecteur de langue à différent endroit des applications Pix avant la connexion. Ce sélecteur ne sera disponible que sur la version internationale des applications Pix.
Ce sélecteur devra afficher une icône avant le label (la langue dans notre cas) sélectionné.

![Screenshot 2023-04-17 at 14 55 52](https://user-images.githubusercontent.com/6919604/232490730-188cf6b4-a760-4c0c-b28b-6b0bcb75ee4f.png)

## :gift: Solution

Ajouter une nouvelle propriété `icon` au composant PixSelect pour afficher une icône de FontAwesome à gauche du label.

## :star2: Remarques

- Uniquement les icônes de type `solid` de FontAwesome sont prises en compte
- ⚠️ Pour tester ce composant sur une application, il faudra regarder la liste des icônes disponibles sur cette application via le fichier `<application>/config/icons.js`, et utiliser l'un des noms d'icône s'y trouvant.

## :santa: Pour tester

- Ouvrir ce lien dans un nouvel onglet : https://ui-pr384.review.pix.fr/?path=/story/form-select--with-icon
- Constater qu'une icône s'affiche à gauche du label
- Retirer le nom de l'icône se trouvant le contrôle nommé `icon`
- Constater que l'icône ne s'affiche plus
- Fournir un nom d'icône présent dans la liste gratuite suivante : https://fontawesome.com/search?o=r&m=free&new=yes&s=solid
- Constater que l'icône s'affiche à gauche du label
