### PR TITLE
[FEATURE] Améliorer le contraste du composant PixProgressGauge (PIX-7268)

### DIFF
--- a/addon/components/pix-progress-gauge.js
+++ b/addon/components/pix-progress-gauge.js
@@ -19,10 +19,10 @@ export default class PixProgressGauge extends Component {
   }
 
   get progressGaugeClass() {
-    const availableColor = ['yellow', 'white'];
+    const availableColor = ['blue', 'white'];
 
     const color =
-      this.args.color && availableColor.includes(this.args.color) ? this.args.color : `yellow`;
+      this.args.color && availableColor.includes(this.args.color) ? this.args.color : `blue`;
 
     return `progress-gauge--${color}`;
   }

--- a/addon/styles/_pix-progress-gauge.scss
+++ b/addon/styles/_pix-progress-gauge.scss
@@ -6,7 +6,7 @@
 
   &__sub-title {
     font-size: 0.813rem;
-    color: $pix-warning-40;
+    color: $pix-primary-60;
     margin: 6px 0;
     letter-spacing: 0.4px;
     text-transform: uppercase;
@@ -74,27 +74,26 @@
     }
   }
 
-  &--yellow {
+  &--blue {
     & .progress-gauge__referrer {
       background-color: $pix-neutral-20;
     }
 
     & .progress-gauge__marker {
-      background: $pix-secondary-app-gradient;
+      background-color: $pix-primary-60;
     }
 
     & .progress-gauge__tooltip {
-      background: $pix-secondary-app-gradient;
+      background-color: $pix-primary-60;
       color: $pix-neutral-0;
 
       &::before {
-        color: $pix-warning-40;
-        border-top-color: $pix-warning-40;
+        border-top-color: $pix-primary-60;
       }
     }
 
     & .progress-gauge__sub-title {
-      color: $pix-warning-40;
+      color: $pix-primary-60;
     }
   }
 

--- a/app/stories/pix-progress-gauge.stories.js
+++ b/app/stories/pix-progress-gauge.stories.js
@@ -48,11 +48,11 @@ export const argTypes = {
   color: {
     name: 'color',
     description:
-      'Modifie la couleur de la barre de progression. Peut prendre les valeurs `yellow` ou `white`',
+      'Modifie la couleur de la barre de progression. Peut prendre les valeurs `blue` ou `white`',
     type: { name: 'string', required: false },
-    table: { defaultValue: { summary: 'yellow' } },
+    table: { defaultValue: { summary: 'blue' } },
     control: { type: 'select' },
-    options: ['yellow', 'white'],
+    options: ['blue', 'white'],
   },
   isArrowLeft: {
     name: 'isArrowLeft',

--- a/tests/integration/components/pix-progress-gauge-test.js
+++ b/tests/integration/components/pix-progress-gauge-test.js
@@ -82,31 +82,31 @@ module('Integration | Component | progress-gauge', function (hooks) {
   });
 
   module('Attributes @color', function () {
-    test('it renders the progress gauge by default with yellow class', async function (assert) {
+    test('it renders the progress gauge by default with blue class', async function (assert) {
       // given & when
       await render(hbs`<PixProgressGauge @value='50' />`);
 
       // then
       const componentElement = this.element.querySelector(PROGRESS_GAUGE_SELECTOR);
-      assert.true(componentElement.classList.contains('progress-gauge--yellow'));
+      assert.true(componentElement.classList.contains('progress-gauge--blue'));
     });
 
-    test('it renders the progress gauge with yellow class when color not exists', async function (assert) {
+    test('it renders the progress gauge with blue class when color not exists', async function (assert) {
       // given & when
       await render(hbs`<PixProgressGauge @value='50' @color='vert-lychen' />`);
 
       // then
       const componentElement = this.element.querySelector(PROGRESS_GAUGE_SELECTOR);
-      assert.true(componentElement.classList.contains('progress-gauge--yellow'));
+      assert.true(componentElement.classList.contains('progress-gauge--blue'));
     });
 
-    test('it renders the progress gauge with yellow class', async function (assert) {
+    test('it renders the progress gauge with blue class', async function (assert) {
       // given & when
-      await render(hbs`<PixProgressGauge @value='50' @color='yellow' />`);
+      await render(hbs`<PixProgressGauge @value='50' @color='blue' />`);
 
       // then
       const componentElement = this.element.querySelector(PROGRESS_GAUGE_SELECTOR);
-      assert.true(componentElement.classList.contains('progress-gauge--yellow'));
+      assert.true(componentElement.classList.contains('progress-gauge--blue'));
     });
 
     test('it renders the progress gauge with white class', async function (assert) {


### PR DESCRIPTION
## :boom: BREAKING_CHANGES
La couleur jaune du PixProgressGauge n'existe plus et a été remplacé par du bleu.

## :christmas_tree: Problème
Les tooltips en jaune et blanc présentent un ratio de contraste insuffisant de 2:1.

## :gift: Solution
Changer les tooltips avec du `pix-primary-60`.

## :santa: Pour tester
Aller sur la storie du PixProgressGauge et vérifier le visuel.
