### PR TITLE
[FEATURE] Rectifier et uniformiser les composants Checkbox et Radio

### DIFF
--- a/addon/components/pix-checkbox.hbs
+++ b/addon/components/pix-checkbox.hbs
@@ -2,19 +2,17 @@
   <input
     id={{@id}}
     type="checkbox"
-    class="pix-checkbox__input {{if @isIndeterminate ' pix-checkbox__input--indeterminate'}}"
+    class={{this.inputClasses}}
     checked={{@checked}}
     ...attributes
   />
 
   {{#if (has-block)}}
-    <span
-      class="pix-checkbox__label
-        {{if @screenReaderOnly 'screen-reader-only'}}
-        {{this.labelSizeClass}}"
-    >{{yield}}</span>
+    <span class={{this.labelClasses}}>{{yield}}</span>
   {{else}}
-    yield required to give a label for PixCheckBox
-    {{@id}}.
+    <span>
+      yield required to give a label for PixCheckbox
+      {{@id}}.
+    </span>
   {{/if}}
 </label>

--- a/addon/components/pix-checkbox.js
+++ b/addon/components/pix-checkbox.js
@@ -1,11 +1,5 @@
 import Component from '@glimmer/component';
 
-const labelSizeToClass = new Map([
-  ['small', 'pix-checkbox__label--small'],
-  ['default', 'pix-checkbox__label--default'],
-  ['large', 'pix-checkbox__label--large'],
-]);
-
 export default class PixCheckbox extends Component {
   constructor() {
     super(...arguments);
@@ -15,7 +9,27 @@ export default class PixCheckbox extends Component {
     }
   }
 
-  get labelSizeClass() {
-    return labelSizeToClass.get(this.args.labelSize);
+  get inputClasses() {
+    const classes = ['pix-checkbox__input'];
+
+    if (this.args.isIndeterminate) {
+      classes.push(`${classes[0]}--indeterminate`);
+    }
+
+    return classes.join(' ');
+  }
+
+  get labelClasses() {
+    const classes = ['pix-checkbox__label'];
+
+    if (this.args.labelSize) {
+      classes.push(`${classes[0]}--${this.args.labelSize}`);
+    }
+
+    if (this.args.screenReaderOnly) {
+      classes.push('screen-reader-only');
+    }
+
+    return classes.join(' ');
   }
 }

--- a/addon/components/pix-radio-button.hbs
+++ b/addon/components/pix-radio-button.hbs
@@ -1,12 +1,10 @@
-<div class="pix-radio-button">
-  <label class="{{if @isDisabled ' pix-radio-button--disabled'}}">
-    <input
-      disabled={{@isDisabled}}
-      aria-disabled="{{@isDisabled}}"
-      type="radio"
-      value={{@value}}
-      ...attributes
-    />
-    {{@label}}
-  </label>
-</div>
+<label class="pix-radio-button">
+  <input
+    class="pix-radio-button__input"
+    type="radio"
+    value={{@value}}
+    disabled={{@isDisabled}}
+    ...attributes
+  />
+  <span class="pix-radio-button__label">{{@label}}</span>
+</label>

--- a/addon/styles/_pix-checkbox.scss
+++ b/addon/styles/_pix-checkbox.scss
@@ -1,74 +1,137 @@
 .pix-checkbox {
+  position: relative;
+  z-index: 0;
   align-items: center;
   display: flex;
   color: $pix-neutral-70;
   cursor: pointer;
 
-  &__label {
-    @extend %pix-body-m;
+  & + .pix-checkbox {
+    margin-top: $pix-spacing-s;
+  }
+}
 
-    &--small {
-      @extend %pix-body-s;
-    }
+/* Label */
+.pix-checkbox__label {
+  padding-left: 12px;
+  color: $pix-neutral-90;
+  font-size: 1rem;
+  line-height: 1.5;
 
-    &--large {
-      @extend %pix-body-l;
+  &--small {
+    font-size: 0.875rem;
+  }
+
+  &--large {
+    font-size: 1.125rem;
+  }
+}
+
+/* Input */
+.pix-checkbox__input {
+  position: relative;
+  width: 1rem;
+  height: 1rem;
+  background-color: $pix-neutral-0;
+  border: 1.5px solid $pix-neutral-70;
+  border-radius: 2px;
+  appearance: none;
+  cursor: pointer;
+
+  // Hover effect
+  &::before {
+    content: '';
+    position: absolute;
+    z-index: -1;
+    top: 50%;
+    left: 50%;
+    width: 1rem;
+    height: 1rem;
+    transform: translate(-50%, -50%) scale(1);
+    border-radius: 50%;
+    background-color: $pix-neutral-15;
+    visibility: hidden;
+    opacity: 0;
+    transition: all 0.3s ease;
+  }
+
+  &:hover,
+  &:focus-visible,
+  &:active {
+    border-color: $pix-neutral-90;
+
+    &::before {
+      visibility: visible;
+      opacity: 1;
+      transform: translate(-50%, -50%) scale(1.75);
     }
   }
 
-  input {
-    cursor: pointer;
+  &:active {
+    &::before {
+      background-color: $pix-neutral-22;
+    }
   }
 
-  &__input {
-    appearance: none;
-    margin: 0 10px;
-    min-width: 18px;
-    min-height: 18px;
-    border: 1.2px solid $pix-neutral-90;
-    border-radius: 2px;
-    position: relative;
+  // Checked state
+  &:checked {
+    background: $pix-primary;
+    border-color: $pix-primary;
 
     &:hover,
-    &:focus {
-      box-shadow: inset 0 1px 3px rgba(0, 0, 0, 0.1), 0 0 0 6px $pix-neutral-15;
+    &:focus-visible,
+    &:active {
+      background: $pix-primary-60;
+      border-color: $pix-primary-60;
     }
 
+    &::after {
+      content: '';
+      position: absolute;
+      inset: 10%;
+      background-repeat: no-repeat;
+      background-position: center;
+      background-size: contain;
+      background-image: url("data:image/svg+xml,%3Csvg width='13' height='10' viewBox='0 0 13 10' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M1.5 3L0 4.5L5 9.5L13 1.5L11.5 0L5 6.5L1.5 3Z' fill='white'/%3E%3C/svg%3E%0A");
+    }
+  }
+
+  // Indeterminate state
+  &--indeterminate:checked {
+    background: $pix-neutral-70;
+    border-color: $pix-neutral-70;
+
+    &:hover,
+    &:focus-visible,
     &:active {
-      box-shadow: inset 0 1px 3px rgba(0, 0, 0, 0.1), 0 0 0 6px $pix-neutral-22;
+      background: $pix-neutral-90;
+      border-color: $pix-neutral-90;
+    }
+
+    &::after {
+      inset: 15%;
+      background-image: url("data:image/svg+xml,%3Csvg width='10' height='2' viewBox='0 0 10 2' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Crect width='10' height='2' fill='white'/%3E%3C/svg%3E%0A");
+    }
+  }
+
+  // Disabled state
+  &:disabled,
+  &--indeterminate:disabled {
+    background: $pix-neutral-10;
+    border-color: $pix-neutral-30;
+    cursor: not-allowed;
+
+    & + .pix-checkbox__label {
+      cursor: not-allowed;
     }
 
     &:checked {
-      background: $pix-primary border-box;
-      border-color: $pix-primary;
-
-      &::after {
-        content: '';
-        background-image: url("data:image/svg+xml,%3Csvg width='13' height='10' viewBox='0 0 13 10' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M1.5 3L0 4.5L5 9.5L13 1.5L11.5 0L5 6.5L1.5 3Z' fill='white'/%3E%3C/svg%3E%0A");
-        background-repeat: no-repeat;
-        background-position: center;
-        width: 16px;
-        height: 16px;
-        position: absolute;
-        top: 0;
-        left: 0;
-      }
+      background: $pix-neutral-30;
+      border-color: $pix-neutral-30;
     }
 
-    &.pix-checkbox__input--indeterminate {
-      &:checked {
-        background: $pix-neutral-60 border-box;
-        border-color: $pix-neutral-60;
-
-        &::after {
-          content: '';
-          background-image: url("data:image/svg+xml,%3Csvg width='10' height='2' viewBox='0 0 10 2' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Crect width='10' height='2' fill='white'/%3E%3C/svg%3E%0A");
-          background-repeat: no-repeat;
-          background-position: center;
-          width: 16px;
-          height: 16px;
-        }
-      }
+    &::before {
+      display: none;
     }
   }
 }

--- a/addon/styles/_pix-radio-button.scss
+++ b/addon/styles/_pix-radio-button.scss
@@ -1,71 +1,95 @@
 .pix-radio-button {
+  display: flex;
+  align-items: center;
   cursor: pointer;
-  font-size: 0.875rem;
-  color: $pix-neutral-70;
 
-  label {
-    display: flex;
-    align-items: center;
+  & + .pix-radio-button {
+    margin-top: $pix-spacing-s;
   }
 
-  input {
-    appearance: none;
-    position: relative;
-    border-radius: 50%;
-    width: 18px;
-    height: 18px;
-    margin: 0 10px 0 0;
-    border: 1px solid $pix-neutral-70;
-    cursor: pointer;
-    background-color: transparent;
+  &__label {
+    padding-left: 12px;
+    color: $pix-neutral-90;
+    font-size: 1rem;
+    line-height: 1.5;
+  }
 
-    &:hover {
+  &__input {
+    position: relative;
+    width: 1rem;
+    height: 1rem;
+    background-color: $pix-neutral-0;
+    border: 1.5px solid $pix-neutral-70;
+    border-radius: 50%;
+    appearance: none;
+
+    // Hover effect
+    &::before {
+      content: '';
+      position: absolute;
+      z-index: -1;
+      top: 50%;
+      left: 50%;
+      width: 1rem;
+      height: 1rem;
+      transform: translate(-50%, -50%) scale(1);
+      border-radius: 50%;
       background-color: $pix-neutral-15;
-      box-shadow: 0 0 0 8px $pix-neutral-15;
+      visibility: hidden;
+      opacity: 0;
       transition: all 0.3s ease;
     }
 
-    &:focus-visible {
-      box-shadow: $pix-neutral-0 0 0 0 2px, $pix-primary 0 0 0 4px;
-      outline: none;
+    &:hover,
+    &:focus-visible,
+    &:active {
+      &::before {
+        visibility: visible;
+        opacity: 1;
+        transform: translate(-50%, -50%) scale(1.75);
+      }
     }
 
     &:active {
-      border-color: $pix-primary;
-      background-color: transparent;
-      box-shadow: none;
+      &::before {
+        background-color: $pix-neutral-22;
+      }
     }
 
+    // Checked state
     &:checked {
       border-color: $pix-primary;
 
-      &:after {
+      &::after {
+        content: '';
+        position: absolute;
+        top: 50%;
+        left: 50%;
+        height: 62.5%;
+        width: 62.5%;
+        transform: translate(-50%, -50%);
         background-color: $pix-primary;
         border-radius: 50%;
-        content: '';
-        height: 12px;
-        width: 12px;
-        position: absolute;
-        left: 50%;
-        top: 50%;
-        transform: translate(-50%, -50%);
       }
     }
 
+    // Disabled state
     &:disabled {
-      border: 1px solid $pix-neutral-45;
-      background-color: transparent;
-      box-shadow: none;
+      background-color: $pix-neutral-10;
+      border-color: $pix-neutral-30;
       cursor: not-allowed;
 
-      &:checked:after {
-        background-color: $pix-neutral-25;
+      & + .pix-radio-button__label {
+        cursor: not-allowed;
+      }
+
+      &::before {
+        display: none;
+      }
+
+      &:checked::after {
+        background-color: $pix-neutral-30;
       }
     }
-  }
-
-  &--disabled {
-    cursor: not-allowed;
-    color: $pix-neutral-45;
   }
 }

--- a/addon/styles/pix-design-tokens/_form.scss
+++ b/addon/styles/pix-design-tokens/_form.scss
@@ -80,10 +80,6 @@
   padding-bottom: 12px;
 }
 
-.pix-radio-button {
-  padding: $pix-spacing-xs 0 $pix-spacing-xs 0;
-}
-
 .pix-form__actions {
   display: flex;
   justify-content: center;

--- a/app/stories/pix-checkbox.stories.js
+++ b/app/stories/pix-checkbox.stories.js
@@ -2,15 +2,18 @@ import { hbs } from 'ember-cli-htmlbars';
 
 export const Template = (args) => {
   return {
-    template: hbs`<PixCheckbox
+    template: hbs`
+<PixCheckbox
   @id={{this.id}}
   @screenReaderOnly={{this.screenReaderOnly}}
   @isIndeterminate={{this.isIndeterminate}}
   @labelSize={{this.labelSize}}
   @checked={{this.checked}}
+  disabled={{this.disabled}}
 >
   {{this.label}}
-</PixCheckbox>`,
+</PixCheckbox>
+`,
     context: args,
   };
 };
@@ -26,6 +29,7 @@ indeterminateCheckbox.args = {
   id: 'accept-newsletter-2',
   label: 'Recevoir la newsletter',
   isIndeterminate: true,
+  checked: true,
 };
 
 export const checkboxWithSmallLabel = Template.bind({});
@@ -40,6 +44,63 @@ checkboxWithLargeLabel.args = {
   id: 'accept-newsletter-2',
   label: 'Recevoir la newsletter',
   labelSize: 'large',
+};
+
+export const checkboxDisabled = Template.bind({});
+checkboxDisabled.args = {
+  id: 'accept-newsletter-2',
+  label: 'Recevoir la newsletter',
+  disabled: true,
+};
+
+export const checkboxCheckedDisabled = Template.bind({});
+checkboxCheckedDisabled.args = {
+  id: 'accept-newsletter-2',
+  label: 'Recevoir la newsletter',
+  disabled: true,
+  checked: true,
+};
+
+export const checkboxInterminateDisabled = Template.bind({});
+checkboxInterminateDisabled.args = {
+  id: 'accept-newsletter-2',
+  label: 'Recevoir la newsletter',
+  disabled: true,
+  checked: true,
+  isIndeterminate: true,
+};
+
+export const MultipleTemplate = (args) => {
+  return {
+    template: hbs`
+<PixCheckbox
+  @id="one"
+  @screenReaderOnly={{this.screenReaderOnly}}
+  @isIndeterminate={{this.isIndeterminate}}
+  @labelSize={{this.labelSize}}
+  @checked={{this.checked}}
+  disabled={{this.disabled}}
+>
+  {{this.label}}
+</PixCheckbox>
+<PixCheckbox
+  @id="two"
+  @screenReaderOnly={{this.screenReaderOnly}}
+  @isIndeterminate={{this.isIndeterminate}}
+  @labelSize={{this.labelSize}}
+  @checked={{this.checked}}
+  disabled={{this.disabled}}
+>
+  {{this.label}}
+</PixCheckbox>
+`,
+    context: args,
+  };
+};
+
+export const multiple = MultipleTemplate.bind({});
+multiple.args = {
+  label: 'Recevoir la newsletter',
 };
 
 export const argTypes = {
@@ -90,6 +151,15 @@ export const argTypes = {
   checked: {
     name: 'checked',
     description: 'Permet de cocher la checkbox',
+    type: { name: 'boolean', required: false },
+    table: {
+      type: { summary: 'boolean' },
+      defaultValue: { summary: false },
+    },
+  },
+  disabled: {
+    name: 'disabled',
+    description: 'Permet de désactiver la checkbox',
     type: { name: 'boolean', required: false },
     table: {
       type: { summary: 'boolean' },

--- a/app/stories/pix-checkbox.stories.mdx
+++ b/app/stories/pix-checkbox.stories.mdx
@@ -12,19 +12,44 @@ La PixCheckbox permet de créer des checkbox basiques ou des checkbox mixées (c
   <Story name="Default" story={stories.Default} height={60} />
 </Canvas>
 
-## Checkbox indéterminée
+### Liste de checkboxes
+
+Il n'est pas rare d'avoir plusieurs champs checkbox qui se suivent.<br/>
+En ce sens, nous avons déjà prévu un espace vertical pour séparer 2 composants qui se suivent.
+
+<Canvas>
+  <Story name="Multiple" story={stories.multiple} height={140} />
+</Canvas>
+
+## États de la Checkbox
+
+<br />
+
+### Checkbox interminée
 
 <Canvas>
   <Story name="Indeterminate" story={stories.indeterminateCheckbox} height={60} />
 </Canvas>
 
-## Checkbox avec un petit label
+### Checkbox désactivée
+
+<Canvas>
+  <Story name="Disabled" story={stories.checkboxDisabled} height={60} />
+  <Story name="CheckedDisabled" story={stories.checkboxCheckedDisabled} height={60} />
+  <Story name="InterminateDisabled" story={stories.checkboxInterminateDisabled} height={60} />
+</Canvas>
+
+## Autres tailles de police du label
+
+<br />
+
+### Small
 
 <Canvas>
   <Story name="SmallLabel" story={stories.checkboxWithSmallLabel} height={60} />
 </Canvas>
 
-## Checkbox avec un grand label
+### Large
 
 <Canvas>
   <Story name="LargeLabel" story={stories.checkboxWithLargeLabel} height={60} />
@@ -38,6 +63,7 @@ La PixCheckbox permet de créer des checkbox basiques ou des checkbox mixées (c
   @screenReaderOnly="{{false}}"
   @isIndeterminate="{{false}}"
   @labelSize="small"
+  disabled
 >
   Recevoir la newsletter
 </PixCheckbox>

--- a/app/stories/pix-radio-button.stories.js
+++ b/app/stories/pix-radio-button.stories.js
@@ -1,5 +1,6 @@
 import { hbs } from 'ember-cli-htmlbars';
 
+/* Default stories */
 const Template = (args) => {
   return {
     template: hbs`<PixRadioButton @label={{this.label}} @value={{this.value}} @isDisabled={{this.isDisabled}} />`,
@@ -18,6 +19,7 @@ isDisabled.args = {
   isDisabled: true,
 };
 
+/* Checked stories */
 const checked = (args) => {
   return {
     template: hbs`<PixRadioButton @label={{this.label}} @isDisabled={{this.isDisabled}} checked />`,
@@ -33,6 +35,23 @@ disabledChecked.args = {
 
 export const defaultChecked = checked.bind({});
 defaultChecked.args = Default.args;
+
+/* Multiple components story */
+const multipleTemplate = (args) => {
+  return {
+    template: hbs`
+<PixRadioButton @label={{this.label}} @isDisabled={{this.isDisabled}} name="radio" />
+<PixRadioButton @label={{this.label}} @isDisabled={{this.isDisabled}} name="radio" />
+<PixRadioButton @label={{this.label}} @isDisabled={{this.isDisabled}} name="radio" />
+`,
+    context: args,
+  };
+};
+
+export const multiple = multipleTemplate.bind({});
+multiple.args = {
+  ...Default.args,
+};
 
 export const argTypes = {
   label: {

--- a/app/stories/pix-radio-button.stories.mdx
+++ b/app/stories/pix-radio-button.stories.mdx
@@ -8,7 +8,7 @@ import * as stories from './pix-radio-button.stories.js';
 
 Un bouton radio permettant de sélectionner une seule option dans une liste.
 
-⚠️ Le bouton radio ne peut pas être utilisé seul : il faut au minimum **2 options**.
+⚠️ Le bouton radio ne peut pas être utilisé seul : il faut au minimum **2 options**.<br/>
 Il est préférable de ne pas sélectionner d’option par défaut pour que le choix de l’utilisateur soit conscient (en particulier si le choix est obligatoire).
 
 ## Default
@@ -16,6 +16,15 @@ Il est préférable de ne pas sélectionner d’option par défaut pour que le c
 <Canvas isColumn>
   <Story name="Default" story={stories.Default} height={60} />
   <Story name="Default checked" story={stories.defaultChecked} height={60} />
+</Canvas>
+
+### Liste de radios
+
+Puisqu'on ne souhaite en aucune avoir un input radio unique, il est déjà prévu l'espacement vertical avec un input radio suivant.<br/>
+Pour les considérer comme un seul groupe d'inputs, **il est nécessaire qu'ils aient chacun un attribut `name` avec une valeur commune**.
+
+<Canvas>
+  <Story name="Multiple" story={stories.multiple} height={140} />
 </Canvas>
 
 ## IsDisabled
@@ -30,7 +39,12 @@ Il est préférable de ne pas sélectionner d’option par défaut pour que le c
 ## Usage
 
 ```html
-<PixRadioButton @label="{{label}}" @value="{{value}}" @isDisabled="{{isDisabled}}" />
+<PixRadioButton
+  name="input-name"
+  @label="{{label}}"
+  @value="{{value}}"
+  @isDisabled="{{isDisabled}}"
+/>
 ```
 
 ## Arguments

--- a/tests/integration/components/pix-checkbox-test.js
+++ b/tests/integration/components/pix-checkbox-test.js
@@ -7,15 +7,13 @@ import createGlimmerComponent from '../../helpers/create-glimmer-component';
 module('Integration | Component | checkbox', function (hooks) {
   setupRenderingTest(hooks);
 
-  const CHECKBOX_INPUT_SELECTOR = '.pix-checkbox input';
-
   test('it should be possible to check the checkbox', async function (assert) {
     // when
     await render(hbs`<PixCheckbox @id='checkboxId'>Recevoir la newsletter</PixCheckbox>`);
     await clickByText('Recevoir la newsletter');
 
     // then
-    const checkbox = this.element.querySelector(CHECKBOX_INPUT_SELECTOR);
+    const checkbox = this.element.querySelector('.pix-checkbox__input');
     assert.true(checkbox.checked);
   });
 
@@ -37,7 +35,7 @@ module('Integration | Component | checkbox', function (hooks) {
 
     // then
     assert
-      .dom(screen.getByLabelText('yield required to give a label for PixCheckBox checkboxId.'))
+      .dom(screen.getByLabelText('yield required to give a label for PixCheckbox checkboxId.'))
       .exists();
   });
 
@@ -47,6 +45,14 @@ module('Integration | Component | checkbox', function (hooks) {
 
     // then
     assert.dom('.pix-checkbox__label--small').exists();
+  });
+
+  test('it should be possible to disable the checkbox', async function (assert) {
+    // when
+    await render(hbs`<PixCheckbox @id='checkboxId' disable>Mini label</PixCheckbox>`);
+
+    // then
+    assert.dom('.pix-checkbox__input[disable]').exists();
   });
 
   test('it should be possible to insert html in label', async function (assert) {
@@ -66,7 +72,7 @@ module('Integration | Component | checkbox', function (hooks) {
     await render(
       hbs`<PixCheckbox @id='checkboxId' @checked={{this.checked}}>Recevoir la newsletter</PixCheckbox>`
     );
-    const checkbox = this.element.querySelector(CHECKBOX_INPUT_SELECTOR);
+    const checkbox = this.element.querySelector('.pix-checkbox__input');
     assert.false(checkbox.checked);
 
     // when

--- a/tests/integration/components/pix-radio-button-test.js
+++ b/tests/integration/components/pix-radio-button-test.js
@@ -6,14 +6,12 @@ import { hbs } from 'ember-cli-htmlbars';
 module('Integration | Component | pix-radio-button', function (hooks) {
   setupRenderingTest(hooks);
 
-  const INPUT_SELECTOR = '.pix-radio-button input';
-
   test('it renders the default PixRadioButton', async function (assert) {
     // when
     await render(hbs`<PixRadioButton @label='Abricot' />`);
 
     // then
-    const componentInputElement = this.element.querySelector(INPUT_SELECTOR);
+    const componentInputElement = this.element.querySelector('.pix-radio-button__input');
     assert.contains('Abricot');
     // TODO: Fix this the next time the file is edited.
     // eslint-disable-next-line qunit/no-assert-equal
@@ -25,7 +23,7 @@ module('Integration | Component | pix-radio-button', function (hooks) {
     await render(hbs`<PixRadioButton @label='Abricot' @id='abricot' @isDisabled='true' />`);
 
     // then
-    const componentInputElement = this.element.querySelector(INPUT_SELECTOR);
+    const componentInputElement = this.element.querySelector('.pix-radio-button__input');
     assert.true(componentInputElement.disabled);
   });
 
@@ -34,7 +32,7 @@ module('Integration | Component | pix-radio-button', function (hooks) {
     await render(hbs`<PixRadioButton @label='Abricot' @id='abricot' @isDisabled='true' checked />`);
 
     // when & then
-    const componentInput = this.element.querySelector(INPUT_SELECTOR);
+    const componentInput = this.element.querySelector('.pix-radio-button__input');
     assert.true(componentInput.checked);
   });
 });


### PR DESCRIPTION
## :boom: BREAKING_CHANGES

- `PixCheckbox` n'a plus de marge à gauche. Elle pouvait être utilisée pour avoir un espace avec un autre élément.
- Les espaces verticaux des `PixRadioButton` ont été revus. Seul un composant radio qui suit un autre composant radio aura automatiquement un espace vertical de 20px.

## :christmas_tree: Problème

Les composants Checkbox et Radio devraient avoir un visuel très ressemblant. Mais jusqu'à présent, ils avaient pas mal de différences.

Aussi, ces deux composants géraient des espaces "préventifs" (horizontaux pour la Checkbox, verticaux pour le Radio). Or, ce n'est pas eux de gérer ça.

![image](https://user-images.githubusercontent.com/7335131/233647803-8c5c4ce0-8e15-4fda-bbd7-25e9e23837a3.png)

## :gift: Solution

- Modifier le style des composants PixCheckbox et PixRadioButton pour qu'ils soit plus proches de ce qui est dans le Design System
- En profiter pour faire une petite refactorisation du code des composants et des stories.

## :santa: Pour tester

Regarder les stories des 2 composants sur la RA
- PixCheckbox : https://ui-pr388.review.pix.fr/?path=/docs/form-checkbox--default
- PixRadioButton : https://ui-pr388.review.pix.fr/?path=/docs/form-radio-button--default
