### PR TITLE
[FEATURE] Ajouter l'argument requiredLabel au TextArea (PIX-7710)

### DIFF
--- a/addon/components/pix-textarea.hbs
+++ b/addon/components/pix-textarea.hbs
@@ -1,16 +1,25 @@
 <div class="pix-textarea">
 
   {{#if this.label}}
-    <label for={{@id}} class="pix-textarea__label">{{this.label}}</label>
+
+    <label for={{@id}} class="pix-textarea__label">
+      {{#if this.requiredLabel}}
+        <abbr title={{this.requiredLabel}} class="mandatory-mark" aria-hidden="true">*</abbr>
+      {{/if}}
+      {{this.label}}
+    </label>
   {{/if}}
 
   <Textarea
     id={{@id}}
     @value={{@value}}
     maxlength={{if @maxlength @maxlength}}
+    aria-required="{{if this.requiredLabel true false}}"
+    required={{if this.requiredLabel true false}}
     class="{{if @errorMessage 'pix-textarea--error'}}"
     ...attributes
   />
+
   {{#if @maxlength}}
     <p>{{this.textLengthIndicator}} / {{@maxlength}}</p>
   {{/if}}

--- a/addon/components/pix-textarea.js
+++ b/addon/components/pix-textarea.js
@@ -7,11 +7,23 @@ export default class PixTextarea extends Component {
 
   get label() {
     const labelIsDefined = this.args.label?.trim();
-    const idIsNotDefined = !this.args.id?.trim();
+    const idIsDefined = this.args.id?.trim();
 
-    if (labelIsDefined && idIsNotDefined) {
+    if (labelIsDefined && !idIsDefined) {
       throw new Error('ERROR in PixTextarea component, @id param is necessary when giving @label');
     }
     return this.args.label || null;
+  }
+
+  get requiredLabel() {
+    const idRequiredLabelDefined = this.args.requiredLabel?.trim();
+    const labelIsDefined = this.args.label?.trim();
+
+    if (idRequiredLabelDefined && !labelIsDefined) {
+      throw new Error(
+        'ERROR in PixTextarea component, @label param is necessary when giving @requiredLabel'
+      );
+    }
+    return this.args.requiredLabel || null;
   }
 }

--- a/app/stories/form.stories.js
+++ b/app/stories/form.stories.js
@@ -71,6 +71,7 @@ export const form = (args) => {
     @value=''
     @maxlength={{200}}
     @label='Un commentaire ?'
+    @requiredLabel='Champ obligatoire'
     @errorMessage={{this.genericErrorMessage}}
   />
   <br />

--- a/app/stories/pix-textarea.stories.js
+++ b/app/stories/pix-textarea.stories.js
@@ -7,6 +7,7 @@ const Template = (args) => {
   @value={{this.value}}
   @maxlength={{this.maxlength}}
   @label={{this.label}}
+  @requiredLabel={{this.requiredLabel}}
   @errorMessage={{this.errorMessage}}
 />`,
     context: args,
@@ -41,6 +42,13 @@ export const argTypes = {
   label: {
     name: 'label',
     description: 'Donne un label au champ.',
+    type: { name: 'string', required: false },
+  },
+
+  requiredLabel: {
+    name: 'requiredLabel',
+    description:
+      'Label indiquant que le champ est requis, le paramètre @label devient obligatoire avec ce paramètre.',
     type: { name: 'string', required: false },
   },
 

--- a/app/stories/pix-textarea.stories.mdx
+++ b/app/stories/pix-textarea.stories.mdx
@@ -23,6 +23,7 @@ Optionellement, il peut afficher le nombre de caractères tapés ainsi que le no
   @value="{{value}}"
   @maxlength="{{maxlength}}"
   @errorMessage="{{errorMessage}}"
+  @requiredLabel="{{requiredLabel}}"
 />
 ```
 

--- a/tests/integration/components/pix-textarea-test.js
+++ b/tests/integration/components/pix-textarea-test.js
@@ -9,6 +9,7 @@ module('Integration | Component | textarea', function (hooks) {
   setupRenderingTest(hooks);
 
   const TEXTAREA_SELECTOR = '.pix-textarea textarea';
+  const ABBR_SELECTOR = '.mandatory-mark';
 
   test('it renders PixTextarea with correct id and content', async function (assert) {
     // given
@@ -56,6 +57,37 @@ module('Integration | Component | textarea', function (hooks) {
     assert.true(textarea.required);
   });
 
+  test('it should add requiredLabel message in label', async function (assert) {
+    // given
+    const requiredLabel = 'Obligatoire';
+    this.set('requiredLabel', requiredLabel);
+
+    // when{{
+    await render(
+      hbs`<PixTextarea @value={{this.value}} @id='pix-textarea' @label='label' @requiredLabel={{this.requiredLabel}}/>`
+    );
+
+    // then
+    const abbr = this.element.querySelector(ABBR_SELECTOR);
+    assert.deepEqual(abbr.title, requiredLabel);
+  });
+
+  test('it should add required html attributes when given a requiredLabel argument', async function (assert) {
+    // given
+    const defaultValue = '';
+    this.set('value', defaultValue);
+
+    // when
+    await render(
+      hbs`<PixTextarea @value={{this.value}} @requiredLabel='Obligatoire' @label='label' @id='id' />`
+    );
+
+    // then
+    const textarea = this.element.querySelector(TEXTAREA_SELECTOR);
+    assert.true(textarea.required);
+    assert.strictEqual(textarea.ariaRequired, 'true');
+  });
+
   test('it should be possible to give a label', async function (assert) {
     // given & when
     await render(hbs`<PixTextarea @id='pix-select-with-label' @label='Décrivez votre problème' />`);
@@ -75,6 +107,20 @@ module('Integration | Component | textarea', function (hooks) {
     );
     assert.throws(function () {
       component.label;
+    }, expectedError);
+  });
+
+  test('it should throw an error if no label is provided when there is a requiredLabel', async function (assert) {
+    // given & when
+    const componentParams = { label: '   ', requiredLabel: 'Obligatoire' };
+    const component = createGlimmerComponent('component:pix-textarea', componentParams);
+
+    // then
+    const expectedError = new Error(
+      'ERROR in PixTextarea component, @label param is necessary when giving @requiredLabel'
+    );
+    assert.throws(function () {
+      component.requiredLabel;
     }, expectedError);
   });
 

--- a/tests/integration/components/pix-textarea-test.js
+++ b/tests/integration/components/pix-textarea-test.js
@@ -21,9 +21,7 @@ module('Integration | Component | textarea', function (hooks) {
     // then
     const textarea = this.element.querySelector(TEXTAREA_SELECTOR);
     assert.contains('Bonjour Pix !');
-    // TODO: Fix this the next time the file is edited.
-    // eslint-disable-next-line qunit/no-assert-equal
-    assert.equal(textarea.id, 7);
+    assert.strictEqual(textarea.id, '7');
   });
 
   test('it should count textarea characters length', async function (assert) {
@@ -41,9 +39,7 @@ module('Integration | Component | textarea', function (hooks) {
 
     // then
     const textarea = this.element.querySelector(TEXTAREA_SELECTOR);
-    // TODO: Fix this the next time the file is edited.
-    // eslint-disable-next-line qunit/no-assert-equal
-    assert.equal(textarea.maxLength, maxlength);
+    assert.strictEqual(textarea.maxLength, maxlength);
     assert.contains('11 / 20');
   });
 

--- a/tests/unit/components/pix-textarea-test.js
+++ b/tests/unit/components/pix-textarea-test.js
@@ -31,5 +31,19 @@ module('Unit | Component | pix-textarea', function (hooks) {
         component.label;
       }, expectedError);
     });
+
+    test('it should throw an error if there is no label provided when requiredLabel is present', function (assert) {
+      // given
+      const componentParams = { requiredLabel: 'Required label' };
+      const component = createGlimmerComponent('component:pix-textarea', componentParams);
+
+      // when & then
+      const expectedError = new Error(
+        'ERROR in PixTextarea component, @label param is necessary when giving @requiredLabel'
+      );
+      assert.throws(function () {
+        component.requiredLabel;
+      }, expectedError);
+    });
   });
 });

--- a/tests/unit/components/pix-textarea-test.js
+++ b/tests/unit/components/pix-textarea-test.js
@@ -15,9 +15,7 @@ module('Unit | Component | pix-textarea', function (hooks) {
       const result = component.label;
 
       // then
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(result, 'Textarea label');
+      assert.strictEqual(result, 'Textarea label');
     });
 
     test('it should throw an error if id is undefined', function (assert) {


### PR DESCRIPTION
## :boom: BREAKING_CHANGES
Normalement aucun, il s'agit d'un ajout d'argument

## :christmas_tree: Problème
Il manque, comme vu sur le input, la possibilité d'ajouter une prop requiredLabel qui va donner un indicateur visuel que ce champ est requis avant de soumetre le formulaire

![acc](https://user-images.githubusercontent.com/6728051/233998203-b6c3a487-cb94-4972-b2b0-9b86f25fd44c.png)

## :gift: Solution
Accepter l'argument requiredLabel qui va ajouter une balise `abbr` dans le label ainsi que les attributs html nécessaires. 

## :star2: Remarques
Comme il est nécessaire d'afficher un label pour afficher l'astérisque, le component renvoie une erreur si `label` n'est pas fourni quand `requiredLabel` est présent

## :santa: Pour tester
Lancer Storybook, jouer avec le Textarea, vérifier que les attributs html soient corrects et que `abbr` apparaît bien
