### PR TITLE
[FEATURE] Améliorer la lisibilité des tags (PIX-7827)

### DIFF
--- a/addon/styles/_pix-selectable-tag.scss
+++ b/addon/styles/_pix-selectable-tag.scss
@@ -3,8 +3,8 @@ $checkmark-width-with-space: $checkmark-width + 0.438rem;
 @mixin checkmarkColor($borderColor) {
   input[type='checkbox']:checked + label::before {
     position: absolute;
-    top: 6px;
-    left: 8px;
+    top: 10px;
+    left: 10px;
     width: $checkmark-width;
     height: 0.3125rem;
     border: 2px solid;
@@ -17,17 +17,20 @@ $checkmark-width-with-space: $checkmark-width + 0.438rem;
 }
 
 .pix-selectable-tag {
+
+  @extend %pix-body-s;
+
   display: inline-block;
   text-align: center;
   position: relative;
   padding: 3px calc(8px + #{$checkmark-width-with-space} / 2);
   letter-spacing: 0.009rem;
-  border-radius: 0.75rem;
+  border-radius: 0.95rem;
   border: $pix-neutral-30 solid 1px;
   color: $pix-neutral-60;
   background-color: $pix-neutral-0;
-  font-size: 0.8125rem;
   cursor: pointer;
+  font-weight: $font-medium;
 
   input {
     position: absolute;

--- a/addon/styles/_pix-tag.scss
+++ b/addon/styles/_pix-tag.scss
@@ -1,14 +1,17 @@
 .pix-tag {
+
+  @extend %pix-body-s;
+
   display: inline-block;
   text-align: center;
   vertical-align: baseline;
   white-space: nowrap;
   padding: 4px 16px;
-  font-size: 0.8125rem;
   border: 1px solid transparent;
-  border-radius: 0.75rem;
+  border-radius: 0.95rem;
   color: $pix-neutral-0;
   background-color: $pix-primary;
+  font-weight: $font-medium;
 
   &--blue-light {
     color: $pix-primary-80;
@@ -63,9 +66,12 @@
   }
 
   &--compact {
-    font-size: 0.6875rem;
+
+    @extend %pix-body-xs;
+
     font-weight: $font-medium;
     text-transform: uppercase;
     padding: 4px 13px;
+    line-height: inherit;
   }
 }


### PR DESCRIPTION
## :boom: BREAKING_CHANGES
Aucun

## :christmas_tree: Problème
Il y a un problème de lisibilité des tags, notamment sur l’onglet activité d’une campagne

## :gift: Solution
Mettre le texte des tags des statuts en bold et augmenter la taille.

## :star2: Remarques
Pour la taille du texte, aucun design token ne correspondait à la taille utilisée sur la maquette (13px), on a donc pris pix-body-s, qui correspond la taille au-dessus (14px)

## :santa: Pour tester
Sur Storybook, vérifier le composant Tag
