### PR TITLE
[BUGFIX] Éviter le rétrécissement des inputs checkbox et radio (PIX-7896).

### DIFF
--- a/addon/styles/_pix-checkbox.scss
+++ b/addon/styles/_pix-checkbox.scss
@@ -32,6 +32,7 @@
   position: relative;
   width: 1rem;
   height: 1rem;
+  flex-shrink: 0;
   background-color: $pix-neutral-0;
   border: 1.5px solid $pix-neutral-70;
   border-radius: 2px;

--- a/addon/styles/_pix-radio-button.scss
+++ b/addon/styles/_pix-radio-button.scss
@@ -18,6 +18,7 @@
     position: relative;
     width: 1rem;
     height: 1rem;
+    flex-shrink: 0;
     background-color: $pix-neutral-0;
     border: 1.5px solid $pix-neutral-70;
     border-radius: 50%;


### PR DESCRIPTION
## :christmas_tree: Problème

Ce qu’on a lorsque le label est assez long pour nécessiter un retour à la ligne (même problème pour checkbox) :

![image](https://user-images.githubusercontent.com/7335131/234817056-e43a7072-5677-40b7-9bc3-7272a2b4fb31.png)

## :gift: Solution

Éviter la réduction de taille en modifiant le style flex (pareil sur checkbox) :

![image](https://user-images.githubusercontent.com/7335131/234817121-fc23da9d-4228-442a-8106-da71c01d85bc.png)

## :santa: Pour tester

- Aller voir les composants [Checkbox](https://ui-pr392.review.pix.fr/?path=/story/form-checkbox--default&args=label:Recevoir+la+newsletter+Recevoir+la+newsletter+Recevoir+la+newsletter+Recevoir+la+newsletter+Recevoir+la+newsletter+Recevoir+la+newsletter+Recevoir+la+newsletter+Recevoir+la+newsletter+Recevoir+la+newsletter+Recevoir+la+newsletter) et [RadioButton](https://ui-pr392.review.pix.fr/?path=/story/form-radio-button--default&args=label:Recevoir+la+newsletter+Recevoir+la+newsletter+Recevoir+la+newsletter+Recevoir+la+newsletter+Recevoir+la+newsletter+Recevoir+la+newsletter+Recevoir+la+newsletter+Recevoir+la+newsletter+Recevoir+la+newsletter+Recevoir+la+newsletter) sur la RA
- Modifier le label pour un texte vraiment long pour attester que l'input ne change pas de taille
