### PR TITLE
[FEATURE] Uniformiser PixRadioButton et PixCheckbox (PIX-7900)

### DIFF
--- a/addon/components/pix-checkbox.hbs
+++ b/addon/components/pix-checkbox.hbs
@@ -1,18 +1,17 @@
-<label class="pix-checkbox {{@class}}" for={{@id}}>
+<div class="pix-checkbox {{@class}}">
   <input
-    id={{@id}}
     type="checkbox"
+    id={{this.id}}
     class={{this.inputClasses}}
     checked={{@checked}}
     ...attributes
   />
 
-  {{#if (has-block)}}
-    <span class={{this.labelClasses}}>{{yield}}</span>
-  {{else}}
-    <span>
-      yield required to give a label for PixCheckbox
-      {{@id}}.
-    </span>
-  {{/if}}
-</label>
+  <label class={{this.labelClasses}} for={{this.id}}>
+    {{#if (has-block)}}
+      {{yield}}
+    {{else}}
+      <span>yield required to give a label for PixCheckbox.</span>
+    {{/if}}
+  </label>
+</div>

--- a/addon/components/pix-checkbox.js
+++ b/addon/components/pix-checkbox.js
@@ -1,12 +1,13 @@
 import Component from '@glimmer/component';
+import { guidFor } from '@ember/object/internals';
 
 export default class PixCheckbox extends Component {
   constructor() {
     super(...arguments);
+  }
 
-    if (!this.args.id || !this.args.id.toString().trim()) {
-      throw new Error('ERROR in PixCheckbox component, @id param is not provided');
-    }
+  get id() {
+    return this.args.id || guidFor(this);
   }
 
   get inputClasses() {

--- a/addon/components/pix-radio-button.hbs
+++ b/addon/components/pix-radio-button.hbs
@@ -1,10 +1,16 @@
-<label class="pix-radio-button">
+<div class="pix-radio-button {{@class}}">
   <input
-    class="pix-radio-button__input"
     type="radio"
+    id={{this.id}}
+    class="pix-radio-button__input"
     value={{@value}}
-    disabled={{@isDisabled}}
     ...attributes
   />
-  <span class="pix-radio-button__label">{{@label}}</span>
-</label>
+  <label class="pix-radio-button__label" for={{this.id}}>
+    {{#if (has-block)}}
+      {{yield}}
+    {{else}}
+      <span>yield required to give a label for PixRadioButton.</span>
+    {{/if}}
+  </label>
+</div>

--- a/addon/components/pix-radio-button.js
+++ b/addon/components/pix-radio-button.js
@@ -1,5 +1,10 @@
 import Component from '@glimmer/component';
+import { guidFor } from '@ember/object/internals';
 
 export default class PixRadioButton extends Component {
   text = 'pix-radio-button';
+
+  get id() {
+    return this.args.id || guidFor(this);
+  }
 }

--- a/addon/styles/_pix-checkbox.scss
+++ b/addon/styles/_pix-checkbox.scss
@@ -4,7 +4,6 @@
   align-items: center;
   display: flex;
   color: $pix-neutral-70;
-  cursor: pointer;
 
   & + .pix-checkbox {
     margin-top: $pix-spacing-s;
@@ -17,6 +16,7 @@
   color: $pix-neutral-90;
   font-size: 1rem;
   line-height: 1.5;
+  cursor: pointer;
 
   &--small {
     font-size: 0.875rem;

--- a/addon/styles/_pix-radio-button.scss
+++ b/addon/styles/_pix-radio-button.scss
@@ -1,7 +1,6 @@
 .pix-radio-button {
   display: flex;
   align-items: center;
-  cursor: pointer;
 
   & + .pix-radio-button {
     margin-top: $pix-spacing-s;
@@ -12,6 +11,7 @@
     color: $pix-neutral-90;
     font-size: 1rem;
     line-height: 1.5;
+    cursor: pointer;
   }
 
   &__input {
@@ -23,6 +23,7 @@
     border: 1.5px solid $pix-neutral-70;
     border-radius: 50%;
     appearance: none;
+    cursor: pointer;
 
     // Hover effect
     &::before {

--- a/app/stories/pix-checkbox.stories.js
+++ b/app/stories/pix-checkbox.stories.js
@@ -5,6 +5,7 @@ export const Template = (args) => {
     template: hbs`
 <PixCheckbox
   @id={{this.id}}
+  @class={{this.class}}
   @screenReaderOnly={{this.screenReaderOnly}}
   @isIndeterminate={{this.isIndeterminate}}
   @labelSize={{this.labelSize}}
@@ -75,6 +76,7 @@ export const MultipleTemplate = (args) => {
     template: hbs`
 <PixCheckbox
   @id="one"
+  @class={{this.class}}
   @screenReaderOnly={{this.screenReaderOnly}}
   @isIndeterminate={{this.isIndeterminate}}
   @labelSize={{this.labelSize}}
@@ -85,6 +87,7 @@ export const MultipleTemplate = (args) => {
 </PixCheckbox>
 <PixCheckbox
   @id="two"
+  @class={{this.class}}
   @screenReaderOnly={{this.screenReaderOnly}}
   @isIndeterminate={{this.isIndeterminate}}
   @labelSize={{this.labelSize}}
@@ -106,8 +109,9 @@ multiple.args = {
 export const argTypes = {
   id: {
     name: 'id',
-    description: 'Identifiant du champ permettant de lui attacher un label',
-    type: { name: 'string', required: true },
+    description:
+      'Identifiant du champ permettant de lui attacher un label. Généré automatiquement si non renseigné.',
+    type: { name: 'string' },
   },
   label: {
     name: 'label',
@@ -115,7 +119,7 @@ export const argTypes = {
   },
   class: {
     name: 'class',
-    description: "Permet d'ajouter une classe css à la checkbox.",
+    description: "Permet d'ajouter une classe au parent du composant.",
     type: { name: 'string' },
   },
   screenReaderOnly: {

--- a/app/stories/pix-checkbox.stories.mdx
+++ b/app/stories/pix-checkbox.stories.mdx
@@ -59,7 +59,6 @@ En ce sens, nous avons déjà prévu un espace vertical pour séparer 2 composan
 
 ```html
 <PixCheckbox
-  @id="superId"
   @screenReaderOnly="{{false}}"
   @isIndeterminate="{{false}}"
   @labelSize="small"

--- a/app/stories/pix-radio-button.stories.js
+++ b/app/stories/pix-radio-button.stories.js
@@ -3,7 +3,15 @@ import { hbs } from 'ember-cli-htmlbars';
 /* Default stories */
 const Template = (args) => {
   return {
-    template: hbs`<PixRadioButton @label={{this.label}} @value={{this.value}} @isDisabled={{this.isDisabled}} />`,
+    template: hbs`
+    <PixRadioButton
+      @value={{this.value}}
+      @id={{this.id}}
+      @class={{this.class}}
+      disabled={{this.disabled}}
+    >
+      {{this.label}}
+    </PixRadioButton>`,
     context: args,
   };
 };
@@ -16,13 +24,14 @@ Default.args = {
 export const isDisabled = Template.bind({});
 isDisabled.args = {
   ...Default.args,
-  isDisabled: true,
+  disabled: true,
 };
 
 /* Checked stories */
 const checked = (args) => {
   return {
-    template: hbs`<PixRadioButton @label={{this.label}} @isDisabled={{this.isDisabled}} checked />`,
+    template: hbs`
+    <PixRadioButton @value={{this.value}} disabled={{this.disabled}} checked>{{this.label}}</PixRadioButton>`,
     context: args,
   };
 };
@@ -30,7 +39,7 @@ const checked = (args) => {
 export const disabledChecked = checked.bind({});
 disabledChecked.args = {
   ...Default.args,
-  isDisabled: true,
+  disabled: true,
 };
 
 export const defaultChecked = checked.bind({});
@@ -40,9 +49,9 @@ defaultChecked.args = Default.args;
 const multipleTemplate = (args) => {
   return {
     template: hbs`
-<PixRadioButton @label={{this.label}} @isDisabled={{this.isDisabled}} name="radio" />
-<PixRadioButton @label={{this.label}} @isDisabled={{this.isDisabled}} name="radio" />
-<PixRadioButton @label={{this.label}} @isDisabled={{this.isDisabled}} name="radio" />
+<PixRadioButton disabled={{this.disabled}} name="radio">{{this.label}}</PixRadioButton>
+<PixRadioButton disabled={{this.disabled}} name="radio">{{this.label}}</PixRadioButton>
+<PixRadioButton disabled={{this.disabled}} name="radio">{{this.label}}</PixRadioButton>
 `,
     context: args,
   };
@@ -54,18 +63,29 @@ multiple.args = {
 };
 
 export const argTypes = {
+  id: {
+    name: 'id',
+    description:
+      'Identifiant du champ permettant de lui attacher un label. Généré automatiquement si non renseigné.',
+    type: { name: 'string' },
+  },
   label: {
     name: 'label',
     description: 'Le label du bouton radio',
     type: { name: 'string', required: true },
+  },
+  class: {
+    name: 'class',
+    description: "Permet d'ajouter une classe CSS au parent du composant.",
+    type: { name: 'string' },
   },
   value: {
     name: 'value',
     description: "Valeur permettant d'identifier l'option sélectionnée",
     type: { name: 'string', required: false },
   },
-  isDisabled: {
-    name: 'isDisabled',
+  disabled: {
+    name: 'disabled',
     description: 'Pour désactiver/activer le bouton radio',
     type: { name: 'boolean', required: false },
     table: {

--- a/app/stories/pix-radio-button.stories.mdx
+++ b/app/stories/pix-radio-button.stories.mdx
@@ -27,7 +27,7 @@ Pour les considérer comme un seul groupe d'inputs, **il est nécessaire qu'ils 
   <Story name="Multiple" story={stories.multiple} height={140} />
 </Canvas>
 
-## IsDisabled
+## Disabled
 
 État inactif du bouton radio.
 
@@ -39,12 +39,7 @@ Pour les considérer comme un seul groupe d'inputs, **il est nécessaire qu'ils 
 ## Usage
 
 ```html
-<PixRadioButton
-  name="input-name"
-  @label="{{label}}"
-  @value="{{value}}"
-  @isDisabled="{{isDisabled}}"
-/>
+<PixRadioButton name="input-name" @value="{{value}}"> Exemple de label </PixRadioButton>
 ```
 
 ## Arguments

--- a/tests/integration/components/pix-checkbox-test.js
+++ b/tests/integration/components/pix-checkbox-test.js
@@ -2,14 +2,13 @@ import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { hbs } from 'ember-cli-htmlbars';
 import { render, clickByText } from '@1024pix/ember-testing-library';
-import createGlimmerComponent from '../../helpers/create-glimmer-component';
 
 module('Integration | Component | checkbox', function (hooks) {
   setupRenderingTest(hooks);
 
   test('it should be possible to check the checkbox', async function (assert) {
     // when
-    await render(hbs`<PixCheckbox @id='checkboxId'>Recevoir la newsletter</PixCheckbox>`);
+    await render(hbs`<PixCheckbox>Recevoir la newsletter</PixCheckbox>`);
     await clickByText('Recevoir la newsletter');
 
     // then
@@ -17,31 +16,17 @@ module('Integration | Component | checkbox', function (hooks) {
     assert.true(checkbox.checked);
   });
 
-  test('it should throw an error if there is no id', async function (assert) {
-    // given & when
-    const componentParams = { id: '   ', label: 'Super label' };
-    const renderComponent = function () {
-      createGlimmerComponent('component:pix-checkbox', componentParams);
-    };
-
-    // then
-    const expectedError = new Error('ERROR in PixCheckbox component, @id param is not provided');
-    assert.throws(renderComponent, expectedError);
-  });
-
   test('it should display error message if there no yield', async function (assert) {
     // given & when
-    const screen = await render(hbs`<PixCheckbox @id='checkboxId' />`);
+    const screen = await render(hbs`<PixCheckbox />`);
 
     // then
-    assert
-      .dom(screen.getByLabelText('yield required to give a label for PixCheckbox checkboxId.'))
-      .exists();
+    assert.dom(screen.getByLabelText('yield required to give a label for PixCheckbox.')).exists();
   });
 
   test('it should be possible to make label small', async function (assert) {
     // when
-    await render(hbs`<PixCheckbox @id='checkboxId' @labelSize='small'>Mini label</PixCheckbox>`);
+    await render(hbs`<PixCheckbox @labelSize='small'>Mini label</PixCheckbox>`);
 
     // then
     assert.dom('.pix-checkbox__label--small').exists();
@@ -49,7 +34,7 @@ module('Integration | Component | checkbox', function (hooks) {
 
   test('it should be possible to disable the checkbox', async function (assert) {
     // when
-    await render(hbs`<PixCheckbox @id='checkboxId' disable>Mini label</PixCheckbox>`);
+    await render(hbs`<PixCheckbox disable>Mini label</PixCheckbox>`);
 
     // then
     assert.dom('.pix-checkbox__input[disable]').exists();
@@ -58,7 +43,7 @@ module('Integration | Component | checkbox', function (hooks) {
   test('it should be possible to insert html in label', async function (assert) {
     // given & when
     const screen = await render(
-      hbs`<PixCheckbox @id='checkboxId'>Accepter les cgu,
+      hbs`<PixCheckbox>Accepter les cgu,
   <a href='https://cgu.example.net'>voir ici</a></PixCheckbox>`
     );
 
@@ -69,9 +54,7 @@ module('Integration | Component | checkbox', function (hooks) {
   test('it should be possible to control state', async function (assert) {
     // given
     this.set('checked', false);
-    await render(
-      hbs`<PixCheckbox @id='checkboxId' @checked={{this.checked}}>Recevoir la newsletter</PixCheckbox>`
-    );
+    await render(hbs`<PixCheckbox @checked={{this.checked}}>Recevoir la newsletter</PixCheckbox>`);
     const checkbox = this.element.querySelector('.pix-checkbox__input');
     assert.false(checkbox.checked);
 

--- a/tests/integration/components/pix-radio-button-test.js
+++ b/tests/integration/components/pix-radio-button-test.js
@@ -8,7 +8,7 @@ module('Integration | Component | pix-radio-button', function (hooks) {
 
   test('it renders the default PixRadioButton', async function (assert) {
     // when
-    await render(hbs`<PixRadioButton @label='Abricot' />`);
+    await render(hbs`<PixRadioButton>Abricot</PixRadioButton>`);
 
     // then
     const componentInputElement = this.element.querySelector('.pix-radio-button__input');
@@ -18,9 +18,9 @@ module('Integration | Component | pix-radio-button', function (hooks) {
     assert.equal(componentInputElement.type, 'radio');
   });
 
-  test('it renders the PixRadioButton component with isDisabled attribute', async function (assert) {
+  test('it renders the PixRadioButton component with disabled attribute', async function (assert) {
     // given & when
-    await render(hbs`<PixRadioButton @label='Abricot' @id='abricot' @isDisabled='true' />`);
+    await render(hbs`<PixRadioButton disabled>Abricot</PixRadioButton>`);
 
     // then
     const componentInputElement = this.element.querySelector('.pix-radio-button__input');
@@ -29,7 +29,7 @@ module('Integration | Component | pix-radio-button', function (hooks) {
 
   test('it should be possible to add more params to PixRadioButton', async function (assert) {
     // given
-    await render(hbs`<PixRadioButton @label='Abricot' @id='abricot' @isDisabled='true' checked />`);
+    await render(hbs`<PixRadioButton disabled checked>Abricot</PixRadioButton>`);
 
     // when & then
     const componentInput = this.element.querySelector('.pix-radio-button__input');


### PR DESCRIPTION
## :boom: BREAKING_CHANGES
- Suppression de l'attribut `@label` pour le PixRadioButton
- Suppression de l'attribut `@isDisabled` pour le PixRadioButton : utiliser l'attribut `disabled` natif à la place.

## :christmas_tree: Problème
Jusqu'à présent, PixRadioButton utilise un attribut `@label` pour afficher son label.
Quant à lui PixCheckbox utilise son slot, ce qui est un comportement qui permet plus de choses.
On veut donc que PixRadioButton se comporte de la même façon que PixCheckbox.

## :gift: Solution
- Utilisation d'un `yield` pour la gestion du label pour le PixRadioButton.
- L'attribut `@id` n'est plus required et s'il n'est pas founi par le développeur, il est alors généré automatiquement.

## :santa: Pour tester
Vérifier que les stories de PixRadioButton et PixCheckbox fonctionnent toujours bien et que des id sont bien présents pour lier le label et l'input.