### PR TITLE
[TECH] Rendre Chromatic non bloquant lors du run de la CI (PIX-7932)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -64,4 +64,4 @@ jobs:
       - restore_cache:
           name: Restore node modules
           key: node_modules
-      - run: npm run chromatic -- --exit-zero-on-changes
+      - run: npm run chromatic -- --auto-accept-changes


### PR DESCRIPTION
## :boom: BREAKING_CHANGES
> _Décrivez ici les changements cassant (voir la doc associée)[https://github.com/1024pix/pix-ui/blob/dev/docs/breaking-changes.stories.mdx], s'il n'y en a pas indiquez le aussi.

Pas de breaking change, c'est un ticket tech

## :christmas_tree: Problème
Le build de Chromatic était bloquant tant que les modifications n'étaient pas review et validées. Hors, c'est un test de Chromatic que nous faisons ici donc c'est pas cool.

## :gift: Solution
Ne plus le rendre bloquant le temps du test

## :star2: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :santa: Pour tester
- euhhhhhhh