### PR TITLE
[FEATURE] Améliorer le composant PixFilterbanner (PIX-7854)

### DIFF
--- a/addon/components/pix-button.hbs
+++ b/addon/components/pix-button.hbs
@@ -13,8 +13,8 @@
     class={{this.className}}
     {{on "click" this.triggerAction}}
     ...attributes
-    disabled={{this.isButtonLoadingOrDisabled}}
-    aria-disabled="{{this.ariaDisabled}}"
+    disabled={{this.isDisabled}}
+    aria-disabled="{{this.isDisabled}}"
   >
     {{#if this.isLoading}}
       <div class="loader loader--{{this.loadingColor}}">

--- a/addon/components/pix-button.js
+++ b/addon/components/pix-button.js
@@ -21,12 +21,8 @@ export default class PixButton extends PixButtonBase {
     return this.args.loadingColor || this.args['loading-color'] || 'white';
   }
 
-  get isButtonLoadingOrDisabled() {
+  get isDisabled() {
     return this.isLoading || this.args.isDisabled;
-  }
-
-  get ariaDisabled() {
-    return this.isButtonLoadingOrDisabled;
   }
 
   get className() {
@@ -35,7 +31,7 @@ export default class PixButton extends PixButtonBase {
 
   @action
   async triggerAction(params) {
-    if (this.type === 'submit' && !this.args.triggerAction) return;
+    if (this.isDisabled || (this.type === 'submit' && !this.args.triggerAction)) return;
     if (!this.args.triggerAction) {
       throw new Error('@triggerAction params is required for PixButton !');
     }

--- a/addon/components/pix-filter-banner.hbs
+++ b/addon/components/pix-filter-banner.hbs
@@ -22,8 +22,7 @@
             @shape="squircle"
             @size="small"
             @triggerAction={{@onClearFilters}}
-            @iconBefore="trash-can"
-            @prefixIconBefore="far"
+            @isDisabled={{@isClearFilterButtonDisabled}}
           >
             {{@clearFiltersLabel}}
           </PixButton>

--- a/addon/components/pix-filter-banner.js
+++ b/addon/components/pix-filter-banner.js
@@ -4,9 +4,11 @@ export default class PixFilterBanner extends Component {
   get displayTitle() {
     return Boolean(this.args.title);
   }
+
   get displayDetails() {
     return Boolean(this.args.details);
   }
+
   get displayClearFilters() {
     return Boolean(this.args.clearFiltersLabel);
   }

--- a/app/stories/pix-filter-banner.stories.js
+++ b/app/stories/pix-filter-banner.stories.js
@@ -8,6 +8,7 @@ export const filterBanner = (args) => {
   @details={{this.details}}
   @clearFiltersLabel={{this.clearFiltersLabel}}
   @onClearFilters={{this.onClearFilters}}
+  @isClearFilterButtonDisabled={{this.isClearFilterButtonDisabled}}
 >
   <PixSelect @options={{this.options}} @onChange={{this.onChange}} @label="mon label" @screenReaderOnly={{true}} @placeholder="placeholer"/>
   <PixSelect @options={{this.options}} @onChange={{this.onChange}} @label="mon label" @screenReaderOnly={{true}} @placeholder="placeholer"/>
@@ -48,5 +49,15 @@ export const argTypes = {
     name: 'onClearFilters',
     description: 'fonction à appeler pour déclencher l’action de suppression des filtres',
     type: { required: false },
+  },
+  isClearFilterButtonDisabled: {
+    name: 'isClearFilterButtonDisabled',
+    description: 'Désactiver le button de la suppresion des filtres',
+    type: { name: 'boolean', required: true },
+    control: { type: 'boolean' },
+    table: {
+      type: { summary: 'boolean' },
+      defaultValue: { summary: false },
+    },
   },
 };

--- a/tests/integration/components/pix-filter-banner-test.js
+++ b/tests/integration/components/pix-filter-banner-test.js
@@ -1,9 +1,9 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import { render } from '@ember/test-helpers';
+import { render } from '@1024pix/ember-testing-library';
+import { click } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import sinon from 'sinon';
-import clickByLabel from '../../helpers/click-by-label';
 
 module('Integration | Component | filter-banner', function (hooks) {
   setupRenderingTest(hooks);
@@ -38,38 +38,60 @@ module('Integration | Component | filter-banner', function (hooks) {
     assert.contains('5 participants filtrés');
   });
 
-  test('it renders the PixFilterBanner with a clearFiltersLabel button', async function (assert) {
-    //given
-    this.clearFiltersLabel = 'Effacer les filtres';
-    this.onClearFilters = sinon.spy();
+  module('clearFilterbutton', function () {
+    test('it renders the PixFilterBanner with a clearFiltersLabel button', async function (assert) {
+      //given
+      this.clearFiltersLabel = 'Effacer les filtres';
+      this.onClearFilters = sinon.spy();
 
-    // when
-    await render(hbs`<PixFilterBanner
-  @clearFiltersLabel={{this.clearFiltersLabel}}
-  @onClearFilters={{this.onClearFilters}}
->
-  content
-</PixFilterBanner>`);
+      // when
+      const screen = await render(hbs`<PixFilterBanner
+    @clearFiltersLabel={{this.clearFiltersLabel}}
+    @onClearFilters={{this.onClearFilters}}
+  >
+    content
+  </PixFilterBanner>`);
 
-    // then
-    assert.contains(this.clearFiltersLabel);
-  });
+      // then
+      const button = screen.getByRole('button', { name: this.clearFiltersLabel });
+      assert.dom(button).exists();
+    });
 
-  test('it should trigger onClearFilters when button clicked', async function (assert) {
-    // given
-    this.clearFiltersLabel = 'some label';
-    this.onClearFilters = sinon.spy();
+    test('it renders the PixFilterBanner with a disabled clearFiltersLabel button', async function (assert) {
+      //given
+      this.clearFiltersLabel = 'Effacer les filtres';
+      this.isClearFilterButtonDisabled = true;
+      this.onClearFilters = sinon.spy();
 
-    //when
-    await render(hbs`<PixFilterBanner
-  @clearFiltersLabel={{this.clearFiltersLabel}}
-  @onClearFilters={{this.onClearFilters}}
->
-  content
-</PixFilterBanner>`);
-    await clickByLabel('some label');
+      // when
+      const screen = await render(hbs`<PixFilterBanner
+    @clearFiltersLabel={{this.clearFiltersLabel}}
+    @isClearFilterButtonDisabled={{this.isClearFilterButtonDisabled}}
+  >
+    content
+  </PixFilterBanner>`);
 
-    // then
-    assert.ok(this.onClearFilters.calledOnce, 'the callback should be called once');
+      // then
+      const button = screen.getByRole('button', { name: this.clearFiltersLabel, hidden: true });
+      assert.dom(button).exists();
+    });
+
+    test('it should trigger onClearFilters when button clicked', async function (assert) {
+      // given
+      this.clearFiltersLabel = 'some label';
+      this.onClearFilters = sinon.spy();
+
+      //when
+      const screen = await render(hbs`<PixFilterBanner
+    @clearFiltersLabel={{this.clearFiltersLabel}}
+    @onClearFilters={{this.onClearFilters}}
+  >
+    content
+  </PixFilterBanner>`);
+      await click(screen.getByRole('button', { name: this.clearFiltersLabel }));
+
+      // then
+      assert.ok(this.onClearFilters.calledOnce, 'the callback should be called once');
+    });
   });
 });


### PR DESCRIPTION
## :boom: BREAKING_CHANGES
RAS

## :christmas_tree: Problème
Une icone poubelle pour effacer les filtres est présent ce qui n'est pas voulu dans le DS
On ne peut pas désactiver le bouton si aucun filtre n'est selectionné

## :gift: Solution
Retirer l'icone poubelle
Ajouter la possibilité de désactiver le bouton lorsqu'il n'y a aucun filtre de selectionnable

## :star2: Remarques
RAS

## :santa: Pour tester

Aller sur PixUI et regarder le canvas PixFilterBanner sans poubelle et que l'option `disabled` fonctionne (_cette description à toujours existé_)