### PR TITLE
[TECH] Suppression de l'utilitaire uniqueId (PIX-8003)

### DIFF
--- a/addon/components/pix-modal.js
+++ b/addon/components/pix-modal.js
@@ -1,6 +1,6 @@
 import Component from '@glimmer/component';
 import { action } from '@ember/object';
-import uniqueId from '@1024pix/pix-ui/utils/unique-id';
+import { guidFor } from '@ember/object/internals';
 
 export default class PixModal extends Component {
   constructor(...args) {
@@ -23,6 +23,6 @@ export default class PixModal extends Component {
   }
 
   get id() {
-    return uniqueId();
+    return guidFor(this);
   }
 }

--- a/addon/components/pix-sidebar.js
+++ b/addon/components/pix-sidebar.js
@@ -1,6 +1,6 @@
 import Component from '@glimmer/component';
 import { action } from '@ember/object';
-import uniqueId from '@1024pix/pix-ui/utils/unique-id';
+import { guidFor } from '@ember/object/internals';
 
 export default class PixSidebar extends Component {
   constructor(...args) {
@@ -23,6 +23,6 @@ export default class PixSidebar extends Component {
   }
 
   get id() {
-    return uniqueId();
+    return guidFor(this);
   }
 }

--- a/addon/utils/unique-id.js
+++ b/addon/utils/unique-id.js
@@ -1,5 +1,0 @@
-export default function uniqueId() {
-  return ([3e7] + -1e3 + -4e3 + -2e3 + -1e11).replace(/[0-3]/g, (a) =>
-    ((a * 4) ^ ((Math.random() * 16) >> (a & 2))).toString(16)
-  );
-}


### PR DESCRIPTION
## :boom: BREAKING_CHANGES
Aucuns

## :christmas_tree: Problème
Un utilitaire a été développé pour généré des identifiants uniques à utiliser dans le code hbs. Cependant il ne garantit pas vraiment unicité des ids produits.

## :gift: Solution
Il existe une méthode de ember qui assigne un identifiant unique par objet appelé [guidFor](https://api.emberjs.com/ember/release/functions/@ember%2Fobject%2Finternals/guidFor).

## :star2: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :santa: Pour tester
> _Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc._
