### PR TITLE
[FEATURE] Améliorer le design de la liste déroulante du PixSelect (PIX-8044)

### DIFF
--- a/addon/styles/_pix-select.scss
+++ b/addon/styles/_pix-select.scss
@@ -14,7 +14,6 @@
     z-index: 200;
     position: absolute;
     max-height: 12.5rem;
-    width: inherit;
     border-top: none;
     border-radius: 0 0 $pix-spacing-xxs $pix-spacing-xxs;
     list-style-type: none;


### PR DESCRIPTION
## :boom: BREAKING_CHANGES

## :christmas_tree: Problème
![image](https://github.com/1024pix/pix-ui/assets/49011144/e4262992-8d7d-4abf-abaa-432cab297e38)
Lorsque les options sont trop longues, la liste déroulante dépasse.

## :gift: Solution
Ajuster le design pour ne pas prendre la taille de l'élément parent.

## :santa: Pour tester
