### PR TITLE
[FEATURE] Enlever l'obligation d'avoir un label ou un ariaLabel pour le PixInput (PIX-8126) 

### DIFF
--- a/addon/components/pix-input.js
+++ b/addon/components/pix-input.js
@@ -1,7 +1,5 @@
 import Component from '@glimmer/component';
 
-const ERROR_MESSAGE = 'ERROR in PixInput component, you must provide @label or @ariaLabel params';
-
 const INPUT_VALIDATION_STATUS_MAP = {
   default: '',
   error: 'pix-input__input--error',
@@ -17,16 +15,10 @@ export default class PixInput extends Component {
   }
 
   get label() {
-    if (!this.args.label && !this.args.ariaLabel) {
-      throw new Error(ERROR_MESSAGE);
-    }
     return this.args.label;
   }
 
   get ariaLabel() {
-    if (!this.args.label && !this.args.ariaLabel) {
-      throw new Error(ERROR_MESSAGE);
-    }
     return this.args.label ? null : this.args.ariaLabel;
   }
 

--- a/app/stories/pix-input.stories.js
+++ b/app/stories/pix-input.stories.js
@@ -55,7 +55,7 @@ export const argTypes = {
   ariaLabel: {
     name: 'ariaLabel',
     description: "L'action du champ, pour l'accessibilité. Requis si label n'est pas définit.",
-    type: { name: 'string', required: true },
+    type: { name: 'string', required: false },
   },
   id: {
     name: 'id',

--- a/app/stories/pix-input.stories.mdx
+++ b/app/stories/pix-input.stories.mdx
@@ -10,7 +10,7 @@ Le PixInput permet de créer un champ de texte.
 
 ## Accessibilité
 
-Si vous utilisez le `PixInput` sans label alors il faut renseigner le paramètre `ariaLabel`, sinon le composant renvoie une erreur.
+Si vous utilisez le `PixInput` sans label alors il faut renseigner le paramètre `ariaLabel`. Il est possible d'ajouter un label en dehors du composant en précisant bien un attribut `for` correspondant à l'`@id` passé au PixInput.
 
 > Si vous renseignez les paramètres label et ariaLabel ensemble, ariaLabel sera nullifié.
 

--- a/tests/integration/components/pix-input-test.js
+++ b/tests/integration/components/pix-input-test.js
@@ -107,21 +107,4 @@ module('Integration | Component | input', function (hooks) {
     const requiredInput = screen.getByLabelText('* Prénom');
     assert.dom(requiredInput).isRequired();
   });
-
-  test('it should throw an error if pix input has neither a label nor an ariaLabel param', async function (assert) {
-    // given & when
-    const componentParams = { label: null, ariaLabel: null };
-    const component = createGlimmerComponent('component:pix-input', componentParams);
-
-    // then
-    const expectedError = new Error(
-      'ERROR in PixInput component, you must provide @label or @ariaLabel params'
-    );
-    assert.throws(function () {
-      component.label;
-    }, expectedError);
-    assert.throws(function () {
-      component.ariaLabel;
-    }, expectedError);
-  });
 });


### PR DESCRIPTION
## :christmas_tree: Problème
Le PixInput rend obligatoire l'ajout d'un attribut `@label` et/ou `@ariaLabel`. Cependant, on aimerait pouvoir parfois ajouter un label custom en dehors du composant.

## :gift: Solution
Enlever le message d'erreur lorsque les attributs ne sont pas ajoutés.

## :santa: Pour tester
Vérifier qu'aucun message d'erreur n'est renvoyé si un `@label` ou un `@ariaLabel` n'est pas passé. 
