### PR TITLE
[FEATURE] Utiliser les éléments HTML native pour le TextArea (PIX-8200)

### DIFF
--- a/addon/components/pix-textarea.hbs
+++ b/addon/components/pix-textarea.hbs
@@ -10,15 +10,15 @@
     </label>
   {{/if}}
 
-  <Textarea
+  <textarea
     id={{@id}}
-    @value={{@value}}
     maxlength={{if @maxlength @maxlength}}
     aria-required="{{if this.requiredLabel true false}}"
     required={{if this.requiredLabel true false}}
     class="{{if @errorMessage 'pix-textarea--error'}}"
+    {{on "keyup" this.updateValue}}
     ...attributes
-  />
+  >{{@value}}</textarea>
 
   {{#if @maxlength}}
     <p>{{this.textLengthIndicator}} / {{@maxlength}}</p>

--- a/addon/components/pix-textarea.js
+++ b/addon/components/pix-textarea.js
@@ -1,8 +1,12 @@
 import Component from '@glimmer/component';
+import { action } from '@ember/object';
+import { tracked } from '@glimmer/tracking';
 
 export default class PixTextarea extends Component {
+  @tracked value = this.args.value;
+
   get textLengthIndicator() {
-    return this.args.value ? this.args.value.length : 0;
+    return this.value ? this.value.length : 0;
   }
 
   get label() {
@@ -13,6 +17,11 @@ export default class PixTextarea extends Component {
       throw new Error('ERROR in PixTextarea component, @id param is necessary when giving @label');
     }
     return this.args.label || null;
+  }
+
+  @action
+  updateValue(event) {
+    this.value = event.target.value;
   }
 
   get requiredLabel() {

--- a/docs/adr/0001-utiliser-les-balises-html-natives.md
+++ b/docs/adr/0001-utiliser-les-balises-html-natives.md
@@ -1,4 +1,4 @@
-# 1. Eviter les balises HTML natives
+# 1. Utiliser les balises HTML natives
 
 Date : 2022-01-04
 
@@ -47,7 +47,5 @@ Ce qui impliquerait :
 Nous privilégierons les éléments HTML natifs et éviterons autant que possible le two-way-binding.
 
 ## Conséquences
-
-Il faut mettre à jour le PixTextarea pour qu'il utilise une balise `<textarea>`.
 
 ⚠️ Pour ne pas casser le comportement existant. lors de la mise à jour des versions v11.0.0 / v11.1.0 de Pix-UI il faut mettre à jour tous les PixInput et PixInputPassword afin qu'il définissent un `onChange`.

--- a/tests/integration/components/pix-textarea-test.js
+++ b/tests/integration/components/pix-textarea-test.js
@@ -1,6 +1,6 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import { render } from '@ember/test-helpers';
+import { render, triggerEvent } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import createGlimmerComponent from '../../helpers/create-glimmer-component';
 import fillInByLabel from '../../helpers/fill-in-by-label';
@@ -40,6 +40,8 @@ module('Integration | Component | textarea', function (hooks) {
 
     // then
     const textarea = this.element.querySelector(TEXTAREA_SELECTOR);
+    await triggerEvent(textarea, 'keyup', { code: 'Enter' });
+
     assert.strictEqual(textarea.maxLength, maxlength);
     assert.contains('11 / 20');
   });


### PR DESCRIPTION
## :boom: BREAKING_CHANGES
Le changement du textarea ember au textarea natif ne permet plus de traquer les value.

A CHANGER :
- Rajouter un {{on "change" votreFonctionOnChange}}

## :christmas_tree: Problème
D'après notre [ADR](https://github.com/1024pix/pix-ui/blob/dev/docs/adr/0001-utiliser-les-balises-html-natives.md), nous privilégions l'utilisation de balises HTML native. Or, notre PixTextarea utilise les helpers ember.

## :gift: Solution
Utiliser les balises natives HTML pour le PixTextarea.

## :star2: Remarques
Des modifications ont été apportés à l'ADR.

## :santa: Pour tester
Vérifier la bonne utilisation du PixTextarea.
