### PR TITLE
[BREAKING] Met à jour la PixProgressBar avec le nouveau design (PIX-8172)

### DIFF
--- a/addon/components/pix-progress-gauge.hbs
+++ b/addon/components/pix-progress-gauge.hbs
@@ -1,19 +1,13 @@
-<div
-  class="progress-gauge
-    {{this.progressGaugeClass}}
-    {{if @isArrowLeft 'progress-gauge--tooltip-left'}}"
-  ...attributes
->
-  <div class="progress-gauge__referrer"></div>
-  <div class="progress-gauge__marker" aria-hidden="true" style={{this.valueGaugeStyle}}></div>
-
-  {{#if @tooltipText}}
-    <div class="progress-gauge__tooltip-wrapper" style={{this.valueGaugeStyle}}>
-      <span class="progress-gauge__tooltip">{{@tooltipText}}</span>
-    </div>
-  {{/if}}
-
-  {{#if this.hasSubtitle}}
+<div class="progress-gauge {{this.themeMode}} {{this.colorClass}}" ...attributes>
+  <div class="progress-gauge__text" role="presentation">{{this.percentageValue}}</div>
+  <label for={{this.id}} class="screen-reader-only">{{@label}}</label>
+  <progress
+    class="progress-gauge__bar"
+    id={{this.id}}
+    max="100"
+    value={{this.value}}
+  >{{this.value}}%</progress>
+  {{#if @subtitle}}
     <p class="progress-gauge__sub-title">{{@subtitle}}</p>
   {{/if}}
 </div>

--- a/addon/components/pix-progress-gauge.js
+++ b/addon/components/pix-progress-gauge.js
@@ -1,29 +1,48 @@
 import Component from '@glimmer/component';
-import { htmlSafe } from '@ember/template';
+import { guidFor } from '@ember/object/internals';
 
 export default class PixProgressGauge extends Component {
-  get progressValue() {
-    if (!this.args.value || this.args.value < 0) {
-      return 0;
+  get id() {
+    return guidFor(this);
+  }
+
+  get value() {
+    if (Number(this.args.value) <= 0) return 0;
+    if (Number(this.args.value) > 100) return 100;
+    if (!this.args.value) {
+      throw new Error('ERROR in PixProgressGauge component, @value param is not provided.');
     }
-
-    return this.args.value > 100 ? 100 : this.args.value;
+    return Number(this.args.value);
   }
 
-  get valueGaugeStyle() {
-    return htmlSafe(`width: ${this.progressValue}%`);
+  get percentageValue() {
+    return Number(this.value / 100).toLocaleString(navigator.language, { style: 'percent' });
   }
 
-  get hasSubtitle() {
-    return !!this.args.subtitle;
+  get label() {
+    if (!this.args.label || !this.args.label.trim()) {
+      throw new Error('ERROR in PixProgressGauge component, @label param is not provided.');
+    }
+    return this.args.label;
   }
 
-  get progressGaugeClass() {
-    const availableColor = ['blue', 'white'];
+  get themeMode() {
+    const availableMode = ['dark', 'light'];
+
+    const themeMode =
+      this.args.themeMode && availableMode.includes(this.args.themeMode)
+        ? this.args.themeMode
+        : 'light';
+
+    return `progress-gauge--theme-${themeMode}`;
+  }
+
+  get colorClass() {
+    const availableColor = ['blue', 'green', 'purple'];
 
     const color =
-      this.args.color && availableColor.includes(this.args.color) ? this.args.color : `blue`;
+      this.args.color && availableColor.includes(this.args.color) ? this.args.color : 'blue';
 
-    return `progress-gauge--${color}`;
+    return `progress-gauge--content-${color}`;
   }
 }

--- a/addon/styles/_pix-progress-gauge.scss
+++ b/addon/styles/_pix-progress-gauge.scss
@@ -1,116 +1,117 @@
 .progress-gauge {
   position: relative;
-  min-width: 200px;
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
   width: 100%;
+  min-width: 200px;
   border-radius: 5px;
 
+  &__bar {
+    flex-grow: 1;
+    height: 0.875rem;
+    border: 2px solid $pix-neutral-20;
+    border-radius: 1.625rem;
+    overflow: hidden;
+
+    &::-webkit-progress-value {
+      background-color: $pix-primary;
+      border-radius: 1.625rem;
+    }
+
+    &::-moz-progress-bar {
+      background-color: $pix-primary;
+      border-radius: 1.625rem;
+    }
+
+    &::-webkit-progress-bar {
+      background-color: $pix-neutral-20;
+    }
+  }
+
+  &__text {
+    @extend %pix-body-s;
+
+    font-weight: 500;
+    margin-right: $pix-spacing-s;
+    white-space: nowrap;
+  }
+
   &__sub-title {
-    font-size: 0.813rem;
-    color: $pix-primary-60;
+    @extend %pix-body-s;
+
+    width: 100%;
     margin: 6px 0;
+    color: $pix-primary-60;
     letter-spacing: 0.4px;
     text-transform: uppercase;
   }
+}
 
-  &__marker,
-  &__referrer {
-    height: 4px;
-    border-radius: 5px;
-    text-align: right;
+// THEME DARK
+.progress-gauge--theme-dark {
+  .progress-gauge__bar {
+    border: 2px solid $pix-neutral-0;
   }
 
-  &__marker {
-    margin-top: -4px;
+  .progress-gauge__bar::-webkit-progress-bar {
+    background-color: $pix-neutral-0;
   }
 
-  &__tooltip-wrapper {
-    position: relative;
+  .progress-gauge__text,
+  .progress-gauge__sub-title {
+    color: $pix-neutral-0;
+  }
+}
+
+// SPECIFIC BAR COLORS
+.progress-gauge--content-blue {
+  .progress-gauge__bar::-webkit-progress-value {
+    background-color: $pix-primary;
   }
 
-  &__tooltip {
-    position: absolute;
-    min-width: 40px;
-    left: 100%;
-    transform: translate(-50%);
-    bottom: calc(100% + 10px);
-    border-radius: 5px;
-    text-align: center;
-    padding: 4px;
-    font-size: 0.8rem;
-    font-weight: $font-bold;
-
-    &::before {
-      content: '';
-      position: absolute;
-      left: calc(50% - 4px);
-      border-top: 4px solid;
-      border-right: 4px solid transparent;
-      border-left: 4px solid transparent;
-      bottom: -4px;
-    }
+  .progress-gauge__bar::-moz-progress-bar {
+    background-color: $pix-primary;
   }
 
-  &--white {
-    & .progress-gauge__referrer {
-      background-color: lighten($pix-primary, 15%);
-    }
-
-    & .progress-gauge__marker {
-      background: $pix-neutral-0;
-    }
-
-    & .progress-gauge__tooltip {
-      background: $pix-neutral-0;
+  &:not(.progress-gauge--theme-dark) {
+    .progress-gauge__text,
+    .progress-gauge__sub-title {
       color: $pix-primary;
-
-      &::before {
-        color: $pix-neutral-0;
-        border-top-color: $pix-neutral-0;
-      }
-    }
-
-    & .progress-gauge__sub-title {
-      color: $pix-neutral-0;
     }
   }
+}
 
-  &--blue {
-    & .progress-gauge__referrer {
-      background-color: $pix-neutral-20;
-    }
-
-    & .progress-gauge__marker {
-      background-color: $pix-primary-60;
-    }
-
-    & .progress-gauge__tooltip {
-      background-color: $pix-primary-60;
-      color: $pix-neutral-0;
-
-      &::before {
-        border-top-color: $pix-primary-60;
-      }
-    }
-
-    & .progress-gauge__sub-title {
-      color: $pix-primary-60;
-    }
+.progress-gauge--content-green {
+  .progress-gauge__bar::-webkit-progress-value {
+    background-color: $pix-success-60;
   }
 
-  &--tooltip-left {
-    & .progress-gauge__tooltip {
-      border-bottom-left-radius: 0;
-      bottom: calc(100% + 14px);
-      transform: none;
-      left: 100%;
+  .progress-gauge__bar::-moz-progress-bar {
+    background-color: $pix-success-60;
+  }
 
-      &::before {
-        border-top: 8px solid;
-        border-right: 8px solid transparent;
-        border-left: none;
-        left: 0;
-        bottom: -8px;
-      }
+  &:not(.progress-gauge--theme-dark) {
+    .progress-gauge__text,
+    .progress-gauge__sub-title {
+      color: $pix-success-60;
+    }
+  }
+}
+
+.progress-gauge--content-purple {
+  .progress-gauge__bar::-webkit-progress-value {
+    background-color: $pix-tertiary-60;
+  }
+
+  .progress-gauge__bar::-moz-progress-bar {
+    background-color: $pix-tertiary-60;
+  }
+
+  &:not(.progress-gauge--theme-dark) {
+    .progress-gauge__text,
+    .progress-gauge__sub-title {
+      color: $pix-tertiary-60;
     }
   }
 }

--- a/app/stories/pix-progress-gauge.stories.js
+++ b/app/stories/pix-progress-gauge.stories.js
@@ -5,36 +5,36 @@ export const Default = (args) => {
     template: hbs`<PixProgressGauge
   @value={{this.value}}
   @color={{this.color}}
-  @isArrowLeft={{this.isArrowLeft}}
+  @themeMode={{this.themeMode}}
   @subtitle={{this.subtitle}}
-  @tooltipText={{this.tooltipText}}
+  @label={{this.label}}
 />`,
     context: args,
   };
 };
 Default.args = {
-  tooltipText: '%',
+  value: '50',
 };
 
-export const whiteProgressGauge = (args) => {
+export const darkModeProgressGauge = (args) => {
   return {
-    template: hbs`<section style='width: 100%; padding: 35px 35px 5px;background-color: lightgray'>
+    template: hbs`<section style='width: 100%; padding: 35px 35px 5px;background-color: #253858'>
   <PixProgressGauge
     @value={{this.value}}
     @color={{this.color}}
-    @isArrowLeft={{this.isArrowLeft}}
+    @label={{this.label}}
+    @themeMode={{this.themeMode}}
     @subtitle={{this.subtitle}}
-    @tooltipText={{this.tooltipText}}
   />
 </section>`,
     context: args,
   };
 };
-whiteProgressGauge.args = {
+darkModeProgressGauge.args = {
   value: '50',
-  tooltipText: '50%',
-  color: 'white',
-  isArrowLeft: true,
+  label: 'Chargement',
+  color: 'purple',
+  themeMode: 'dark',
   subtitle: 'Avancement',
 };
 
@@ -42,33 +42,37 @@ export const argTypes = {
   value: {
     name: 'value',
     description: 'Valeur atteinte sur 100',
-    type: { name: 'number', required: false },
+    type: { name: 'number', required: true },
     table: { defaultValue: { summary: null } },
+  },
+  label: {
+    name: 'label',
+    description:
+      "Afficher un label caché permettant d'expliciter le contexte de la jauge de progression",
+    type: { name: 'string', required: true },
+    table: { defaultValue: { summary: 'null' } },
+  },
+  themeMode: {
+    name: 'themeMode',
+    description:
+      "Permet d'indiquer si le thème de la barre de progression est en dark mode ou light mode. Modifie la couleur de fond de la barre de progression. Peut prendre les valeurs `light` ou `dark`",
+    type: { name: 'string', required: false },
+    table: { defaultValue: { summary: 'light' } },
+    control: { type: 'select' },
+    options: ['dark', 'light'],
   },
   color: {
     name: 'color',
     description:
-      'Modifie la couleur de la barre de progression. Peut prendre les valeurs `blue` ou `white`',
+      "Modifie la couleur du contenu de la barre de progression. Peut prendre les valeurs `blue`, 'green' ou `purple`",
     type: { name: 'string', required: false },
     table: { defaultValue: { summary: 'blue' } },
     control: { type: 'select' },
-    options: ['blue', 'white'],
-  },
-  isArrowLeft: {
-    name: 'isArrowLeft',
-    description: "Modifie la position de l'info bulle sur la gauche",
-    type: { name: 'boolean', required: false },
-    table: { defaultValue: { summary: false } },
+    options: ['blue', 'green', 'purple'],
   },
   subtitle: {
     name: 'subtitle',
     description: 'Afficher un sous-titre sous la barre de progression',
-    type: { name: 'string', required: false },
-    table: { defaultValue: { summary: 'null' } },
-  },
-  tooltipText: {
-    name: 'tooltipText',
-    description: "Afficher un label dans l'info bulle au dessus de la barre de progression",
     type: { name: 'string', required: false },
     table: { defaultValue: { summary: 'null' } },
   },

--- a/app/stories/pix-progress-gauge.stories.mdx
+++ b/app/stories/pix-progress-gauge.stories.mdx
@@ -3,7 +3,7 @@ import * as stories from './pix-progress-gauge.stories.js';
 
 <Meta title="Others/Progress Gauge" component="PixProgressGauge" argTypes={stories.argTypes} />
 
-# Progress Gauge
+# PixProgressGauge
 
 ## Default
 

--- a/app/stories/pix-progress-gauge.stories.mdx
+++ b/app/stories/pix-progress-gauge.stories.mdx
@@ -7,18 +7,20 @@ import * as stories from './pix-progress-gauge.stories.js';
 
 ## Default
 
-Permet d'afficher un barre de progression sur un barème de 100%. Des paramètres existent pour changer la position de la tooltip ou la couleur du composant
+Permet d'afficher un barre de progression sur un barème de 100%. Des paramètres existent pour changer le mode (dark ou light) ou la couleur du composant.
+
+> **⚠️** **Il est nécessaire d'avoir un `label` pour rendre le composant accessible !**
 
 <Canvas>
   <Story name="Default" story={stories.Default} height={60} />
 </Canvas>
 
-## White
+## Dark mode
 
-Démonstration d'une barre de progression blanche avec l'info bulle à gauche avec un sous titre
+Démonstration d'une barre de progression blanche en dark mode avec un sous titre.
 
 <Canvas>
-  <Story name="White" story={stories.whiteProgressGauge} height={100} />
+  <Story name="Dark" story={stories.darkModeProgressGauge} height={100} />
 </Canvas>
 
 ## Usage
@@ -26,9 +28,9 @@ Démonstration d'une barre de progression blanche avec l'info bulle à gauche av
 ```html
 <PixProgressGauge
   @value="50"
-  @color="white"
-  @tooltipText="50%"
-  @isArrowLeft="true"
+  @label="Chargement"
+  @color="green"
+  @themeMode="dark"
   @subTitle="Un sous titre"
 />
 ```

--- a/tests/integration/components/pix-progress-gauge-test.js
+++ b/tests/integration/components/pix-progress-gauge-test.js
@@ -1,83 +1,73 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import { render } from '@ember/test-helpers';
+import { render } from '@1024pix/ember-testing-library';
 import { hbs } from 'ember-cli-htmlbars';
+import createGlimmerComponent from '../../helpers/create-glimmer-component';
 
 module('Integration | Component | progress-gauge', function (hooks) {
   setupRenderingTest(hooks);
 
-  const MARKER_SELECTOR = '.progress-gauge__marker';
   const PROGRESS_GAUGE_SELECTOR = '.progress-gauge';
 
   module('Attributes @value', function () {
-    test('it renders the progress gauge with correct width', async function (assert) {
+    test('it should throw an error if there is no value', async function (assert) {
       // given & when
-      await render(hbs`<PixProgressGauge @value='50' />`);
+      const componentParams = { value: undefined };
+      const component = createGlimmerComponent('pix-progress-gauge', componentParams);
 
       // then
-      const componentElement = this.element.querySelector(MARKER_SELECTOR);
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(componentElement.style.width, '50%');
+      const expectedError = new Error(
+        'ERROR in PixProgressGauge component, @value param is not provided.'
+      );
+      assert.throws(function () {
+        component.value;
+      }, expectedError);
     });
 
-    test('it renders the progress tooltip with correct information', async function (assert) {
+    test('it renders the value with percentage', async function (assert) {
       // given & when
-      await render(hbs`<PixProgressGauge @value='50' @tooltipText='50%' />`);
+      const screen = await render(hbs`<PixProgressGauge @value='50' />`);
 
       // then
-      assert.contains('50%');
-    });
-
-    test('it should not renders the progress tooltip if no tooltipText', async function (assert) {
-      // given & when
-      await render(hbs`<PixProgressGauge @value='50' />`);
-
-      // then
-      const componentElement = this.element.querySelector('.progress-gauge__tooltip');
-      assert.notOk(componentElement);
+      const frenchLocale = String(navigator.language).toLowerCase() === 'fr-fr';
+      assert.strictEqual(
+        screen.getByRole('presentation').innerText,
+        frenchLocale ? '50\xA0%' : '50%'
+      );
     });
 
     test('it renders the progress gauge with correct width never exceed 100%', async function (assert) {
       // given & when
-      await render(hbs`<PixProgressGauge @value='110' />`);
+      const screen = await render(hbs`<PixProgressGauge @value='110' />`);
 
       // then
-      const markerComponent = this.element.querySelector(MARKER_SELECTOR);
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(markerComponent.style.width, '100%');
+      const progressbar = screen.getByRole('progressbar');
+      assert.strictEqual(progressbar.value, 100);
     });
 
     test('it renders the progress gauge with correct width never under 0%', async function (assert) {
       // given & when
-      await render(hbs`<PixProgressGauge @value='-1' />`);
+      const screen = await render(hbs`<PixProgressGauge @value='-20' />`);
 
       // then
-      const markerComponent = this.element.querySelector(MARKER_SELECTOR);
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(markerComponent.style.width, '0%');
+      const progressbar = screen.getByRole('progressbar');
+      assert.strictEqual(progressbar.value, 0);
     });
   });
 
-  module('Attributes @isArrowLeft', function () {
-    test('it renders the progress gauge with default tootlip', async function (assert) {
+  module('Attributes @label', function () {
+    test('it should throw an error if there is no label', async function (assert) {
       // given & when
-      await render(hbs`<PixProgressGauge @value='50' />`);
+      const componentParams = { label: null };
+      const component = createGlimmerComponent('pix-progress-gauge', componentParams);
 
       // then
-      const componentElement = this.element.querySelector(PROGRESS_GAUGE_SELECTOR);
-      assert.false(componentElement.classList.contains('progress-gauge--tooltip-left'));
-    });
-
-    test('it renders the progress gauge with tootlip left class', async function (assert) {
-      // given & when
-      await render(hbs`<PixProgressGauge @value='50' @isArrowLeft='true' />`);
-
-      // then
-      const componentElement = this.element.querySelector(PROGRESS_GAUGE_SELECTOR);
-      assert.true(componentElement.classList.contains('progress-gauge--tooltip-left'));
+      const expectedError = new Error(
+        'ERROR in PixProgressGauge component, @label param is not provided.'
+      );
+      assert.throws(function () {
+        component.label;
+      }, expectedError);
     });
   });
 
@@ -88,7 +78,7 @@ module('Integration | Component | progress-gauge', function (hooks) {
 
       // then
       const componentElement = this.element.querySelector(PROGRESS_GAUGE_SELECTOR);
-      assert.true(componentElement.classList.contains('progress-gauge--blue'));
+      assert.true(componentElement.classList.contains('progress-gauge--content-blue'));
     });
 
     test('it renders the progress gauge with blue class when color not exists', async function (assert) {
@@ -97,7 +87,7 @@ module('Integration | Component | progress-gauge', function (hooks) {
 
       // then
       const componentElement = this.element.querySelector(PROGRESS_GAUGE_SELECTOR);
-      assert.true(componentElement.classList.contains('progress-gauge--blue'));
+      assert.true(componentElement.classList.contains('progress-gauge--content-blue'));
     });
 
     test('it renders the progress gauge with blue class', async function (assert) {
@@ -106,16 +96,63 @@ module('Integration | Component | progress-gauge', function (hooks) {
 
       // then
       const componentElement = this.element.querySelector(PROGRESS_GAUGE_SELECTOR);
-      assert.true(componentElement.classList.contains('progress-gauge--blue'));
+      assert.true(componentElement.classList.contains('progress-gauge--content-blue'));
     });
 
-    test('it renders the progress gauge with white class', async function (assert) {
+    test('it renders the progress gauge with green class', async function (assert) {
       // given & when
-      await render(hbs`<PixProgressGauge @value='50' @color='white' />`);
+      await render(hbs`<PixProgressGauge @value='50' @color='green' />`);
 
       // then
       const componentElement = this.element.querySelector(PROGRESS_GAUGE_SELECTOR);
-      assert.true(componentElement.classList.contains('progress-gauge--white'));
+      assert.true(componentElement.classList.contains('progress-gauge--content-green'));
+    });
+
+    test('it renders the progress gauge with purple class', async function (assert) {
+      // given & when
+      await render(hbs`<PixProgressGauge @value='50' @color='purple' />`);
+
+      // then
+      const componentElement = this.element.querySelector(PROGRESS_GAUGE_SELECTOR);
+      assert.true(componentElement.classList.contains('progress-gauge--content-purple'));
+    });
+  });
+
+  module('Attributes @themeMode', function () {
+    test('it renders the progress gauge by default with light mode', async function (assert) {
+      // given & when
+      await render(hbs`<PixProgressGauge @value='50' />`);
+
+      // then
+      const componentElement = this.element.querySelector(PROGRESS_GAUGE_SELECTOR);
+      assert.true(componentElement.classList.contains('progress-gauge--theme-light'));
+    });
+
+    test('it renders the progress gauge with light mode when value not exists', async function (assert) {
+      // given & when
+      await render(hbs`<PixProgressGauge @value='50' @themeMode='darken-light' />`);
+
+      // then
+      const componentElement = this.element.querySelector(PROGRESS_GAUGE_SELECTOR);
+      assert.true(componentElement.classList.contains('progress-gauge--theme-light'));
+    });
+
+    test('it renders the progress gauge with light mode', async function (assert) {
+      // given & when
+      await render(hbs`<PixProgressGauge @value='50' @themeMode='light' />`);
+
+      // then
+      const componentElement = this.element.querySelector(PROGRESS_GAUGE_SELECTOR);
+      assert.true(componentElement.classList.contains('progress-gauge--theme-light'));
+    });
+
+    test('it renders the progress gauge with dark mode', async function (assert) {
+      // given & when
+      await render(hbs`<PixProgressGauge @value='50' @themeMode="dark" />`);
+
+      // then
+      const componentElement = this.element.querySelector(PROGRESS_GAUGE_SELECTOR);
+      assert.true(componentElement.classList.contains('progress-gauge--theme-dark'));
     });
   });
 
@@ -135,9 +172,7 @@ module('Integration | Component | progress-gauge', function (hooks) {
 
       // then
       const componentElement = this.element.querySelector('.progress-gauge__sub-title');
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(componentElement.textContent.trim(), 'toto');
+      assert.strictEqual(componentElement.textContent.trim(), 'toto');
     });
   });
 });


### PR DESCRIPTION
## :boom: BREAKING_CHANGES
La tooltip n'existant plus : 
- l'attribut `@tooltipText`a été enlevé.
- l'attribut `@isArrowLeft` a été enlevé.

L'attribut `@label` a été ajouté et est obligatoire pour être accessible.
L'attribut `@value` est obligatoire.


## :christmas_tree: Problème
Le design de la PixProgressBar a été actualisé.

## :gift: Solution
Créer un mode `dark` et `light`.
Proposer une version `blue`, `purple` et `green`.
Enlever la tooltip et mettre le texte à gauche de la barre de progression.
Revoir la sémantique pour plus d'accessiblité.

## :star2: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :santa: Pour tester
Aller sur la story et tester le bon fonctionnement de la barre de progression
