### PR TITLE
[TECH] Précise comment documenter un Breaking Change

### DIFF
--- a/docs/breaking-changes.stories.mdx
+++ b/docs/breaking-changes.stories.mdx
@@ -69,10 +69,14 @@ Pour aller plus loin, il est possible d'utiliser l'outil SourceGraph pour recher
 
 C'est au développeur qui ouvre la _pull request_ qu'incombe la responsabilité
 d'identifier les éventuels _breaking changes_ dans ses modifications et, le cas
-échéant, de les signaler dans le titre de la PR. Il lui faudra donner aussi un
-maximum d'informations dans une section breaking changes de la PR sur ce qu'il
-convient de faire pour vérifier que rien de casse lors de la montée de version
-de Pix UI.
+échéant, de les signaler en préfixe dans le titre de la PR :
+
+```
+[BREAKING] Changement de couleur de fond par défaut du PixButton (PIX-1234)
+```
+
+Enumérer précisément les fonctionnalités impactées par le breaking change, et la modification à apporter (solution de contournement ou définitive).
+Le développeur pourra ainsi déterminer s'il les utilise, et si c'est le cas, apporter les modifications.
 
 Ainsi :
 


### PR DESCRIPTION
## :christmas_tree: Problème
La documentation sur la communication des Breaking Change laisse beaucoup de liberté sur la manière. On se rend compte que l'on a pas les mêmes attentes entre les équipes.

## :gift: Solution
Mieux standardiser la communication des Breaking Changes en utilisant le tag `[BREAKING]` dans le titre de la PR ajouté récemment : https://github.com/1024pix/pix-bot/pull/256

Ainsi, le Breaking Change apparaîtra en haut de la liste du changelog.

## :star2: Remarques
RAS

## :santa: Pour tester
Vérifier que la doc est bien mise à jour sur la page [`?path=/docs/développement-breaking-changes--page`](https://ui-pr420.review.pix.fr/?path=/docs/développement-breaking-changes--page)