### PR TITLE
[BUGFIX] définir une largeur fixe pour le texte de pourcentage de PixProgressGauge (PIX-8439).

### DIFF
--- a/addon/styles/_pix-progress-gauge.scss
+++ b/addon/styles/_pix-progress-gauge.scss
@@ -32,9 +32,10 @@
   &__text {
     @extend %pix-body-s;
 
-    font-weight: 500;
-    margin-right: $pix-spacing-s;
+    min-width: 5ch;
+    margin-right: $pix-spacing-xxs;
     white-space: nowrap;
+    font-weight: 500;
   }
 
   &__sub-title {


### PR DESCRIPTION
## :christmas_tree: Problème

Entre un pourcentage à 0% et à 100%, on avait pas la même taille de texte.
Cela créait un décalage visuel non souhaité.

![image](https://github.com/1024pix/pix-ui/assets/7335131/ec419fae-d9b8-4e5c-a11d-58dea9f5c85b)

## :gift: Solution

Fixer la largeur du texte à la taille de "100 %".

## :santa: Pour tester

- Regarder [le canvas du composant](https://ui-pr424.review.pix.fr/?path=/story/others-progress-gauge--default)
- Tester différentes valeurs de pourcentage (argument `value`) pour constater que la largeur du texte ne change pas.
