### PR TITLE
[BUGFIX] Réduire la largeur minimum de PixProgressGauge (PIX-8457)

### DIFF
--- a/addon/styles/_pix-progress-gauge.scss
+++ b/addon/styles/_pix-progress-gauge.scss
@@ -1,13 +1,18 @@
 .progress-gauge {
   position: relative;
-  display: flex;
-  flex-wrap: wrap;
+  display: grid;
+  grid-template-areas:
+    'text progressbar'
+    'subtitle subtitle';
+  grid-template-columns: auto 1fr;
   align-items: center;
   width: 100%;
-  min-width: 200px;
+  min-width: 6rem;
   border-radius: 5px;
 
   &__bar {
+    grid-area: progressbar;
+    inline-size: unset;
     flex-grow: 1;
     height: 0.875rem;
     border: 2px solid $pix-neutral-20;
@@ -32,20 +37,25 @@
   &__text {
     @extend %pix-body-s;
 
+    grid-area: text;
     min-width: 5ch;
     margin-right: $pix-spacing-xxs;
     white-space: nowrap;
     font-weight: 500;
+    line-height: 1;
   }
 
   &__sub-title {
     @extend %pix-body-s;
 
+    grid-area: subtitle;
     width: 100%;
     margin: 6px 0;
     color: $pix-primary-60;
     letter-spacing: 0.4px;
     text-transform: uppercase;
+    text-overflow: ellipsis;
+    overflow: hidden;
   }
 }
 


### PR DESCRIPTION
## :boom: BREAKING_CHANGES
RAS

## :christmas_tree: Problème

On avait défini une largeur minimum de 200px sur le composant.
Or, pour un besoin de design, on a besoin d'avoir des largeurs plus petites.

## :gift: Solution

Permettre au composant d'être plus "responsive", en faisant 100% de la largeur de son conteneur et en gardant une largeur minimum de ~100px pour que le composant ait quand même du sens graphiquement (il faut qu'on soit capable de voir la progressbar).

## :santa: Pour tester

Changer la `width` du tag parent du composant et vérifier le comportement de celui-ci.
