### PR TITLE
[BREAKING] Montée de version de Node.js minimum à la v16.17.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -88,8 +88,7 @@
         "webpack": "^5.75.0"
       },
       "engines": {
-        "node": "16",
-        "npm": ">=8.13.2 <9"
+        "node": "^16.17"
       }
     },
     "node_modules/@1024pix/ember-testing-library": {

--- a/package.json
+++ b/package.json
@@ -8,8 +8,7 @@
   "license": "MIT",
   "author": "GIP Pix",
   "engines": {
-    "node": "16",
-    "npm": ">=8.13.2 <9"
+    "node": "^16.17"
   },
   "ember": {
     "edition": "octane"


### PR DESCRIPTION
## :boom: BREAKING_CHANGES
On ne supporte plus les version de Node.js inférieures à la v16.17.0. Cela nous assure d'avoir la version `npm` embarquée supérieure à la 8.13.2 qui posait problème. 

## :christmas_tree: Problème
Depuis la v15.0.0, on a forcé une version de `npm` supérieure ou égale à la `8.13.2` car elle posait problème. On laissait par contre la liberté de choisir sa version de Node.js. Voir https://github.com/1024pix/pix-ui/pull/224#issuecomment-1170916327

Lors d'une montée de version inévitable en [v18.14.0](https://nodejs.org/en/blog/release/v18.14.0) ou supérieure qui package npm en version 9, on risque d'avoir des soucis de compatibilité car Pix UI ne permet pour l'instant pas de l'utiliser.

## :gift: Solution
Pour simplifier les choses, on propose avec l'équipe Tech Days UP de montée la version minimum de Node.js qui embarque une version suffisante de npm (8.15.0), c'est à dire la v16.17.0.

Il est aussi possible d'utiliser la version de npm de son choix, par exemple si on veut essayer des montées de version.

## :star2: Remarques
Un autre avantage est que le correctement est plus proche de ce que fait Circle CI.

## :santa: Pour tester
Vérifier que la CI et la RA fonctionne toujours.