### PR TITLE
[TECH] Débloque la CI le temps de comprendre ce qui se passe

### DIFF
--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -2,8 +2,38 @@
 
 const { embroiderSafe, embroiderOptimized } = require('@embroider/test-setup');
 
+const safe = embroiderSafe();
+const optimized = embroiderOptimized();
+
 module.exports = async function () {
+  const pinnedDependencies = {
+    '@embroider/core': `3.0.2`,
+    '@embroider/webpack': `3.0.0`,
+    '@embroider/compat': `3.0.2`,
+  };
+
   return {
-    scenarios: [embroiderSafe(), embroiderOptimized()],
+    scenarios: [
+      {
+        ...safe,
+        npm: {
+          ...safe.npm,
+          devDependencies: {
+            ...safe.npm.devDependencies,
+            ...pinnedDependencies,
+          },
+        },
+      },
+      {
+        ...optimized,
+        npm: {
+          ...optimized.npm,
+          devDependencies: {
+            ...optimized.npm.devDependencies,
+            ...pinnedDependencies,
+          },
+        },
+      },
+    ],
   };
 };


### PR DESCRIPTION
## :christmas_tree: Problème
Depuis la release 3.1.0 de dépendances embroider, la CI ne passe plus. Lorsqu'on exécute `ember-try`, il télécharge les dépendances pour essayer avec les dernières versions d'Embroider. Notre CI n'est donc pas prédictible.

## :gift: Solution
Pinner les versions des dépendances Embroider pour s'assurer que les scénarios de tests ne cassent pas sans changements dans notre code.

Il faudra mettre à jour ces versions de temps pour assurer notre compatibilité. 

Dans la prochaine version mineure, il faudra corriger quelque chose mais on n'a pas trouvé de solution pour le moment (lié à l'instanciation des components dans nos tests unitaires).

## :star2: Remarques
La version de Webpack n'a pas été pinné pour le moment car le build passe avec la version actuelle. Peut être faudra-t-il le faire aussi.

## :santa: Pour tester
Vérifier que la CI passe.
