### PR TITLE
[BREAKING_CHANGES][BUGFIX] Ajuster la taille du bouton upload à son contenu.

### DIFF
--- a/addon/styles/_pix-button-base.scss
+++ b/addon/styles/_pix-button-base.scss
@@ -11,6 +11,7 @@
   justify-content: center;
   align-items: center;
   text-decoration: none;
+  width: fit-content;
 
   &--shape-rounded {
     border-radius: 25px;


### PR DESCRIPTION
## :boom: BREAKING_CHANGES
Le bouton d'upload prenait toute la largeur disponible, ce n'est désormais plus le cas. Veuillez faire attention à la dimension de vos `<PixButtonUpload />` 

## :christmas_tree: Problème
Actuellement, les boutons upload prennent toutes la place disponible et ne se comporte donc pas comme les autres boutons. 
![image](https://github.com/1024pix/pix-ui/assets/26384707/e5520020-fd1e-4521-8bcd-1f9c12b4677f)


## :gift: Solution
Appliquer `width: fit-content;` à la classe `.pix-button` pour avoir le même comportement pour tous les boutons.

## :star2: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :santa: Pour tester
- Se rendre sur la RA 
- Aller sur le bouton d'upload 
- Modifier la taille de la div ayant la class `ember-view` par `width: 100vw`, constater que le bouton ne s'agrandit pas
- Reproduire sur la production et constater que le bouton est agrandi. 