### PR TITLE
[TECH] Ajustements des versions de Node et npm

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,7 +34,6 @@ workflows:
           matrix:
             parameters:
               node-version:
-                - "16.20.1"
                 - "18.17.0"
           filters:
             branches:

--- a/.github/workflows/deploy-storybook.yml
+++ b/.github/workflows/deploy-storybook.yml
@@ -14,7 +14,6 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version-file: 'package.json'
-      - run: npm i -g npm@9.6.4
       - run: npm ci
       - name: Deploy storybook to Github Pages
         run: npm run deploy-storybook -- --ci

--- a/package-lock.json
+++ b/package-lock.json
@@ -90,8 +90,7 @@
         "webpack": "^5.75.0"
       },
       "engines": {
-        "node": "16 || 18",
-        "npm": "8 || 9"
+        "node": "^16.17 || ^18"
       }
     },
     "node_modules/@1024pix/ember-testing-library": {

--- a/package.json
+++ b/package.json
@@ -8,8 +8,7 @@
   "license": "MIT",
   "author": "GIP Pix",
   "engines": {
-    "node": "16 || 18",
-    "npm": "8 || 9"
+    "node": "^16.17 || ^18"
   },
   "ember": {
     "edition": "octane"


### PR DESCRIPTION
## :christmas_tree: Problème
- On précise dans le `engines` les versions de npm supportées alors qu'on ne souhaite plus le faire.
- Au déploiement, on peut utiliser la version embarquée de npm avec notre version de Node.
- On faisait tourner Chromatic avec deux versions de Node.js ce qui risque d'impacter nos quotas.

## :gift: Solution
- Retirer la précision de version de npm dans le `engines`.
- Ne plus forcer d'installation de version de npm dans l'action de déploiement.
- Faire tourner Chromatic uniquement dans la future version de Node supportée.

## :star2: Remarques
Changement de format d'indication de version Node.js dans le engines en accord avec ce qu'on fait pour le moment.

## :santa: Pour tester
CI 🍏

Lors de la prochaine version, vérifier que le déploiement de ui.pix.fr fonctionnement correctement.
