### PR TITLE
[BUGFIX] Ajuster la taille du bouton upload.

### DIFF
--- a/addon/components/pix-button-upload.js
+++ b/addon/components/pix-button-upload.js
@@ -7,7 +7,7 @@ export default class PixButtonUpload extends PixButtonBase {
   files = [];
 
   get className() {
-    return super.baseClassNames.join(' ');
+    return [...super.baseClassNames, 'pix-button-upload'].join(' ');
   }
 
   @action

--- a/addon/styles/_pix-button-base.scss
+++ b/addon/styles/_pix-button-base.scss
@@ -2,7 +2,6 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  width: fit-content;
   color: $pix-neutral-0;
   font-weight: $font-medium;
   font-size: 0.875rem;

--- a/addon/styles/_pix-button-upload.scss
+++ b/addon/styles/_pix-button-upload.scss
@@ -1,4 +1,6 @@
 .pix-button-upload {
+  width: fit-content;
+
   &__input {
     display: none;
   }


### PR DESCRIPTION
## :christmas_tree: Problème

L'ajustement de la largeur du bouton à son contenu entraine des régressions sur les applications Pix qui sont peu faciles à détecter.
Cet ajustement a été introduit dans la version 38.0.0.
Le problème d'origine qui était traité avec la [Pull Request #435](https://github.com/1024pix/pix-ui/pull/435) était l'ajustement de la largeur du bouton PixButtonUpload.


## :gift: Solution

On revert le changement de la version 38.0.0.
On applique la classe `pix-button-upolad` au bouton `PixButtonUpload`.
On définit la largeur du `PixButtonUpload` à `fit-content` pour éviter à ce bouton d'occuper toute la largeur de son conteneur.


## :star2: Remarques

Lors de l'intégration de cette modification dans l'application Pix Orga, le correctif du bouton de connexion pourra être supprimé.


## :santa: Pour tester

Se rendre sur la RA
Aller sur le bouton d'upload
Modifier la taille de la div ayant la class ember-view par width: 100vw, constater que le bouton ne s'agrandit pas
Reproduire sur la production et constater que le bouton est agrandi.

