### PR TITLE
[FEATURE] Ajout des styles disabled et readonly du PixInput (PIX-8793).

### DIFF
--- a/addon/styles/_pix-input.scss
+++ b/addon/styles/_pix-input.scss
@@ -51,6 +51,17 @@
     &::placeholder {
       color: $pix-neutral-30;
     }
+
+    &[aria-disabled],
+    &[disabled],
+    &[readonly] {
+      @include formElementDisabled();
+      @include hoverFormElementDisabled();
+    }
+
+    &[readonly] {
+      cursor: default;
+    }
   }
 
   &__input--error {

--- a/addon/styles/pix-design-tokens/_form.scss
+++ b/addon/styles/pix-design-tokens/_form.scss
@@ -14,6 +14,7 @@
 
 @mixin formElementDisabled() {
   background-color: $pix-neutral-20;
+  cursor: not-allowed;
 }
 
 @mixin focusFormElement() {

--- a/app/stories/pix-input.mdx
+++ b/app/stories/pix-input.mdx
@@ -37,26 +37,37 @@ screen.getByLabelText('Prénom exemple: Barry');
 
 <Story of={ComponentStories.Default} height={100} />
 
-
 ## With label and information
 
 <Story of={ComponentStories.withLabel} height={110} />
-
 
 ## Error state (with error message)
 
 <Story of={ComponentStories.errorState} height={110} />
 
-
 ## Success state
 
 <Story of={ComponentStories.successState} height={100} />
 
+## Disabled & readonly states
+
+[📖 Lire la différence entre les 2 états.](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/readonly#attribute_interactions)
+
+#### Disabled
+
+Un input désactivé n'est pas focusable et n'est pas censé être envoyé à la soumission de formulaire.
+
+<Story of={ComponentStories.disabledState} height={100} />
+
+#### Readonly
+
+En readonly, l'input n'est pas modifiable, mais il est toujours focusable et est soumis normalement.
+
+<Story of={ComponentStories.readonlyState} height={100} />
 
 ## With required label
 
 <Story of={ComponentStories.withRequiredLabel} height={100} />
-
 
 ## Usage
 

--- a/app/stories/pix-input.stories.js
+++ b/app/stories/pix-input.stories.js
@@ -65,6 +65,8 @@ const Template = (args) => {
   @requiredLabel={{this.requiredLabel}}
   @ariaLabel={{this.ariaLabel}}
   @validationStatus={{this.validationStatus}}
+  disabled={{this.disabled}}
+  readonly={{this.readonly}}
 />`,
     context: args,
   };
@@ -96,6 +98,20 @@ successState.args = {
   id: 'first-name',
   label: 'Prénom',
   validationStatus: 'success',
+};
+
+export const disabledState = Template.bind({});
+disabledState.args = {
+  id: 'first-name',
+  label: 'Prénom',
+  disabled: true,
+};
+
+export const readonlyState = Template.bind({});
+readonlyState.args = {
+  id: 'first-name',
+  label: 'Prénom',
+  readonly: true,
 };
 
 export const withRequiredLabel = Template.bind({});


### PR DESCRIPTION
## :christmas_tree: Problème

Le composant PixInput ne change pas de style lorsqu'il est `disabled` ou `readonly`.

## :gift: Solution

Ajouter ces styles comme définis sur [le Figma](https://www.figma.com/file/8RJ3aCSfdeQ8AZZVBBYKS8/Design-System-Pix?type=design&node-id=206-1821&mode=design&t=cwd7FtUZ2QuRMYUv-4).

Visuellement, la seule différence que nous aurons : en `disabled`, le pointeur passe en mode `not-allowed`.
Alors qu'en `readonly`, on laisse le pointeur "flèche" par défaut.

## :star2: Remarques

Une description de la différence entre les 2 états est indiquée dans la doc Storybook.
[Voir doc MDN.](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/readonly#attribute_interactions)

## :santa: Pour tester

Regarder la section dédiée à ces états dans [la story du composant](https://ui-pr456.review.pix.fr/?path=/docs/form-inputs-input--docs#disabled--readonly-states).
