### PR TITLE
[CLEANUP] Retirer les propriétés override par le `reset.css` (PIX-6918).

### DIFF
--- a/addon/styles/normalize-reset/_reset.scss
+++ b/addon/styles/normalize-reset/_reset.scss
@@ -3,7 +3,6 @@
 /*** box sizing border-box for all elements ***/
 html {
   font-size: 16px;
-  -webkit-text-size-adjust: 100%;
   -ms-text-size-adjust: 100%;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
@@ -56,7 +55,6 @@ dd {
   margin: 0;
 }
 
-h1,
 h2,
 h3,
 h4,


### PR DESCRIPTION
## :christmas_tree: Problème
Des propriétés CSS présentes dans le fichier `_normalize.css` sont override dans le fichier `_reset.css`.

## :gift: Proposition
Les supprimer.

## :star2: Remarques
- `-webkit-text-size-adjust` n'est pas encore supportées par safari, car encore [experimental](https://developer.mozilla.org/en-US/docs/Web/CSS/text-size-adjust).
- Sur la balise `a`, la propriété `text-decoration: none` qui supprime le soulignement d'un lien n'est pas [A11y](https://www.w3.org/TR/WCAG20-TECHS/F73.html).

## :santa: Pour tester
- Se rendre sur Pix App (par exemple) et vérifier le bon comportement.
