### PR TITLE
[DOCS] Réorganisation des composants dans Storybook avec un atomic design

### DIFF
--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -31,6 +31,11 @@ const preview = {
             'Architecture',
             'Storybook'
           ],
+          'Design System',
+          [
+            'Atoms',
+            'Molecules'
+          ]
         ],
       },
     },

--- a/app/stories/pix-banner.stories.js
+++ b/app/stories/pix-banner.stories.js
@@ -1,7 +1,7 @@
 import { hbs } from 'ember-cli-htmlbars';
 
 export default {
-  title: 'Notification/Banner',
+  title: 'Design System/Molecules/Banner',
   argTypes: {
     actionLabel: {
       name: 'actionLabel',

--- a/app/stories/pix-button.stories.js
+++ b/app/stories/pix-button.stories.js
@@ -1,7 +1,7 @@
 import { hbs } from 'ember-cli-htmlbars';
 
 export default {
-  title: 'Basics/Button',
+  title: 'Design System/Atoms/Button',
   argTypes: {
     type: {
       name: 'type',

--- a/app/stories/pix-checkbox.stories.js
+++ b/app/stories/pix-checkbox.stories.js
@@ -1,7 +1,7 @@
 import { hbs } from 'ember-cli-htmlbars';
 
 export default {
-  title: 'Form/Checkbox',
+  title: 'Design System/Atoms/Checkbox',
   argTypes: {
     id: {
       name: 'id',

--- a/app/stories/pix-collapsible.stories.js
+++ b/app/stories/pix-collapsible.stories.js
@@ -1,7 +1,7 @@
 import { hbs } from 'ember-cli-htmlbars';
 
 export default {
-  title: 'Others/Collapsible',
+  title: 'Design System/Molecules/Collapsible',
   argTypes: {
     title: {
       name: 'title',

--- a/app/stories/pix-icon-button.stories.js
+++ b/app/stories/pix-icon-button.stories.js
@@ -2,7 +2,7 @@ import { hbs } from 'ember-cli-htmlbars';
 import { action } from '@storybook/addon-actions';
 
 export default {
-  title: 'Basics/Icon button',
+  title: 'Design System/Atoms/Icon button',
   argTypes: {
     ariaLabel: {
       name: 'ariaLabel',

--- a/app/stories/pix-modal.stories.js
+++ b/app/stories/pix-modal.stories.js
@@ -1,7 +1,7 @@
 import { hbs } from 'ember-cli-htmlbars';
 
 export default {
-  title: 'Basics/Modal',
+  title: 'Design System/Molecules/Modal',
   render: (args) => ({
     template: hbs`<PixModal
   @showModal={{this.showModal}}

--- a/app/stories/pix-multi-select.stories.js
+++ b/app/stories/pix-multi-select.stories.js
@@ -2,7 +2,7 @@ import { hbs } from 'ember-cli-htmlbars';
 import { action } from '@storybook/addon-actions';
 
 export default {
-  title: 'Form/Multi Select',
+  title: 'Design System/Molecules/Multi Select',
   render: (args) => ({
     template: hbs`
   <style>

--- a/app/stories/pix-pagination.stories.js
+++ b/app/stories/pix-pagination.stories.js
@@ -1,7 +1,7 @@
 import { hbs } from 'ember-cli-htmlbars';
 
 export default {
-  title: 'Basics/Pagination',
+  title: 'Design System/Molecules/Pagination',
   render: (args) => ({
     template: hbs`<PixPagination
   @pagination={{this.pagination}}

--- a/app/stories/pix-progress-gauge.stories.js
+++ b/app/stories/pix-progress-gauge.stories.js
@@ -1,7 +1,7 @@
 import { hbs } from 'ember-cli-htmlbars';
 
 export default {
-  title: 'Others/Progress Gauge',
+  title: 'Design System/Molecules/Progress Gauge',
   argTypes: {
     value: {
       name: 'value',

--- a/app/stories/pix-radio-button.stories.js
+++ b/app/stories/pix-radio-button.stories.js
@@ -1,7 +1,7 @@
 import { hbs } from 'ember-cli-htmlbars';
 
 export default {
-  title: 'Form/Radio Button',
+  title: 'Design System/Atoms/Radio Button',
   argTypes: {
     id: {
       name: 'id',

--- a/app/stories/pix-search-input.stories.js
+++ b/app/stories/pix-search-input.stories.js
@@ -2,7 +2,7 @@ import { hbs } from 'ember-cli-htmlbars';
 import { action } from '@storybook/addon-actions';
 
 export default {
-  title: 'Others/SearchInput',
+  title: 'Design System/Molecules/SearchInput',
   argTypes: {
     id: {
       name: 'id',

--- a/app/stories/pix-select.stories.js
+++ b/app/stories/pix-select.stories.js
@@ -2,7 +2,7 @@ import { hbs } from 'ember-cli-htmlbars';
 import { action } from '@storybook/addon-actions';
 
 export default {
-  title: 'Form/Select',
+  title: 'Design System/Molecules/Select',
   argTypes: {
     options: {
       name: 'options',

--- a/app/stories/pix-selectable-tag.stories.js
+++ b/app/stories/pix-selectable-tag.stories.js
@@ -1,7 +1,7 @@
 import { hbs } from 'ember-cli-htmlbars';
 
 export default {
-  title: 'basics/Tag/Selectable Tag',
+  title: 'Design System/Atoms/Tag/Selectable Tag',
   argTypes: {
     label: {
       name: 'label',

--- a/app/stories/pix-stars.stories.js
+++ b/app/stories/pix-stars.stories.js
@@ -1,7 +1,7 @@
 import { hbs } from 'ember-cli-htmlbars';
 
 export default {
-  title: 'Others/PixStars',
+  title: 'Design System/Atoms/PixStars',
   argTypes: {
     count: {
       name: 'count',

--- a/app/stories/pix-tag.stories.js
+++ b/app/stories/pix-tag.stories.js
@@ -1,7 +1,7 @@
 import { hbs } from 'ember-cli-htmlbars';
 
 export default {
-  title: 'Basics/Tag',
+  title: 'Design System/Atoms/Tag/Default',
   render: (args) => ({
     template: hbs`<PixTag @color={{this.color}} @compact={{this.compact}}>
   Contenu du tag

--- a/app/stories/pix-textarea.stories.js
+++ b/app/stories/pix-textarea.stories.js
@@ -1,7 +1,7 @@
 import { hbs } from 'ember-cli-htmlbars';
 
 export default {
-  title: 'Form/Textarea',
+  title: 'Design System/Molecules/Textarea',
   argTypes: {
     id: {
       name: 'id',

--- a/app/stories/pix-toggle.stories.js
+++ b/app/stories/pix-toggle.stories.js
@@ -2,7 +2,7 @@ import { hbs } from 'ember-cli-htmlbars';
 import { action } from '@storybook/addon-actions';
 
 export default {
-  title: 'Form/Toggle',
+  title: 'Design System/Atoms/Toggle',
   argTypes: {
     label: {
       name: 'label',

--- a/app/stories/pix-tooltip.stories.js
+++ b/app/stories/pix-tooltip.stories.js
@@ -1,7 +1,7 @@
 import { hbs } from 'ember-cli-htmlbars';
 
 export default {
-  title: 'Basics/Tooltip',
+  title: 'Design System/Atoms/Tooltip',
   argTypes: {
     id: {
       name: 'id',


### PR DESCRIPTION
## :christmas_tree: Problème
Actuellement, l'organisation de la documentation des composants dans Storybook rend la recherche un peu compliquée.

## :gift: Proposition
Dans Figma, Quentin a implémenté l'atomic design. On pourrait se baser dessus pour réorganiser les composants, et avoir une continuité entre les maquettes et Storybook
[Lien Figma](https://www.figma.com/file/8RJ3aCSfdeQ8AZZVBBYKS8/Design-System-Pix?type=design&node-id=383-5012&mode=design&t=0eFSFJIcQMPhmYiC-0)
[Définitions des éléments de l'atomic design](https://lagrandeourse.design/blog/ui-design-et-da/la-difference-entre-le-design-system-et-latomic-design/)

## :star2: Remarques
- Je n'ai bougé que les composants qui existent dans Figma, les autres restent pour l'instant dans les anciennes catégories. À voir où on souhaite les mettre.
- À discuter, si ce découpage est pertinent / compréhensible pour nous

## :santa: Pour tester
`npm run storybook`, et en avant Guingamp !

**Aperçu**

| Actuel      | Atomic |
| ----------- | ----------- |
| <img width="218" alt="Capture d’écran 2023-10-10 à 15 29 30" src="https://github.com/1024pix/pix-ui/assets/11388201/06babea1-333d-4cb6-8629-a9fecb6ea809"> |<img width="218" alt="Capture d’écran 2023-10-10 à 15 30 08" src="https://github.com/1024pix/pix-ui/assets/11388201/5981b51b-8d88-4ea4-be92-8fee7b59fb2c"> |




