### PR TITLE
[BUGFIX] Corrige les scénarios ember-try

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -65,7 +65,7 @@ jobs:
         type: string
     docker:
       - image: cimg/node:<< parameters.node-version >>-browsers
-    resource_class: medium+
+    resource_class: large
     steps:
       - browser-tools/install-chrome
       - checkout

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -7,9 +7,10 @@ const optimized = embroiderOptimized();
 
 module.exports = async function () {
   const pinnedDependencies = {
-    '@embroider/core': `3.0.2`,
-    '@embroider/webpack': `3.0.0`,
-    '@embroider/compat': `3.0.2`,
+    '@embroider/core': '3.0.2',
+    '@embroider/webpack': '3.0.0',
+    '@embroider/compat': '3.0.2',
+    '@embroider/test-setup': '3.0.0',
   };
 
   return {


### PR DESCRIPTION
## :christmas_tree: Problème
@embroider/test-setup est sortie en version 3.0.2 avec en peer dependencies @embroider/core 3.3.0. Mais les tests unitaires utilisent un mécanisme qui ne fonctionne pas avec embroider/core 3.3.0: https://github.com/1024pix/pix-ui/blob/91b3e9caaa1e31ed9b6447a2a86c23b52d6787a0/tests/helpers/create-glimmer-component.js#L9

## :gift: Proposition
Fixer la version de @embroider/test-setup a la 3.0.0

## :santa: Pour tester
CI verte
