### PR TITLE
[TECH] Suppression du support Node 16 et Node 18

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,8 +11,6 @@ workflows:
           matrix:
             parameters:
               node-version:
-                - "16.20.1"
-                - "18.17.0"
                 - "20.8.0"
           filters:
             branches:
@@ -25,8 +23,6 @@ workflows:
                 - embroider-safe
                 - embroider-optimized
               node-version:
-                - "16.20.1"
-                - "18.17.0"
                 - "20.8.0"
           filters:
             branches:
@@ -36,7 +32,6 @@ workflows:
           matrix:
             parameters:
               node-version:
-                - "18.17.0"
                 - "20.8.0"
           filters:
             branches:

--- a/package-lock.json
+++ b/package-lock.json
@@ -92,7 +92,7 @@
         "webpack": "^5.75.0"
       },
       "engines": {
-        "node": "^16.17 || ^18 || ^20"
+        "node": "^20"
       }
     },
     "node_modules/@1024pix/ember-testing-library": {

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "license": "MIT",
   "author": "GIP Pix",
   "engines": {
-    "node": "^16.17 || ^18 || ^20"
+    "node": "^20"
   },
   "ember": {
     "edition": "octane"


### PR DESCRIPTION
## :boom: BREAKING_CHANGES
Arrêt du support de Node.js 16 et Node.js 20. Support de Node.js 20 uniquement.

## :christmas_tree: Problème
On supporte des versions qu'on ne souhaite plus maintenir.

## :gift: Proposition
Supprimer le support des versions de Node qu'on ne souhaite plus (16 et 18). Ne maintenir que Node 20.

## :star2: Remarques
RAS

## :santa: Pour tester
Vérifier que la CI passe. Idéalement link sur les projets qui utilisent Pix UI pour vérifier.
