### PR TITLE
[TECH] Mise à jour de la classe .screen-reader-only

### DIFF
--- a/addon/styles/_a11y.scss
+++ b/addon/styles/_a11y.scss
@@ -1,10 +1,15 @@
+// https://gist.github.com/ffoodd/000b59f431e3e64e4ce1a24d5bb36034
+
 .screen-reader-only, .screen-reader-only > * {
-  position: absolute;
-  width: 1px;
-  height: 1px;
-  margin: -1px;
-  padding: 0;
-  overflow: hidden;
-  border: 0;
-  clip: rect(0, 0, 0, 0);
+  border: 0 !important;
+  clip: rect(1px, 1px, 1px, 1px) !important;
+  -webkit-clip-path: inset(50%) !important;
+  clip-path: inset(50%) !important;
+  height: 1px !important;
+  margin: -1px !important;
+  overflow: hidden !important;
+  padding: 0 !important;
+  position: absolute !important;
+  width: 1px !important;
+  white-space: nowrap !important;
 }

--- a/addon/styles/_a11y.scss
+++ b/addon/styles/_a11y.scss
@@ -1,15 +1,36 @@
 // https://gist.github.com/ffoodd/000b59f431e3e64e4ce1a24d5bb36034
 
 .screen-reader-only, .screen-reader-only > * {
+  position: absolute !important;
+  width: 1px !important;
+  height: 1px !important;
+  margin: -1px !important;
+  padding: 0 !important;
+  overflow: hidden !important;
+  white-space: nowrap !important;
   border: 0 !important;
   clip: rect(1px, 1px, 1px, 1px) !important;
   -webkit-clip-path: inset(50%) !important;
   clip-path: inset(50%) !important;
-  height: 1px !important;
-  margin: -1px !important;
-  overflow: hidden !important;
-  padding: 0 !important;
-  position: absolute !important;
-  width: 1px !important;
-  white-space: nowrap !important;
+}
+
+/*
+	Use in conjunction with .screen-reader-only to only display content when it's focused.
+	@note Useful for skip links
+	@see http://www.w3.org/TR/2013/NOTE-WCAG20-TECHS-20130905/G1
+	@note Based on a HTML5 Boilerplate technique, included in Bootstrap
+	@note Fixed a bug with position: static on iOS 10.0.2 + VoiceOver
+		@author Sylvain Pigeard
+		@see https://github.com/twbs/bootstrap/issues/20732
+*/
+.screen-reader-only-focusable:focus,
+.screen-reader-only-focusable:active {
+  width: auto !important;
+  height: auto !important;
+  margin: auto !important;
+  overflow: visible !important;
+  white-space: normal !important;
+  clip: auto !important;
+  -webkit-clip-path: none !important;
+  clip-path: none !important;
 }


### PR DESCRIPTION
## :christmas_tree: Problème
La classe `screen-reader-only` utilise la propriété `clip`, qui est dépréciée.

La propriété `width: 1px` a des effets négatifs sur le rendu du texte, notamment sur l'espacement entre les mots, et peut nuire à la qualité de la vocalisation.

La classe n'est pas utilisable sur les éléments focusables, comme les liens d'évitement.

## :gift: Proposition
Ajouter la propriété `clip-path`, qui est le futur de `clip`, tout en gardant `clip` car `clip-path` n'est pas acceptée partout.

Contrer les effets de `width: 1px`

Ajout d'une classe `screen-reader-only-focusable`

## :star2: Remarques

Le code est basé sur celui de ce [gisthub](https://gist.github.com/ffoodd/000b59f431e3e64e4ce1a24d5bb36034), qui est bien décrit dans cet article (en FR) : https://www.ffoodd.fr/cache-cache-css/