### PR TITLE
[DOC] Ajout de la doc pour la classe `screen-reader-only` (pix-7740)

### DIFF
--- a/docs/use-utility-classes.mdx
+++ b/docs/use-utility-classes.mdx
@@ -1,0 +1,12 @@
+import { Meta } from '@storybook/blocks';
+
+<Meta title="Utiliser Pix UI/Classes CSS utilitaires" />
+
+# Classes CSS utilitaires
+
+## `screen-reader-only`
+
+La classe `screen-reader-only` permet d'ajouter un texte ou du contexte, sans que cela n'apparaisse à l'écran.
+Ce texte ne sera accessible que par les **lecteurs d'écran** ("screen-readers").
+
+Pour en savoir plus sur le code utilisé, vous pouvez aller lire cet article, conseillé par nos amis de Tanaguru : https://www.ffoodd.fr/cache-cache-css/


### PR DESCRIPTION
## :christmas_tree: Problème
Il n'existe aucune documentation concernant les classes utilitaires

## :gift: Proposition
Commencer la doc avec la classe `screen-reader-only`

## :santa: Pour tester
Check si le texte ne contient aucune fôte

https://ui-pr494.review.pix.fr/?path=/docs/utiliser-pix-ui-classes-css-utilitaires--docs
