### PR TITLE
[TECH] Ajout d'un délai d'attente avant la prise de Snapshots Chromatic

### DIFF
--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -16,6 +16,10 @@ const preview = {
     previewTabs: {
       'storybook/docs/panel': { index: -1 },
     },
+    parameters: {
+      // Sets a delay for the component's stories
+      chromatic: { delay: 600 },
+    },
     options: {
       storySort: {
         order: [


### PR DESCRIPTION
## :christmas_tree: Problème
Les snapshots de stories contenant un Pix Select sont très souvent décalés par rapport à la baseline et nous affiche des changements de visuels alors que, clairement, il n'y en a pas.

La supposition est que, comme la width du select est calculée selon son contenu, il est possible que le snapshot soit pris un poil trop tôt
## :gift: Proposition
Ajouter un délai d'attente avant la prise de snapshot

## :star2: Remarques
PR très très courte

## :santa: Pour tester
Euh... Attendre de voir qu'il n'y a plus aucun build Chromatic avec ce genre d'erreurs mais ça arrive un peu comme un flaky donc c'est à voir sur la durée