### PR TITLE
[BUGFIX] Corriger le soucis de hover sur le bouton de retour. (PIX-10553)

### DIFF
--- a/addon/styles/_pix-return-to.scss
+++ b/addon/styles/_pix-return-to.scss
@@ -13,19 +13,6 @@
     font-size: 1rem;
   }
 
-  &__icon::before {
-    position: absolute;
-    top: 0;
-    left: 0;
-    z-index: -1;
-    width: 100%;
-    height: 100%;
-    border-radius: 50%;
-    opacity: 0;
-    transition: 0.3s ease opacity;
-    content: '';
-  }
-
   &:focus,
   &:hover,
   &:active {
@@ -33,10 +20,6 @@
     border-bottom-color: transparent;
     outline: 0;
     cursor: pointer;
-
-    ::before {
-      opacity: 1;
-    }
   }
 
   @mixin coloriseLink($defaultColor, $arrowHoverColor, $arrowBgColor) {
@@ -47,10 +30,8 @@
     &:active {
       .pix-return-to__icon {
         color: $arrowHoverColor;
-      }
-
-      ::before {
         background-color: $arrowBgColor;
+        border-radius: 50%;
         outline: 1px solid var(--pix-neutral-0);
         outline-offset: -3px;
       }


### PR DESCRIPTION
## :christmas_tree: Problème
Lorsque l'on passe en hover sur tous les buttons de retour de l'app Certif, l'icone flèche devient blanche mais le cercle bleu en background ne s'affiche pas.

## :gift: Proposition
Ne plus utiliser de :before: lors du hover mais directement un background sur l'icone du ReturnTo button.

## :santa: Pour tester
CI ok, design toujours ok
