### PR TITLE
[BUGFIX] Ajouter la font-weight medium pour les Label des inputs (PIX-10622)

### DIFF
--- a/addon/styles/_pix-checkbox.scss
+++ b/addon/styles/_pix-checkbox.scss
@@ -14,6 +14,7 @@
 
     padding-left: var(--pix-spacing-3x);
     color: var(--pix-neutral-900);
+    font-weight: var(--pix-font-normal);
     cursor: pointer;
 
     &--small {

--- a/addon/styles/_pix-radio-button.scss
+++ b/addon/styles/_pix-radio-button.scss
@@ -11,6 +11,7 @@
 
     padding-left: var(--pix-spacing-3x);
     color: var(--pix-neutral-900);
+    font-weight: var(--pix-font-normal);
     cursor: pointer;
   }
 

--- a/addon/styles/component-state/_form.scss
+++ b/addon/styles/component-state/_form.scss
@@ -58,11 +58,12 @@
 }
 
 %pix-label {
-  @extend %pix-body-m;
+  @extend %pix-body-s;
 
   display: block;
   margin-bottom: var(--pix-spacing-1x);
   color: var(--pix-neutral-900);
+  font-weight: var(--pix-font-medium);
 }
 
 %pix-sublabel {


### PR DESCRIPTION
## :christmas_tree: Problème
Suite au refacto des mixin / placeholder un oubli c'est glissé dans le code

## :gift: Proposition
Rajouter la font weight mediaum sur les label

## :star2: Remarques
RAS

## :santa: Pour tester
Vérifier que la font-weight est bien présente