### PR TITLE
[BUGFIX] Harmoniser la taille des boutons (PIX-10623).

### DIFF
--- a/addon/components/pix-button-link.js
+++ b/addon/components/pix-button-link.js
@@ -5,6 +5,6 @@ export default class PixButtonLink extends PixButtonBase {
   defaultParams = {};
 
   get className() {
-    return super.baseClassNames.join(' ');
+    return [...super.baseClassNames, 'pix-button-link'].join(' ');
   }
 }

--- a/addon/styles/_pix-button-base.scss
+++ b/addon/styles/_pix-button-base.scss
@@ -240,3 +240,7 @@
     }
   }
 }
+
+.pix-button-link {
+  line-height: initial;
+}

--- a/addon/styles/_pix-button-base.scss
+++ b/addon/styles/_pix-button-base.scss
@@ -8,7 +8,7 @@
   white-space: nowrap;
   text-decoration: none;
   background-color: var(--pix-primary-500);
-  border: 1px solid transparent;
+  border: 2px solid transparent;
   outline: none;
   cursor: pointer;
 

--- a/addon/styles/component-state/_form.scss
+++ b/addon/styles/component-state/_form.scss
@@ -86,6 +86,7 @@
 
 .pix-form__actions {
   display: flex;
+  gap: 4px;
   justify-content: center;
 
   & > .pix-button:first-child {

--- a/app/stories/form.mdx
+++ b/app/stories/form.mdx
@@ -1,12 +1,11 @@
 import { Meta, Story, Canvas } from '@storybook/addon-docs';
-import * as stories from './form.stories.js';
+import * as stories from './form.stories';
 
-<Meta title="Form/Example" />
+<Meta of={stories} />
 
 # Formulaire avec les composants Pix UI
 
 Un formulaire complet avec les composants Pix UI :
 
-<Canvas>
-  <Story name="Form" story={stories.form} height={700} />
-</Canvas>
+<Story of={stories.form} height={700} />
+

--- a/app/stories/form.stories.js
+++ b/app/stories/form.stories.js
@@ -2,7 +2,7 @@ import { hbs } from 'ember-cli-htmlbars';
 import { action } from '@storybook/addon-actions';
 
 export default {
-  title: 'Form',
+  title: 'Form/Exemple de formulaire',
 };
 
 export const form = (args) => {
@@ -83,16 +83,21 @@ export const form = (args) => {
 
   <br /><br />
 
-  <div class='pix-form__actions'>
-    <PixButton
-      @triggerAction={{this.cancel}}
-      @backgroundColor='transparent-light'
-      @isBorderVisible={{true}}
-    >
-      Annuler
-    </PixButton>
-    <PixButton @type='submit'>Envoyer mes réponses</PixButton>
-  </div>
+  <ul class='pix-form__actions'>
+    <li>
+      <PixButtonLink
+        @route=''
+        @model=''
+        @backgroundColor='transparent-light'
+        @isBorderVisible={{true}}
+      >
+        Annuler
+      </PixButtonLink>
+    </li>
+    <li>
+      <PixButton @type='submit'>Envoyer mes réponses</PixButton>
+    </li>
+  </ul>
 </form>`,
     context: args,
   };


### PR DESCRIPTION
## :christmas_tree: Problème
Entre deux PixButtons primary et tertiary, on a une légère différence de taille : 
<img width="1064" alt="Capture d’écran 2024-01-05 à 15 35 36" src="https://github.com/1024pix/pix-ui/assets/58915422/72d74539-61d6-49f6-8032-37f06b59a91d">

Encore plus visible entre un PixButtonLink et PixButton :
<img width="310" alt="Capture d’écran 2024-01-05 à 15 37 19" src="https://github.com/1024pix/pix-ui/assets/58915422/224b055c-1c85-464b-8ed0-0d63f741ebc8">

## :gift: Proposition

- Augmenter la border du PixButton par défaut.
- Supprimer la line-height pour le PixButtonLink

## :star2: Remarques
On a fixé le dossier Form sur Storybook, que l'on a renommé en : "Exemple de formulaire"

## :santa: Pour tester
Aller sur le formulaire d'exemple et voir que les deux boutons en fin de formulaire son iso sur leurs tailles (un pixButtonLink et pixButton cote a cote)