### PR TITLE
[BUGFIX] Harmoniser la taille du PixButtonUpload avec les autres boutons (PIX-10669).

### DIFF
--- a/addon/styles/_pix-button-base.scss
+++ b/addon/styles/_pix-button-base.scss
@@ -241,6 +241,7 @@
   }
 }
 
-.pix-button-link {
+.pix-button-link,
+.pix-button-upload {
   line-height: initial;
 }

--- a/app/stories/form.stories.js
+++ b/app/stories/form.stories.js
@@ -97,6 +97,11 @@ export const form = (args) => {
     <li>
       <PixButton @type='submit'>Envoyer mes réponses</PixButton>
     </li>
+    <li>
+      <PixButtonUpload @id='file-upload' accept='.csv'>
+        Importer un fichier
+      </PixButtonUpload>
+    </li>
   </ul>
 </form>`,
     context: args,


### PR DESCRIPTION
## :christmas_tree: Problème
Petit oubli du composant PixButtonUpload pour qu'il soit harmonisé avec les autres sur sa taille.

## :gift: Proposition
Mettre la ligne-height à initial

## :star2: Remarques
Suite de la PR https://github.com/1024pix/pix-ui/pull/524/files

## :santa: Pour tester
Aller sur le formulaire d'exemple et voir que les trois boutons en fin de formulaire son iso sur leurs tailles
