### PR TITLE
[FEATURE] Ajout de paramètres sur le composant Pix Collapsible pour afficher un tag (PIX-10851).

### DIFF
--- a/addon/components/pix-collapsible.hbs
+++ b/addon/components/pix-collapsible.hbs
@@ -8,7 +8,7 @@
     aria-expanded={{if this.isUnCollapsed "true" "false"}}
     ...attributes
   >
-    <span class="pix-collapsible-title__label">
+    <span>
       {{#if @titleIcon}}
         <FaIcon class="pix-collapsible-title__icon" @icon={{@titleIcon}} />
       {{/if}}
@@ -20,10 +20,17 @@
       {{/if}}
     </span>
 
-    <FaIcon
-      class="pix-collapsible-title__toggle-icon"
-      @icon="{{if this.isCollapsed 'chevron-down' 'chevron-up'}}"
-    />
+    <span class="pix-collapsible-title__container">
+      {{#if @tagContent}}
+        <PixTag @compact={{false}} @color={{@tagColor}}>
+          {{@tagContent}}
+        </PixTag>
+      {{/if}}
+      <FaIcon
+        class="pix-collapsible-title-container__toggle-icon"
+        @icon="{{if this.isCollapsed 'chevron-down' 'chevron-up'}}"
+      />
+    </span>
   </button>
 
   <div

--- a/addon/styles/_pix-collapsible.scss
+++ b/addon/styles/_pix-collapsible.scss
@@ -53,7 +53,6 @@
 .pix-collapsible-title {
   &__container {
     display: flex;
-    flex-grow: 1;
     align-items: center;
   }
 
@@ -61,6 +60,9 @@
     margin-right: var(--pix-spacing-2x);
     color: var(--pix-neutral-500);
   }
+}
+
+.pix-collapsible-title-container {
 
   &__toggle-icon {
     width: 1rem;

--- a/app/stories/pix-collapsible.mdx
+++ b/app/stories/pix-collapsible.mdx
@@ -17,6 +17,12 @@ Par défaut le contenu est masqué et cliquer sur le libellé permet de montrer 
 
 <Story of={ComponentStories.multipleCollapsible} height={260} />
 
+### Collapsible avec tag
+Les paramètres `tagContent` et `tagColor` permettent d'afficher un `Pix Tag` près du chevron.
+
+
+<Story of={ComponentStories.collapsibleWithTag} height={260} />
+
 
 ## Usage
 

--- a/app/stories/pix-collapsible.stories.js
+++ b/app/stories/pix-collapsible.stories.js
@@ -13,6 +13,18 @@ export default {
       description: "Ajoute l'icône donnée en paramètre avant le titre du PixCollapsible",
       type: { name: 'string', required: false },
     },
+    tagContent: {
+      name: 'tagContent',
+      description: "Contenu du tag qui s'affiche près du chevron",
+      type: { name: 'string', required: false },
+    },
+    tagColor: {
+      name: 'tagColor',
+      description:
+        "Couleur du tag qui s'affiche près du chevron. Doit s'ajouter avec le paramètre tagContent. Voir le composant Pix Tag pour les couleurs disponibles",
+      type: { name: 'string', required: false },
+      table: { defaultValue: { summary: 'primary' } },
+    },
   },
 };
 
@@ -58,6 +70,33 @@ export const multipleCollapsible = (args) => {
 
   <PixCollapsible @title='Titre C' @titleIcon={{this.titleIcon}}>
     <div>Contenu C</div>
+  </PixCollapsible>
+</div>`,
+    context: args,
+  };
+};
+
+export const collapsibleWithTag = (args) => {
+  return {
+    template: hbs`{{! template-lint-disable no-inline-styles }}
+<div style='width:800px'>
+  {{! template-lint-disable no-inline-styles }}
+  <PixCollapsible
+    @title='Titre A'
+    @titleIcon={{this.titleIcon}}
+    @tagColor='success'
+    @tagContent='tag 1'
+  >
+    <div>Contenu A</div>
+  </PixCollapsible>
+
+  <PixCollapsible
+    @title='Titre B'
+    @titleIcon={{this.titleIcon}}
+    @tagColor='error'
+    @tagContent='tag 2'
+  >
+    <div>Contenu B</div>
   </PixCollapsible>
 </div>`,
     context: args,

--- a/app/stories/pix-tag.mdx
+++ b/app/stories/pix-tag.mdx
@@ -25,7 +25,7 @@ Customiser la couleur du tag:
 <PixTag @color="purple"> This is a purple tag </PixTag>
 
 Tag Compact
-<PixTag @compact="{{true}}" @color="blue"> This is a compactg tag </PixTag>
+<PixTag @compact="{{true}}" @color="blue"> This is a compact tag </PixTag>
 ```
 
 ## Arguments


### PR DESCRIPTION
## :christmas_tree: Problème
Un besoin coté Pix Certif d'avoir la présence d'un tag dans le composant Pix Collapsible. Cette forme du composant est voué a être réutilisé, il est donc ajouté dans le composant Pix UI

## :gift: Proposition
<img width="946" alt="Capture d’écran 2024-01-18 à 17 54 17" src="https://github.com/1024pix/pix-ui/assets/58915422/5bba24d0-6351-43d9-900f-70e50ad33d56">

## :santa: Pour tester
Se rendre sur le doc du collapsible et voir le design du composant avec et sans tag
