### PR TITLE
:recycle: Improve checkbox component state

### DIFF
--- a/addon/components/pix-checkbox.hbs
+++ b/addon/components/pix-checkbox.hbs
@@ -14,6 +14,7 @@
       class={{this.inputClasses}}
       checked={{@checked}}
       aria-disabled={{@isDisabled}}
+      {{on "change" this.toggleChecked}}
       ...attributes
     />
 

--- a/addon/components/pix-checkbox.js
+++ b/addon/components/pix-checkbox.js
@@ -1,11 +1,8 @@
 import Component from '@glimmer/component';
 import { guidFor } from '@ember/object/internals';
+import { action } from '@ember/object';
 
 export default class PixCheckbox extends Component {
-  constructor() {
-    super(...arguments);
-  }
-
   get id() {
     return this.args.id || guidFor(this);
   }
@@ -18,5 +15,12 @@ export default class PixCheckbox extends Component {
     }
 
     return classes.join(' ');
+  }
+
+  @action
+  toggleChecked() {
+    if (this.args.onChange) {
+      return this.args.onChange(!this.args.checked, this.args.value);
+    }
   }
 }

--- a/addon/components/pix-multi-select.hbs
+++ b/addon/components/pix-multi-select.hbs
@@ -74,10 +74,11 @@
               @checked={{option.checked}}
               @size="small"
               @class="pix-multi-select-list__item-label"
-              value={{option.value}}
-              {{on "change" this.onSelect}}
+              @value={{option.value}}
+              @onChange={{this.onSelect}}
               {{on-enter-action this.hideDropDown this.multiSelectId}}
               tabindex={{if this.isExpanded "0" "-1"}}
+              option={{option}}
             >
               <:label>{{yield option}}</:label>
             </PixCheckbox>

--- a/addon/components/pix-multi-select.js
+++ b/addon/components/pix-multi-select.js
@@ -95,12 +95,13 @@ export default class PixMultiSelect extends Component {
   }
 
   @action
-  onSelect(event) {
+  onSelect(targetChecked, targetValue) {
     let selected = [...(this.args.values || [])];
-    if (event.target.checked) {
-      selected.push(event.target.value);
+
+    if (targetChecked) {
+      selected.push(targetValue);
     } else {
-      selected = selected.filter((value) => value !== event.target.value);
+      selected = selected.filter((value) => value !== targetValue);
     }
 
     if (this.args.onChange) {

--- a/app/stories/pix-checkbox.stories.js
+++ b/app/stories/pix-checkbox.stories.js
@@ -26,12 +26,14 @@ export default {
     },
     checked: {
       name: 'checked',
-      description: 'Permet de cocher la checkbox',
-      type: { name: 'boolean', required: false },
-      table: {
-        type: { summary: 'boolean' },
-        defaultValue: { summary: false },
-      },
+      description: 'Détermine si la checkbox est cochée',
+      type: { name: 'boolean', required: true, defaultValue: false },
+    },
+    onChange: {
+      name: 'onChange',
+      description: "Fonction à appeler quand la checkbox change d'état",
+      type: { required: true },
+      control: { disable: true },
     },
     isDisabled: {
       name: 'isDisabled',
@@ -99,6 +101,7 @@ const Template = (args) => {
   @size={{this.size}}
   @inlineLabel={{this.inlineLabel}}
   @screenReaderOnly={{this.screenReaderOnly}}
+  @onChange={{this.onChange}}
 >
   <:label>{{this.label}}</:label>
 </PixCheckbox>`,
@@ -176,6 +179,7 @@ const MultipleTemplate = (args) => {
   @checked={{this.checked}}
   disabled={{this.disabled}}
   @isDisabled={{this.isDisabled}}
+  @onChange={{this.onChange}}
 >
   <:label>{{this.label}}</:label>
 </PixCheckbox>
@@ -188,6 +192,7 @@ const MultipleTemplate = (args) => {
   @checked={{this.checked}}
   disabled={{this.disabled}}
   @isDisabled={{this.isDisabled}}
+  @onChange={{this.onChange}}
 >
   <:label>{{this.label}}</:label>
 </PixCheckbox>`,

--- a/tests/integration/components/pix-checkbox-test.js
+++ b/tests/integration/components/pix-checkbox-test.js
@@ -3,10 +3,11 @@ import { setupRenderingTest } from 'ember-qunit';
 import { hbs } from 'ember-cli-htmlbars';
 import { render, clickByText } from '@1024pix/ember-testing-library';
 
-module('Integration | Component | checkbox', function (hooks) {
+module('Integration | Component | PixCheckbox', function (hooks) {
   setupRenderingTest(hooks);
 
   test('it should be possible to check the checkbox', async function (assert) {
+    // given
     // when
     await render(hbs`<PixCheckbox><:label>Recevoir la newsletter</:label></PixCheckbox>`);
     await clickByText('Recevoir la newsletter');

--- a/tests/integration/components/pix-filterable-and-searchable-select-test.js
+++ b/tests/integration/components/pix-filterable-and-searchable-select-test.js
@@ -115,6 +115,7 @@ module('Integration | Component | PixFilterableAndSearchableSelect', function (h
 </PixFilterableAndSearchableSelect>`);
 
     await click(screen.getByText(`${this.categoriesPlaceholder} (0)`));
+
     await click(await screen.findByRole('checkbox', { name: 'Hamburger' }));
     await click(await screen.findByRole('checkbox', { name: 'Sushi' }));
 

--- a/tests/integration/components/pix-multi-select-test.js
+++ b/tests/integration/components/pix-multi-select-test.js
@@ -15,9 +15,9 @@ module('Integration | Component | multi-select', function (hooks) {
   setupRenderingTest(hooks);
 
   const DEFAULT_OPTIONS = [
-    { value: '1', label: 'Salade' },
-    { value: '2', label: 'Tomate' },
-    { value: '3', label: 'Oignon' },
+    { value: '1', label: 'Salade', checked: false },
+    { value: '2', label: 'Tomate', checked: true },
+    { value: '3', label: 'Oignon', checked: false },
   ];
 
   module('common cases', function () {
@@ -786,7 +786,6 @@ module('Integration | Component | multi-select', function (hooks) {
 
       // when
       await fillByLabel('multiSelectLabel', 'Oi');
-
       await screen.findByRole('menu');
 
       await clickByName('Oignon');
@@ -795,6 +794,7 @@ module('Integration | Component | multi-select', function (hooks) {
 
       // then
       const listElement = screen.getAllByRole('checkbox');
+
       assert.strictEqual(listElement.length, 3);
       assert.strictEqual(listElement[0].labels[0].innerText.trim(), 'Oignon');
       assert.strictEqual(listElement[1].labels[0].innerText.trim(), 'Salade');


### PR DESCRIPTION
Note : 

Le changement pose quelques soucis, notamment parce que la checkbox est utilisée par le composant multi-select et un filter (qui appelle multi select qui appelle checkbox). On se retrouve avec un enchainement d'actions au on-change.

Est-ce que ce ne serait pas l'occasion de passer aux composants Ember Checkbox ?



## :christmas_tree: Problème
Il y a un décalage entre l'état réel du composant et le paramètre `isChecked`.
Si on passe le `isChecked` à `true`, puis qu'on clique sur la checkbox, le `isChecked` reste à `true` au lieu de repasser à `false`.

## :gift: Proposition
Modifier le paramètre au clic.

## :santa: Pour tester
Cliquer sur la checkbox, vérifier que tout est OK
