### PR TITLE
[TECH] Utiliser le padding au lieu de définir une height pour les composant select

### DIFF
--- a/addon/styles/_pix-multi-select.scss
+++ b/addon/styles/_pix-multi-select.scss
@@ -11,8 +11,7 @@
   display: flex;
   align-items: center;
   width: 100%;
-  height: 36px;
-  padding: 0 var(--pix-spacing-8x) 0 var(--pix-spacing-4x);
+  padding: var(--pix-spacing-2x) var(--pix-spacing-3x);
   color: var(--pix-neutral-900);
   background-color: var(--pix-neutral-0);
   border: 1px var(--pix-neutral-500) solid;

--- a/addon/styles/_pix-select.scss
+++ b/addon/styles/_pix-select.scss
@@ -85,8 +85,7 @@
   align-items: center;
   justify-content: space-between;
   width: 100%;
-  height: 2.25rem;
-  padding: 0 var(--pix-spacing-4x) 0 var(--pix-spacing-4x);
+  padding: var(--pix-spacing-2x) var(--pix-spacing-3x);
   color: var(--pix-neutral-900);
   background-color: var(--pix-neutral-0);
   border: 1px var(--pix-neutral-500) solid;


### PR DESCRIPTION
## :christmas_tree: Problème
les select n'ont pas la même hauteur que les input. du notamment au fait qu'il ont une height de definit a 2.25rem . alors que les input joue sur le padding

## :gift: Proposition
Utiliser les paddings aussi pour les select

## :star2: Remarques
RAS

## :santa: Pour tester
Essayer d'installer cette version sur Pix Admin et vérifier que les select à côté des input font maintenant la même taille