### PR TITLE
[TECH] Déclencher le workflow release sur la branche dev

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,7 @@ name: release
 on:
   push:
     branches:
-      - main
+      - dev
   repository_dispatch:
     types: [ 'deploy' ]
   workflow_dispatch:


### PR DESCRIPTION
## :christmas_tree: Problème
Le workflow `release` ne se lance pas sur dev, qui est la branche principale

## :gift: Proposition
Remplacer le trigger par la branche `dev`

## :star2: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :santa: Pour tester
> _Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc._
