### PR TITLE
[TECH] Faire en sorte que l'action `auto-merge` fasse un push sur dev qui déclenche les autres actions.  

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -20,4 +20,4 @@ jobs:
     steps:
       - uses: 1024pix/pix-actions/auto-merge@v0
         with:
-          auto_merge_token: "${{ github.token }}"
+          auto_merge_token: '${{ secrets.PIX_SERVICE_ACTIONS_TOKEN }}'


### PR DESCRIPTION
## :christmas_tree: Problème
Actuellement, toutes les actions qui attendent un push sur dev ne se lance pas car l'action `auto-merge` aka JP n'a pas un token personnel. En effet, un token action ne peut pas déclencher une autre action (pas la meilleure des sources mais dans l'idée : https://github.com/orgs/community/discussions/25812#discussioncomment-4408810) 

## :gift: Proposition
Utiliser comme sur notre repo le token de service

## :star2: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :santa: Pour tester
Merger sur dev et constater