### PR TITLE
[TECH] Donner les droits à l'action `release` de pusher sur dev

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,5 +25,5 @@ jobs:
         with:
           npmPublish: true
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.PIX_SERVICE_ACTIONS_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_PUBLISH_ACCESS_TOKEN }}


### PR DESCRIPTION
## :christmas_tree: Problème
Actuellement, l'action release utilise un GITHUB_TOKEN qui ne peut pas pusher sur une branche protégée

![Screenshot 2024-02-23 at 17 25 54](https://github.com/1024pix/pix-ui/assets/26384707/03ce9e88-6c00-4d6d-b933-666f02f42aef)


## :gift: Proposition
Utiliser notre token de service qui lui a les droits.

## :star2: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :santa: Pour tester
> _Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc._
