### PR TITLE
[TECH] Utiliser le bon token GitHub pour l'action `release`

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - uses: actions/setup-node@v4
         with:


### PR DESCRIPTION
## :christmas_tree: Problème
Actuellement l'action `release`ne fonctionne pas alors que nous lui avons passé le bon token à utilisé. En réalité, c'est de la faute à l'action `actions/checkout` qui persiste l'authentification faite au départ avec le token fourni par GitHub

## :gift: Proposition
Pour remédier à ce comportement GitHub propose une option `persist-credentials: false`

![Screenshot 2024-02-23 at 17 38 47](https://github.com/1024pix/pix-ui/assets/26384707/4783c42f-e6c2-4321-b993-fdc2c5226c6c)

https://github.com/actions/checkout?tab=readme-ov-file#checkout-v4

## :star2: Remarques
Cette fois ci c'est la bonne

## :santa: Pour tester
Merger c'est tester