### PR TITLE
[TECH] Prévenir les mauvais titre de PR.

### DIFF
--- a/.github/workflows/check-pr-title.yaml
+++ b/.github/workflows/check-pr-title.yaml
@@ -1,0 +1,14 @@
+name: pr title check
+on:
+  pull_request:
+    types: [opened, edited, ready_for_review, reopened]
+jobs:
+  lint-pr-title:
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.draft == false && github.event.pull_request.state == 'open'
+    permissions:
+      pull-requests: read
+    steps:
+      - uses: Slashgear/action-check-pr-title@v4.3.0
+        with:
+          regexp: '^\[[A-Z]+\] '


### PR DESCRIPTION
## :christmas_tree: Problème
L'action `release`  nécessite des TAG spécifique pour choisir le type de version à effectuer, mais des erreurs peuvent être commises.

## :gift: Proposition
Prévenir les erreurs en ajoutant [la même action que sur le repo principal](https://github.com/1024pix/pix/blob/754588636b611bce2ba4ea545d8bdae14529b2cc/.github/workflows/check-pr-title.yaml).

## :star2: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :santa: Pour tester
Changer le titre de la PR voir le check passer au rouge et le remettre :) 