### PR TITLE
[TECH] Déployer Storybook à chaque release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,7 +32,6 @@ jobs:
           NPM_TOKEN: ${{ secrets.NPM_PUBLISH_ACCESS_TOKEN }}
 
       - name: Deploy storybook to Github Pages
-        if: steps.semantic.outputs.new_release_published == 'true'
         run: npm run deploy-storybook -- --ci
         env:
           GH_TOKEN: 1024pix:${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## :christmas_tree: Problème
Notre Storybook ui.pix.fr ne se déploie plus automatiquement depuis la v44.0.0 (voir le changelog).

## :gift: Proposition
Ne plus contraindre le déploiement (avec un `if` qui ne passe jamais ^^").

## :star2: Remarques
RAS

## :santa: Pour tester
Je ne sais pas.
