### PR TITLE
[BUGFIX] corrige la position du chevron dans le multiselect (pix-11962)

### DIFF
--- a/addon/styles/_pix-multi-select.scss
+++ b/addon/styles/_pix-multi-select.scss
@@ -17,7 +17,9 @@
 
   position: relative;
   display: flex;
+  gap: var(--pix-spacing-1x);
   align-items: center;
+  justify-content: space-between;
   width: 100%;
   padding: var(--pix-spacing-2x) var(--pix-spacing-3x);
   color: var(--pix-neutral-900);
@@ -56,9 +58,6 @@
   &__dropdown-icon {
     @extend %pix-body-s;
 
-    position: absolute;
-    top: calc(50% - 6px);
-    right: 10px;
     color: var(--pix-neutral-900);
     pointer-events: none;
   }


### PR DESCRIPTION
## :christmas_tree: Problème
L'icon chevron du composant multiselect est recouvert par le texte quand celui-ci est un peu long.

## :gift: Proposition
On évite que le texte recouvre l'icone

## :star2: Remarques
Etant donnée que le layout du bouton est flex, j'ai simplement rajouté une propriété `gap: var(--pix-space-1x);` et remis l'icon dans le flux. On aurait pu aussi mettre un padding à droite plus important  mais cela aurait donnée lié à des calculs plus compliqués pour que le padding tombe juste. 

## :santa: Pour tester
Ouvrir le composant multiselect et valider que l'icon n'est pas recouvert par le texte
