### PR TITLE
[TECH] Vérifier que la version de nodeJs soit disponible sur scalingo

### DIFF
--- a/.github/workflows/check-node-version-availability-on-scalingo.yml
+++ b/.github/workflows/check-node-version-availability-on-scalingo.yml
@@ -1,0 +1,12 @@
+name: Check node version availability on Scalingo
+
+on: [push]
+
+jobs:
+  check-node-compatibility:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+
+      - uses: 1024pix/pix-actions/check-node-version-availability-on-scalingo@v0


### PR DESCRIPTION
## :christmas_tree: Problème
Actuellement JP ne vérifie pas que la version de node que l'on install soit ok avec ce que scalingo met à disposition

## :gift: Proposition
Ajouter la config.yml nécessaire sur pix-ui


## :santa: Pour tester
CI ok