### PR TITLE
[BUGFIX] Permet le clique entre les input `radio` ou `checkbox` et leur label

### DIFF
--- a/addon/components/pix-checkbox.hbs
+++ b/addon/components/pix-checkbox.hbs
@@ -1,13 +1,4 @@
 <div class="pix-checkbox {{@class}}">
-  <input
-    type="checkbox"
-    id={{this.id}}
-    class={{this.inputClasses}}
-    checked={{@checked}}
-    aria-disabled={{@isDisabled}}
-    ...attributes
-  />
-
   <PixLabel
     @for={{this.id}}
     @requiredLabel={{@requiredLabel}}
@@ -15,7 +6,17 @@
     @inlineLabel={{true}}
     @screenReaderOnly={{@screenReaderOnly}}
     @isDisabled={{@isDisabled}}
+    @wrappedElement={{true}}
   >
+    <input
+      type="checkbox"
+      id={{this.id}}
+      class={{this.inputClasses}}
+      checked={{@checked}}
+      aria-disabled={{@isDisabled}}
+      ...attributes
+    />
+
     {{yield to="label"}}
   </PixLabel>
 </div>

--- a/addon/components/pix-label.js
+++ b/addon/components/pix-label.js
@@ -5,6 +5,7 @@ export default class PixLabel extends Component {
     const classes = ['pix-label'];
 
     if (this.args.screenReaderOnly) classes.push('screen-reader-only');
+    if (this.args.wrappedElement) classes.push('pix-label--wrapped-element');
     if (this.args.inlineLabel) classes.push('pix-label--inline-label');
     if (this.args.isDisabled) classes.push('pix-label--disabled');
 

--- a/addon/components/pix-radio-button.hbs
+++ b/addon/components/pix-radio-button.hbs
@@ -1,11 +1,4 @@
 <div class="pix-radio-button {{@class}}">
-  <input
-    type="radio"
-    id={{this.id}}
-    class="pix-radio-button__input"
-    value={{@value}}
-    ...attributes
-  />
   <PixLabel
     @for={{this.id}}
     @requiredLabel={{@requiredLabel}}
@@ -13,7 +6,15 @@
     @screenReaderOnly={{@screenReaderOnly}}
     @isDisabled={{@isDisabled}}
     @inlineLabel={{true}}
+    @wrappedElement={{true}}
   >
+    <input
+      type="radio"
+      id={{this.id}}
+      class="pix-radio-button__input"
+      value={{@value}}
+      ...attributes
+    />
     {{yield to="label"}}
   </PixLabel>
 </div>

--- a/addon/styles/_pix-checkbox.scss
+++ b/addon/styles/_pix-checkbox.scss
@@ -1,9 +1,6 @@
 .pix-checkbox {
   position: relative;
   z-index: 0;
-  display: flex;
-  gap: var(--pix-spacing-3x);
-  align-items: center;
 
   & + .pix-checkbox {
     margin-top: var(--pix-spacing-4x);

--- a/addon/styles/_pix-label.scss
+++ b/addon/styles/_pix-label.scss
@@ -3,6 +3,12 @@
   color: var(--pix-neutral-900);
   font-weight: var(--pix-font-medium);
 
+  &--wrapped-element {
+    display: flex;
+    gap: var(--pix-spacing-3x);
+    align-items: center;
+  }
+
   &--disabled {
     color: var(--pix-neutral-500);
   }

--- a/addon/styles/_pix-radio-button.scss
+++ b/addon/styles/_pix-radio-button.scss
@@ -1,8 +1,4 @@
 .pix-radio-button {
-  display: flex;
-  gap: var(--pix-spacing-3x);
-  align-items: center;
-
   & + .pix-radio-button {
     margin-top: var(--pix-spacing-4x);
   }

--- a/app/stories/pix-label.stories.js
+++ b/app/stories/pix-label.stories.js
@@ -56,6 +56,15 @@ export default {
       },
       control: { type: 'boolean' },
     },
+    wrappedElement: {
+      name: 'wrappedElement',
+      description: "Permet de définir si le label englobe l'input associé",
+      type: { name: 'boolean', required: false },
+      table: {
+        defaultValue: { summary: false },
+      },
+      control: { type: 'boolean' },
+    },
   },
 };
 


### PR DESCRIPTION
## :christmas_tree: Problème
Depuis la v45, on ne peut plus cliquer entre un input "radio" ou "checkbox" et son label associé.

![image(23)](https://github.com/1024pix/pix-ui/assets/5855339/982b9246-75d9-45df-a131-cecda3acc6bc)

## :gift: Proposition
Replacer l'input à l'intérieur du label et utiliser flexbox comme avant.

## :star2: Remarques
R AS

## :santa: Pour tester
Vérifier qu'on peut correctement interagir avec les composants `PixRadioButton` et `PixCheckbox`.
