### PR TITLE
[FEATURE] Gérer l'abscence de label pour les inputs et textarea

### DIFF
--- a/addon/components/pix-input.hbs
+++ b/addon/components/pix-input.hbs
@@ -1,14 +1,16 @@
 <div class="pix-input {{if @inlineLabel ' pix-input--inline'}}">
-  <PixLabel
-    @for={{this.id}}
-    @requiredLabel={{@requiredLabel}}
-    @subLabel={{@subLabel}}
-    @size={{@size}}
-    @screenReaderOnly={{@screenReaderOnly}}
-    @inlineLabel={{@inlineLabel}}
-  >
-    {{yield to="label"}}
-  </PixLabel>
+  {{#if (has-block "label")}}
+    <PixLabel
+      @for={{this.id}}
+      @requiredLabel={{@requiredLabel}}
+      @subLabel={{@subLabel}}
+      @size={{@size}}
+      @screenReaderOnly={{@screenReaderOnly}}
+      @inlineLabel={{@inlineLabel}}
+    >
+      {{yield to="label"}}
+    </PixLabel>
+  {{/if}}
   <div>
     <div class="pix-input__container">
       <input

--- a/addon/components/pix-textarea.hbs
+++ b/addon/components/pix-textarea.hbs
@@ -1,14 +1,16 @@
 <div class="pix-textarea {{if @inlineLabel ' pix-textarea--inline'}}">
-  <PixLabel
-    @for={{this.id}}
-    @requiredLabel={{@requiredLabel}}
-    @subLabel={{@subLabel}}
-    @size={{@size}}
-    @screenReaderOnly={{@screenReaderOnly}}
-    @inlineLabel={{@inlineLabel}}
-  >
-    {{yield to="label"}}
-  </PixLabel>
+  {{#if (has-block "label")}}
+    <PixLabel
+      @for={{this.id}}
+      @requiredLabel={{@requiredLabel}}
+      @subLabel={{@subLabel}}
+      @size={{@size}}
+      @screenReaderOnly={{@screenReaderOnly}}
+      @inlineLabel={{@inlineLabel}}
+    >
+      {{yield to="label"}}
+    </PixLabel>
+  {{/if}}
 
   <div>
     <textarea

--- a/app/stories/pix-input.mdx
+++ b/app/stories/pix-input.mdx
@@ -72,6 +72,10 @@ En readonly, l'input n'est pas modifiable, mais il est toujours focusable et est
 
 <Story of={ComponentStories.withRequiredLabel} height={100} />
 
+## Without label
+
+<Story of={ComponentStories.withoutLabel} height={100} />
+
 ## Usage
 
 ```html

--- a/app/stories/pix-input.stories.js
+++ b/app/stories/pix-input.stories.js
@@ -102,6 +102,24 @@ const Template = (args) => {
   };
 };
 
+const TemplateWithoutLabel = (args) => {
+  return {
+    template: hbs`<PixInput
+  @id={{this.id}}
+  @errorMessage={{this.errorMessage}}
+  placeholder='Jeanne, Pierre ...'
+  @validationStatus={{this.validationStatus}}
+  @size={{this.size}}
+  disabled={{this.disabled}}
+  readonly={{this.readonly}}
+  @subLabel={{this.subLabel}}
+  @inlineLabel={{this.inlineLabel}}
+  @requiredLabel={{this.requiredLabel}}
+/>`,
+    context: args,
+  };
+};
+
 export const Default = Template.bind({});
 Default.args = {
   id: 'first-name',
@@ -149,4 +167,9 @@ withRequiredLabel.args = {
   id: 'first-name',
   label: 'Prénom',
   requiredLabel: 'Champ obligatoire',
+};
+
+export const withoutLabel = TemplateWithoutLabel.bind({});
+withoutLabel.args = {
+  id: 'first-name',
 };

--- a/app/stories/pix-textarea.mdx
+++ b/app/stories/pix-textarea.mdx
@@ -15,6 +15,9 @@ Si vous utilisez le `PixTextarea` sans vouloir afficher le label, il faudra rens
 
 <Story of={ComponentStories.textarea} height={100} />
 
+## Without Label
+
+<Story of={ComponentStories.textareaWithoutLabel} height={100} />
 
 ## Usage
 

--- a/app/stories/pix-textarea.stories.js
+++ b/app/stories/pix-textarea.stories.js
@@ -90,8 +90,30 @@ const Template = (args) => {
   };
 };
 
+const TemplateWithoutlabel = (args) => {
+  return {
+    template: hbs`<PixTextarea
+  @id={{this.id}}
+  @value={{this.value}}
+  @maxlength={{this.maxlength}}
+  @errorMessage={{this.errorMessage}}
+  @size={{this.size}}
+  @subLabel={{this.subLabel}}
+  @requiredLabel={{this.requiredLabel}}
+  @inlineLabel={{this.inlineLabel}}
+/>`,
+    context: args,
+  };
+};
+
 export const textarea = Template.bind({});
 textarea.args = {
   id: 'textarea',
+  value: 'Contenu du textarea',
+};
+
+export const textareaWithoutLabel = TemplateWithoutlabel.bind({});
+textarea.args = {
+  id: 'textarea-without-label',
   value: 'Contenu du textarea',
 };


### PR DESCRIPTION
## :christmas_tree: Problème
Actuellement, Il n'est pas possible d'utiliser les composants `PixInput` et `PixTextarea` de la version 45.0.0 de pix-ui dans Pix App. En effet, si on ne passe pas un label en yield aux composants `PixInput` et `PixTextarea`, un élément html label vide est quand même généré par ces composants. Cela cause des problèmes d'accessibilité et des regressions visuelles. 

## :gift: Proposition
Utiliser la gestion de l'absence de label à la manière du `PixSelect`.

## :santa: Pour tester
Aller sur storyBook
Constater l'absence de label pour les `PixInput` et `PixTextarea` en inspectant le html des éléments concernés