### PR TITLE
[TECH] Avoir une CI déterministe

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,16 +23,6 @@ workflows:
             branches:
               ignore:
                 - gh-pages
-      - try-scenarios:
-          matrix:
-            parameters:
-              try-scenario:
-                - embroider-safe
-                - embroider-optimized
-          filters:
-            branches:
-              ignore:
-                - gh-pages
       - chromatic-deployment:
           filters:
             branches:
@@ -51,18 +41,6 @@ jobs:
       - run: npm run lint:hbs
       - run: npm run lint:scss
       - run: npm test
-
-  try-scenarios:
-    executor: node-browsers-docker
-    parameters:
-      try-scenario:
-        type: string
-    resource_class: large
-    steps:
-      - browser-tools/install-chrome
-      - checkout
-      - run: npm ci
-      - run: npx ember try:one << parameters.try-scenario >>
 
   chromatic-deployment:
     executor: node-browsers-docker


### PR DESCRIPTION
## :christmas_tree: Problème
La CI casse quand des mises à jour d'Embroider ou de Webpack ont lieu.

## :gift: Proposition
Ne pas faire casser la CI dans ces cas et la rendre donc déterministe.

## :star2: Remarques
J'ai laissé la config d'`ember-try` si jamais on veut l'utiliser en local : https://github.com/1024pix/pix-ui/blob/dev/config/ember-try.js. Peut être veut-on ne plus pin les versions ?

## :santa: Pour tester
Vérifier que la CI n'exécute plus les scenarios (et qu'elle ne casse plus donc).
