### PR TITLE
[TECH] Amélioration de la documentation des composants PixInput et PixTextarea (PIX-12403).

### DIFF
--- a/app/stories/pix-input.mdx
+++ b/app/stories/pix-input.mdx
@@ -9,8 +9,17 @@ Le PixInput permet de créer un champ de texte.
 
 ## Accessibilité
 
-Si vous utilisez le `PixInput` sans vouloir afficher le label, il faudra renseigner `screenReaderOnly` à `true`.
-Il est possible d'ajouter un label en dehors du composant en précisant bien un attribut `for` correspondant à l'`@id` passé au PixInput.
+La propriété label est optionnelle pour le composant.
+
+Mais au niveau de l'accessibilité, il est quand même nécessaire que le champ soit rattaché à un label.
+
+Il y a alors plusieurs possibilités :
+
+- Vous pouvez cacher le label visuellement mais le rendre disponible pour les lecteurs d'écran via la propriété `screenReaderOnly` à `true`.
+- Les attributs `aria-label` et `aria-labelledby` sont utilisables.
+- Un attribut `@for` pointant vers l'id de l'input peut être ajouté à un composant `<PixLabel />` extérieur.
+
+## Tests
 
 Pour acceder à l'élément via son label avec testing-library:
 

--- a/app/stories/pix-input.stories.js
+++ b/app/stories/pix-input.stories.js
@@ -31,7 +31,7 @@ export default {
     label: {
       name: 'label',
       description: 'Le label du champ',
-      type: { name: 'string', required: true },
+      type: { name: 'string', required: false },
       table: {
         type: { summary: 'string' },
       },

--- a/app/stories/pix-textarea.mdx
+++ b/app/stories/pix-textarea.mdx
@@ -9,13 +9,19 @@ Un textarea permettant d'avoir un champ de saisie libre.
 
 Optionellement, il peut afficher le nombre de caractères tapés ainsi que le nombre de caractères maximum.
 
+<Story of={ComponentStories.textarea} height={150} />
+
 ## Accessibilité
 
-Si vous utilisez le `PixTextarea` sans vouloir afficher le label, il faudra renseigner `screenReaderOnly` à `true`.
+La propriété label est optionnelle pour le composant.
 
-<Story of={ComponentStories.textarea} height={100} />
+Mais au niveau de l'accessibilité, il est quand même nécessaire que le champ soit rattaché à un label.
 
-## Without Label
+Il y a alors plusieurs possibilités :
+
+- Vous pouvez cacher le label visuellement mais le rendre disponible pour les lecteurs d'écran via la propriété `screenReaderOnly` à `true`.
+- Les attributs `aria-label` et `aria-labelledby` sont utilisables.
+- Un attribut `@for` pointant vers l'id du textarea peut être ajouté à un composant `<PixLabel />` extérieur.
 
 <Story of={ComponentStories.textareaWithoutLabel} height={100} />
 

--- a/app/stories/pix-textarea.stories.js
+++ b/app/stories/pix-textarea.stories.js
@@ -11,7 +11,7 @@ export default {
     value: {
       name: 'value',
       description: 'Valeur du champ',
-      type: { name: 'string', required: true },
+      type: { name: 'string', required: false },
     },
     maxlength: {
       name: 'maxlength',
@@ -23,11 +23,10 @@ export default {
       description: 'Affiche une erreur en dessous du champ.',
       type: { name: 'string', required: false },
     },
-
     label: {
       name: 'label',
       description: 'Donne un label au champ.',
-      type: { name: 'string', required: true },
+      type: { name: 'string', required: false },
     },
     subLabel: {
       name: 'subLabel',
@@ -109,11 +108,13 @@ const TemplateWithoutlabel = (args) => {
 export const textarea = Template.bind({});
 textarea.args = {
   id: 'textarea',
+  label: 'Label du textarea',
+  subLabel: 'Sous-label',
   value: 'Contenu du textarea',
 };
 
 export const textareaWithoutLabel = TemplateWithoutlabel.bind({});
-textarea.args = {
+textareaWithoutLabel.args = {
   id: 'textarea-without-label',
-  value: 'Contenu du textarea',
+  value: 'Contenu du textarea sans label affiché',
 };


### PR DESCRIPTION
## :christmas_tree: Problème
Actuellement, la documentation des composants PixInput et PixTextarea est incomplète. Améliorons là !

## :gift: Proposition
Compléter les descriptions des champs Pix Input et Pix Text Area.

## :santa: Pour tester
Aller sur la documentation et constater que la nouvelle description est correcte.