### PR TITLE
[TECH] Màj GHA check titre PR pour utiliser Pix Actions

### DIFF
--- a/.github/workflows/check-pr-title.yaml
+++ b/.github/workflows/check-pr-title.yaml
@@ -1,14 +1,11 @@
 name: pr title check
+
 on:
   pull_request:
     types: [opened, edited, ready_for_review, reopened]
+
 jobs:
   lint-pr-title:
     runs-on: ubuntu-latest
-    if: github.event.pull_request.draft == false && github.event.pull_request.state == 'open'
-    permissions:
-      pull-requests: read
     steps:
-      - uses: Slashgear/action-check-pr-title@v4.3.0
-        with:
-          regexp: '^\[[A-Z]+\] '
+      - uses: 1024pix/pix-actions/check-pr-title@main


### PR DESCRIPTION
Bloquer la CI si la PR ne respecte pas la convention de titre de PR

https://github.com/1024pix/pix-actions?tab=readme-ov-file#check-pr-title 