### PR TITLE
[DOCS] Revues diverse

### DIFF
--- a/app/stories/pix-checkbox.mdx
+++ b/app/stories/pix-checkbox.mdx
@@ -7,18 +7,16 @@ import * as ComponentStories from './pix-checkbox.stories';
 
 La PixCheckbox permet de créer des checkbox basiques ou des checkbox mixées (checkbox servant d'indicateur lors d'une sélection multiple).
 
+<Story of={ComponentStories.Default} height={60} />
 
- <Story of={ComponentStories.Default} height={60} />
-
+<Story of={ComponentStories.DefaultChecked} height={60} />
 
 ### Liste de checkboxes
 
 Il n'est pas rare d'avoir plusieurs champs checkbox qui se suivent.<br/>
 En ce sens, nous avons déjà prévu un espace vertical pour séparer 2 composants qui se suivent.
 
-
-  <Story of={ComponentStories.multiple} height={140} />
-
+<Story of={ComponentStories.multiple} height={140} />
 
 ## États de la Checkbox
 
@@ -26,16 +24,13 @@ En ce sens, nous avons déjà prévu un espace vertical pour séparer 2 composan
 
 ### Checkbox interminée
 
-
-  <Story of={ComponentStories.indeterminateCheckbox} height={60} />
-
+<Story of={ComponentStories.isIndeterminate} height={60} />
 
 ### Checkbox désactivée
 
-  <Story of={ComponentStories.checkboxDisabled} height={60} />
-  <Story of={ComponentStories.checkboxCheckedDisabled} height={60} />
-  <Story of={ComponentStories.checkboxInterminateDisabled} height={60} />
-
+<Story of={ComponentStories.isDisabled} height={60} />
+<Story of={ComponentStories.checkedIsDisabled} height={60} />
+<Story of={ComponentStories.isIndeterminateIsDisabled} height={60} />
 
 ## Autres tailles de police du label
 
@@ -43,9 +38,7 @@ En ce sens, nous avons déjà prévu un espace vertical pour séparer 2 composan
 
 ### Small
 
-
-  <Story of={ComponentStories.checkboxWithSmallLabel} height={60} />
-
+<Story of={ComponentStories.withSmallLabel} height={60} />
 
 ## Usage
 

--- a/app/stories/pix-checkbox.stories.js
+++ b/app/stories/pix-checkbox.stories.js
@@ -138,14 +138,14 @@ export const checkboxDisabled = Template.bind({});
 checkboxDisabled.args = {
   id: 'accept-newsletter-2',
   label: 'Recevoir la newsletter',
-  disabled: true,
+  isDisabled: true,
 };
 
 export const checkboxCheckedDisabled = Template.bind({});
 checkboxCheckedDisabled.args = {
   id: 'accept-newsletter-2',
   label: 'Recevoir la newsletter',
-  disabled: true,
+  isDisabled: true,
   checked: true,
 };
 
@@ -153,7 +153,7 @@ export const checkboxInterminateDisabled = Template.bind({});
 checkboxInterminateDisabled.args = {
   id: 'accept-newsletter-2',
   label: 'Recevoir la newsletter',
-  disabled: true,
+  isDisabled: true,
   checked: true,
   isIndeterminate: true,
 };

--- a/app/stories/pix-checkbox.stories.js
+++ b/app/stories/pix-checkbox.stories.js
@@ -112,45 +112,52 @@ Default.args = {
   label: 'Recevoir la newsletter',
 };
 
-export const indeterminateCheckbox = Template.bind({});
-indeterminateCheckbox.args = {
+export const DefaultChecked = Template.bind({});
+DefaultChecked.args = {
+  id: 'accept-newsletter',
+  label: 'Recevoir la newsletter',
+  checked: true,
+};
+
+export const isIndeterminate = Template.bind({});
+isIndeterminate.args = {
   id: 'accept-newsletter-2',
   label: 'Recevoir la newsletter',
   isIndeterminate: true,
   checked: true,
 };
 
-export const checkboxWithSmallLabel = Template.bind({});
-checkboxWithSmallLabel.args = {
+export const withSmallLabel = Template.bind({});
+withSmallLabel.args = {
   id: 'accept-newsletter-2',
   label: 'Recevoir la newsletter',
   size: 'small',
 };
 
-export const checkboxWithLargeLabel = Template.bind({});
-checkboxWithLargeLabel.args = {
+export const withLargeLabel = Template.bind({});
+withLargeLabel.args = {
   id: 'accept-newsletter-2',
   label: 'Recevoir la newsletter',
   size: 'large',
 };
 
-export const checkboxDisabled = Template.bind({});
-checkboxDisabled.args = {
+export const isDisabled = Template.bind({});
+isDisabled.args = {
   id: 'accept-newsletter-2',
   label: 'Recevoir la newsletter',
   isDisabled: true,
 };
 
-export const checkboxCheckedDisabled = Template.bind({});
-checkboxCheckedDisabled.args = {
+export const checkedIsDisabled = Template.bind({});
+checkedIsDisabled.args = {
   id: 'accept-newsletter-2',
   label: 'Recevoir la newsletter',
   isDisabled: true,
   checked: true,
 };
 
-export const checkboxInterminateDisabled = Template.bind({});
-checkboxInterminateDisabled.args = {
+export const isIndeterminateIsDisabled = Template.bind({});
+isIndeterminateIsDisabled.args = {
   id: 'accept-newsletter-2',
   label: 'Recevoir la newsletter',
   isDisabled: true,

--- a/app/stories/pix-checkbox.stories.js
+++ b/app/stories/pix-checkbox.stories.js
@@ -87,7 +87,7 @@ export default {
   },
 };
 
-export const Template = (args) => {
+const Template = (args) => {
   return {
     template: hbs`<PixCheckbox
   @id={{this.id}}
@@ -158,7 +158,7 @@ checkboxInterminateDisabled.args = {
   isIndeterminate: true,
 };
 
-export const MultipleTemplate = (args) => {
+const MultipleTemplate = (args) => {
   return {
     template: hbs`<PixCheckbox
   @id='one'

--- a/app/stories/pix-checkbox.stories.js
+++ b/app/stories/pix-checkbox.stories.js
@@ -95,7 +95,7 @@ const Template = (args) => {
   @isIndeterminate={{this.isIndeterminate}}
   @checked={{this.checked}}
   @isDisabled={{this.isDisabled}}
-  disabled={{this.isDisabled}}
+  disabled={{this.disabled}}
   @size={{this.size}}
   @inlineLabel={{this.inlineLabel}}
   @screenReaderOnly={{this.screenReaderOnly}}
@@ -167,7 +167,7 @@ const MultipleTemplate = (args) => {
   @isIndeterminate={{this.isIndeterminate}}
   @size={{this.size}}
   @checked={{this.checked}}
-  disabled={{this.isDisabled}}
+  disabled={{this.disabled}}
   @isDisabled={{this.isDisabled}}
 >
   <:label>{{this.label}}</:label>
@@ -179,7 +179,7 @@ const MultipleTemplate = (args) => {
   @isIndeterminate={{this.isIndeterminate}}
   @size={{this.size}}
   @checked={{this.checked}}
-  disabled={{this.isDisabled}}
+  disabled={{this.disabled}}
   @isDisabled={{this.isDisabled}}
 >
   <:label>{{this.label}}</:label>

--- a/app/stories/pix-input-code.stories.js
+++ b/app/stories/pix-input-code.stories.js
@@ -55,7 +55,7 @@ export default {
   },
 };
 
-export const Template = (args) => {
+const Template = (args) => {
   return {
     template: hbs`<PixInputCode
   @ariaLabel={{this.ariaLabel}}

--- a/app/stories/pix-radio-button.mdx
+++ b/app/stories/pix-radio-button.mdx
@@ -24,15 +24,13 @@ Pour les considérer comme un seul groupe d'inputs, **il est nécessaire qu'ils 
 
 <Story of={ComponentStories.multiple} height={140} />
 
-
 ## Disabled
 
 État inactif du bouton radio.
 
 <Story of={ComponentStories.isDisabled} height={60} />
 
-<Story of={ComponentStories.disabledChecked} height={60} />
-
+<Story of={ComponentStories.checkedIsDisabled} height={60} />
 
 ## Usage
 

--- a/app/stories/pix-radio-button.stories.js
+++ b/app/stories/pix-radio-button.stories.js
@@ -106,22 +106,22 @@ Default.args = {
   label: 'Poivron',
 };
 
+export const defaultChecked = Template.bind({});
+defaultChecked.args = {
+  ...Default.args,
+  checked: true,
+};
+
 export const isDisabled = Template.bind({});
 isDisabled.args = {
   ...Default.args,
   isDisabled: true,
 };
 
-export const disabledChecked = Template.bind({});
-disabledChecked.args = {
+export const checkedIsDisabled = Template.bind({});
+checkedIsDisabled.args = {
   ...Default.args,
   isDisabled: true,
-  checked: true,
-};
-
-export const defaultChecked = Template.bind({});
-defaultChecked.args = {
-  ...Default.args,
   checked: true,
 };
 

--- a/app/stories/pix-radio-button.stories.js
+++ b/app/stories/pix-radio-button.stories.js
@@ -19,6 +19,15 @@ export default {
       description: "Valeur permettant d'identifier l'option sélectionnée",
       type: { name: 'string', required: false },
     },
+    checked: {
+      name: 'checked',
+      description: 'Permet de cocher la radio',
+      type: { name: 'boolean', required: false },
+      table: {
+        type: { summary: 'boolean' },
+        defaultValue: { summary: false },
+      },
+    },
     isDisabled: {
       name: 'isDisabled',
       description: 'Pour désactiver/activer le bouton radio',
@@ -79,6 +88,7 @@ const Template = (args) => {
   @value={{this.value}}
   @id={{this.id}}
   @class={{this.class}}
+  checked={{this.checked}}
   disabled={{this.disabled}}
   @isDisabled={{this.isDisabled}}
   @size={{this.size}}
@@ -102,23 +112,18 @@ isDisabled.args = {
   isDisabled: true,
 };
 
-/* Checked stories */
-const checked = (args) => {
-  return {
-    template: hbs`<PixRadioButton @value={{this.value}} disabled={{this.disabled}} @isDisabled={{this.isDisabled}} checked><:label
-  >{{this.label}}</:label></PixRadioButton>`,
-    context: args,
-  };
-};
-
-export const disabledChecked = checked.bind({});
+export const disabledChecked = Template.bind({});
 disabledChecked.args = {
   ...Default.args,
   isDisabled: true,
+  checked: true,
 };
 
-export const defaultChecked = checked.bind({});
-defaultChecked.args = Default.args;
+export const defaultChecked = Template.bind({});
+defaultChecked.args = {
+  ...Default.args,
+  checked: true,
+};
 
 /* Multiple components story */
 const multipleTemplate = (args) => {

--- a/app/stories/pix-radio-button.stories.js
+++ b/app/stories/pix-radio-button.stories.js
@@ -99,13 +99,13 @@ Default.args = {
 export const isDisabled = Template.bind({});
 isDisabled.args = {
   ...Default.args,
-  disabled: true,
+  isDisabled: true,
 };
 
 /* Checked stories */
 const checked = (args) => {
   return {
-    template: hbs`<PixRadioButton @value={{this.value}} disabled={{this.disabled}} checked><:label
+    template: hbs`<PixRadioButton @value={{this.value}} disabled={{this.disabled}} @isDisabled={{this.isDisabled}} checked><:label
   >{{this.label}}</:label></PixRadioButton>`,
     context: args,
   };
@@ -114,7 +114,7 @@ const checked = (args) => {
 export const disabledChecked = checked.bind({});
 disabledChecked.args = {
   ...Default.args,
-  disabled: true,
+  isDisabled: true,
 };
 
 export const defaultChecked = checked.bind({});

--- a/app/stories/pix-radio-button.stories.js
+++ b/app/stories/pix-radio-button.stories.js
@@ -79,7 +79,7 @@ const Template = (args) => {
   @value={{this.value}}
   @id={{this.id}}
   @class={{this.class}}
-  disabled={{this.isDisabled}}
+  disabled={{this.disabled}}
   @isDisabled={{this.isDisabled}}
   @size={{this.size}}
   @screenReaderOnly={{this.screenReaderOnly}}
@@ -123,12 +123,15 @@ defaultChecked.args = Default.args;
 /* Multiple components story */
 const multipleTemplate = (args) => {
   return {
-    template: hbs`<PixRadioButton disabled={{this.isDisabled}} @isDisabled={{this.isDisabled}} name='radio'><:label
-  >{{this.label}}</:label></PixRadioButton>
-<PixRadioButton disabled={{this.isDisabled}} @isDisabled={{this.isDisabled}} name='radio'><:label
-  >{{this.label}}</:label></PixRadioButton>
-<PixRadioButton disabled={{this.isDisabled}} @isDisabled={{this.isDisabled}} name='radio'><:label
-  >{{this.label}}</:label></PixRadioButton>`,
+    template: hbs`<PixRadioButton disabled={{this.disabled}} @isDisabled={{this.isDisabled}} name='radio'>
+  <:label>{{this.label}}</:label>
+</PixRadioButton>
+<PixRadioButton disabled={{this.disabled}} @isDisabled={{this.isDisabled}} name='radio'>
+  <:label>{{this.label}}</:label>
+</PixRadioButton>
+<PixRadioButton disabled={{this.disabled}} @isDisabled={{this.isDisabled}} name='radio'>
+  <:label>{{this.label}}</:label>
+</PixRadioButton>`,
     context: args,
   };
 };

--- a/app/stories/pix-search-input.stories.js
+++ b/app/stories/pix-search-input.stories.js
@@ -90,7 +90,7 @@ export default {
   },
 };
 
-export const Template = (args) => {
+const Template = (args) => {
   return {
     template: hbs`<PixSearchInput
   @id={{this.id}}

--- a/app/stories/pix-select.stories.js
+++ b/app/stories/pix-select.stories.js
@@ -196,7 +196,7 @@ export default {
   },
 };
 
-export const Template = (args) => {
+const Template = (args) => {
   return {
     template: hbs`{{#if this.id}}
   <div>
@@ -230,7 +230,7 @@ export const Template = (args) => {
   };
 };
 
-export const TemplatePopover = (args) => {
+const TemplatePopover = (args) => {
   return {
     template: hbs`{{! template-lint-disable no-inline-styles }}
 <div style='display:flex;height:330px'>

--- a/app/stories/pix-sidebar.stories.js
+++ b/app/stories/pix-sidebar.stories.js
@@ -28,7 +28,7 @@ export default {
   },
 };
 
-export const Template = (args) => {
+const Template = (args) => {
   return {
     template: hbs`<PixSidebar
   @showSidebar={{this.showSidebar}}

--- a/app/stories/pix-toggle.stories.js
+++ b/app/stories/pix-toggle.stories.js
@@ -68,7 +68,7 @@ export default {
   },
 };
 
-export const Template = (args) => {
+const Template = (args) => {
   return {
     template: hbs`<PixToggle
   @onLabel={{this.onLabel}}
@@ -86,7 +86,7 @@ export const Template = (args) => {
   };
 };
 
-export const TemplateWithYields = (args) => {
+const TemplateWithYields = (args) => {
   return {
     template: hbs`<PixToggle @toggled={{this.toggled}} @onChange={{this.onChange}}>
   <:label>{{this.label}}</:label>

--- a/blueprints/pix-component/files/app/stories/pix-__name__.stories.js
+++ b/blueprints/pix-component/files/app/stories/pix-__name__.stories.js
@@ -13,7 +13,7 @@ export default {
   }
 }
 
-export const Template = (args) => {
+const Template = (args) => {
   return {
     template: hbs`
       <Pix<%= classifiedModuleName %>


### PR DESCRIPTION
## :christmas_tree: Problème
- Des stories ne servent à rien,
- Des paramètres ne sont pas contrôlables dans certaines stories,
- Sur les checkbox et radio, la différence entre `disabled` et `isDisabled` n'est pas très claire.

## :gift: Proposition
- Supprimer les stories inutiles,
- Brancher les paramètres non contrôlables (`checked` `disabled` `isDisabled` selon les cas),
- Réalignement des docs sur les checkbox et radio.

## :star2: Remarques
Les Radio et Checkbox contrôlés par `isDisabled` mettent en place uniquement le `aria-disabled` sans que ça n'empêche de les utiliser. On veut encourager cet usage plutôt que `disabled` qui empêche l'accès aux lecteurs d'écrans. Je propose de bloquer l'interaction avec ces composants dans une autre PR.

## :santa: Pour tester
Check Storybook.
