### PR TITLE
[FEATURE] Améliorations états `disabled` des champs de formulaire

### DIFF
--- a/addon/components/pix-checkbox.hbs
+++ b/addon/components/pix-checkbox.hbs
@@ -13,8 +13,8 @@
       id={{this.id}}
       class={{this.inputClasses}}
       checked={{@checked}}
-      aria-disabled={{@isDisabled}}
-      {{on "click" this.avoidCheckedStateChangeIfDisabled}}
+      aria-disabled={{this.isDisabled}}
+      {{on "click" this.avoidCheckedStateChangeIfIsDisabled}}
       ...attributes
     />
 

--- a/addon/components/pix-checkbox.hbs
+++ b/addon/components/pix-checkbox.hbs
@@ -14,6 +14,7 @@
       class={{this.inputClasses}}
       checked={{@checked}}
       aria-disabled={{@isDisabled}}
+      {{on "click" this.avoidCheckedStateChangeIfDisabled}}
       ...attributes
     />
 

--- a/addon/components/pix-checkbox.hbs
+++ b/addon/components/pix-checkbox.hbs
@@ -5,7 +5,7 @@
     @size={{@size}}
     @inlineLabel={{true}}
     @screenReaderOnly={{@screenReaderOnly}}
-    @isDisabled={{@isDisabled}}
+    @isDisabled={{this.isDisabled}}
     @wrappedElement={{true}}
   >
     <input

--- a/addon/components/pix-checkbox.js
+++ b/addon/components/pix-checkbox.js
@@ -21,6 +21,10 @@ export default class PixCheckbox extends Component {
     return classes.join(' ');
   }
 
+  get isDisabled() {
+    return this.args.isDisabled || this.args.disabled;
+  }
+
   @action
   avoidCheckedStateChangeIfIsDisabled(event) {
     if (this.args.isDisabled) {

--- a/addon/components/pix-checkbox.js
+++ b/addon/components/pix-checkbox.js
@@ -1,5 +1,6 @@
 import Component from '@glimmer/component';
 import { guidFor } from '@ember/object/internals';
+import { action } from '@ember/object';
 
 export default class PixCheckbox extends Component {
   constructor() {
@@ -18,5 +19,12 @@ export default class PixCheckbox extends Component {
     }
 
     return classes.join(' ');
+  }
+
+  @action
+  avoidCheckedStateChangeIfIsDisabled(event) {
+    if (this.args.isDisabled) {
+      event.preventDefault();
+    }
   }
 }

--- a/addon/components/pix-radio-button.hbs
+++ b/addon/components/pix-radio-button.hbs
@@ -13,8 +13,8 @@
       id={{this.id}}
       class="pix-radio-button__input"
       value={{@value}}
-      aria-disabled={{@isDisabled}}
-      {{on "click" this.avoidCheckedStateChangeIfDisabled}}
+      aria-disabled={{this.isDisabled}}
+      {{on "click" this.avoidCheckedStateChangeIfIsDisabled}}
       ...attributes
     />
     {{yield to="label"}}

--- a/addon/components/pix-radio-button.hbs
+++ b/addon/components/pix-radio-button.hbs
@@ -14,6 +14,7 @@
       class="pix-radio-button__input"
       value={{@value}}
       aria-disabled={{@isDisabled}}
+      {{on "click" this.avoidCheckedStateChangeIfDisabled}}
       ...attributes
     />
     {{yield to="label"}}

--- a/addon/components/pix-radio-button.hbs
+++ b/addon/components/pix-radio-button.hbs
@@ -13,6 +13,7 @@
       id={{this.id}}
       class="pix-radio-button__input"
       value={{@value}}
+      aria-disabled={{@isDisabled}}
       ...attributes
     />
     {{yield to="label"}}

--- a/addon/components/pix-radio-button.hbs
+++ b/addon/components/pix-radio-button.hbs
@@ -4,7 +4,7 @@
     @requiredLabel={{@requiredLabel}}
     @size={{@size}}
     @screenReaderOnly={{@screenReaderOnly}}
-    @isDisabled={{@isDisabled}}
+    @isDisabled={{this.isDisabled}}
     @inlineLabel={{true}}
     @wrappedElement={{true}}
   >

--- a/addon/components/pix-radio-button.js
+++ b/addon/components/pix-radio-button.js
@@ -9,6 +9,10 @@ export default class PixRadioButton extends Component {
     return this.args.id || guidFor(this);
   }
 
+  get isDisabled() {
+    return this.args.isDisabled || this.args.disabled;
+  }
+
   @action
   avoidCheckedStateChangeIfIsDisabled(event) {
     if (this.args.isDisabled) {

--- a/addon/components/pix-radio-button.js
+++ b/addon/components/pix-radio-button.js
@@ -1,10 +1,18 @@
 import Component from '@glimmer/component';
 import { guidFor } from '@ember/object/internals';
+import { action } from '@ember/object';
 
 export default class PixRadioButton extends Component {
   text = 'pix-radio-button';
 
   get id() {
     return this.args.id || guidFor(this);
+  }
+
+  @action
+  avoidCheckedStateChangeIfIsDisabled(event) {
+    if (this.args.isDisabled) {
+      event.preventDefault();
+    }
   }
 }

--- a/addon/styles/_pix-checkbox.scss
+++ b/addon/styles/_pix-checkbox.scss
@@ -98,7 +98,9 @@
     }
 
     // Disabled state
+    &[aria-disabled],
     &:disabled,
+    &--indeterminate[aria-disabled],
     &--indeterminate:disabled {
       background: var(--pix-neutral-100);
       border-color: var(--pix-neutral-100);

--- a/addon/styles/_pix-checkbox.scss
+++ b/addon/styles/_pix-checkbox.scss
@@ -106,11 +106,6 @@
       border-color: var(--pix-neutral-100);
       cursor: not-allowed;
 
-      & + .pix-checkbox__label {
-        color: var(--pix-neutral-500);
-        cursor: not-allowed;
-      }
-
       &:checked {
         background: var(--pix-neutral-100);
         border-color: var(--pix-neutral-100);

--- a/addon/styles/_pix-label.scss
+++ b/addon/styles/_pix-label.scss
@@ -25,10 +25,9 @@
     @extend %pix-body-l;
   }
 
-
   &--inline-label {
     margin: 0;
-    font-weight: var(--pix-font-normal)
+    font-weight: var(--pix-font-normal);
   }
 
   &__sub-label {

--- a/addon/styles/_pix-radio-button.scss
+++ b/addon/styles/_pix-radio-button.scss
@@ -76,10 +76,6 @@
       border-color: var(--pix-neutral-100);
       cursor: not-allowed;
 
-      & + .pix-radio-button__label {
-        cursor: not-allowed;
-      }
-
       &::before {
         display: none;
       }

--- a/addon/styles/_pix-radio-button.scss
+++ b/addon/styles/_pix-radio-button.scss
@@ -70,6 +70,7 @@
     }
 
     // Disabled state
+    &[aria-disabled],
     &:disabled {
       background: var(--pix-neutral-20);
       border-color: var(--pix-neutral-100);

--- a/addon/styles/component-state/_form.scss
+++ b/addon/styles/component-state/_form.scss
@@ -42,9 +42,9 @@
     outline: 2px solid var(--pix-primary-300);
   }
 
-  &[aria-disabled="true"],
-  &[disabled="true"],
-  &[readonly="true"] {
+  &[aria-disabled],
+  &[disabled],
+  &[readonly] {
     color: var(--pix-neutral-500);
     background-color: var(--pix-neutral-20);
     border-color:  var(--pix-neutral-100);
@@ -56,7 +56,7 @@
     }
   }
 
-  &[readonly="true"] {
+  &[readonly] {
     cursor: default;
   }
 }

--- a/tests/integration/components/pix-checkbox-test.js
+++ b/tests/integration/components/pix-checkbox-test.js
@@ -63,4 +63,39 @@ module('Integration | Component | checkbox', function (hooks) {
     // then
     assert.true(checkbox.checked);
   });
+
+  test('it should not be possible to control state when disabled', async function (assert) {
+    // given
+    const screen = await render(
+      hbs`<PixCheckbox checked disabled><:label>Recevoir la newsletter</:label></PixCheckbox>`,
+    );
+    const checkbox = screen.getByLabelText('Recevoir la newsletter');
+    assert.true(checkbox.checked);
+
+    // when
+    try {
+      await clickByName('Recevoir la newsletter');
+
+      // should have thrown an error
+      assert.true(false);
+    } catch (error) {
+      // then
+      assert.true(checkbox.checked);
+    }
+  });
+
+  test('it should not be possible to control state when aria-disabled', async function (assert) {
+    // given
+    const screen = await render(
+      hbs`<PixCheckbox checked @isDisabled={{true}}><:label>Recevoir la newsletter</:label></PixCheckbox>`,
+    );
+    const checkbox = screen.getByLabelText('Recevoir la newsletter');
+    assert.true(checkbox.checked);
+
+    // when
+    await clickByName('Recevoir la newsletter');
+
+    // then
+    assert.true(checkbox.checked);
+  });
 });

--- a/tests/integration/components/pix-checkbox-test.js
+++ b/tests/integration/components/pix-checkbox-test.js
@@ -1,27 +1,40 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { hbs } from 'ember-cli-htmlbars';
-import { render, clickByText } from '@1024pix/ember-testing-library';
+import { render, clickByName } from '@1024pix/ember-testing-library';
 
 module('Integration | Component | checkbox', function (hooks) {
   setupRenderingTest(hooks);
 
   test('it should be possible to check the checkbox', async function (assert) {
     // when
-    await render(hbs`<PixCheckbox><:label>Recevoir la newsletter</:label></PixCheckbox>`);
-    await clickByText('Recevoir la newsletter');
+    const screen = await render(
+      hbs`<PixCheckbox><:label>Recevoir la newsletter</:label></PixCheckbox>`,
+    );
+    await clickByName('Recevoir la newsletter');
 
     // then
-    const checkbox = this.element.querySelector('.pix-checkbox__input');
-    assert.true(checkbox.checked);
+    assert.true(screen.getByLabelText('Recevoir la newsletter').checked);
+  });
+
+  test('it should be possible to aria-disabled the checkbox', async function (assert) {
+    // when
+    const screen = await render(
+      hbs`<PixCheckbox @isDisabled='{{true}}'><:label>Mini label</:label></PixCheckbox>`,
+    );
+
+    // then
+    assert.strictEqual(screen.getByLabelText('Mini label').getAttribute('aria-disabled'), 'true');
   });
 
   test('it should be possible to disable the checkbox', async function (assert) {
     // when
-    await render(hbs`<PixCheckbox disable><:label>Mini label</:label></PixCheckbox>`);
+    const screen = await render(
+      hbs`<PixCheckbox disabled><:label>Mini label</:label></PixCheckbox>`,
+    );
 
     // then
-    assert.dom('.pix-checkbox__input[disable]').exists();
+    assert.true(screen.getByLabelText('Mini label').disabled);
   });
 
   test('it should be possible to insert html in label', async function (assert) {
@@ -38,10 +51,10 @@ module('Integration | Component | checkbox', function (hooks) {
   test('it should be possible to control state', async function (assert) {
     // given
     this.set('checked', false);
-    await render(
+    const screen = await render(
       hbs`<PixCheckbox @checked={{this.checked}}><:label>Recevoir la newsletter</:label></PixCheckbox>`,
     );
-    const checkbox = this.element.querySelector('.pix-checkbox__input');
+    const checkbox = screen.getByLabelText('Recevoir la newsletter');
     assert.false(checkbox.checked);
 
     // when

--- a/tests/integration/components/pix-radio-button-test.js
+++ b/tests/integration/components/pix-radio-button-test.js
@@ -18,6 +18,16 @@ module('Integration | Component | pix-radio-button', function (hooks) {
     assert.equal(componentInputElement.type, 'radio');
   });
 
+  test('it should be possible to aria-disabled the radiobutton', async function (assert) {
+    // when
+    const screen = await render(
+      hbs`<PixRadioButton @isDisabled='{{true}}'><:label>Abricot</:label></PixRadioButton>`,
+    );
+
+    // then
+    assert.strictEqual(screen.getByLabelText('Abricot').getAttribute('aria-disabled'), 'true');
+  });
+
   test('it renders the PixRadioButton component with disabled attribute', async function (assert) {
     // given & when
     await render(hbs`<PixRadioButton disabled><:label>Abricot</:label></PixRadioButton>`);

--- a/tests/integration/components/pix-radio-button-test.js
+++ b/tests/integration/components/pix-radio-button-test.js
@@ -1,6 +1,6 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import { render } from '@1024pix/ember-testing-library';
+import { render, clickByName } from '@1024pix/ember-testing-library';
 import { hbs } from 'ember-cli-htmlbars';
 
 module('Integration | Component | pix-radio-button', function (hooks) {
@@ -42,5 +42,40 @@ module('Integration | Component | pix-radio-button', function (hooks) {
 
     // when & then
     assert.true(screen.getByLabelText('Abricot').checked);
+  });
+
+  test('it should not be possible to control state when disabled', async function (assert) {
+    // given
+    const screen = await render(
+      hbs`<PixRadioButton disabled><:label>Abricot</:label></PixRadioButton>`,
+    );
+    const radio = screen.getByLabelText('Abricot');
+    assert.false(radio.checked);
+
+    // when
+    try {
+      await clickByName('Abricot');
+
+      // should have thrown an error
+      assert.true(false);
+    } catch (error) {
+      // then
+      assert.false(radio.checked);
+    }
+  });
+
+  test('it should not be possible to control state when aria-disabled', async function (assert) {
+    // given
+    const screen = await render(
+      hbs`<PixRadioButton @isDisabled={{true}}><:label>Abricot</:label></PixRadioButton>`,
+    );
+    const radio = screen.getByLabelText('Abricot');
+    assert.false(radio.checked);
+
+    // when
+    await clickByName('Abricot');
+
+    // then
+    assert.false(radio.checked);
   });
 });

--- a/tests/integration/components/pix-radio-button-test.js
+++ b/tests/integration/components/pix-radio-button-test.js
@@ -8,14 +8,10 @@ module('Integration | Component | pix-radio-button', function (hooks) {
 
   test('it renders the default PixRadioButton', async function (assert) {
     // when
-    await render(hbs`<PixRadioButton><:label>Abricot</:label></PixRadioButton>`);
+    const screen = await render(hbs`<PixRadioButton><:label>Abricot</:label></PixRadioButton>`);
 
     // then
-    const componentInputElement = this.element.querySelector('.pix-radio-button__input');
-    assert.contains('Abricot');
-    // TODO: Fix this the next time the file is edited.
-    // eslint-disable-next-line qunit/no-assert-equal
-    assert.equal(componentInputElement.type, 'radio');
+    assert.strictEqual(screen.getByLabelText('Abricot').type, 'radio');
   });
 
   test('it should be possible to aria-disabled the radiobutton', async function (assert) {
@@ -30,19 +26,21 @@ module('Integration | Component | pix-radio-button', function (hooks) {
 
   test('it renders the PixRadioButton component with disabled attribute', async function (assert) {
     // given & when
-    await render(hbs`<PixRadioButton disabled><:label>Abricot</:label></PixRadioButton>`);
+    const screen = await render(
+      hbs`<PixRadioButton disabled><:label>Abricot</:label></PixRadioButton>`,
+    );
 
     // then
-    const componentInputElement = this.element.querySelector('.pix-radio-button__input');
-    assert.true(componentInputElement.disabled);
+    assert.true(screen.getByLabelText('Abricot').disabled);
   });
 
   test('it should be possible to add more params to PixRadioButton', async function (assert) {
     // given
-    await render(hbs`<PixRadioButton disabled checked><:label>Abricot</:label></PixRadioButton>`);
+    const screen = await render(
+      hbs`<PixRadioButton disabled checked><:label>Abricot</:label></PixRadioButton>`,
+    );
 
     // when & then
-    const componentInput = this.element.querySelector('.pix-radio-button__input');
-    assert.true(componentInput.checked);
+    assert.true(screen.getByLabelText('Abricot').checked);
   });
 });


### PR DESCRIPTION
## :christmas_tree: Problème
Radio button
- ne gère pas l'attribut `isDisabled` pour placer un `aria-disabled`,

Radio et Checkbox
- restent utilisables quand `aria-disabled`,
- ne sont pas stylisés comme étant inutilisable quand `aria-disabled`,
- ont leur label non grisé si `disabled`.

Inputs, Selects et Textarea : 
- ne sont pas grisés en `disabled`/`aria-disabled`/`ready-only`.

## :gift: Proposition
Radio button : le paramètre `isDisabled` gère le `aria-disabled`.

Radio et Checkbox : 
- ne sont plus utilisables si `isDisabled`,
- ont le même style que `disabled` si `isDisabled`.

Inputs, Selects et Textarea : corriger l'application de styles différents si `disabled`/`aria-disabled`/`ready-only`.

## :star2: Remarques
Me reste un doute sur les `cursor` qui font des trucs bizarres...

## :santa: Pour tester
Vérifier tous les cas d'usage des Checkbox et Radio.
