### PR TITLE
[BUGFIX] Corriger l'affichage des Checkbox/radioButton dans le cas du screen reader only

### DIFF
--- a/addon/components/pix-checkbox.hbs
+++ b/addon/components/pix-checkbox.hbs
@@ -2,22 +2,24 @@
   <PixLabel
     @for={{this.id}}
     @requiredLabel={{@requiredLabel}}
+    @subLabel={{@subLabel}}
     @size={{@size}}
     @inlineLabel={{true}}
     @screenReaderOnly={{@screenReaderOnly}}
     @isDisabled={{this.isDisabled}}
     @wrappedElement={{true}}
   >
-    <input
-      type="checkbox"
-      id={{this.id}}
-      class={{this.inputClasses}}
-      checked={{@checked}}
-      aria-disabled={{this.isDisabled}}
-      {{on "click" this.avoidCheckedStateChangeIfIsDisabled}}
-      ...attributes
-    />
-
-    {{yield to="label"}}
+    <:inputElement>
+      <input
+        type="checkbox"
+        id={{this.id}}
+        class={{this.inputClasses}}
+        checked={{@checked}}
+        aria-disabled={{this.isDisabled}}
+        {{on "click" this.avoidCheckedStateChangeIfIsDisabled}}
+        ...attributes
+      />
+    </:inputElement>
+    <:default>{{yield to="label"}}</:default>
   </PixLabel>
 </div>

--- a/addon/components/pix-label.hbs
+++ b/addon/components/pix-label.hbs
@@ -1,11 +1,17 @@
 <label for={{@for}} class={{this.className}} ...attributes>
-  {{#if @requiredLabel}}
-    <abbr title={{@requiredLabel}} class="mandatory-mark">*</abbr>
+  {{#if (has-block "inputElement")}}
+    {{yield to="inputElement"}}
   {{/if}}
 
-  {{yield}}
+  <span class={{if @screenReaderOnly "screen-reader-only"}}>
+    {{#if @requiredLabel}}
+      <abbr title={{@requiredLabel}} class="mandatory-mark">*</abbr>
+    {{/if}}
 
-  {{#if @subLabel}}
-    <span class="pix-label__sub-label">{{@subLabel}}</span>
-  {{/if}}
+    {{yield}}
+
+    {{#if @subLabel}}
+      <span class="pix-label__sub-label">{{@subLabel}}</span>
+    {{/if}}
+  </span>
 </label>

--- a/addon/components/pix-label.js
+++ b/addon/components/pix-label.js
@@ -4,9 +4,9 @@ export default class PixLabel extends Component {
   get className() {
     const classes = ['pix-label'];
 
-    if (this.args.screenReaderOnly) classes.push('screen-reader-only');
     if (this.args.wrappedElement) classes.push('pix-label--wrapped-element');
-    if (this.args.inlineLabel) classes.push('pix-label--inline-label');
+    if (this.args.inlineLabel && !this.args.screenReaderOnly)
+      classes.push('pix-label--inline-label');
     if (this.args.isDisabled) classes.push('pix-label--disabled');
 
     const size = ['small', 'large'].includes(this.args.size) ? this.args.size : 'default';

--- a/addon/components/pix-radio-button.hbs
+++ b/addon/components/pix-radio-button.hbs
@@ -2,21 +2,24 @@
   <PixLabel
     @for={{this.id}}
     @requiredLabel={{@requiredLabel}}
+    @subLabel={{@subLabel}}
     @size={{@size}}
     @screenReaderOnly={{@screenReaderOnly}}
     @isDisabled={{this.isDisabled}}
     @inlineLabel={{true}}
     @wrappedElement={{true}}
   >
-    <input
-      type="radio"
-      id={{this.id}}
-      class="pix-radio-button__input"
-      value={{@value}}
-      aria-disabled={{this.isDisabled}}
-      {{on "click" this.avoidCheckedStateChangeIfIsDisabled}}
-      ...attributes
-    />
-    {{yield to="label"}}
+    <:inputElement>
+      <input
+        type="radio"
+        id={{this.id}}
+        class="pix-radio-button__input"
+        value={{@value}}
+        aria-disabled={{this.isDisabled}}
+        {{on "click" this.avoidCheckedStateChangeIfIsDisabled}}
+        ...attributes
+      />
+    </:inputElement>
+    <:default>{{yield to="label"}}</:default>
   </PixLabel>
 </div>

--- a/app/stories/pix-checkbox.stories.js
+++ b/app/stories/pix-checkbox.stories.js
@@ -97,6 +97,8 @@ const Template = (args) => {
   @isDisabled={{this.isDisabled}}
   disabled={{this.disabled}}
   @size={{this.size}}
+  @subLabel={{this.subLabel}}
+  @requiredLabel={{this.requiredLabel}}
   @inlineLabel={{this.inlineLabel}}
   @screenReaderOnly={{this.screenReaderOnly}}
 >

--- a/app/stories/pix-radio-button.stories.js
+++ b/app/stories/pix-radio-button.stories.js
@@ -94,6 +94,7 @@ const Template = (args) => {
   @size={{this.size}}
   @screenReaderOnly={{this.screenReaderOnly}}
   @requiredLabel={{this.requiredLabel}}
+  @subLabel={{this.subLabel}}
 >
   <:label>{{this.label}}</:label>
 </PixRadioButton>`,


### PR DESCRIPTION
## :christmas_tree: Problème
la checkbox disparait complement dans le cas ou l'on decide de cacher visuellement le label

## :gift: Proposition
Corriger cela 

## :star2: Remarques
Ajout d'un named yield pour séparer l'insertion de l'input et du text label

## :santa: Pour tester
faire un tour sur PixUI ( installer sur une App orga de préférence) et vérifier que les checkbox de suppression fonctionne. ainsi que l'affichage des input ayant un label caché ( ex : dans les filtres )