### PR TITLE
[BREAKING] Renommer les attributs des boutons (PIX-12417)

### DIFF
--- a/addon/components/pix-button-base.js
+++ b/addon/components/pix-button-base.js
@@ -1,8 +1,8 @@
 import Component from '@glimmer/component';
 
 export default class PixButtonBase extends Component {
-  get backgroundColor() {
-    return this.args.backgroundColor || 'primary';
+  get variant() {
+    return this.args.variant || 'primary';
   }
 
   get size() {
@@ -13,7 +13,7 @@ export default class PixButtonBase extends Component {
     const classNames = [
       'pix-button',
       `pix-button--size-${this.size}`,
-      `pix-button--${this.backgroundColor}`,
+      `pix-button--${this.variant}`,
     ];
 
     this.args.isBorderVisible && classNames.push('pix-button--border');

--- a/addon/components/pix-button-base.js
+++ b/addon/components/pix-button-base.js
@@ -6,7 +6,7 @@ export default class PixButtonBase extends Component {
   }
 
   get size() {
-    return this.args.size || 'big';
+    return this.args.size || 'large';
   }
 
   get baseClassNames() {

--- a/addon/styles/_pix-button-base.scss
+++ b/addon/styles/_pix-button-base.scss
@@ -36,7 +36,7 @@
     }
   }
 
-  &--size-big {
+  &--size-large {
     padding: var(--pix-spacing-3x) var(--pix-spacing-6x);
   }
 

--- a/addon/styles/_pix-button-base.scss
+++ b/addon/styles/_pix-button-base.scss
@@ -66,29 +66,7 @@
     }
   }
 
-  &--success {
-    background-color: var(--pix-success-500);
-
-    &:not([aria-disabled="true"]) {
-      &:hover {
-        background-color: var(--pix-success-700);
-      }
-
-      &:focus,
-      &:focus-visible {
-        background-color: var(--pix-success-700);
-        outline: 1px solid var(--pix-neutral-0);
-        outline-offset: -4px;
-      }
-
-      &:active {
-        background-color: var(--pix-success-900);
-        outline: none;
-      }
-    }
-  }
-
-  &--secondary {
+  &--primary-bis {
     color: var(--pix-neutral-900);
     background-color: var(--pix-secondary-500);
 
@@ -109,6 +87,80 @@
       &:active {
         color: var(--pix-neutral-0);
         background-color: var(--pix-secondary-900);
+        outline: none;
+      }
+    }
+  }
+
+  &--secondary {
+    color: var(--pix-primary-700);
+    background-color: transparent;
+    border: 2px solid var(--pix-primary-700);
+
+    &:not([aria-disabled="true"]) {
+      &:hover {
+        color: var(--pix-neutral-700);
+        background-color: var(--pix-primary-100);
+      }
+
+      &:focus,
+      &:focus-visible {
+        color: var(--pix-primary-900);
+        background-color: var(--pix-primary-100);
+        outline: 1px solid var(--pix-primary-700);
+        outline-offset: -5px;
+      }
+
+      &:active {
+        color: var(--pix-neutral-0);
+        background-color: var(--pix-primary-700);
+        outline: none;
+      }
+    }
+  }
+
+  &--tertiary {
+    color: var(--pix-neutral-900);
+    background-color: var(--pix-neutral-20);
+
+    &:not([aria-disabled="true"]) {
+      &:hover {
+        background-color: var(--pix-neutral-100);
+      }
+
+      &:focus,
+      &:focus-visible {
+        color: var(--pix-neutral-0);
+        background-color: var(--pix-neutral-900);
+        outline: 1px solid var(--pix-neutral-0);
+        outline-offset: -4px;
+      }
+
+      &:active {
+        color: var(--pix-neutral-900);
+        background-color: var(--pix-neutral-100);
+        outline: none;
+      }
+    }
+  }
+
+  &--success {
+    background-color: var(--pix-success-500);
+
+    &:not([aria-disabled="true"]) {
+      &:hover {
+        background-color: var(--pix-success-700);
+      }
+
+      &:focus,
+      &:focus-visible {
+        background-color: var(--pix-success-700);
+        outline: 1px solid var(--pix-neutral-0);
+        outline-offset: -4px;
+      }
+
+      &:active {
+        background-color: var(--pix-success-900);
         outline: none;
       }
     }
@@ -137,58 +189,7 @@
     }
   }
 
-  &--neutral {
-    color: var(--pix-neutral-900);
-    background-color: var(--pix-neutral-20);
-
-    &:not([aria-disabled="true"]) {
-      &:hover {
-        background-color: var(--pix-neutral-100);
-      }
-
-      &:focus,
-      &:focus-visible {
-        color: var(--pix-neutral-0);
-        background-color: var(--pix-neutral-900);
-        outline: 1px solid var(--pix-neutral-0);
-        outline-offset: -4px;
-      }
-
-      &:active {
-        color: var(--pix-neutral-900);
-        background-color: var(--pix-neutral-100);
-        outline: none;
-      }
-    }
-  }
-
-  &--transparent-light {
-    color: var(--pix-primary-700);
-    background-color: transparent;
-    border: 2px solid var(--pix-primary-700);
-
-    &:not([aria-disabled="true"]) {
-      &:hover {
-        color: var(--pix-neutral-700);
-        background-color: var(--pix-primary-100);
-      }
-
-      &:focus,
-      &:focus-visible {
-        color: var(--pix-primary-900);
-        background-color: var(--pix-primary-100);
-        outline: 1px solid var(--pix-primary-700);
-        outline-offset: -5px;
-      }
-
-      &:active {
-        color: var(--pix-neutral-0);
-        background-color: var(--pix-primary-700);
-        outline: none;
-      }
-    }
-  }
-
+  // DO NOT USE DEPRECATED
   &--transparent-dark {
     color: var(--pix-neutral-0);
     background-color: transparent;

--- a/app/stories/form.stories.js
+++ b/app/stories/form.stories.js
@@ -92,12 +92,7 @@ export const form = (args) => {
 
   <ul class='pix-form__actions'>
     <li>
-      <PixButtonLink
-        @route=''
-        @model=''
-        @backgroundColor='transparent-light'
-        @isBorderVisible={{true}}
-      >
+      <PixButtonLink @route='' @model='' @variant='transparent-light' @isBorderVisible={{true}}>
         Annuler
       </PixButtonLink>
     </li>

--- a/app/stories/form.stories.js
+++ b/app/stories/form.stories.js
@@ -92,7 +92,7 @@ export const form = (args) => {
 
   <ul class='pix-form__actions'>
     <li>
-      <PixButtonLink @route='' @model='' @variant='transparent-light' @isBorderVisible={{true}}>
+      <PixButtonLink @route='' @model='' @variant='secondary' @isBorderVisible={{true}}>
         Annuler
       </PixButtonLink>
     </li>

--- a/app/stories/pix-button-link.mdx
+++ b/app/stories/pix-button-link.mdx
@@ -8,7 +8,7 @@ import * as ComponentStories from './pix-button-link.stories';
 
 Affiche un lien avec le style d'un bouton Pix. Il peut être de type HTML ou Route EmberJS.
 
-Hérite des styles de base de `PixButton` (`backgroundColor`, `size`, `isBorderVisible`, `isDisabled`)
+Hérite des styles de base de `PixButton` (`variant`, `size`, `isBorderVisible`, `isDisabled`)
 
 ## Lien HTML
 

--- a/app/stories/pix-button-link.stories.js
+++ b/app/stories/pix-button-link.stories.js
@@ -29,14 +29,14 @@ export default {
     variant: {
       name: 'variant',
       description:
-        'color: `primary`, `secondary`, `success`, `error`, `neutral`, `transparent-light`, `transparent-dark`',
+        'color: `primary`, `primary-bis`, `secondary`,`tertiary`, `success`, `error`, `transparent-dark`',
       options: [
         'primary',
+        'primary-bis',
         'secondary',
+        'tertiary',
         'success',
         'error',
-        'neutral',
-        'transparent-light',
         'transparent-dark',
       ],
       type: { name: 'string', required: false },
@@ -60,7 +60,7 @@ export default {
     isBorderVisible: {
       name: 'isBorderVisible',
       description:
-        'Paramètre utilisé seulement quand le `variant` est `transparent-light` ou `transparent-dark`',
+        'Paramètre utilisé seulement quand le `variant` est `secondary` ou `transparent-dark`',
       type: { name: 'boolean', required: false },
       control: { type: 'boolean' },
       table: {

--- a/app/stories/pix-button-link.stories.js
+++ b/app/stories/pix-button-link.stories.js
@@ -48,13 +48,13 @@ export default {
     },
     size: {
       name: 'size',
-      description: 'taille: `big`,`small`',
-      options: ['big', 'small'],
+      description: 'taille: `large`,`small`',
+      options: ['large', 'small'],
       type: { name: 'string', required: false },
       control: { type: 'select' },
       table: {
         type: { summary: 'string' },
-        defaultValue: { summary: 'big' },
+        defaultValue: { summary: 'large' },
       },
     },
     isBorderVisible: {

--- a/app/stories/pix-button-link.stories.js
+++ b/app/stories/pix-button-link.stories.js
@@ -26,8 +26,8 @@ export default {
         "Paramètre facultatif du <LinkTo> Ember permettant d'ajouter des paires de clé/valeur dans les paramètres d'une URL",
       type: { required: false },
     },
-    backgroundColor: {
-      name: 'backgroundColor',
+    variant: {
+      name: 'variant',
       description:
         'color: `primary`, `secondary`, `success`, `error`, `neutral`, `transparent-light`, `transparent-dark`',
       options: [
@@ -60,7 +60,7 @@ export default {
     isBorderVisible: {
       name: 'isBorderVisible',
       description:
-        'Paramètre utilisé seulement quand le `backgroundColor` est `transparent-light` ou `transparent-dark`',
+        'Paramètre utilisé seulement quand le `variant` est `transparent-light` ou `transparent-dark`',
       type: { name: 'boolean', required: false },
       control: { type: 'boolean' },
       table: {
@@ -85,7 +85,7 @@ export const htmlLink = {
     template: hbs`<PixButtonLink
   @href='https://pix.fr'
   target='NEW'
-  @backgroundColor={{this.backgroundColor}}
+  @variant={{this.variant}}
   @size={{this.size}}
   @isBorderVisible={{this.isBorderVisible}}
   @isDisabled={{this.isDisabled}}
@@ -102,7 +102,7 @@ export const emberLink = (args) => {
   @route=''
   @model=''
   @query={{this.query}}
-  @backgroundColor={{this.backgroundColor}}
+  @variant={{this.variant}}
   @size={{this.size}}
   @isBorderVisible={{this.isBorderVisible}}
   @isDisabled={{this.isDisabled}}

--- a/app/stories/pix-button-upload.mdx
+++ b/app/stories/pix-button-upload.mdx
@@ -7,7 +7,7 @@ import * as ComponentStories from './pix-button-upload.stories';
 
 Affiche un bouton d'upload de fichiers.
 
-Hérite des styles de base de `PixButton` (`backgroundColor`, `size`, `isBorderVisible`)
+Hérite des styles de base de `PixButton` (`variant`, `size`, `isBorderVisible`)
 
 Toutes les [propriétés HTML d'un input de type file](https://developer.mozilla.org/fr/docs/Web/HTML/Element/Input/file) sont supportées.
 

--- a/app/stories/pix-button-upload.stories.js
+++ b/app/stories/pix-button-upload.stories.js
@@ -38,12 +38,12 @@ export default {
     size: {
       name: 'size',
       description: 'taille: `big`,`small`',
-      options: ['big', 'small'],
+      options: ['large', 'small'],
       type: { name: 'string', required: false },
       control: { type: 'select' },
       table: {
         type: { summary: 'string' },
-        defaultValue: { summary: 'big' },
+        defaultValue: { summary: 'large' },
       },
     },
     isBorderVisible: {

--- a/app/stories/pix-button-upload.stories.js
+++ b/app/stories/pix-button-upload.stories.js
@@ -15,8 +15,8 @@ export default {
         "fonction à exécuter au moment de l'upload du fichier, elle prend en entrée la liste des fichiers uploadés.",
       type: { name: 'function', required: true },
     },
-    backgroundColor: {
-      name: 'backgroundColor',
+    variant: {
+      name: 'variant',
       description:
         'color: `primary`, `success`, `secondary`, `error`, `neutral`, `transparent-light`, `transparent-dark`',
       options: [
@@ -49,7 +49,7 @@ export default {
     isBorderVisible: {
       name: 'isBorderVisible',
       description:
-        'Paramètre utilisé seulement quand le `backgroundColor` est `transparent-light` ou `transparent-dark`',
+        'Paramètre utilisé seulement quand le `variant` est `transparent-light` ou `transparent-dark`',
       type: { name: 'boolean', required: false },
       control: { type: 'boolean' },
       table: {
@@ -65,7 +65,7 @@ export const buttonUpload = (args) => {
     template: hbs`<PixButtonUpload
   @id={{this.id}}
   @onChange={{this.onChange}}
-  @backgroundColor={{this.backgroundColor}}
+  @variant={{this.variant}}
   @size={{this.size}}
   @isBorderVisible={{this.isBorderVisible}}
 >

--- a/app/stories/pix-button-upload.stories.js
+++ b/app/stories/pix-button-upload.stories.js
@@ -18,14 +18,14 @@ export default {
     variant: {
       name: 'variant',
       description:
-        'color: `primary`, `success`, `secondary`, `error`, `neutral`, `transparent-light`, `transparent-dark`',
+        'color: `primary`, `primary-bis`, `secondary`,`tertiary`, `success`, `error`, `transparent-dark`',
       options: [
         'primary',
-        'success',
+        'primary-bis',
         'secondary',
+        'tertiary',
+        'success',
         'error',
-        'neutral',
-        'transparent-light',
         'transparent-dark',
       ],
       type: { name: 'string', required: false },
@@ -49,7 +49,7 @@ export default {
     isBorderVisible: {
       name: 'isBorderVisible',
       description:
-        'Paramètre utilisé seulement quand le `variant` est `transparent-light` ou `transparent-dark`',
+        'Paramètre utilisé seulement quand le `variant` est `secondary` ou `transparent-dark`',
       type: { name: 'boolean', required: false },
       control: { type: 'boolean' },
       table: {

--- a/app/stories/pix-button.mdx
+++ b/app/stories/pix-button.mdx
@@ -11,17 +11,11 @@ Le bouton par défaut qui empêche les clics multiples.
 
   <Story of={ComponentStories.Default} />
 
-## Borders
+## Variants
 
-Le bouton avec bordures et fond transparent
+Le bouton avec toutes ses variations
 
-  <Story of={ComponentStories.borders} height={150} />
-
-## Colors
-
-Le bouton avec toutes ses variations de couleur
-
-  <Story of={ComponentStories.colors} height={500} />
+  <Story of={ComponentStories.variants} height={500} />
 
 ## Icons
 
@@ -71,7 +65,7 @@ Un petit bouton avec les bords arrondis en fond transparent avec une bordure
   @triggerAction="{{action"
   triggerAction}}
   @loadingColor="white"
-  @variant="transparent-light"
+  @variant="secondary"
   @isDisabled="{{false}}"
   @size="small"
   @isBorderVisible="{{true}}"

--- a/app/stories/pix-button.mdx
+++ b/app/stories/pix-button.mdx
@@ -71,7 +71,7 @@ Un petit bouton avec les bords arrondis en fond transparent avec une bordure
   @triggerAction="{{action"
   triggerAction}}
   @loadingColor="white"
-  @backgroundColor="transparent-light"
+  @variant="transparent-light"
   @isDisabled="{{false}}"
   @size="small"
   @isBorderVisible="{{true}}"

--- a/app/stories/pix-button.stories.js
+++ b/app/stories/pix-button.stories.js
@@ -116,13 +116,13 @@ export default {
     },
     size: {
       name: 'size',
-      description: 'taille: `big`,`small`',
-      options: ['big', 'small'],
+      description: 'taille: `large`,`small`',
+      options: ['large', 'small'],
       type: { name: 'string', required: false },
       control: { type: 'select' },
       table: {
         type: { summary: 'string' },
-        defaultValue: { summary: 'big' },
+        defaultValue: { summary: 'large' },
       },
     },
     isBorderVisible: {
@@ -182,7 +182,7 @@ const Template = (args) => ({
 export const Default = Template.bind({});
 Default.args = {
   loadingColor: 'white',
-  size: 'big',
+  size: 'large',
   variant: 'primary',
   label: 'Bouton',
 };

--- a/app/stories/pix-button.stories.js
+++ b/app/stories/pix-button.stories.js
@@ -30,8 +30,8 @@ export default {
         defaultValue: { summary: 'white' },
       },
     },
-    backgroundColor: {
-      name: 'backgroundColor',
+    variant: {
+      name: 'variant',
       description:
         'color: `primary`, `secondary`, `success`, `error`, `neutral`, `transparent-light`, `transparent-dark`',
       options: [
@@ -128,7 +128,7 @@ export default {
     isBorderVisible: {
       name: 'isBorderVisible',
       description:
-        'Paramètre utilisé seulement quand le `backgroundColor` est `transparent-light` ou `transparent-dark`',
+        'Paramètre utilisé seulement quand le `variant` est `transparent-light` ou `transparent-dark`',
       type: { name: 'boolean', required: false },
       control: { type: 'boolean' },
       table: {
@@ -144,7 +144,7 @@ const Template = (args) => ({
   <PixButton
     @triggerAction={{this.triggerAction}}
     @loadingColor={{this.loadingColor}}
-    @backgroundColor={{this.backgroundColor}}
+    @variant={{this.variant}}
     @isDisabled={{this.isDisabled}}
     @isLoading={{this.isLoading}}
     @size={{this.size}}
@@ -162,7 +162,7 @@ const Template = (args) => ({
     <PixButton
       @triggerAction={{this.triggerAction}}
       @loadingColor={{button.loadingColor}}
-      @backgroundColor={{button.backgroundColor}}
+      @variant={{button.variant}}
       @isDisabled={{button.isDisabled}}
       @isLoading={{button.isLoading}}
       @size={{button.size}}
@@ -183,7 +183,7 @@ export const Default = Template.bind({});
 Default.args = {
   loadingColor: 'white',
   size: 'big',
-  backgroundColor: 'primary',
+  variant: 'primary',
   label: 'Bouton',
 };
 
@@ -191,7 +191,7 @@ export const borders = Template.bind({});
 borders.args = {
   ...Default.args,
   label: 'Bouton avec bordure sur fond clair',
-  backgroundColor: 'transparent-light',
+  variant: 'transparent-light',
   loadingColor: 'grey',
   isBorderVisible: true,
   extraButtons: [
@@ -199,7 +199,7 @@ borders.args = {
       ...Default.args,
       label: 'Bouton avec bordure sur fond sombre',
       style: 'background-color: #775555',
-      backgroundColor: 'transparent-dark',
+      variant: 'transparent-dark',
       isBorderVisible: true,
     },
   ],
@@ -213,27 +213,27 @@ colors.args = {
     {
       ...Default.args,
       label: 'Bouton avec background success',
-      backgroundColor: 'success',
+      variant: 'success',
     },
     {
       ...Default.args,
       label: 'Bouton avec background secondary',
-      backgroundColor: 'secondary',
+      variant: 'secondary',
     },
     {
       ...Default.args,
       label: 'Bouton avec background error',
-      backgroundColor: 'error',
+      variant: 'error',
     },
     {
       ...Default.args,
       label: 'Bouton avec background neutral',
-      backgroundColor: 'neutral',
+      variant: 'neutral',
     },
     {
       ...Default.args,
       label: 'Bouton avec bordure sur fond clair',
-      backgroundColor: 'transparent-light',
+      variant: 'transparent-light',
       loadingColor: 'grey',
       isBorderVisible: true,
     },
@@ -241,7 +241,7 @@ colors.args = {
       ...Default.args,
       label: 'Bouton avec bordure sur fond sombre',
       style: 'background-color: #775555',
-      backgroundColor: 'transparent-dark',
+      variant: 'transparent-dark',
       isBorderVisible: true,
     },
   ],
@@ -265,7 +265,7 @@ export const loader = Template.bind({});
 loader.args = {
   ...Default.args,
   label: 'Bouton avec loader au clic',
-  backgroundColor: 'yellow',
+  variant: 'yellow',
   loadingColor: 'grey',
   triggerAction: () => {
     return new Promise((resolve) => {

--- a/app/stories/pix-button.stories.js
+++ b/app/stories/pix-button.stories.js
@@ -33,14 +33,14 @@ export default {
     variant: {
       name: 'variant',
       description:
-        'color: `primary`, `secondary`, `success`, `error`, `neutral`, `transparent-light`, `transparent-dark`',
+        'color: `primary`, `primary-bis`, `secondary`,`tertiary`, `success`, `error`, `transparent-dark`',
       options: [
         'primary',
+        'primary-bis',
         'secondary',
+        'tertiary',
         'success',
         'error',
-        'neutral',
-        'transparent-light',
         'transparent-dark',
       ],
       type: { name: 'string', required: false },
@@ -128,7 +128,7 @@ export default {
     isBorderVisible: {
       name: 'isBorderVisible',
       description:
-        'Paramètre utilisé seulement quand le `variant` est `transparent-light` ou `transparent-dark`',
+        'Paramètre utilisé seulement quand le `variant` est `secondary` ou `transparent-dark`',
       type: { name: 'boolean', required: false },
       control: { type: 'boolean' },
       table: {
@@ -187,59 +187,40 @@ Default.args = {
   label: 'Bouton',
 };
 
-export const borders = Template.bind({});
-borders.args = {
+export const variants = Template.bind({});
+variants.args = {
   ...Default.args,
-  label: 'Bouton avec bordure sur fond clair',
-  variant: 'transparent-light',
-  loadingColor: 'grey',
-  isBorderVisible: true,
+  label: 'Bouton primary (default)',
   extraButtons: [
     {
       ...Default.args,
-      label: 'Bouton avec bordure sur fond sombre',
-      style: 'background-color: #775555',
-      variant: 'transparent-dark',
-      isBorderVisible: true,
-    },
-  ],
-};
-
-export const colors = Template.bind({});
-colors.args = {
-  ...Default.args,
-  label: 'Bouton avec background primary (default)',
-  extraButtons: [
-    {
-      ...Default.args,
-      label: 'Bouton avec background success',
-      variant: 'success',
+      label: 'Bouton primary-bis',
+      variant: 'primary-bis',
+      loadingColor: 'grey',
     },
     {
       ...Default.args,
-      label: 'Bouton avec background secondary',
+      label: 'Bouton secondary',
       variant: 'secondary',
     },
     {
       ...Default.args,
-      label: 'Bouton avec background error',
+      label: 'Bouton tertiary',
+      variant: 'tertiary',
+    },
+    {
+      ...Default.args,
+      label: 'Bouton success',
+      variant: 'success',
+    },
+    {
+      ...Default.args,
+      label: 'Bouton error',
       variant: 'error',
     },
     {
       ...Default.args,
-      label: 'Bouton avec background neutral',
-      variant: 'neutral',
-    },
-    {
-      ...Default.args,
-      label: 'Bouton avec bordure sur fond clair',
-      variant: 'transparent-light',
-      loadingColor: 'grey',
-      isBorderVisible: true,
-    },
-    {
-      ...Default.args,
-      label: 'Bouton avec bordure sur fond sombre',
+      label: 'Bouton avec bordure sur fond sombre (DEPRECATED)',
       style: 'background-color: #775555',
       variant: 'transparent-dark',
       isBorderVisible: true,
@@ -265,7 +246,7 @@ export const loader = Template.bind({});
 loader.args = {
   ...Default.args,
   label: 'Bouton avec loader au clic',
-  variant: 'yellow',
+  variant: 'primary-bis',
   loadingColor: 'grey',
   triggerAction: () => {
     return new Promise((resolve) => {

--- a/app/stories/pix-modal.mdx
+++ b/app/stories/pix-modal.mdx
@@ -37,7 +37,7 @@ Ce composant possède deux `yield` :
  </:content>
  <:footer>
   <PixButton
-    @backgroundColor="transparent-light"
+    @variant="transparent-light"
     @isBorderVisible={{true}}
     @triggerAction={{this.closeModal}}
   >

--- a/app/stories/pix-modal.mdx
+++ b/app/stories/pix-modal.mdx
@@ -37,7 +37,7 @@ Ce composant possède deux `yield` :
  </:content>
  <:footer>
   <PixButton
-    @variant="transparent-light"
+    @variant="secondary"
     @isBorderVisible={{true}}
     @triggerAction={{this.closeModal}}
   >

--- a/app/stories/pix-modal.stories.js
+++ b/app/stories/pix-modal.stories.js
@@ -25,7 +25,7 @@ export default {
       style='display: flex; justify-content: flex-end; flex-wrap: wrap; gap: 16px; margin-bottom: 16px'
     >
       <PixButton
-        @variant='transparent-light'
+        @variant='secondary'
         @isBorderVisible='true'
         @triggerAction={{fn (mut this.showModal) (not this.showModal)}}
       >Annuler</PixButton>

--- a/app/stories/pix-modal.stories.js
+++ b/app/stories/pix-modal.stories.js
@@ -25,7 +25,7 @@ export default {
       style='display: flex; justify-content: flex-end; flex-wrap: wrap; gap: 16px; margin-bottom: 16px'
     >
       <PixButton
-        @backgroundColor='transparent-light'
+        @variant='transparent-light'
         @isBorderVisible='true'
         @triggerAction={{fn (mut this.showModal) (not this.showModal)}}
       >Annuler</PixButton>

--- a/app/stories/pix-sidebar.mdx
+++ b/app/stories/pix-sidebar.mdx
@@ -33,7 +33,7 @@ Ce composant possède deux `yield` :
  </:content>
  <:footer>
   <PixButton
-    @backgroundColor="transparent-light"
+    @variant="transparent-light"
     @isBorderVisible={{true}}
     @triggerAction={{this.closeSidebar}}
   >

--- a/app/stories/pix-sidebar.mdx
+++ b/app/stories/pix-sidebar.mdx
@@ -33,7 +33,7 @@ Ce composant possède deux `yield` :
  </:content>
  <:footer>
   <PixButton
-    @variant="transparent-light"
+    @variant="secondary"
     @isBorderVisible={{true}}
     @triggerAction={{this.closeSidebar}}
   >

--- a/app/stories/pix-sidebar.stories.js
+++ b/app/stories/pix-sidebar.stories.js
@@ -45,7 +45,7 @@ const Template = (args) => {
     {{! template-lint-disable no-inline-styles }}
     <div style='display: flex; gap: 8px'>
       <PixButton
-        @variant='transparent-light'
+        @variant='secondary'
         @isBorderVisible='true'
         @triggerAction={{fn (mut this.showSidebar) (not this.showSidebar)}}
       >Annuler</PixButton>

--- a/app/stories/pix-sidebar.stories.js
+++ b/app/stories/pix-sidebar.stories.js
@@ -45,7 +45,7 @@ const Template = (args) => {
     {{! template-lint-disable no-inline-styles }}
     <div style='display: flex; gap: 8px'>
       <PixButton
-        @backgroundColor='transparent-light'
+        @variant='transparent-light'
         @isBorderVisible='true'
         @triggerAction={{fn (mut this.showSidebar) (not this.showSidebar)}}
       >Annuler</PixButton>

--- a/tests/dummy/app/templates/modal-page.hbs
+++ b/tests/dummy/app/templates/modal-page.hbs
@@ -8,7 +8,7 @@
   </:content>
   <:footer>
     <PixButton
-      @variant="transparent-light"
+      @variant="secondary"
       @isBorderVisible="true"
       @triggerAction={{fn (mut this.showModal) (not this.showModal)}}
     >Annuler</PixButton>

--- a/tests/dummy/app/templates/modal-page.hbs
+++ b/tests/dummy/app/templates/modal-page.hbs
@@ -8,7 +8,7 @@
   </:content>
   <:footer>
     <PixButton
-      @backgroundColor="transparent-light"
+      @variant="transparent-light"
       @isBorderVisible="true"
       @triggerAction={{fn (mut this.showModal) (not this.showModal)}}
     >Annuler</PixButton>

--- a/tests/dummy/app/templates/sidebar-page.hbs
+++ b/tests/dummy/app/templates/sidebar-page.hbs
@@ -8,7 +8,7 @@
   </:content>
   <:footer>
     <PixButton
-      @backgroundColor="transparent-light"
+      @variant="transparent-light"
       @isBorderVisible="true"
       @triggerAction={{fn (mut this.showSidebar) (not this.showSidebar)}}
     >

--- a/tests/dummy/app/templates/sidebar-page.hbs
+++ b/tests/dummy/app/templates/sidebar-page.hbs
@@ -8,7 +8,7 @@
   </:content>
   <:footer>
     <PixButton
-      @variant="transparent-light"
+      @variant="secondary"
       @isBorderVisible="true"
       @triggerAction={{fn (mut this.showSidebar) (not this.showSidebar)}}
     >


### PR DESCRIPTION
## :boom: BREAKING_CHANGES

`backgroundColor` => `variant` pour tout les boutons ( PixButtonUpload / PixButton )

`secondary` => `primary-bis`
`transparent-light` => `secondary`
`neutral` => `tertiary`

size: `big` => `large`

## :star2: Remarques
le changement du look du tertiary sera fait dans un second temps

## :santa: Pour tester
Vérifier que le variant correspond bien à sa maquette dans le DS