### PR TITLE
[FEATURE] Mieux gérer les valeurs acceptées d'`isDisabled` des Checkbox/Radio

### DIFF
--- a/addon/components/pix-checkbox.js
+++ b/addon/components/pix-checkbox.js
@@ -1,6 +1,7 @@
 import Component from '@glimmer/component';
 import { guidFor } from '@ember/object/internals';
 import { action } from '@ember/object';
+import { warn } from '@ember/debug';
 
 export default class PixCheckbox extends Component {
   constructor() {
@@ -22,7 +23,15 @@ export default class PixCheckbox extends Component {
   }
 
   get isDisabled() {
-    return this.args.isDisabled || this.args.disabled;
+    warn(
+      'PixCheckbox: @isDisabled attribute should be a boolean.',
+      [true, false, undefined, null].includes(this.args.isDisabled),
+      {
+        id: 'pix-ui.checkbox.is-disabled.not-boolean',
+      },
+    );
+
+    return this.args.isDisabled || this.args.disabled ? 'true' : null;
   }
 
   @action

--- a/addon/components/pix-radio-button.js
+++ b/addon/components/pix-radio-button.js
@@ -1,6 +1,7 @@
 import Component from '@glimmer/component';
 import { guidFor } from '@ember/object/internals';
 import { action } from '@ember/object';
+import { warn } from '@ember/debug';
 
 export default class PixRadioButton extends Component {
   text = 'pix-radio-button';
@@ -10,7 +11,15 @@ export default class PixRadioButton extends Component {
   }
 
   get isDisabled() {
-    return this.args.isDisabled || this.args.disabled;
+    warn(
+      'PixRadioButton: @isDisabled attribute should be a boolean.',
+      [true, false, undefined, null].includes(this.args.isDisabled),
+      {
+        id: 'pix-ui.radio-button.is-disabled.not-boolean',
+      },
+    );
+
+    return this.args.isDisabled || this.args.disabled ? 'true' : null;
   }
 
   @action

--- a/addon/styles/_pix-checkbox.scss
+++ b/addon/styles/_pix-checkbox.scss
@@ -98,9 +98,9 @@
     }
 
     // Disabled state
-    &[aria-disabled],
+    &[aria-disabled='true'],
     &:disabled,
-    &--indeterminate[aria-disabled],
+    &--indeterminate[aria-disabled='true'],
     &--indeterminate:disabled {
       background: var(--pix-neutral-100);
       border-color: var(--pix-neutral-100);

--- a/addon/styles/_pix-radio-button.scss
+++ b/addon/styles/_pix-radio-button.scss
@@ -73,7 +73,7 @@
     }
 
     // Disabled state
-    &[aria-disabled],
+    &[aria-disabled='true'],
     &:disabled {
       background: var(--pix-neutral-20);
       border-color: var(--pix-neutral-100);

--- a/app/stories/pix-checkbox.mdx
+++ b/app/stories/pix-checkbox.mdx
@@ -28,6 +28,8 @@ En ce sens, nous avons déjà prévu un espace vertical pour séparer 2 composan
 
 ### Checkbox désactivée
 
+L'attribut `@isDisabled` permet de désactiver la checkbox en conservant la possibilité de naviguer avec le clavier ou le lecteur d'écran. Il est préféré à l'attribut natif `disabled` qui empêche ces usages.
+
 <Story of={ComponentStories.isDisabled} height={60} />
 <Story of={ComponentStories.checkedIsDisabled} height={60} />
 <Story of={ComponentStories.isIndeterminateIsDisabled} height={60} />
@@ -44,10 +46,10 @@ En ce sens, nous avons déjà prévu un espace vertical pour séparer 2 composan
 
 ```html
 <PixCheckbox
-  @screenReaderOnly="{{false}}"
-  @isIndeterminate="{{false}}"
+  @screenReaderOnly={{false}}
+  @isIndeterminate={{false}}
   @size="small"
-  disabled
+  @isDisabled={{true}}
 >
   <:label>Recevoir la newsletter</:label>
 </PixCheckbox>

--- a/app/stories/pix-radio-button.mdx
+++ b/app/stories/pix-radio-button.mdx
@@ -26,7 +26,7 @@ Pour les considérer comme un seul groupe d'inputs, **il est nécessaire qu'ils 
 
 ## Disabled
 
-État inactif du bouton radio.
+L'attribut `@isDisabled` permet de désactiver la radio en conservant la possibilité de naviguer avec le clavier ou le lecteur d'écran. Il est préféré à l'attribut natif `disabled` qui empêche ces usages.
 
 <Story of={ComponentStories.isDisabled} height={60} />
 

--- a/tests/integration/components/pix-radio-button-test.js
+++ b/tests/integration/components/pix-radio-button-test.js
@@ -2,6 +2,8 @@ import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { render, clickByName } from '@1024pix/ember-testing-library';
 import { hbs } from 'ember-cli-htmlbars';
+import EmberDebug from '@ember/debug';
+import sinon from 'sinon';
 
 module('Integration | Component | pix-radio-button', function (hooks) {
   setupRenderingTest(hooks);
@@ -14,26 +16,6 @@ module('Integration | Component | pix-radio-button', function (hooks) {
     assert.strictEqual(screen.getByLabelText('Abricot').type, 'radio');
   });
 
-  test('it should be possible to aria-disabled the radiobutton', async function (assert) {
-    // when
-    const screen = await render(
-      hbs`<PixRadioButton @isDisabled='{{true}}'><:label>Abricot</:label></PixRadioButton>`,
-    );
-
-    // then
-    assert.strictEqual(screen.getByLabelText('Abricot').getAttribute('aria-disabled'), 'true');
-  });
-
-  test('it renders the PixRadioButton component with disabled attribute', async function (assert) {
-    // given & when
-    const screen = await render(
-      hbs`<PixRadioButton disabled><:label>Abricot</:label></PixRadioButton>`,
-    );
-
-    // then
-    assert.true(screen.getByLabelText('Abricot').disabled);
-  });
-
   test('it should be possible to add more params to PixRadioButton', async function (assert) {
     // given
     const screen = await render(
@@ -44,38 +26,115 @@ module('Integration | Component | pix-radio-button', function (hooks) {
     assert.true(screen.getByLabelText('Abricot').checked);
   });
 
-  test('it should not be possible to control state when disabled', async function (assert) {
-    // given
-    const screen = await render(
-      hbs`<PixRadioButton disabled><:label>Abricot</:label></PixRadioButton>`,
-    );
-    const radio = screen.getByLabelText('Abricot');
-    assert.false(radio.checked);
+  module('@isDisabled', function (hooks) {
+    let sandbox;
+    hooks.beforeEach(function () {
+      sandbox = sinon.createSandbox();
+      sandbox.stub(EmberDebug, 'warn');
+    });
 
-    // when
-    try {
-      await clickByName('Abricot');
+    hooks.afterEach(function () {
+      sandbox.restore();
+    });
 
-      // should have thrown an error
-      assert.true(false);
-    } catch (error) {
+    test(`it should not be possible to interact when @isDisabled={{true}}`, async function (assert) {
+      // given
+      this.set('isDisabled', true);
+      const screen = await render(
+        hbs`<PixRadioButton @isDisabled={{this.isDisabled}}><:label>Abricot</:label></PixRadioButton>`,
+      );
+      sandbox.assert.calledWith(
+        EmberDebug.warn,
+        'PixRadioButton: @isDisabled attribute should be a boolean.',
+        true,
+        {
+          id: 'pix-ui.radio-button.is-disabled.not-boolean',
+        },
+      );
+      const radiobutton = screen.getByRole('radio', {
+        name: 'Abricot',
+        disabled: true,
+      });
+      assert.false(radiobutton.checked, 'Radiobutton is not checked by default');
+      assert.strictEqual(
+        radiobutton.getAttribute('aria-disabled'),
+        'true',
+        '`aria-disabled` should be forced to "true" else VoiceOver don\'t consider the input as "dimmed"',
+      );
+
+      // when
+      await clickByName('Abricot'); // should not throw!
+
       // then
-      assert.false(radio.checked);
-    }
-  });
+      assert.false(radiobutton.checked, "Radiobutton has changed state, but shouldn't have");
+    });
 
-  test('it should not be possible to control state when aria-disabled', async function (assert) {
-    // given
-    const screen = await render(
-      hbs`<PixRadioButton @isDisabled={{true}}><:label>Abricot</:label></PixRadioButton>`,
-    );
-    const radio = screen.getByLabelText('Abricot');
-    assert.false(radio.checked);
+    ['true', 'false', 'null', 'undefined'].forEach(function (testCase) {
+      test(`it should not be possible to interact when @isDisabled="${testCase}"`, async function (assert) {
+        // given
+        this.set('isDisabled', testCase);
+        const screen = await render(
+          hbs`<PixRadioButton @isDisabled={{this.isDisabled}}><:label>Abricot</:label></PixRadioButton>`,
+        );
+        sandbox.assert.calledWith(
+          EmberDebug.warn,
+          'PixRadioButton: @isDisabled attribute should be a boolean.',
+          false,
+          {
+            id: 'pix-ui.radio-button.is-disabled.not-boolean',
+          },
+        );
+        const radiobutton = screen.getByRole('radio', {
+          name: 'Abricot',
+          disabled: true,
+        });
+        assert.false(radiobutton.checked, 'Radiobutton is not checked by default');
+        assert.strictEqual(
+          radiobutton.getAttribute('aria-disabled'),
+          'true',
+          '`aria-disabled` should be forced to "true" else VoiceOver don\'t consider the input as "dimmed"',
+        );
 
-    // when
-    await clickByName('Abricot');
+        // when
+        await clickByName('Abricot'); // should not throw!
 
-    // then
-    assert.false(radio.checked);
+        // then
+        assert.false(radiobutton.checked, "Radiobutton has changed state, but shouldn't have");
+      });
+    });
+
+    [false, null, undefined].forEach(function (testCase) {
+      test(`it should be possible to interact when @isDisabled={{${testCase}}}`, async function (assert) {
+        // given
+        this.set('isDisabled', testCase);
+        const screen = await render(
+          hbs`<PixRadioButton @isDisabled={{this.isDisabled}}><:label>Abricot</:label></PixRadioButton>`,
+        );
+        sandbox.assert.calledWith(
+          EmberDebug.warn,
+          'PixRadioButton: @isDisabled attribute should be a boolean.',
+          true,
+          {
+            id: 'pix-ui.radio-button.is-disabled.not-boolean',
+          },
+        );
+        const radiobutton = screen.getByRole('radio', {
+          name: 'Abricot',
+          disabled: true,
+        });
+        assert.false(radiobutton.checked, 'Radiobutton is not checked by default');
+        assert.strictEqual(
+          radiobutton.getAttribute('aria-disabled'),
+          null,
+          '`aria-disabled` should not be set',
+        );
+
+        // when
+        await clickByName('Abricot');
+
+        // then
+        assert.true(radiobutton.checked, 'Radiobutton should have changed state');
+      });
+    });
   });
 });


### PR DESCRIPTION
## :christmas_tree: Problème
Pour le moment on peut se retrouver avec `aria-disabled=""` selon ce qu'on passe au composant. L'attribut `aria-disabled` avec une valeur autre que `"true"` ne considère pas l'input comme "disabled" pour VoiceOver qui n'énonce pas "dimmed checkbox". C'est trompeur pour l'usager.

## :gift: Proposition
S'assurer de bien transmettre la valeur `"true"`. On s'est aligné sur les contrats d'interface attendus par `disabled` par exemple, càd n'importe quelle string considère que c'est "true". Voir https://stackblitz.com/edit/ember-cli-editor-output-pauj7r?file=app%2Ftemplates%2Fapplication.hbs

Un warning en environnement de dev a été ajouté en cas d'erreur potentielle. Ce warning ne s'exécutera pas dans un environnement de production (`NODE_ENV=production`) grâce à [`@ember/debug`](https://api.emberjs.com/ember/5.8/classes/@ember%2Fdebug/methods/warn?anchor=warn).

On a ajouté beaucoup de cas de tests pour s'assurer de ne pas casser les multiples cas d'usages dans le futur.

## :star2: Remarques
À noter un comportement tricky de testing-library : une checkbox `aria-disabled` est "clickable" sans que ça ne throw, mais rien ne se passe (comme prévu).

## :santa: Pour tester
S'assurer que les différents états de la Checkbox fonctionnent correctement, y compris avec VoiceOver.

S'assurer que les différents états du RadioButton fonctionnent correctement, y compris avec VoiceOver.
