### PR TITLE
[FEATURE] Mise à jour des tailles des boutons (PIX-12418)

### DIFF
--- a/addon/styles/_pix-button-base.scss
+++ b/addon/styles/_pix-button-base.scss
@@ -2,14 +2,9 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  color: var(--pix-neutral-0);
-  font-weight: var(--pix-font-bold);
-  font-size: 0.875rem;
   white-space: nowrap;
   text-decoration: none;
-  background-color: var(--pix-primary-500);
   border: 2px solid transparent;
-  border-radius: 25px;
   outline: none;
   cursor: pointer;
 
@@ -37,14 +32,21 @@
   }
 
   &--size-large {
+    @extend %pix-cta-l;
+
     padding: var(--pix-spacing-3x) var(--pix-spacing-6x);
+    border-radius: 50px;
   }
 
   &--size-small {
+    @extend %pix-cta-s;
+
     padding: var(--pix-spacing-2x) var(--pix-spacing-6x);
+    border-radius: 25px;
   }
 
   &--primary {
+    color: var(--pix-neutral-0);
     background-color: var(--pix-primary-500);
 
     &:not([aria-disabled="true"]) {
@@ -145,6 +147,7 @@
   }
 
   &--success {
+    color: var(--pix-neutral-0);
     background-color: var(--pix-success-500);
 
     &:not([aria-disabled="true"]) {

--- a/addon/styles/pix-design-tokens/_typography.scss
+++ b/addon/styles/pix-design-tokens/_typography.scss
@@ -85,6 +85,22 @@
   font-family: var(--_pix-font-family-body);
 }
 
+%pix-cta-s {
+  @extend %-pix-body;
+
+  font-weight: var(--pix-font-bold);
+  font-size: 0.875rem;
+  line-height: 1.429;
+}
+
+%pix-cta-l {
+  @extend %-pix-body;
+
+  font-weight: var(--pix-font-bold);
+  font-size: 1.125rem;
+  line-height: 1.556;
+}
+
 %pix-body-xs,
 .pix-body-xs {
   @extend %-pix-body;

--- a/addon/styles/pix-design-tokens/_typography.scss
+++ b/addon/styles/pix-design-tokens/_typography.scss
@@ -2,7 +2,7 @@
 
 // Placeholder pour permettre l'utilisation dans une classe css si jamais le tag html a trop de classe
 %-pix-title {
-  font-weight: 700;
+  font-weight: var(--pix-font-bold);
 
   // stylelint-disable-next-line custom-property-pattern
   font-family: var(--_pix-font-family-title);
@@ -79,7 +79,7 @@
 }
 
 %-pix-body {
-  font-weight: 400;
+  font-weight: var(--pix-font-normal);
 
   // stylelint-disable-next-line custom-property-pattern
   font-family: var(--_pix-font-family-body);


### PR DESCRIPTION
## :christmas_tree: Problème
les marges internes / espacement ne sont plus cohérent avec le DS

## :gift: Proposition
Aligner tout ça afin que les boutons aient la même tailles que sur le DS

## :star2: Remarques
les espacements gauche droite semble bon depuis au moins 5mois. 

## :santa: Pour tester
Vérifier que les boutons sont cohérent avec le DS