### PR TITLE
[BUGIFX] Ne plus passer un un wrapped label pour les checkbox/radiobutton (PIX-12562)

### DIFF
--- a/addon/components/pix-checkbox.hbs
+++ b/addon/components/pix-checkbox.hbs
@@ -1,4 +1,14 @@
 <div class="pix-checkbox {{@class}}">
+  <input
+    type="checkbox"
+    id={{this.id}}
+    class={{this.inputClasses}}
+    checked={{@checked}}
+    aria-disabled={{this.isDisabled}}
+    {{on "click" this.avoidCheckedStateChangeIfIsDisabled}}
+    ...attributes
+  />
+
   <PixLabel
     @for={{this.id}}
     @requiredLabel={{@requiredLabel}}
@@ -7,19 +17,7 @@
     @inlineLabel={{true}}
     @screenReaderOnly={{@screenReaderOnly}}
     @isDisabled={{this.isDisabled}}
-    @wrappedElement={{true}}
   >
-    <:inputElement>
-      <input
-        type="checkbox"
-        id={{this.id}}
-        class={{this.inputClasses}}
-        checked={{@checked}}
-        aria-disabled={{this.isDisabled}}
-        {{on "click" this.avoidCheckedStateChangeIfIsDisabled}}
-        ...attributes
-      />
-    </:inputElement>
-    <:default>{{yield to="label"}}</:default>
+    {{yield to="label"}}
   </PixLabel>
 </div>

--- a/addon/components/pix-label.hbs
+++ b/addon/components/pix-label.hbs
@@ -1,17 +1,11 @@
 <label for={{@for}} class={{this.className}} ...attributes>
-  {{#if (has-block "inputElement")}}
-    {{yield to="inputElement"}}
+  {{#if @requiredLabel}}
+    <abbr title={{@requiredLabel}} class="mandatory-mark">*</abbr>
   {{/if}}
 
-  <span class={{if @screenReaderOnly "screen-reader-only"}}>
-    {{#if @requiredLabel}}
-      <abbr title={{@requiredLabel}} class="mandatory-mark">*</abbr>
-    {{/if}}
+  {{yield}}
 
-    {{yield}}
-
-    {{#if @subLabel}}
-      <span class="pix-label__sub-label">{{@subLabel}}</span>
-    {{/if}}
-  </span>
+  {{#if @subLabel}}
+    <span class="pix-label__sub-label">{{@subLabel}}</span>
+  {{/if}}
 </label>

--- a/addon/components/pix-label.js
+++ b/addon/components/pix-label.js
@@ -4,9 +4,8 @@ export default class PixLabel extends Component {
   get className() {
     const classes = ['pix-label'];
 
-    if (this.args.wrappedElement) classes.push('pix-label--wrapped-element');
-    if (this.args.inlineLabel && !this.args.screenReaderOnly)
-      classes.push('pix-label--inline-label');
+    if (this.args.screenReaderOnly) classes.push('screen-reader-only');
+    if (this.args.inlineLabel) classes.push('pix-label--inline-label');
     if (this.args.isDisabled) classes.push('pix-label--disabled');
 
     const size = ['small', 'large'].includes(this.args.size) ? this.args.size : 'default';

--- a/addon/components/pix-radio-button.hbs
+++ b/addon/components/pix-radio-button.hbs
@@ -1,4 +1,14 @@
 <div class="pix-radio-button {{@class}}">
+  <input
+    type="radio"
+    id={{this.id}}
+    class="pix-radio-button__input"
+    value={{@value}}
+    aria-disabled={{this.isDisabled}}
+    {{on "click" this.avoidCheckedStateChangeIfIsDisabled}}
+    ...attributes
+  />
+
   <PixLabel
     @for={{this.id}}
     @requiredLabel={{@requiredLabel}}
@@ -7,19 +17,7 @@
     @screenReaderOnly={{@screenReaderOnly}}
     @isDisabled={{this.isDisabled}}
     @inlineLabel={{true}}
-    @wrappedElement={{true}}
   >
-    <:inputElement>
-      <input
-        type="radio"
-        id={{this.id}}
-        class="pix-radio-button__input"
-        value={{@value}}
-        aria-disabled={{this.isDisabled}}
-        {{on "click" this.avoidCheckedStateChangeIfIsDisabled}}
-        ...attributes
-      />
-    </:inputElement>
-    <:default>{{yield to="label"}}</:default>
+    {{yield to="label"}}
   </PixLabel>
 </div>

--- a/addon/styles/_pix-checkbox.scss
+++ b/addon/styles/_pix-checkbox.scss
@@ -1,6 +1,8 @@
 .pix-checkbox {
   position: relative;
   z-index: 0;
+  display: flex;
+  align-items: center;
 
   & + .pix-checkbox {
     margin-top: var(--pix-spacing-4x);

--- a/addon/styles/_pix-label.scss
+++ b/addon/styles/_pix-label.scss
@@ -3,12 +3,6 @@
   color: var(--pix-neutral-900);
   font-weight: var(--pix-font-medium);
 
-  &--wrapped-element {
-    display: flex;
-    gap: var(--pix-spacing-3x);
-    align-items: center;
-  }
-
   &--disabled {
     color: var(--pix-neutral-500);
   }
@@ -27,6 +21,7 @@
 
   &--inline-label {
     margin: 0;
+    padding: 0 var(--pix-spacing-2x);
     font-weight: var(--pix-font-normal);
   }
 

--- a/addon/styles/_pix-radio-button.scss
+++ b/addon/styles/_pix-radio-button.scss
@@ -1,6 +1,8 @@
 .pix-radio-button {
   position: relative;
   z-index: 0;
+  display: flex;
+  align-items: center;
 
   & + .pix-radio-button {
     margin-top: var(--pix-spacing-4x);

--- a/tests/integration/components/pix-checkbox-test.js
+++ b/tests/integration/components/pix-checkbox-test.js
@@ -8,15 +8,28 @@ import sinon from 'sinon';
 module('Integration | Component | checkbox', function (hooks) {
   setupRenderingTest(hooks);
 
-  test('it should be possible to check the checkbox', async function (assert) {
-    // when
-    const screen = await render(
-      hbs`<PixCheckbox><:label>Recevoir la newsletter</:label></PixCheckbox>`,
-    );
-    await clickByName('Recevoir la newsletter');
+  module('it should be possible to check the checkbox', function () {
+    test('when label is displayed', async function (assert) {
+      // when
+      const screen = await render(
+        hbs`<PixCheckbox><:label>Recevoir la newsletter</:label></PixCheckbox>`,
+      );
+      await clickByName('Recevoir la newsletter');
 
-    // then
-    assert.true(screen.getByLabelText('Recevoir la newsletter').checked);
+      // then
+      assert.true(screen.getByLabelText('Recevoir la newsletter').checked);
+    });
+
+    test('when label is hidden', async function (assert) {
+      // when
+      const screen = await render(
+        hbs`<PixCheckbox @screenReaderOnly={{true}}><:label>Recevoir la newsletter</:label></PixCheckbox>`,
+      );
+      await clickByName('Recevoir la newsletter');
+
+      // then
+      assert.true(screen.getByLabelText('Recevoir la newsletter').checked);
+    });
   });
 
   test('it should be possible to insert html in label', async function (assert) {

--- a/tests/integration/components/pix-radio-button-test.js
+++ b/tests/integration/components/pix-radio-button-test.js
@@ -8,12 +8,26 @@ import sinon from 'sinon';
 module('Integration | Component | pix-radio-button', function (hooks) {
   setupRenderingTest(hooks);
 
-  test('it renders the default PixRadioButton', async function (assert) {
-    // when
-    const screen = await render(hbs`<PixRadioButton><:label>Abricot</:label></PixRadioButton>`);
+  module('it should be possible to check the radiobutton', function () {
+    test('when label is displayed', async function (assert) {
+      // when
+      const screen = await render(hbs`<PixRadioButton><:label>Abricot</:label></PixRadioButton>`);
+      await clickByName('Abricot');
 
-    // then
-    assert.strictEqual(screen.getByLabelText('Abricot').type, 'radio');
+      // then
+      assert.true(screen.getByLabelText('Abricot').checked);
+    });
+
+    test('when label is hidden', async function (assert) {
+      // when
+      const screen = await render(
+        hbs`<PixRadioButton @screenReaderOnly={{true}}><:label>Abricot</:label></PixRadioButton>`,
+      );
+      await clickByName('Abricot');
+
+      // then
+      assert.true(screen.getByLabelText('Abricot').checked);
+    });
   });
 
   test('it should be possible to add more params to PixRadioButton', async function (assert) {


### PR DESCRIPTION
## :christmas_tree: Problème
le wrapped element pose régulièrement souci ( notamment dans le cas d'un label en screenreader only sur la page des epreuves )

## :gift: Proposition
ne plus passer par un gap pour gérer l'espacement mais un padding. qui permettra le click dans la zone blanche. et nous évitera tout un tas de bidouille pour que tout fonctionne partout 

## :star2: Remarques
RAS

## :santa: Pour tester
Vérifier que tout fonctionne sur les épreuves 