### PR TITLE
[FEATURE] Rendre la taille des boutons à small par défaut.

### DIFF
--- a/addon/components/pix-button-base.js
+++ b/addon/components/pix-button-base.js
@@ -6,7 +6,7 @@ export default class PixButtonBase extends Component {
   }
 
   get size() {
-    return this.args.size || 'large';
+    return this.args.size || 'small';
   }
 
   get baseClassNames() {

--- a/app/stories/pix-button-link.stories.js
+++ b/app/stories/pix-button-link.stories.js
@@ -54,7 +54,7 @@ export default {
       control: { type: 'select' },
       table: {
         type: { summary: 'string' },
-        defaultValue: { summary: 'large' },
+        defaultValue: { summary: 'small' },
       },
     },
     isBorderVisible: {

--- a/app/stories/pix-button-upload.stories.js
+++ b/app/stories/pix-button-upload.stories.js
@@ -43,7 +43,7 @@ export default {
       control: { type: 'select' },
       table: {
         type: { summary: 'string' },
-        defaultValue: { summary: 'large' },
+        defaultValue: { summary: 'small' },
       },
     },
     isBorderVisible: {

--- a/app/stories/pix-button.mdx
+++ b/app/stories/pix-button.mdx
@@ -51,7 +51,7 @@ Le loader peut être affiché de deux façons :
 
 ## Size
 
-Le bouton en small
+Le bouton en large (small étant la valeur par défaut)
 
  <Story of={ComponentStories.size} height={75} />
 

--- a/app/stories/pix-button.stories.js
+++ b/app/stories/pix-button.stories.js
@@ -122,7 +122,7 @@ export default {
       control: { type: 'select' },
       table: {
         type: { summary: 'string' },
-        defaultValue: { summary: 'large' },
+        defaultValue: { summary: 'small' },
       },
     },
     isBorderVisible: {
@@ -182,7 +182,6 @@ const Template = (args) => ({
 export const Default = Template.bind({});
 Default.args = {
   loadingColor: 'white',
-  size: 'large',
   variant: 'primary',
   label: 'Bouton',
 };
@@ -266,6 +265,6 @@ loader.args = {
 export const size = Template.bind({});
 size.args = {
   ...Default.args,
-  label: 'Bouton small',
-  size: 'small',
+  label: 'Bouton large',
+  size: 'large',
 };

--- a/app/stories/pix-icon-button.mdx
+++ b/app/stories/pix-icon-button.mdx
@@ -13,11 +13,11 @@ Le bouton en version big et sans fond grisé.
 
 <Story of={ComponentStories.Default} height={60} />
 
-## Small
+## Size
 
-Le bouton en version small.
+Le bouton en version small. (big étant la valeur par défaut)
 
-<Story of={ComponentStories.small} height={60} />
+<Story of={ComponentStories.size} height={60} />
 
 ## With Background
 

--- a/app/stories/pix-icon-button.stories.js
+++ b/app/stories/pix-icon-button.stories.js
@@ -86,8 +86,8 @@ Default.args = {
   triggerAction,
 };
 
-export const small = Template.bind({});
-small.args = {
+export const size = Template.bind({});
+size.args = {
   ...Default.args,
   size: 'small',
   triggerAction,


### PR DESCRIPTION
## :christmas_tree: Problème
La PR https://github.com/1024pix/pix-ui/pull/642 à permis d'aligner la taille des boutons afin d'être en cohérence avec le DS.
Les boutons `large` sont bien plus grands.

Or la taille par défaut d'un bouton est le `large`et certaines page de nos applications montre des contrastes trop importants entre la taille des champs (qui doivent être modifiés mais plus tard) et les boutons.

## :gift: Proposition
Passer la taille par défaut à small

## :santa: Pour tester
Aller voir la doc des boutons gérant leur size d'après le button-base

https://ui-pr648.review.pix.fr/?path=/docs/basics-button--docs
https://ui-pr648.review.pix.fr/?path=/docs/basics-icon-button--docs => lui n'est pas lié à button base et reste tel quel
https://ui-pr648.review.pix.fr/?path=/docs/basics-buttonupload--docs
