### PR TITLE
[TECH] Aligner la hauteur de tous éléments boutons (PIX-12652)

### DIFF
--- a/addon/styles/_pix-button-base.scss
+++ b/addon/styles/_pix-button-base.scss
@@ -199,7 +199,3 @@
   }
 }
 
-.pix-button-link,
-.pix-button-upload {
-  line-height: initial;
-}


### PR DESCRIPTION
## :boom: BREAKING_CHANGES
RAS

## :christmas_tree: Problème
[La récente modification des tailles des boutons](https://github.com/1024pix/pix-ui/pull/642) présente dans la version 4.6.2 du storybook amène une différence de hauteur entre les (vrais) boutons (pix-button) et ceux qui ressemble à des boutons (pix-button-link | pix-button-upload).

Une propriété css vient perturber l’homogénéité de la hauteur de tous ces éléments.

## :gift: Proposition
Retirer la propriété CSS impactant la hauteur des éléments concernés.

## :star2: Remarques
RAS

## :santa: Pour tester (facilement)

1. Se rendre sur l'onglet Exemplaire de formulaire / Form
2. Constater que tous les boutons ont la même hauteur de 40px, plus précisément que les `pix-button-link` et `pix-button-upload` ont la même hauteur que le `pix-button`. (voir screenshots)

**AVANT :**
![Capture d’écran 2024-05-23 à 16 28 11](https://github.com/1024pix/pix-ui/assets/152303583/bc10e45b-42b4-499c-a466-f3a9de8cf054)

**APRÈS :**
![Capture d’écran 2024-05-23 à 16 25 34](https://github.com/1024pix/pix-ui/assets/152303583/4d749d17-e8cf-4b10-8911-a082aafd2bac)
