### PR TITLE
[BUGFIX] `PixTextarea` prend tout l'espace à sa disposition (PIX-12468)

### DIFF
--- a/addon/components/pix-textarea.hbs
+++ b/addon/components/pix-textarea.hbs
@@ -12,23 +12,24 @@
     </PixLabel>
   {{/if}}
 
-  <div>
+  <div class="pix-textarea__container">
     <textarea
       id={{this.id}}
       maxlength={{if @maxlength @maxlength}}
       aria-required="{{if @requiredLabel true false}}"
       required={{if @requiredLabel true false}}
-      class="{{if @errorMessage 'pix-textarea--error'}}"
+      class="pix-textarea-container__input {{if @errorMessage 'pix-textarea--error'}}"
       {{on "keyup" this.updateValue}}
       ...attributes
     >{{@value}}</textarea>
 
     {{#if @maxlength}}
-      <p>{{this.textLengthIndicator}} / {{@maxlength}}</p>
+      {{! prettier-ignore }}
+      <p class="pix-textarea-container__text-length-indicator">{{this.textLengthIndicator}} / {{@maxlength}}</p>
     {{/if}}
 
     {{#if @errorMessage}}
-      <label for={{this.id}} class="pix-textarea__error-message">{{@errorMessage}}</label>
+      <label for={{this.id}} class="pix-textarea-container__error-message">{{@errorMessage}}</label>
     {{/if}}
   </div>
 

--- a/addon/styles/_pix-textarea.scss
+++ b/addon/styles/_pix-textarea.scss
@@ -1,7 +1,20 @@
+.pix-textarea {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+
+  &__container {
+    display: flex;
+    flex-direction: column;
+    flex-grow: 1;
+  }
+}
+
 .pix-textarea-container {
   &__input {
     @extend %pix-form-element-state;
 
+    flex-grow: 1;
     width: 100%;
     padding: 10px var(--pix-spacing-4x);
     color: var(--pix-neutral-900);

--- a/addon/styles/_pix-textarea.scss
+++ b/addon/styles/_pix-textarea.scss
@@ -1,5 +1,5 @@
-.pix-textarea {
-  textarea {
+.pix-textarea-container {
+  &__input {
     @extend %pix-form-element-state;
 
     width: 100%;
@@ -16,7 +16,7 @@
     }
   }
 
-  p {
+  &__text-length-indicator {
     display: flex;
     flex-direction: row-reverse;
     margin-top: 6px;

--- a/app/stories/pix-textarea.mdx
+++ b/app/stories/pix-textarea.mdx
@@ -11,6 +11,12 @@ Optionellement, il peut afficher le nombre de caractères tapés ainsi que le no
 
 <Story of={ComponentStories.textarea} height={150} />
 
+## Dimensions
+
+Le PixTextarea prend tout l'espace à sa disposition.
+
+<Story of={ComponentStories.FullWidth} height={290} />
+
 ## Accessibilité
 
 La propriété label est optionnelle pour le composant.

--- a/app/stories/pix-textarea.stories.js
+++ b/app/stories/pix-textarea.stories.js
@@ -113,6 +113,32 @@ textarea.args = {
   value: 'Contenu du textarea',
 };
 
+const FullWidthTemplate = (args) => {
+  return {
+    template: hbs`{{! template-lint-disable no-inline-styles }}
+<div
+  style='border: 1px solid var(--pix-neutral-500); background: var(--pix-neutral-20); padding: var(--pix-spacing-4x); width: 500px; height: 250px;'
+>
+  <PixTextarea
+    @id={{this.id}}
+    @value={{this.value}}
+    @subLabel={{this.subLabel}}
+    @maxlength={{this.maxlength}}
+  ><:label>{{this.label}}</:label></PixTextarea>
+</div>`,
+    context: args,
+  };
+};
+
+export const FullWidth = FullWidthTemplate.bind({});
+FullWidth.args = {
+  id: 'textarea',
+  label: 'Label du textarea',
+  subLabel: 'Sous-label',
+  value: 'Contenu du textarea',
+  maxlength: 120,
+};
+
 export const textareaWithoutLabel = TemplateWithoutlabel.bind({});
 textareaWithoutLabel.args = {
   id: 'textarea-without-label',


### PR DESCRIPTION
## :christmas_tree: Problème
Dans une version précédente, le component `PixTextarea` a arrêté de prendre tout l'espace à sa disposition.

## :gift: Proposition
Le remettre en place et le documenter.

## :star2: Remarques
RAS

## :santa: Pour tester
Vérifier la doc Storybook du composant `PixTextarea`.
