### PR TITLE
[FEATURE] Ajouter un variant `tile` au composant `PixCheckbox` (PIX-12120)

### DIFF
--- a/addon/components/pix-checkbox.hbs
+++ b/addon/components/pix-checkbox.hbs
@@ -7,6 +7,7 @@
     @inlineLabel={{true}}
     @screenReaderOnly={{@screenReaderOnly}}
     @isDisabled={{this.isDisabled}}
+    @variant={{@variant}}
   >
     <:inputElement>
       <input

--- a/addon/components/pix-label-wrapped.js
+++ b/addon/components/pix-label-wrapped.js
@@ -2,10 +2,11 @@ import Component from '@glimmer/component';
 
 export default class PixLabelWrapped extends Component {
   get className() {
-    const classes = ['pix-label', 'pix-label--wrapped'];
+    const classes = ['pix-label', 'pix-label-wrapped'];
 
     if (this.args.inlineLabel) classes.push('pix-label--inline-label');
-    if (this.args.isDisabled) classes.push('pix-label--disabled');
+    if (this.args.isDisabled) classes.push('pix-label-wrapped--disabled');
+    if (this.args.variant === 'tile') classes.push('pix-label-wrapped--variant-tile');
 
     const size = ['small', 'large'].includes(this.args.size) ? this.args.size : 'default';
 

--- a/addon/styles/_pix-label-wrapped.scss
+++ b/addon/styles/_pix-label-wrapped.scss
@@ -2,4 +2,39 @@
   display: flex;
   gap: var(--pix-spacing-2x);
   align-items: center;
+
+  &--variant-tile {
+    position: relative;
+    z-index: -2;
+    padding: var(--pix-spacing-3x) var(--pix-spacing-4x);
+    background: var(--pix-neutral-0);
+    border: 1px solid var(--pix-neutral-100);
+    border-radius: 4px;
+
+    &:focus-within {
+      border: 1px solid var(--pix-primary-500);
+      outline: 2px solid var(--pix-primary-300);
+    }
+
+    &:hover,
+    &:active {
+      background: var(--pix-primary-10);
+    }
+
+    &.pix-label-wrapped {
+      &--disabled {
+        background: var(--pix-neutral-20);
+        border-color: var(--pix-neutral-100);
+
+        &:hover,
+        &:active {
+          background: var(--pix-neutral-20);
+        }
+      }
+    }
+  }
+
+  &--disabled {
+    cursor: not-allowed;
+  }
 }

--- a/addon/styles/_pix-label-wrapped.scss
+++ b/addon/styles/_pix-label-wrapped.scss
@@ -1,0 +1,5 @@
+.pix-label-wrapped {
+  display: flex;
+  gap: var(--pix-spacing-2x);
+  align-items: center;
+}

--- a/addon/styles/_pix-label-wrapped.scss
+++ b/addon/styles/_pix-label-wrapped.scss
@@ -2,6 +2,7 @@
   display: flex;
   gap: var(--pix-spacing-2x);
   align-items: center;
+  cursor: pointer;
 
   &--variant-tile {
     position: relative;

--- a/addon/styles/_pix-label.scss
+++ b/addon/styles/_pix-label.scss
@@ -3,12 +3,6 @@
   color: var(--pix-neutral-900);
   font-weight: var(--pix-font-medium);
 
-  &--wrapped {
-    display: flex;
-    gap: var(--pix-spacing-2x);
-    align-items: center;
-  }
-
   &--disabled {
     color: var(--pix-neutral-500);
   }

--- a/addon/styles/addon.scss
+++ b/addon/styles/addon.scss
@@ -21,6 +21,7 @@
 @import 'pix-button-upload';
 @import 'pix-input';
 @import 'pix-label';
+@import 'pix-label-wrapped';
 @import 'pix-input-password';
 @import 'pix-radio-button';
 @import 'pix-modal';

--- a/app/stories/pix-checkbox.mdx
+++ b/app/stories/pix-checkbox.mdx
@@ -18,11 +18,15 @@ En ce sens, nous avons déjà prévu un espace vertical pour séparer 2 composan
 
 <Story of={ComponentStories.multiple} height={140} />
 
-### Dimensions du label
+### Variations graphiques du composant
 
-La PixCheckbox prend tout l'espace à sa disposition.
+La PixCheckbox prend toute la largeur à sa disposition.
 
 <Story of={ComponentStories.FullWidth} height={100} />
+
+Si le paramètre `variant` est précisé avec la valeur `tile`, la checkbox et son label sont visuellement regroupés dans un ensemble intégralement cliquable.
+
+<Story of={ComponentStories.VariantTile} height={100} />
 
 ## États de la Checkbox
 
@@ -39,6 +43,10 @@ L'attribut `@isDisabled` permet de désactiver la checkbox en conservant la poss
 <Story of={ComponentStories.isDisabled} height={60} />
 <Story of={ComponentStories.checkedIsDisabled} height={60} />
 <Story of={ComponentStories.isIndeterminateIsDisabled} height={60} />
+
+<Story of={ComponentStories.isDisabledVariantTile} height={100} />
+<Story of={ComponentStories.checkedIsDisabledVariantTile} height={100} />
+<Story of={ComponentStories.isIndeterminateIsDisabledVariantTile} height={100} />
 
 ## Autres tailles de police du label
 

--- a/app/stories/pix-checkbox.mdx
+++ b/app/stories/pix-checkbox.mdx
@@ -6,6 +6,7 @@ import * as ComponentStories from './pix-checkbox.stories';
 # PixCheckbox
 
 La PixCheckbox permet de créer des checkbox basiques ou des checkbox mixées (checkbox servant d'indicateur lors d'une sélection multiple).
+Un cursor `pointer` est défini sur la checkbox et son label par défaut.
 
 <Story of={ComponentStories.Default} height={60} />
 
@@ -20,7 +21,7 @@ En ce sens, nous avons déjà prévu un espace vertical pour séparer 2 composan
 
 ### Variations graphiques du composant
 
-La PixCheckbox prend toute la largeur à sa disposition.
+La PixCheckbox prend toute la largeur à sa disposition par défaut.
 
 <Story of={ComponentStories.FullWidth} height={100} />
 
@@ -39,6 +40,7 @@ Si le paramètre `variant` est précisé avec la valeur `tile`, la checkbox et s
 ### Checkbox désactivée
 
 L'attribut `@isDisabled` permet de désactiver la checkbox en conservant la possibilité de naviguer avec le clavier ou le lecteur d'écran. Il est préféré à l'attribut natif `disabled` qui empêche ces usages.
+Un cursor `not-allowed` est défini sur la checkbox et son label lorsqu'elle est dans un état `disabled`.
 
 <Story of={ComponentStories.isDisabled} height={60} />
 <Story of={ComponentStories.checkedIsDisabled} height={60} />

--- a/app/stories/pix-checkbox.stories.js
+++ b/app/stories/pix-checkbox.stories.js
@@ -120,6 +120,24 @@ const FullWidthTemplate = (args) => {
   };
 };
 
+const VariantTileTemplate = (args) => {
+  return {
+    template: hbs`{{! template-lint-disable no-inline-styles }}
+<div
+  style='border: 1px solid var(--pix-neutral-500); padding: var(--pix-spacing-4x); width: 500px'
+><PixCheckbox
+    @id={{this.id}}
+    @isIndeterminate={{this.isIndeterminate}}
+    @checked={{this.checked}}
+    @isDisabled={{this.isDisabled}}
+    @variant='tile'
+  >
+    <:label>{{this.label}}</:label>
+  </PixCheckbox></div>`,
+    context: args,
+  };
+};
+
 export const Default = Template.bind({});
 Default.args = {
   id: 'accept-newsletter',
@@ -135,6 +153,12 @@ DefaultChecked.args = {
 
 export const FullWidth = FullWidthTemplate.bind({});
 FullWidth.args = {
+  id: 'proposal',
+  label: 'Une réponse',
+};
+
+export const VariantTile = VariantTileTemplate.bind({});
+VariantTile.args = {
   id: 'proposal',
   label: 'Une réponse',
 };
@@ -178,6 +202,30 @@ checkedIsDisabled.args = {
 
 export const isIndeterminateIsDisabled = Template.bind({});
 isIndeterminateIsDisabled.args = {
+  id: 'accept-newsletter-2',
+  label: 'Recevoir la newsletter',
+  isDisabled: true,
+  checked: true,
+  isIndeterminate: true,
+};
+
+export const isDisabledVariantTile = VariantTileTemplate.bind({});
+isDisabledVariantTile.args = {
+  id: 'accept-newsletter-2',
+  label: 'Recevoir la newsletter',
+  isDisabled: true,
+};
+
+export const checkedIsDisabledVariantTile = VariantTileTemplate.bind({});
+checkedIsDisabledVariantTile.args = {
+  id: 'accept-newsletter-2',
+  label: 'Recevoir la newsletter',
+  isDisabled: true,
+  checked: true,
+};
+
+export const isIndeterminateIsDisabledVariantTile = VariantTileTemplate.bind({});
+isIndeterminateIsDisabledVariantTile.args = {
   id: 'accept-newsletter-2',
   label: 'Recevoir la newsletter',
   isDisabled: true,


### PR DESCRIPTION
## :christmas_tree: Problème
Le composant `PixCheckbox` prend aujourd'hui les dimensions minimales disponibles pour être le plus passe partout possible. Ça ne nous permet pas d'agrandir la zone de sélection de la checkbox.

## :gift: Proposition
Ajouter un paramètre au composant `PixCheckbox` pour avoir une zone de sélection plus grande.

Techniquement le paramètre se nomme `variant` et prend la valeur `tile` pour permettre ce nouvel usage.

Un background est ajouté aux états `:hover` et `:active`.

Les maquettes sont disponibles ici : https://www.figma.com/design/47MuKB1wXoLEgMal06idN3/R%26D-DevComp?node-id=3082-10729&t=u6kaWVpuASMw1lry-0

## :star2: Remarques
Nous avons appliqué un `cursor: pointer` par défaut sur les `pix-label-wrapped` et un `cursor: not allowed` sur les `pix-label-wrapped` dans un état `disabled` de manière à avoir un comportement similaire entre les différents `PixCheckbox`.

## :santa: Pour tester
Pas de régression sur le reste des `PixCheckbox`

Vérifier les démos de ce nouveau `variant`.
