### PR TITLE
[FEATURE] Détailler les icônes utilisées par Pix UI

### DIFF
--- a/config/icons.js
+++ b/config/icons.js
@@ -1,6 +1,21 @@
-module.exports = function () {
-  return {
-    'free-solid-svg-icons': 'all',
-    'free-regular-svg-icons': 'all',
-  };
-};
+module.exports = () => ({
+  'free-solid-svg-icons': [
+    'arrow-right',
+    'bullhorn',
+    'check',
+    'chevron-up',
+    'chevron-down',
+    'circle-check',
+    'circle-exclamation',
+    'circle-info',
+    'circle-question',
+    'earth-europe',
+    'eye',
+    'eye-slash',
+    'plus',
+    'triangle-exclamation',
+    'up-right-from-square',
+    'user',
+    'xmark',
+  ],
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -32,7 +32,6 @@
         "@embroider/macros": "^1.11.0",
         "@embroider/test-setup": "^4.0.0",
         "@fortawesome/ember-fontawesome": "^2.0.0",
-        "@fortawesome/free-regular-svg-icons": "^6.2.1",
         "@fortawesome/free-solid-svg-icons": "^6.2.1",
         "@glimmer/component": "^1.1.2",
         "@glimmer/syntax": "^0.92.0",
@@ -7192,20 +7191,6 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
-      "dependencies": {
-        "@fortawesome/fontawesome-common-types": "6.5.2"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/@fortawesome/free-regular-svg-icons": {
-      "version": "6.5.2",
-      "resolved": "https://registry.npmjs.org/@fortawesome/free-regular-svg-icons/-/free-regular-svg-icons-6.5.2.tgz",
-      "integrity": "sha512-iabw/f5f8Uy2nTRtJ13XZTS1O5+t+anvlamJ3zJGLEVE2pKsAWhPv2lq01uQlfgCX7VaveT3EVs515cCN9jRbw==",
-      "dev": true,
-      "hasInstallScript": true,
-      "license": "(CC-BY-4.0 AND MIT)",
       "dependencies": {
         "@fortawesome/fontawesome-common-types": "6.5.2"
       },

--- a/package.json
+++ b/package.json
@@ -69,7 +69,6 @@
     "@embroider/macros": "^1.11.0",
     "@embroider/test-setup": "^4.0.0",
     "@fortawesome/ember-fontawesome": "^2.0.0",
-    "@fortawesome/free-regular-svg-icons": "^6.2.1",
     "@fortawesome/free-solid-svg-icons": "^6.2.1",
     "@glimmer/component": "^1.1.2",
     "@glimmer/syntax": "^0.92.0",

--- a/package.json
+++ b/package.json
@@ -135,6 +135,7 @@
   "files": [
     "addon/",
     "app/",
+    "config/icons.js",
     "public/",
     "scripts/migrate-colors-scss-vars-to-css-vars.sh",
     "scripts/migrate-spacing-scss-vars-to-css-vars.sh"


### PR DESCRIPTION
## :christmas_tree: Problème
Aujourd'hui il n'y a pas moyen de savoir quelles icônes sont utilisées par nos composants Pix UI.

## :gift: Proposition
Détailler les icônes utilisées dans le fichier `config/icons.svg`. On peut ainsi étendre cette liste dans nos applications : 

```javascript
const getCommonIcons = require('@1024pix/pix-ui/config/icons.js`);
const commonIcons = getCommonIcons();

module.exports = () => ({
  ...commonIcons,
  'free-brands-svg-icons': ['facebook-f', 'linkedin-in', 'twitter'],
  'free-solid-svg-icons': [
    ...commonIcons['free-solid-svg-icons'],
    // ...
  ]
});
```

Démo sur Pix App : https://github.com/1024pix/pix/pull/9164

## :star2: Remarques
RAS

## :santa: Pour tester
Vérifer que les icônes sont toujours bien affichées.
