### PR TITLE
[FEATURE] Ajouter un variant tile au composant PixRadioButton (PIX-12828) 

### DIFF
--- a/addon/components/pix-radio-button.hbs
+++ b/addon/components/pix-radio-button.hbs
@@ -7,6 +7,7 @@
     @screenReaderOnly={{@screenReaderOnly}}
     @isDisabled={{this.isDisabled}}
     @inlineLabel={{true}}
+    @variant={{@variant}}
   >
     <:inputElement>
       <input

--- a/app/stories/pix-radio-button.mdx
+++ b/app/stories/pix-radio-button.mdx
@@ -24,11 +24,15 @@ Pour les considérer comme un seul groupe d'inputs, **il est nécessaire qu'ils 
 
 <Story of={ComponentStories.multiple} height={140} />
 
-### Dimensions du label
+### Variations graphiques du composant
 
-PixRadioButton prend tout l'espace à sa disposition.
+Le PixRadioButton prend toute la largeur à sa disposition.
 
 <Story of={ComponentStories.FullWidth} height={100} />
+
+Si le paramètre `variant` est précisé avec la valeur `tile`, le radiobutton et son label sont visuellement regroupés dans un ensemble intégralement cliquable.
+
+<Story of={ComponentStories.VariantTile} height={100} />
 
 ## Disabled
 

--- a/app/stories/pix-radio-button.stories.js
+++ b/app/stories/pix-radio-button.stories.js
@@ -114,6 +114,23 @@ const FullWidthTemplate = (args) => {
   };
 };
 
+const VariantTileTemplate = (args) => {
+  return {
+    template: hbs`{{! template-lint-disable no-inline-styles }}
+<div
+  style='border: 1px solid var(--pix-neutral-500); background: var(--pix-neutral-20); padding: var(--pix-spacing-4x); width: 500px'
+><PixRadioButton
+    @id={{this.id}}
+    @isDisabled={{this.isDisabled}}
+    checked={{this.checked}}
+    @variant='tile'
+  >
+    <:label>{{this.label}}</:label>
+  </PixRadioButton></div>`,
+    context: args,
+  };
+};
+
 export const Default = Template.bind({});
 Default.args = {
   label: 'Poivron',
@@ -130,15 +147,36 @@ FullWidth.args = {
   label: 'Une réponse',
 };
 
+export const VariantTile = VariantTileTemplate.bind({});
+VariantTile.args = {
+  id: 'proposal',
+  label: 'Une réponse',
+};
+
 export const isDisabled = Template.bind({});
 isDisabled.args = {
   ...Default.args,
   isDisabled: true,
 };
 
+export const isDisabledVariantTile = VariantTileTemplate.bind({});
+isDisabledVariantTile.args = {
+  id: 'accept-newsletter-2',
+  label: 'Recevoir la newsletter',
+  isDisabled: true,
+};
+
 export const checkedIsDisabled = Template.bind({});
 checkedIsDisabled.args = {
   ...Default.args,
+  isDisabled: true,
+  checked: true,
+};
+
+export const checkedIsDisabledVariantTile = VariantTileTemplate.bind({});
+checkedIsDisabledVariantTile.args = {
+  id: 'accept-newsletter-2',
+  label: 'Recevoir la newsletter',
   isDisabled: true,
   checked: true,
 };


### PR DESCRIPTION
## :christmas_tree: Problème
Le composant PixRadioButton prend aujourd'hui les dimensions minimales disponibles pour être le plus passe partout possible. Ça ne nous permet pas d'agrandir la zone de sélection de la checkbox.

## :gift: Proposition
Ajouter un paramètre au composant PixRadioButton pour avoir une zone de sélection plus grande.

Techniquement le paramètre se nomme variant et prend la valeur tile pour permettre ce nouvel usage.

Les maquettes sont disponibles ici : https://www.figma.com/design/47MuKB1wXoLEgMal06idN3/R%26D-DevComp?node-id=3082-10706&t=QvFZHLAhvdNMyMGu-0

## :star2: Remarques
Dans une [PR précedente](https://github.com/1024pix/pix-ui/pull/662) un `cursor: pointer` a été appliqué par défaut sur les pix-label-wrapped et un `cursor: not allowed` sur les pix-label-wrapped dans un état disabled de manière à avoir un comportement similaire entre les différents PixCheckbox. Cela touche également les PixRadioButton.

## :santa: Pour tester
Pas de régression sur le reste des PixRadioButton

Vérifier les démos de ce nouveau variant : 
- https://ui-pr664.review.pix.fr/?path=/story/form-radio-button--variant-tile
- https://ui-pr664.review.pix.fr/?path=/story/form-radio-button--is-disabled-variant-tile
- https://ui-pr664.review.pix.fr/?path=/story/form-radio-button--checked-is-disabled-variant-tile
