### PR TITLE
[BUGFIX] Réparer la largeur du Select (PIX-12845).

### DIFF
--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -1,3 +1,5 @@
+import './storybook.css';
+
 const preview = {
   parameters: {
     layout: 'centered',
@@ -33,11 +35,11 @@ const preview = {
             'Breaking changes',
             'Faire une release',
             'Architecture',
-            'Storybook'
+            'Storybook',
           ],
         ],
       },
     },
-  }
+  },
 };
 export default preview;

--- a/.storybook/storybook.css
+++ b/.storybook/storybook.css
@@ -1,0 +1,3 @@
+#storybook-root {
+  min-width: 0;
+}

--- a/addon/components/pix-select.hbs
+++ b/addon/components/pix-select.hbs
@@ -1,5 +1,5 @@
 <div
-  class="pix-select {{if @inlineLabel ' pix-select--inline'}}"
+  class="pix-select {{if @inlineLabel 'pix-select--inline'}} {{if @icon 'pix-select--with-icon'}}"
   id="container-{{this.selectId}}"
   {{on-click-outside this.hideDropdown}}
   {{on-arrow-down-up-action this.listId this.showDropdown this.isExpanded}}
@@ -33,19 +33,19 @@
         aria-disabled={{@isDisabled}}
       >
         {{#if @icon}}
-          <FaIcon @icon={{@icon}} />
+          <FaIcon class="pix-select-button__icon pix-select-button__icon--prefix" @icon={{@icon}} />
         {{/if}}
 
         <span class="pix-select-button__text">{{this.placeholder}}</span>
 
         <FaIcon
-          class="pix-select-button__dropdown-icon"
+          class="pix-select-button__icon pix-select-button__icon--arrow"
           @icon={{if this.isExpanded "chevron-up" "chevron-down"}}
         />
       </button>
       <div
         {{popover}}
-        class="pix-select__dropdown{{unless this.isExpanded ' pix-select__dropdown--closed'}}"
+        class="pix-select__dropdown{{if this.isExpanded ' pix-select__dropdown--expanded'}}"
         {{on "transitionend" this.focus}}
       >
         {{#if @isSearchable}}
@@ -75,7 +75,8 @@
             {{on-enter-action (fn this.onChange this.defaultOption)}}
             {{on-space-action (fn this.onChange this.defaultOption)}}
           >
-            {{@placeholder}}
+            <span class="pix-select-option__text">{{@placeholder}}</span>
+            <FaIcon class="icon" @icon="check" role="presentation" />
           </li>
           {{#if this.results}}
             {{#if this.displayCategory}}
@@ -113,11 +114,9 @@
                       {{on-enter-action (fn this.onChange option)}}
                       {{on-space-action (fn this.onChange option)}}
                     >
-                      {{option.label}}
+                      <span class="pix-select-option__text">{{option.label}}</span>
 
-                      {{#if (eq option.value @value)}}
-                        <FaIcon @icon="check" role="presentation" />
-                      {{/if}}
+                      <FaIcon class="icon" @icon="check" role="presentation" />
                     </li>
                   {{/each}}
                 </ul>
@@ -136,11 +135,9 @@
                   {{on-enter-action (fn this.onChange option)}}
                   {{on-space-action (fn this.onChange this.defaultOption)}}
                 >
-                  {{option.label}}
+                  <span class="pix-select-option__text">{{option.label}}</span>
 
-                  {{#if (eq option.value @value)}}
-                    <FaIcon @icon="check" role="presentation" />
-                  {{/if}}
+                  <FaIcon @icon="check" role="presentation" />
                 </li>
               {{/each}}
             {{/if}}

--- a/addon/components/pix-select.js
+++ b/addon/components/pix-select.js
@@ -25,23 +25,7 @@ export default class PixSelect extends Component {
     });
     this.displayCategory = categories.length > 0;
 
-    if (!this.args.isComputeWidthDisabled) {
-      this.elementHelper.waitForElement(this.selectId).then((elementList) => {
-        const baseFontRemRatio = Number(
-          getComputedStyle(document.querySelector('html')).fontSize.match(/\d+(\.\d+)?/)[0],
-        );
-        const checkIconWidth = 1.125 * baseFontRemRatio;
-        const listWidth = elementList.getBoundingClientRect().width;
-        const selectWidth = (listWidth + checkIconWidth) / baseFontRemRatio;
-
-        const className = `sizing-select-${this.selectId}`;
-        this.elementHelper.createClass(`.${className}`, `width: ${selectWidth}rem;`);
-
-        const element = document.getElementById(`container-${this.selectId}`);
-
-        element.className = element.className + ' ' + className;
-      });
-    }
+    this._setSelectWidth();
   }
 
   get displayDefaultOption() {
@@ -162,6 +146,27 @@ export default class PixSelect extends Component {
       } else if (this.displayDefaultOption) {
         document.querySelector("[aria-selected='true']").focus();
       }
+    }
+  }
+
+  _setSelectWidth() {
+    if (!this.args.isComputeWidthDisabled) {
+      this.elementHelper.waitForElement(this.selectId).then(() => {
+        const baseFontRemRatio = Number(
+          getComputedStyle(document.querySelector('html')).fontSize.match(/\d+(\.\d+)?/)[0],
+        );
+
+        const listWidth = document
+          .getElementById(this.listId)
+          .parentNode.getBoundingClientRect().width;
+        const selectWidth = listWidth / baseFontRemRatio;
+
+        const className = `sizing-select-${this.selectId}`;
+        this.elementHelper.createClass(`.${className}`, `max-width: ${selectWidth}rem;`);
+
+        const element = document.getElementById(`container-${this.selectId}`);
+        element.className = element.className + ' ' + className;
+      });
     }
   }
 }

--- a/addon/styles/_pix-select.scss
+++ b/addon/styles/_pix-select.scss
@@ -3,6 +3,7 @@
   display: inline-flex;
   flex-direction: column;
   gap: var(--pix-spacing-1x);
+  width: 100%;
 
   &--inline {
     flex-direction: row;
@@ -10,76 +11,14 @@
     align-items: center;
   }
 
-  &__dropdown {
-    @extend %pix-shadow-sm;
-
-    position: absolute;
-    z-index: 200;
-    width: 100%;
-    min-width: fit-content;
-    max-height: 12.5rem;
-    margin-top: var(--pix-spacing-1x);
-    padding: 0;
-    overflow-y: auto;
-    white-space: nowrap;
-    list-style-type: none;
-    background-color: var(--pix-neutral-0);
-    border-top: none;
-    border-radius: 0 0 var(--pix-spacing-1x) var(--pix-spacing-1x);
-    transition: all 0.1s ease-in-out;
-
-    &::-webkit-scrollbar {
-      width: 0.5rem;
+  &--with-icon {
+    .pix-select-button {
+      padding-inline-start: var(--pix-spacing-8x);
     }
 
-    &::-webkit-scrollbar-track {
-      background: var(--pix-neutral-20);
-      border: 1px solid var(--pix-neutral-20);
-      border-radius: var(--pix-spacing-1x);
+    .pix-select-option__text {
+      margin-right: 14px;
     }
-
-    &::-webkit-scrollbar-thumb {
-      width: 0.375rem;
-      background: var(--pix-neutral-100);
-      border-radius: var(--pix-spacing-1x);
-    }
-
-    &::-webkit-scrollbar-thumb:hover {
-      background: var(--pix-neutral-100);
-    }
-
-    &--closed {
-      visibility: hidden;
-      opacity: 0;
-    }
-  }
-
-  &__empty-search-message {
-    @extend %pix-body-s;
-
-    color: var(--pix-neutral-800);
-    text-align: center;
-  }
-
-  &__search {
-    display: flex;
-    margin: var(--pix-spacing-4x) var(--pix-spacing-6x);
-    color: var(--pix-neutral-100);
-    border-bottom: 2px solid var(--pix-neutral-100);
-    border-radius: var(--pix-spacing-1x) var(--pix-spacing-1x) 0 0;
-
-    &:focus-within {
-      background: var(--pix-neutral-20);
-      border-bottom: 2px solid var(--pix-primary-500);
-    }
-  }
-
-  &__options {
-    border-top: 1px solid var(--pix-neutral-20);
-  }
-
-  &__error-message {
-    @extend %pix-input-error-message;
   }
 }
 
@@ -93,7 +32,8 @@
   align-items: center;
   justify-content: space-between;
   width: 100%;
-  padding: var(--pix-spacing-2x) var(--pix-spacing-3x);
+  padding-block: var(--pix-spacing-2x);
+  padding-inline: var(--pix-spacing-3x) var(--pix-spacing-8x);
   color: var(--pix-neutral-900);
   background-color: var(--pix-neutral-0);
   border: 1px var(--pix-neutral-500) solid;
@@ -105,26 +45,85 @@
   }
 
   &__text {
+    flex-grow: 1;
     overflow: hidden;
     white-space: nowrap;
+    text-align: left;
     text-overflow: ellipsis;
   }
 
-  &__dropdown-icon {
-    @extend %pix-body-s;
-
+  &__icon {
+    position: absolute;
+    top: 50%;
     color: var(--pix-neutral-900);
+    transform: translateY(-50%);
     pointer-events: none;
+
+    &--prefix {
+      left: var(--pix-spacing-3x);
+    }
+
+    &--arrow {
+      right: var(--pix-spacing-3x);
+    }
   }
 }
 
-.pix-select-options__category {
-  margin: 0;
+.pix-select__dropdown {
+  @extend %pix-shadow-sm;
+
+  position: absolute;
+  z-index: 200;
+  max-width: 100%;
+  max-height: 12.5rem;
+  margin-top: var(--pix-spacing-1x);
   padding: 0;
-  list-style: none;
+  overflow-y: auto;
+  white-space: nowrap;
+  list-style-type: none;
+  background-color: var(--pix-neutral-0);
+  border-top: none;
+  border-radius: 0 0 var(--pix-spacing-1x) var(--pix-spacing-1x);
+  visibility: hidden;
+  opacity: 0;
+  transition: all 0.1s ease-in-out;
+
+  &--expanded {
+    visibility: visible;
+    opacity: 1;
+  }
+
+  &::-webkit-scrollbar {
+    width: 0.5rem;
+  }
+
+  &::-webkit-scrollbar-track {
+    background: var(--pix-neutral-20);
+    border: 1px solid var(--pix-neutral-20);
+    border-radius: var(--pix-spacing-1x);
+  }
+
+  &::-webkit-scrollbar-thumb {
+    width: 0.375rem;
+    background: var(--pix-neutral-100);
+    border-radius: var(--pix-spacing-1x);
+  }
+
+  &::-webkit-scrollbar-thumb:hover {
+    background: var(--pix-neutral-100);
+  }
+}
+
+.pix-select__options {
+  width: 100%;
+  border-top: 1px solid var(--pix-neutral-20);
 }
 
 .pix-select-options-category {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+
   &__name {
     @extend %pix-body-s;
 
@@ -136,10 +135,9 @@
   &__option {
     @extend %pix-body-s;
 
-    display: flex;
-    gap: var(--pix-spacing-6x);
-    justify-content: space-between;
-    padding: var(--pix-spacing-2x) var(--pix-spacing-6x);
+    position: relative;
+    padding-block: var(--pix-spacing-2x);
+    padding-inline: var(--pix-spacing-6x) var(--pix-spacing-10x);
     color: var(--pix-neutral-900);
 
     &:hover,
@@ -150,7 +148,11 @@
     }
 
     svg {
+      position: absolute;
+      top: 50%;
+      right: var(--pix-spacing-2x);
       font-size: 1.125rem;
+      transform: translateY(-50%);
       visibility: hidden;
       opacity: 0;
     }
@@ -170,7 +172,28 @@
       padding-top: 0;
       padding-bottom: 0;
       visibility: hidden;
+      opacity: 0;
     }
+  }
+}
+
+.pix-select-option__text {
+  display: block;
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+}
+
+.pix-select__search {
+  display: flex;
+  margin: var(--pix-spacing-4x) var(--pix-spacing-6x);
+  color: var(--pix-neutral-100);
+  border-bottom: 2px solid var(--pix-neutral-100);
+  border-radius: var(--pix-spacing-1x) var(--pix-spacing-1x) 0 0;
+
+  &:focus-within {
+    background: var(--pix-neutral-20);
+    border-bottom: 2px solid var(--pix-primary-500);
   }
 }
 
@@ -192,4 +215,15 @@
   &__icon {
     margin: auto var(--pix-spacing-1x);
   }
+}
+
+.pix-select__empty-search-message {
+  @extend %pix-body-s;
+
+  color: var(--pix-neutral-800);
+  text-align: center;
+}
+
+.pix-select__error-message {
+  @extend %pix-input-error-message;
 }

--- a/app/stories/pix-select.mdx
+++ b/app/stories/pix-select.mdx
@@ -10,46 +10,46 @@ Affiche un menu déroulant avec la liste des options fournies.
 Les options sont représentées par un tableau d'objet contenant les propriétés value et label.
 
 > **⚠️** **Il est nécessaire d'avoir au moins un label ou un placeholder !**
-
+>
 > **⚠️** **N'oubliez pas de rajouter un searchLabel dans le cas ou le menu déroulant est cherchable pour le rendre accessible !**
-
+>
 > Pour aider l'utilisateur, rajoutez un placeholder cohérent !
-
+>
 > **⚠️** Pour un champ de filtre sur des résultats qui ne s'affichent pas dans une liste déroulante, utilisez plutôt le [PixSearchInput](?path=/story/others-searchinput--default).
 
 ## Default
 
-<Story of={ComponentStories.Default} height={200} />
+<Story of={ComponentStories.Default} height={320} />
 
 ## WithId
 
-<Story of={ComponentStories.WithId} height={200} />
+<Story of={ComponentStories.WithId} height={320} />
 
 ## WithCustomClass
 
-<Story of={ComponentStories.WithCustomClass} height={200} />
+<Story of={ComponentStories.WithCustomClass} height={320} />
 
 ## WithCategories
 
-<Story of={ComponentStories.WithCategories} height={200} />
+<Story of={ComponentStories.WithCategories} height={320} />
 
 ## WithSearch
 
-<Story of={ComponentStories.WithSearch} height={200} />
+<Story of={ComponentStories.WithSearch} height={320} />
 
 ## WithCategoriesAndSearch
 
-<Story of={ComponentStories.WithCategoriesAndSearch} height={200} />
+<Story of={ComponentStories.WithCategoriesAndSearch} height={320} />
 
 ## WithDropDownAtTheTop
 
 Ici nous avons forcé le placement de la dropdown en haut du select mais sachez que ce placement se fait automatiquement par défaut.
 
-<Story of={ComponentStories.WithDropDownAtTheTop} />
+<Story of={ComponentStories.WithDropDownAtTheTop} height={320} />
 
 ## WithIcon
 
-<Story of={ComponentStories.WithIcon} />
+<Story of={ComponentStories.WithIcon} height={200} />
 
 ## Usage
 

--- a/app/stories/pix-select.mdx
+++ b/app/stories/pix-select.mdx
@@ -21,6 +21,15 @@ Les options sont représentées par un tableau d'objet contenant les propriété
 
 <Story of={ComponentStories.Default} height={320} />
 
+### Variations graphiques du composant
+
+Le PixSelect a une largeur fixée par la taille de l'option la plus longue.
+
+<br />
+Il est tronqué si le conteneur n'est pas capable d'en afficher la totalité.
+
+<Story of={ComponentStories.ExtraLongPlaceholder} height={320} />
+
 ## WithCategories
 
 <Story of={ComponentStories.WithCategories} height={320} />

--- a/app/stories/pix-select.mdx
+++ b/app/stories/pix-select.mdx
@@ -21,14 +21,6 @@ Les options sont représentées par un tableau d'objet contenant les propriété
 
 <Story of={ComponentStories.Default} height={320} />
 
-## WithId
-
-<Story of={ComponentStories.WithId} height={320} />
-
-## WithCustomClass
-
-<Story of={ComponentStories.WithCustomClass} height={320} />
-
 ## WithCategories
 
 <Story of={ComponentStories.WithCategories} height={320} />

--- a/app/stories/pix-select.stories.js
+++ b/app/stories/pix-select.stories.js
@@ -297,6 +297,27 @@ Default.args = {
   onChange: action('onChange'),
 };
 
+export const ExtraLongPlaceholder = Template.bind({});
+ExtraLongPlaceholder.args = {
+  options: [
+    { value: '1', label: 'Figues' },
+    { value: '3', label: 'Fraises' },
+    { value: '2', label: 'Bananes' },
+    { value: '4', label: 'Mangues' },
+    { value: '5', label: 'Kaki' },
+    {
+      value: '6',
+      label: 'Asiminier trilobé oblong vert (à ne pas confondre avec la papaye)',
+    },
+  ],
+  label: 'Mon label',
+  placeholder:
+    '- This is a very super long placeholder - lorem ipsum dolor sit amet, consectetur adipiscing elit. Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas -',
+  isSearchable: false,
+  hideDefaultOption: false,
+  onChange: action('onChange'),
+};
+
 export const WithCategories = Template.bind({});
 WithCategories.args = {
   options: [

--- a/app/stories/pix-select.stories.js
+++ b/app/stories/pix-select.stories.js
@@ -211,6 +211,9 @@ export default {
       control: { type: 'boolean' },
     },
   },
+  parameters: {
+    layout: 'padded',
+  },
 };
 
 const Template = (args) => {
@@ -250,7 +253,7 @@ const Template = (args) => {
 const TemplatePopover = (args) => {
   return {
     template: hbs`{{! template-lint-disable no-inline-styles }}
-<div style='display:flex;height:330px'>
+<div style='display:flex;height:260px'>
   <div style='align-self:flex-end'>
     {{#if this.id}}
       <div>

--- a/app/stories/pix-select.stories.js
+++ b/app/stories/pix-select.stories.js
@@ -218,12 +218,7 @@ export default {
 
 const Template = (args) => {
   return {
-    template: hbs`{{#if this.id}}
-  <div>
-    <label for={{this.id}}>Un label en dehors du composant</label>
-  </div>
-{{/if}}
-<PixSelect
+    template: hbs`<PixSelect
   @id={{this.id}}
   @className={{this.className}}
   @options={{this.options}}
@@ -255,11 +250,6 @@ const TemplatePopover = (args) => {
     template: hbs`{{! template-lint-disable no-inline-styles }}
 <div style='display:flex;height:260px'>
   <div style='align-self:flex-end'>
-    {{#if this.id}}
-      <div>
-        <label for={{this.id}}>Un label en dehors du composant</label>
-      </div>
-    {{/if}}
     <PixSelect
       @id={{this.id}}
       @className={{this.className}}
@@ -285,46 +275,6 @@ const TemplatePopover = (args) => {
 </div>`,
     context: args,
   };
-};
-
-export const WithId = Template.bind({});
-WithId.args = {
-  id: 'custom',
-  options: [
-    { value: '1', label: 'Figues' },
-    { value: '3', label: 'Fraises' },
-    { value: '2', label: 'Bananes' },
-    { value: '4', label: 'Mangues' },
-    { value: '5', label: 'Kaki' },
-    {
-      value: '6',
-      label: 'Asiminier trilobé oblong vert (à ne pas confondre avec la papaye)',
-    },
-  ],
-  placeholder: 'Mon innerText',
-  isSearchable: false,
-  onChange: action('onChange'),
-};
-
-export const WithCustomClass = Template.bind({});
-WithCustomClass.args = {
-  className: 'custom',
-  options: [
-    { value: '1', label: 'Figues' },
-    { value: '3', label: 'Fraises' },
-    { value: '2', label: 'Bananes' },
-    { value: '4', label: 'Mangues' },
-    { value: '5', label: 'Kaki' },
-    {
-      value: '6',
-      label: 'Asiminier trilobé oblong vert (à ne pas confondre avec la papaye)',
-    },
-  ],
-  label: 'Mon label',
-  placeholder: 'Mon innerText',
-  subLabel: 'Mon sous label',
-  isSearchable: false,
-  onChange: action('onChange'),
 };
 
 export const Default = Template.bind({});

--- a/tests/dummy/app/controllers/select-page.js
+++ b/tests/dummy/app/controllers/select-page.js
@@ -1,0 +1,26 @@
+import Controller from '@ember/controller';
+import { tracked } from '@glimmer/tracking';
+import { action } from '@ember/object';
+
+export default class SelectPage extends Controller {
+  @tracked selectedOption = null;
+
+  @action
+  onChange(option) {
+    this.selectedOption = option;
+  }
+
+  get options() {
+    return [
+      { value: '1', label: 'Figues' },
+      { value: '3', label: 'Fraises' },
+      { value: '2', label: 'Bananes' },
+      { value: '4', label: 'Mangues' },
+      { value: '5', label: 'Kaki' },
+      {
+        value: '6',
+        label: 'Asiminier trilobé oblong vert (à ne pas confondre avec la papaye)',
+      },
+    ];
+  }
+}

--- a/tests/dummy/app/router.js
+++ b/tests/dummy/app/router.js
@@ -11,4 +11,5 @@ Router.map(function () {
   this.route('bye', { path: '/bye/:id' });
   this.route('modal-page', { path: '/modal' });
   this.route('sidebar-page', { path: '/sidebar' });
+  this.route('select-page', { path: '/select' });
 });

--- a/tests/dummy/app/templates/select-page.hbs
+++ b/tests/dummy/app/templates/select-page.hbs
@@ -1,0 +1,12 @@
+<h1>PixSelect</h1>
+
+<PixSelect
+  @options={{this.options}}
+  @onChange={{this.onChange}}
+  @value={{this.selectedOption}}
+  @hideDefaultOption={{true}}
+  @placeholder="Select an option"
+  @isSearchable={{true}}
+>
+  <:label>Label</:label>
+</PixSelect>

--- a/tests/integration/components/pix-select-test.js
+++ b/tests/integration/components/pix-select-test.js
@@ -95,8 +95,12 @@ module('Integration | Component | PixSelect', function (hooks) {
       await screen.findByRole('listbox');
 
       // then
-      assert.strictEqual(screen.queryByText(this.placeholder, { selector: 'li' }).tabIndex, -1);
+      assert.strictEqual(
+        screen.queryByRole('listbox').querySelector('li:first-child').tabIndex,
+        -1,
+      );
       assert.strictEqual(screen.queryByRole('option', { name: this.placeholder }), null);
+      assert.strictEqual(screen.queryAllByRole('option').length, 3);
     });
   });
 
@@ -284,7 +288,7 @@ module('Integration | Component | PixSelect', function (hooks) {
 
         await screen.findByRole('listbox');
 
-        await screen.getByText('Tomate').focus();
+        await screen.getByText('Tomate').parentNode.focus();
 
         await userEvent.keyboard('[Enter]');
 
@@ -310,7 +314,7 @@ module('Integration | Component | PixSelect', function (hooks) {
 
         await screen.findByRole('listbox');
 
-        await screen.getByText('Tomate').focus();
+        await screen.getByText('Tomate').parentNode.focus();
 
         await click(screen.getByRole('button', { name: 'Focus me' }));
 
@@ -335,7 +339,7 @@ module('Integration | Component | PixSelect', function (hooks) {
 
         await screen.findByRole('listbox');
 
-        await screen.getByText('Tomate').focus();
+        await screen.getByText('Tomate').parentNode.focus();
 
         await userEvent.keyboard('[Space]');
 


### PR DESCRIPTION
## :christmas_tree: Problème

À l'heure actuelle, le select ne voit plus sa largeur s'adapter à la taille de l'option la plus longue.

## :gift: Proposition

Réparer le script permettant d'obtenir cette largeur spécifique à partir de la longueur du menu déroulant.

## :star2: Remarques

- La largeur du select ne doit pas faire plus que 100% de la largeur disponible. Auquel cas, un ellipsis gère le surplus de texte (dans l'input et dans les options).
- Le premier commit, technique, permet d'avoir un affichage ellipsis fonctionnel dans les previews storybook ([cassée à cause de leur utilisation d'un conteneur en flex](https://www.bigbinary.com/blog/understanding-the-automatic-minimum-size-of-flex-items#the-solutions))
- Seul le composant Select est pour l'instant impacté

## :santa: Pour tester

- Vérifier sur [Storybook en RA](https://ui-pr666.review.pix.fr/?path=/docs/form-select--docs) (dans l'inspecteur, faire varier la longueur du texte affiché dans l'input)

**Des environnements de tests reliés à cette branche ont été créés :**
- [PixApp](https://app-pr9225.review.pix.fr/challenges/rechUXZhn1FiLU28x/preview) (exemple d'une épreuve avec des selects ici, mais possibilité de modifier la langue de l'utilisateur aussi)
- [PixOrga](https://orga-pr9225.review.pix.fr/connexion) (notamment la selection des profils cible lors de la création d'une campagne/filtres/pagination)
- [PixAdmin](https://admin-pr9225.review.pix.fr/organizations/list) (par exemple dans la création de profil cible)

(ces 3 apps devraient couvrir les différents usages)
