### PR TITLE
[FEATURE] Ajouter des états succès/erreur au Checkbox `tile` (PIX-12834)

### DIFF
--- a/addon/components/pix-checkbox.hbs
+++ b/addon/components/pix-checkbox.hbs
@@ -17,6 +17,7 @@
         class={{this.inputClasses}}
         checked={{@checked}}
         aria-disabled={{this.isDisabled}}
+        aria-describedby={{this.stateId}}
         {{on "click" this.avoidCheckedStateChangeIfIsDisabled}}
         ...attributes
       />
@@ -25,4 +26,12 @@
       {{yield to="label"}}
     </:default>
   </PixLabelWrapped>
+
+  <span class="screen-reader-only" id={{this.stateId}}>
+    {{#if this.hasSuccessState}}
+      {{this.stateSuccessMessage}}
+    {{else if this.hasErrorState}}
+      {{this.stateErrorMessage}}
+    {{/if}}
+  </span>
 </div>

--- a/addon/components/pix-checkbox.hbs
+++ b/addon/components/pix-checkbox.hbs
@@ -8,6 +8,7 @@
     @screenReaderOnly={{@screenReaderOnly}}
     @isDisabled={{this.isDisabled}}
     @variant={{@variant}}
+    @state={{@state}}
   >
     <:inputElement>
       <input

--- a/addon/components/pix-checkbox.js
+++ b/addon/components/pix-checkbox.js
@@ -19,6 +19,14 @@ export default class PixCheckbox extends Component {
       classes.push(`${classes[0]}--indeterminate`);
     }
 
+    if (this.args.state === 'success') {
+      classes.push(`${classes[0]}--state-success`);
+    }
+
+    if (this.args.state === 'error') {
+      classes.push(`${classes[0]}--state-error`);
+    }
+
     return classes.join(' ');
   }
 

--- a/addon/components/pix-checkbox.js
+++ b/addon/components/pix-checkbox.js
@@ -32,12 +32,8 @@ export default class PixCheckbox extends Component {
       classes.push(`${classes[0]}--indeterminate`);
     }
 
-    if (this.hasSuccessState) {
-      classes.push(`${classes[0]}--state-success`);
-    }
-
-    if (this.hasErrorState) {
-      classes.push(`${classes[0]}--state-error`);
+    if (this.hasSuccessState || this.hasErrorState) {
+      classes.push(`${classes[0]}--state`);
     }
 
     return classes.join(' ');

--- a/addon/components/pix-checkbox.js
+++ b/addon/components/pix-checkbox.js
@@ -2,6 +2,7 @@ import Component from '@glimmer/component';
 import { guidFor } from '@ember/object/internals';
 import { action } from '@ember/object';
 import { warn } from '@ember/debug';
+import { formatMessage } from '../translations';
 
 export default class PixCheckbox extends Component {
   constructor() {
@@ -12,6 +13,18 @@ export default class PixCheckbox extends Component {
     return this.args.id || guidFor(this);
   }
 
+  get stateId() {
+    return `${this.id}-state`;
+  }
+
+  get hasSuccessState() {
+    return this.args.state === 'success';
+  }
+
+  get hasErrorState() {
+    return this.args.state === 'error';
+  }
+
   get inputClasses() {
     const classes = ['pix-checkbox__input'];
 
@@ -19,11 +32,11 @@ export default class PixCheckbox extends Component {
       classes.push(`${classes[0]}--indeterminate`);
     }
 
-    if (this.args.state === 'success') {
+    if (this.hasSuccessState) {
       classes.push(`${classes[0]}--state-success`);
     }
 
-    if (this.args.state === 'error') {
+    if (this.hasErrorState) {
       classes.push(`${classes[0]}--state-error`);
     }
 
@@ -47,5 +60,17 @@ export default class PixCheckbox extends Component {
     if (this.args.isDisabled) {
       event.preventDefault();
     }
+  }
+
+  get stateSuccessMessage() {
+    return this.formatMessage('state.success');
+  }
+
+  get stateErrorMessage() {
+    return this.formatMessage('state.error');
+  }
+
+  formatMessage(message) {
+    return formatMessage('fr', `input.${message}`);
   }
 }

--- a/addon/components/pix-label-wrapped.hbs
+++ b/addon/components/pix-label-wrapped.hbs
@@ -1,4 +1,11 @@
 <label for={{@for}} class={{this.className}} ...attributes>
+  {{#if this.hasError}}
+    <FaIcon @icon="circle-xmark" />
+  {{/if}}
+  {{#if this.hasSuccess}}
+    <FaIcon @icon="circle-check" />
+  {{/if}}
+
   {{yield to="inputElement"}}
 
   <span class="{{if @screenReaderOnly 'screen-reader-only'}}">

--- a/addon/components/pix-label-wrapped.js
+++ b/addon/components/pix-label-wrapped.js
@@ -7,6 +7,8 @@ export default class PixLabelWrapped extends Component {
     if (this.args.inlineLabel) classes.push('pix-label--inline-label');
     if (this.args.isDisabled) classes.push('pix-label-wrapped--disabled');
     if (this.args.variant === 'tile') classes.push('pix-label-wrapped--variant-tile');
+    if (this.args.state === 'success') classes.push('pix-label-wrapped--state-success');
+    if (this.args.state === 'error') classes.push('pix-label-wrapped--state-error');
 
     const size = ['small', 'large'].includes(this.args.size) ? this.args.size : 'default';
 

--- a/addon/components/pix-label-wrapped.js
+++ b/addon/components/pix-label-wrapped.js
@@ -16,4 +16,12 @@ export default class PixLabelWrapped extends Component {
 
     return classes.join(' ');
   }
+
+  get hasError() {
+    return this.args.state === 'error';
+  }
+
+  get hasSuccess() {
+    return this.args.state === 'success';
+  }
 }

--- a/addon/styles/_pix-checkbox.scss
+++ b/addon/styles/_pix-checkbox.scss
@@ -115,24 +115,9 @@
         display: none;
       }
 
-      &.pix-checkbox__input--state-success {
-        background: var(--pix-success-700);
-        border-color: var(--pix-success-700);
-        border-radius: 50%;
-
-        &::after {
-          background-image: url("data:image/svg+xml,%3Csvg width='8' height='8' viewBox='0 0 13 10' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M1.5 3L0 4.5L5 9.5L13 1.5L11.5 0L5 6.5L1.5 3Z' fill='white'/%3E%3C/svg%3E%0A");
-        }
-      }
-
-      &.pix-checkbox__input--state-error {
-        background: var(--pix-error-700);
-        border-color: var(--pix-error-700);
-        border-radius: 50%;
-
-        &::after {
-          background-image: url("data:image/svg+xml,%3Csvg width='8' height='8' viewBox='0 0 384 512' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M342.6 150.6c12.5-12.5 12.5-32.8 0-45.3s-32.8-12.5-45.3 0L192 210.7 86.6 105.4c-12.5-12.5-32.8-12.5-45.3 0s-12.5 32.8 0 45.3L146.7 256 41.4 361.4c-12.5 12.5-12.5 32.8 0 45.3s32.8 12.5 45.3 0L192 301.3 297.4 406.6c12.5 12.5 32.8 12.5 45.3 0s12.5-32.8 0-45.3L237.3 256 342.6 150.6z' fill='white'/%3E%3C/svg%3E%0A");
-        }
+      &.pix-checkbox__input--state {
+        position: absolute;
+        visibility: hidden;
       }
     }
   }

--- a/addon/styles/_pix-checkbox.scss
+++ b/addon/styles/_pix-checkbox.scss
@@ -114,6 +114,26 @@
       &::before {
         display: none;
       }
+
+      &.pix-checkbox__input--state-success {
+        background: var(--pix-success-700);
+        border-color: var(--pix-success-700);
+        border-radius: 50%;
+
+        &::after {
+          background-image: url("data:image/svg+xml,%3Csvg width='8' height='8' viewBox='0 0 13 10' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M1.5 3L0 4.5L5 9.5L13 1.5L11.5 0L5 6.5L1.5 3Z' fill='white'/%3E%3C/svg%3E%0A");
+        }
+      }
+
+      &.pix-checkbox__input--state-error {
+        background: var(--pix-error-700);
+        border-color: var(--pix-error-700);
+        border-radius: 50%;
+
+        &::after {
+          background-image: url("data:image/svg+xml,%3Csvg width='8' height='8' viewBox='0 0 384 512' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M342.6 150.6c12.5-12.5 12.5-32.8 0-45.3s-32.8-12.5-45.3 0L192 210.7 86.6 105.4c-12.5-12.5-32.8-12.5-45.3 0s-12.5 32.8 0 45.3L146.7 256 41.4 361.4c-12.5 12.5-12.5 32.8 0 45.3s32.8 12.5 45.3 0L192 301.3 297.4 406.6c12.5 12.5 32.8 12.5 45.3 0s12.5-32.8 0-45.3L237.3 256 342.6 150.6z' fill='white'/%3E%3C/svg%3E%0A");
+        }
+      }
     }
   }
 }

--- a/addon/styles/_pix-label-wrapped.scss
+++ b/addon/styles/_pix-label-wrapped.scss
@@ -24,12 +24,29 @@
 
     &.pix-label-wrapped {
       &--disabled {
-        background: var(--pix-neutral-20);
-        border-color: var(--pix-neutral-100);
+        --state-background-color: var(--pix-neutral-20);
+        --state-border-color: var(--pix-neutral-100);
+
+        &.pix-label-wrapped--state-success {
+          --state-background-color: var(--pix-neutral-0);
+          --state-border-color: var(--pix-success-300);
+
+          color: var(--pix-success-700);
+        }
+
+        &.pix-label-wrapped--state-error {
+          --state-background-color: var(--pix-neutral-0);
+          --state-border-color: var(--pix-error-500);
+
+          color: var(--pix-error-700);
+        }
+
+        background: var(--state-background-color);
+        border-color: var(--state-border-color);
 
         &:hover,
         &:active {
-          background: var(--pix-neutral-20);
+          background: var(--state-background-color);
         }
       }
     }

--- a/addon/translations/fr.js
+++ b/addon/translations/fr.js
@@ -1,4 +1,10 @@
 export default {
+  input: {
+    state: {
+      success: 'Sélection correcte',
+      error: 'Sélection incorrecte',
+    },
+  },
   pagination: {
     beforeResultsPerPage: 'Voir',
     selectPageSizeLabel: "Nombre d'élément à afficher par page",

--- a/app/stories/pix-checkbox-variant-tile.mdx
+++ b/app/stories/pix-checkbox-variant-tile.mdx
@@ -23,6 +23,13 @@ Un cursor `not-allowed` est défini sur la checkbox et son label lorsqu'elle est
 <Story of={ComponentStories.checkedIsDisabledVariantTile} height={120} />
 <Story of={ComponentStories.isIndeterminateIsDisabledVariantTile} height={120} />
 
+#### Succès/Erreur
+
+Un champ de statut permet de préciser une coloration particulière en cas de "succès" ou d'"erreur".
+
+<Story of={ComponentStories.isDisabledIsSuccessVariantTile} height={120} />
+<Story of={ComponentStories.isDisabledIsErrorVariantTile} height={120} />
+
 ## Usage
 
 ```html

--- a/app/stories/pix-checkbox-variant-tile.stories.js
+++ b/app/stories/pix-checkbox-variant-tile.stories.js
@@ -11,6 +11,16 @@ export default {
       control: { type: 'select' },
       type: { required: true },
     },
+    state: {
+      name: 'state',
+      description: 'Si `isDisabled` permet de marquer la checkbox comme correcte ou incorrecte',
+      options: ['neutral', 'success', 'error'],
+      control: { type: 'select' },
+      table: {
+        type: { summary: 'string' },
+        defaultValue: { summary: 'neutral' },
+      },
+    },
     ...pixCheckboxStories.argTypes,
   },
 };
@@ -26,6 +36,7 @@ const VariantTileTemplate = (args) => {
     @checked={{this.checked}}
     @isDisabled={{this.isDisabled}}
     @variant={{this.variant}}
+    @state={{this.state}}
   >
     <:label>{{this.label}}</:label>
   </PixCheckbox></div>`,
@@ -45,6 +56,7 @@ isDisabledVariantTile.args = {
   id: 'accept-newsletter-2',
   label: 'Recevoir la newsletter',
   variant: 'tile',
+  state: 'neutral',
   isDisabled: true,
 };
 
@@ -53,6 +65,7 @@ checkedIsDisabledVariantTile.args = {
   id: 'accept-newsletter-2',
   label: 'Recevoir la newsletter',
   variant: 'tile',
+  state: 'neutral',
   isDisabled: true,
   checked: true,
 };
@@ -62,7 +75,28 @@ isIndeterminateIsDisabledVariantTile.args = {
   id: 'accept-newsletter-2',
   label: 'Recevoir la newsletter',
   variant: 'tile',
+  state: 'neutral',
   isDisabled: true,
   checked: true,
   isIndeterminate: true,
+};
+
+export const isDisabledIsSuccessVariantTile = VariantTileTemplate.bind({});
+isDisabledIsSuccessVariantTile.args = {
+  id: 'accept-newsletter-2',
+  label: 'Recevoir la newsletter',
+  variant: 'tile',
+  isDisabled: true,
+  checked: true,
+  state: 'success',
+};
+
+export const isDisabledIsErrorVariantTile = VariantTileTemplate.bind({});
+isDisabledIsErrorVariantTile.args = {
+  id: 'accept-newsletter-2',
+  label: 'Recevoir la newsletter',
+  variant: 'tile',
+  isDisabled: true,
+  checked: true,
+  state: 'error',
 };

--- a/app/stories/pix-checkbox.stories.js
+++ b/app/stories/pix-checkbox.stories.js
@@ -42,7 +42,6 @@ export default {
         defaultValue: { summary: false },
       },
     },
-
     label: {
       name: 'label',
       description: 'Le label du champ',

--- a/config/icons.js
+++ b/config/icons.js
@@ -10,6 +10,7 @@ module.exports = () => ({
     'circle-exclamation',
     'circle-info',
     'circle-question',
+    'circle-xmark',
     'earth-europe',
     'eye',
     'eye-slash',

--- a/tests/integration/components/pix-checkbox-test.js
+++ b/tests/integration/components/pix-checkbox-test.js
@@ -116,6 +116,7 @@ module('Integration | Component | checkbox', function (hooks) {
         .dom(
           screen.getByRole('checkbox', {
             description: 'Sélection correcte',
+            hidden: true,
           }),
         )
         .exists();
@@ -135,6 +136,7 @@ module('Integration | Component | checkbox', function (hooks) {
         .dom(
           screen.getByRole('checkbox', {
             description: 'Sélection incorrecte',
+            hidden: true,
           }),
         )
         .exists();

--- a/tests/integration/components/pix-checkbox-test.js
+++ b/tests/integration/components/pix-checkbox-test.js
@@ -102,6 +102,44 @@ module('Integration | Component | checkbox', function (hooks) {
       assert.true(checkbox.checked, "Checkbox has changed state, but shouldn't have");
     });
 
+    test(`it should read success state info if given`, async function (assert) {
+      // given
+      this.set('isDisabled', true);
+
+      // when
+      const screen = await render(
+        hbs`<PixCheckbox checked @isDisabled={{this.isDisabled}} @state='success'><:label>Recevoir la newsletter</:label></PixCheckbox>`,
+      );
+
+      // then
+      assert
+        .dom(
+          screen.getByRole('checkbox', {
+            description: 'Sélection correcte',
+          }),
+        )
+        .exists();
+    });
+
+    test(`it should read error state info if given`, async function (assert) {
+      // given
+      this.set('isDisabled', true);
+
+      // when
+      const screen = await render(
+        hbs`<PixCheckbox checked @isDisabled={{this.isDisabled}} @state='error'><:label>Recevoir la newsletter</:label></PixCheckbox>`,
+      );
+
+      // then
+      assert
+        .dom(
+          screen.getByRole('checkbox', {
+            description: 'Sélection incorrecte',
+          }),
+        )
+        .exists();
+    });
+
     ['true', 'false', 'null', 'undefined'].forEach(function (testCase) {
       test(`it should not be possible to interact when @isDisabled="${testCase}"`, async function (assert) {
         // given


### PR DESCRIPTION
## :christmas_tree: Problème
Dans la variante `tile`, on souhaite avoir un design particulier si une checkbox/radio cochée et `isDisabled` est en succès ou en erreur.

## :gift: Proposition
Ajouter un paramètre `state` qui prend les valeurs suivantes : `neutral` (défaut), `success`, `error`.

Maquettes : https://www.figma.com/design/47MuKB1wXoLEgMal06idN3/R%26D-DevComp?node-id=3835-4921&m=dev

## :star2: Remarques
RAS

## :santa: Pour tester
Vérifier les nouvelles stories et les différents états mélangés.