### PR TITLE
[TECH] Ajouter le paquet "ember-modifier" manquant

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -59,6 +59,7 @@
         "ember-disable-prototype-extensions": "^1.1.3",
         "ember-export-application-global": "^2.0.1",
         "ember-load-initializers": "^2.1.2",
+        "ember-modifier": "^4.1.0",
         "ember-page-title": "^8.0.0",
         "ember-qunit": "^8.0.0",
         "ember-resolver": "^11.0.0",
@@ -22645,7 +22646,6 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/ember-modifier/-/ember-modifier-4.1.0.tgz",
       "integrity": "sha512-YFCNpEYj6jdyy3EjslRb2ehNiDvaOrXTilR9+ngq+iUqSHYto2zKV0rleiA1XJQ27ELM1q8RihT29U6Lq5EyqQ==",
-      "license": "MIT",
       "dependencies": {
         "@embroider/addon-shim": "^1.8.4",
         "ember-cli-normalize-entity-name": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -96,6 +96,7 @@
     "ember-disable-prototype-extensions": "^1.1.3",
     "ember-export-application-global": "^2.0.1",
     "ember-load-initializers": "^2.1.2",
+    "ember-modifier": "^4.1.0",
     "ember-page-title": "^8.0.0",
     "ember-qunit": "^8.0.0",
     "ember-resolver": "^11.0.0",


### PR DESCRIPTION
## :christmas_tree: Problème

Le package "ember-modifier" est utilisé ([exemple](https://github.com/1024pix/pix-ui/blob/dev/app/modifiers/on-space-action.js#L1)) mais n'est plus présent dans le package-json.

## :gift: Proposition

Ajouter la dépendance NPM.

## :santa: Pour tester

- Lancer en local et tester quelques changements de code.
- Tout devrait fonctionner comme attendu
