### PR TITLE
[BUGFIX] Ajoute des icônes manquantes `magnifying-glass` et `arrow-left`

### DIFF
--- a/app/stories/pix-button.stories.js
+++ b/app/stories/pix-button.stories.js
@@ -55,7 +55,7 @@ export default {
       description: `Nom de l'icône font-awesome à afficher **avant** le label`,
       type: { name: 'string', required: false },
       control: { type: 'select' },
-      options: ['trash-can', 'heart', 'magnifying-glass', 'plus', 'xmark'],
+      options: ['magnifying-glass', 'plus', 'xmark'],
       table: {
         type: { summary: 'string' },
         defaultValue: { summary: null },
@@ -66,7 +66,7 @@ export default {
       description: `Nom de l'icône font-awesome à afficher **après** le label`,
       type: { name: 'string', required: false },
       control: { type: 'select' },
-      options: ['trash-can', 'heart', 'magnifying-glass', 'plus', 'xmark'],
+      options: ['magnifying-glass', 'plus', 'xmark'],
       table: {
         type: { summary: 'string' },
         defaultValue: { summary: null },
@@ -231,7 +231,7 @@ export const icons = Template.bind({});
 icons.args = {
   ...Default.args,
   iconBefore: 'magnifying-glass',
-  iconAfter: 'heart',
+  iconAfter: 'plus',
 };
 
 export const disabled = Template.bind({});

--- a/app/stories/pix-icon-button.mdx
+++ b/app/stories/pix-icon-button.mdx
@@ -52,7 +52,7 @@ Bouton de fermeture
 ```html
 <PixIconButton
   @ariaLabel="L'action du bouton"
-  @icon="times"
+  @icon="xmark"
   @triggerAction="{{triggerAction}}"
   @withBackground="{{true}}"
 />
@@ -63,7 +63,7 @@ Bouton d'action
 ```html
 <PixIconButton
   @ariaLabel="L'action du bouton"
-  @icon="arrow-left"
+  @icon="arrow-right"
   @triggerAction="{{triggerAction}}"
   @size="small"
   @withBackground="{{true}}"

--- a/app/stories/pix-toggle.stories.js
+++ b/app/stories/pix-toggle.stories.js
@@ -90,8 +90,8 @@ const TemplateWithYields = (args) => {
   return {
     template: hbs`<PixToggle @toggled={{this.toggled}} @onChange={{this.onChange}}>
   <:label>{{this.label}}</:label>
-  <:on><FaIcon @icon='sun' /></:on>
-  <:off><FaIcon @icon='moon' /></:off>
+  <:on><FaIcon @icon='eye' /></:on>
+  <:off><FaIcon @icon='eye-slash' /></:off>
 </PixToggle>`,
     context: args,
   };

--- a/config/icons.js
+++ b/config/icons.js
@@ -12,6 +12,7 @@ module.exports = () => ({
     'earth-europe',
     'eye',
     'eye-slash',
+    'magnifying-glass',
     'plus',
     'triangle-exclamation',
     'up-right-from-square',

--- a/config/icons.js
+++ b/config/icons.js
@@ -1,5 +1,6 @@
 module.exports = () => ({
   'free-solid-svg-icons': [
+    'arrow-left',
     'arrow-right',
     'bullhorn',
     'check',


### PR DESCRIPTION
## :christmas_tree: Problème
Dans #663, 2 icônes ont été oubliées :
- la loupe `magnifying-glass` utilisée notamment par le `PixSearchInput`,
- la flèche gauche `arrow-left` utilisée dans `PixPagination`.

## :gift: Proposition
Ajouter les icônes manquantes.

## :star2: Remarques
Aussi, n'utiliser que des icônes disponibles de Pix UI dans Storybook.

## :santa: Pour tester
Vérifier la présence des icônes sur tous les composants.
La CI ne doit pas indiquer de warning lié.

