### PR TITLE
[BUGFIX] Réparer la largeur du Select (PIX-12845).

### DIFF
--- a/addon/components/pix-select.js
+++ b/addon/components/pix-select.js
@@ -26,20 +26,15 @@ export default class PixSelect extends Component {
     this.displayCategory = categories.length > 0;
 
     if (!this.args.isComputeWidthDisabled) {
-      this.elementHelper.waitForElement(this.selectId).then((elementList) => {
+      this.elementHelper.waitForElement(this.listId).then((elementList) => {
         const baseFontRemRatio = Number(
           getComputedStyle(document.querySelector('html')).fontSize.match(/\d+(\.\d+)?/)[0],
         );
-        const checkIconWidth = 1.125 * baseFontRemRatio;
         const listWidth = elementList.getBoundingClientRect().width;
-        const selectWidth = (listWidth + checkIconWidth) / baseFontRemRatio;
-
-        const className = `sizing-select-${this.selectId}`;
-        this.elementHelper.createClass(`.${className}`, `width: ${selectWidth}rem;`);
+        const selectWidth = listWidth / baseFontRemRatio;
 
         const element = document.getElementById(`container-${this.selectId}`);
-
-        element.className = element.className + ' ' + className;
+        element.style.setProperty('--pix-select-width', `${selectWidth}rem`);
       });
     }
   }

--- a/addon/styles/_pix-select.scss
+++ b/addon/styles/_pix-select.scss
@@ -3,6 +3,8 @@
   display: inline-flex;
   flex-direction: column;
   gap: var(--pix-spacing-1x);
+  width: var(--pix-select-width);
+  max-width: 100%;
 
   &--inline {
     flex-direction: row;
@@ -136,10 +138,8 @@
   &__option {
     @extend %pix-body-s;
 
-    display: flex;
-    gap: var(--pix-spacing-6x);
-    justify-content: space-between;
-    padding: var(--pix-spacing-2x) var(--pix-spacing-6x);
+    position: relative;
+    padding: var(--pix-spacing-2x) var(--pix-spacing-8x) var(--pix-spacing-2x) var(--pix-spacing-6x);
     color: var(--pix-neutral-900);
 
     &:hover,
@@ -150,7 +150,11 @@
     }
 
     svg {
+      position: absolute;
+      top: 50%;
+      right: var(--pix-spacing-2x);
       font-size: 1.125rem;
+      transform: translateY(-50%);
       visibility: hidden;
       opacity: 0;
     }

--- a/tests/dummy/app/controllers/select-page.js
+++ b/tests/dummy/app/controllers/select-page.js
@@ -1,0 +1,35 @@
+import Controller from '@ember/controller';
+import { tracked } from '@glimmer/tracking';
+import { action } from '@ember/object';
+
+export default class SelectPage extends Controller {
+  @tracked selectedOption = null;
+
+  @action
+  onChange(option) {
+    this.selectedOption = option;
+  }
+
+  get options() {
+    return [
+      { value: '1', label: 'Figues' },
+      { value: '3', label: 'Fraises' },
+      { value: '2', label: 'Bananes' },
+      { value: '4', label: 'Mangues' },
+      { value: '5', label: 'Kaki' },
+      {
+        value: '6',
+        label: 'Asiminier trilobé oblong vert (à ne pas confondre avec la papaye)',
+      },
+    ];
+  }
+
+  get pagination() {
+    return {
+      page: 1,
+      pageSize: 5,
+      rowCount: 12,
+      pageCount: 3,
+    };
+  }
+}

--- a/tests/dummy/app/router.js
+++ b/tests/dummy/app/router.js
@@ -10,5 +10,6 @@ Router.map(function () {
   this.route('hello', { path: '/hello-world' });
   this.route('bye', { path: '/bye/:id' });
   this.route('modal-page', { path: '/modal' });
+  this.route('select-page', { path: '/select' });
   this.route('sidebar-page', { path: '/sidebar' });
 });

--- a/tests/dummy/app/templates/select-page.hbs
+++ b/tests/dummy/app/templates/select-page.hbs
@@ -1,0 +1,14 @@
+<h1>PixSelect</h1>
+
+<PixSelect
+  @options={{this.options}}
+  @onChange={{this.onChange}}
+  @value={{this.selectedOption}}
+  @hideDefaultOption={{true}}
+  @placeholder="Select an option"
+  @isSearchable={{true}}
+>
+  <:label>Label</:label>
+</PixSelect>
+
+<PixPagination @pagination={{this.pagination}} />


### PR DESCRIPTION
## :christmas_tree: Problème

À l'heure actuelle, le select ne voit plus sa largeur s'adapter à la taille de l'option la plus longue.

## :gift: Proposition

Réparer le script permettant d'obtenir cette largeur spécifique à partir de la longueur du menu déroulant.

## :santa: Pour tester

- Vérifier sur [Storybook en RA](https://ui-pr678.review.pix.fr/?path=/docs/form-select--docs) (dans l'inspecteur, faire varier la longueur du texte affiché dans l'input)

**Des environnements de tests reliés à cette branche ont été créés :**
- [PixApp épreuve 1](https://app-pr9307.review.pix.fr/challenges/challenge1ELsd1oVwJRXoI/preview) / [Épreuve 2](https://app-pr9307.review.pix.fr/challenges/rechUXZhn1FiLU28x/preview)
- [PixOrga](https://orga-pr9307.review.pix.fr/connexion) (notamment la selection des profils cible lors de la création d'une campagne/filtres/pagination)
- [PixAdmin](https://admin-pr9307.review.pix.fr/organizations/list) (par exemple dans la création de profil cible)

(ces 3 apps devraient couvrir les différents usages)