### PR TITLE
[FEATURE]  Ajouter des états succès/erreur au RadioButton tile (PIX-12836) 

### DIFF
--- a/addon/components/pix-radio-button.hbs
+++ b/addon/components/pix-radio-button.hbs
@@ -13,7 +13,7 @@
       <input
         type="radio"
         id={{this.id}}
-        class="pix-radio-button__input"
+        class={{this.inputClasses}}
         value={{@value}}
         aria-disabled={{this.isDisabled}}
         {{on "click" this.avoidCheckedStateChangeIfIsDisabled}}

--- a/addon/components/pix-radio-button.hbs
+++ b/addon/components/pix-radio-button.hbs
@@ -17,6 +17,7 @@
         class={{this.inputClasses}}
         value={{@value}}
         aria-disabled={{this.isDisabled}}
+        aria-describedby={{this.stateId}}
         {{on "click" this.avoidCheckedStateChangeIfIsDisabled}}
         ...attributes
       />
@@ -25,4 +26,12 @@
       {{yield to="label"}}
     </:default>
   </PixLabelWrapped>
+
+  <span class="screen-reader-only" id={{this.stateId}}>
+    {{#if this.hasSuccessState}}
+      {{this.stateSuccessMessage}}
+    {{else if this.hasErrorState}}
+      {{this.stateErrorMessage}}
+    {{/if}}
+  </span>
 </div>

--- a/addon/components/pix-radio-button.hbs
+++ b/addon/components/pix-radio-button.hbs
@@ -8,6 +8,7 @@
     @isDisabled={{this.isDisabled}}
     @inlineLabel={{true}}
     @variant={{@variant}}
+    @state={{@state}}
   >
     <:inputElement>
       <input

--- a/addon/components/pix-radio-button.js
+++ b/addon/components/pix-radio-button.js
@@ -5,7 +5,22 @@ import { warn } from '@ember/debug';
 import { formatMessage } from '../translations';
 
 export default class PixRadioButton extends Component {
+  constructor() {
+    super(...arguments);
+
+    warn(
+      'PixRadioButton: @state attribute should be used along with @isDisabled attribute.',
+      this.stateWarning,
+      {
+        id: 'pix-ui.radio-button.state.cant-be-used-without-is-disabled',
+      },
+    );
+  }
   text = 'pix-radio-button';
+
+  get stateWarning() {
+    return Boolean(this.isDisabled) && (!this.hasErrorState || !this.hasSuccessState);
+  }
 
   get id() {
     return this.args.id || guidFor(this);

--- a/addon/components/pix-radio-button.js
+++ b/addon/components/pix-radio-button.js
@@ -2,12 +2,25 @@ import Component from '@glimmer/component';
 import { guidFor } from '@ember/object/internals';
 import { action } from '@ember/object';
 import { warn } from '@ember/debug';
+import { formatMessage } from '../translations';
 
 export default class PixRadioButton extends Component {
   text = 'pix-radio-button';
 
   get id() {
     return this.args.id || guidFor(this);
+  }
+
+  get stateId() {
+    return `${this.id}-state`;
+  }
+
+  get hasSuccessState() {
+    return this.args.state === 'success';
+  }
+
+  get hasErrorState() {
+    return this.args.state === 'error';
   }
 
   get isDisabled() {
@@ -25,11 +38,23 @@ export default class PixRadioButton extends Component {
   get inputClasses() {
     const classes = ['pix-radio-button__input'];
 
-    if (this.args.state === 'success' || this.args.state === 'error') {
+    if (this.hasSuccessState || this.hasErrorState) {
       classes.push(`${classes[0]}--state`);
     }
 
     return classes.join(' ');
+  }
+
+  get stateSuccessMessage() {
+    return this.formatMessage('state.success');
+  }
+
+  get stateErrorMessage() {
+    return this.formatMessage('state.error');
+  }
+
+  formatMessage(message) {
+    return formatMessage('fr', `input.${message}`);
   }
 
   @action

--- a/addon/components/pix-radio-button.js
+++ b/addon/components/pix-radio-button.js
@@ -22,6 +22,12 @@ export default class PixRadioButton extends Component {
     return this.args.isDisabled || this.args.disabled ? 'true' : null;
   }
 
+  get inputClasses() {
+    const classes = ['pix-radio-button__input'];
+
+    return classes.join(' ');
+  }
+
   @action
   avoidCheckedStateChangeIfIsDisabled(event) {
     if (this.args.isDisabled) {

--- a/addon/components/pix-radio-button.js
+++ b/addon/components/pix-radio-button.js
@@ -25,6 +25,10 @@ export default class PixRadioButton extends Component {
   get inputClasses() {
     const classes = ['pix-radio-button__input'];
 
+    if (this.args.state === 'success' || this.args.state === 'error') {
+      classes.push(`${classes[0]}--state`);
+    }
+
     return classes.join(' ');
   }
 

--- a/addon/styles/_pix-radio-button.scss
+++ b/addon/styles/_pix-radio-button.scss
@@ -86,6 +86,11 @@
       &:checked::after {
         background-color: var(--pix-neutral-100);
       }
+
+      &.pix-radio-button__input--state {
+        position: absolute;
+        visibility: hidden;
+      }
     }
   }
 }

--- a/app/stories/pix-checkbox-variant-tile.mdx
+++ b/app/stories/pix-checkbox-variant-tile.mdx
@@ -25,7 +25,7 @@ Un cursor `not-allowed` est défini sur la checkbox et son label lorsqu'elle est
 
 #### Succès/Erreur
 
-Un champ de statut permet de préciser une coloration particulière en cas de "succès" ou d'"erreur".
+Cumulée à la désactivation, une propriété de statut permet de préciser une coloration particulière en cas de "succès" ou d'"erreur".
 
 <Story of={ComponentStories.isDisabledIsSuccessVariantTile} height={120} />
 <Story of={ComponentStories.isDisabledIsErrorVariantTile} height={120} />

--- a/app/stories/pix-radio-button-variant-tile.mdx
+++ b/app/stories/pix-radio-button-variant-tile.mdx
@@ -26,6 +26,13 @@ Un cursor `not-allowed` est défini sur le RadioButton et son label lorsqu'il es
 <Story of={ComponentStories.isDisabledVariantTile} height={120} />
 <Story of={ComponentStories.checkedIsDisabledVariantTile} height={120} />
 
+#### Succès/Erreur
+
+Cumulée à la désactivation, une propriété de statut permet de préciser une coloration particulière en cas de "succès" ou d'"erreur".
+
+<Story of={ComponentStories.isDisabledIsSuccessVariantTile} height={120} />
+<Story of={ComponentStories.isDisabledIsErrorVariantTile} height={120} />
+
 ## Usage
 
 ```html

--- a/app/stories/pix-radio-button-variant-tile.stories.js
+++ b/app/stories/pix-radio-button-variant-tile.stories.js
@@ -11,6 +11,16 @@ export default {
       control: { type: 'select' },
       type: { required: true },
     },
+    state: {
+      name: 'state',
+      description: 'Si `isDisabled` permet de marquer le radiobutton comme correcte ou incorrecte',
+      options: ['neutral', 'success', 'error'],
+      control: { type: 'select' },
+      table: {
+        type: { summary: 'string' },
+        defaultValue: { summary: 'neutral' },
+      },
+    },
     ...pixRadioButtonStories.argTypes,
   },
 };
@@ -25,6 +35,8 @@ const VariantTileTemplate = (args) => {
     @isDisabled={{this.isDisabled}}
     checked={{this.checked}}
     @variant={{this.variant}}
+    @state={{this.state}}
+    @size={{this.size}}
   >
     <:label>{{this.label}}</:label>
   </PixRadioButton></div>`,
@@ -37,6 +49,7 @@ VariantTile.args = {
   id: 'proposal',
   label: 'Une réponse',
   variant: 'tile',
+  state: 'neutral',
 };
 
 export const isDisabledVariantTile = VariantTileTemplate.bind({});
@@ -45,6 +58,7 @@ isDisabledVariantTile.args = {
   label: 'Recevoir la newsletter',
   variant: 'tile',
   isDisabled: true,
+  state: 'neutral',
 };
 
 export const checkedIsDisabledVariantTile = VariantTileTemplate.bind({});
@@ -54,4 +68,25 @@ checkedIsDisabledVariantTile.args = {
   variant: 'tile',
   isDisabled: true,
   checked: true,
+  state: 'neutral',
+};
+
+export const isDisabledIsSuccessVariantTile = VariantTileTemplate.bind({});
+isDisabledIsSuccessVariantTile.args = {
+  id: 'accept-newsletter-2',
+  label: 'La réponse est correcte',
+  variant: 'tile',
+  isDisabled: true,
+  checked: true,
+  state: 'success',
+};
+
+export const isDisabledIsErrorVariantTile = VariantTileTemplate.bind({});
+isDisabledIsErrorVariantTile.args = {
+  id: 'accept-newsletter-2',
+  label: 'La réponse est fausse',
+  variant: 'tile',
+  isDisabled: true,
+  checked: true,
+  state: 'error',
 };

--- a/tests/integration/components/pix-radio-button-test.js
+++ b/tests/integration/components/pix-radio-button-test.js
@@ -104,6 +104,31 @@ module('Integration | Component | pix-radio-button', function (hooks) {
         .exists();
     });
 
+    module('when @isDisabled is false', function () {
+      test(`it should not be possible to add a state`, async function (assert) {
+        // given
+        this.set('isDisabled', false);
+        this.set('state', 'success');
+
+        // when
+        await render(
+          hbs`<PixRadioButton checked @isDisabled={{this.isDisabled}} @state={{this.state}}><:label>Bonne réponse
+    !</:label></PixRadioButton>`,
+        );
+
+        // then
+        sandbox.assert.calledWith(
+          EmberDebug.warn,
+          'PixRadioButton: @state attribute should be used along with @isDisabled attribute.',
+          false,
+          {
+            id: 'pix-ui.radio-button.state.cant-be-used-without-is-disabled',
+          },
+        );
+        assert.ok(true);
+      });
+    });
+
     test(`it should read error state info if given`, async function (assert) {
       // given
       this.set('isDisabled', true);

--- a/tests/integration/components/pix-radio-button-test.js
+++ b/tests/integration/components/pix-radio-button-test.js
@@ -83,6 +83,48 @@ module('Integration | Component | pix-radio-button', function (hooks) {
       assert.false(radiobutton.checked, "Radiobutton has changed state, but shouldn't have");
     });
 
+    test(`it should read success state info if given`, async function (assert) {
+      // given
+      this.set('isDisabled', true);
+
+      // when
+      const screen = await render(
+        hbs`<PixRadioButton checked @isDisabled={{this.isDisabled}} @state='success'><:label>Recevoir la
+    newsletter</:label></PixRadioButton>`,
+      );
+
+      // then
+      assert
+        .dom(
+          screen.getByRole('radio', {
+            description: 'Sélection correcte',
+            hidden: true,
+          }),
+        )
+        .exists();
+    });
+
+    test(`it should read error state info if given`, async function (assert) {
+      // given
+      this.set('isDisabled', true);
+
+      // when
+      const screen = await render(
+        hbs`<PixRadioButton checked @isDisabled={{this.isDisabled}} @state='error'><:label>Recevoir la
+    newsletter</:label></PixRadioButton>`,
+      );
+
+      // then
+      assert
+        .dom(
+          screen.getByRole('radio', {
+            description: 'Sélection incorrecte',
+            hidden: true,
+          }),
+        )
+        .exists();
+    });
+
     ['true', 'false', 'null', 'undefined'].forEach(function (testCase) {
       test(`it should not be possible to interact when @isDisabled="${testCase}"`, async function (assert) {
         // given

--- a/tests/unit/components/pix-radio-button-test.js
+++ b/tests/unit/components/pix-radio-button-test.js
@@ -1,0 +1,86 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+import createGlimmerComponent from '../../helpers/create-glimmer-component';
+
+module('Unit | Component | PixRadioButton', function (hooks) {
+  setupTest(hooks);
+
+  module('#isDisabled', function () {
+    module('when @isDisabled is a boolean', function () {
+      module('when @isDisabled is true', function () {
+        test('it should return "true"', function (assert) {
+          // given
+          const isDisabled = true;
+          const component = createGlimmerComponent('pix-radio-button', { isDisabled });
+
+          // when
+          const result = component.isDisabled;
+
+          // then
+          assert.strictEqual(result, 'true');
+        });
+      });
+
+      module('when @isDisabled is false', function () {
+        test('it should return null', function (assert) {
+          // given
+          const isDisabled = false;
+          const component = createGlimmerComponent('pix-radio-button', { isDisabled });
+
+          // when
+          const result = component.isDisabled;
+
+          // then
+          assert.strictEqual(result, null);
+        });
+      });
+    });
+
+    module('when @isDisabled is a string', function () {
+      module('when @isDisabled is "true"', function () {
+        test('it should return "true"', function (assert) {
+          // given
+          const isDisabled = 'true';
+          const component = createGlimmerComponent('pix-radio-button', { isDisabled });
+
+          // when
+          const result = component.isDisabled;
+
+          // then
+          assert.strictEqual(result, 'true');
+        });
+      });
+
+      module('when @isDisabled is "false"', function () {
+        test('it should return "true"', function (assert) {
+          // given
+          const isDisabled = 'false';
+          const component = createGlimmerComponent('pix-radio-button', { isDisabled });
+
+          // when
+          const result = component.isDisabled;
+
+          // then
+          assert.strictEqual(result, 'true');
+        });
+      });
+    });
+  });
+
+  module('#stateWarning', function () {
+    module('when @isDisabled is false and @state is success', function () {
+      test('it should return false', function (assert) {
+        // given
+        const isDisabled = false;
+        const state = 'success';
+        const component = createGlimmerComponent('pix-radio-button', { isDisabled, state });
+
+        // when
+        const result = component.stateWarning;
+
+        // then
+        assert.false(result);
+      });
+    });
+  });
+});


### PR DESCRIPTION
## :christmas_tree: Problème
Dans la variante `tile`, on souhaite avoir un design particulier si un radiobutton est coché et `isDisabled` est en succès ou en erreur.

## :gift: Proposition
Ajouter un paramètre state qui prend les valeurs suivantes : neutral (défaut), success, error.

Maquettes : https://www.figma.com/design/47MuKB1wXoLEgMal06idN3/R%26D-DevComp?node-id=3835-4921&m=dev

## :star2: Remarques
RAS.

## :santa: Pour tester
Vérifier les nouvelles stories et les différents états mélangés : 
- https://ui-pr679.review.pix.fr/?path=/story/form-inputs-radio-button-variant-tile--is-disabled-is-success-variant-tile
- https://ui-pr679.review.pix.fr/?path=/story/form-inputs-radio-button-variant-tile--is-disabled-is-error-variant-tile