### PR TITLE
[BUGFIX] Rendre le composant Select vraiment accessible (PIX-13052).

### DIFF
--- a/addon/components/pix-select.hbs
+++ b/addon/components/pix-select.hbs
@@ -9,7 +9,7 @@
 >
   {{#if (has-block "label")}}
     <PixLabel
-      @for={{this.selectId}}
+      id="label-{{this.selectId}}"
       @requiredLabel={{@requiredLabel}}
       @subLabel={{@subLabel}}
       @size={{@size}}
@@ -22,14 +22,19 @@
 
   <div>
     <PopperJS @placement={{or @placement "bottom-start"}} as |reference popover|>
-      <button
+      <div
         {{reference}}
-        type="button"
+        role="combobox"
         id={{this.selectId}}
         class={{this.className}}
+        tabindex="0"
         {{on "click" this.toggleDropdown}}
-        aria-expanded={{this.isAriaExpanded}}
+        {{on-enter-action this.toggleDropdown}}
+        {{on-space-action this.toggleDropdown}}
+        aria-haspopup="listbox"
         aria-controls={{this.listId}}
+        aria-expanded="{{this.isExpanded}}"
+        aria-labelledby="label-{{this.selectId}}"
         aria-disabled={{@isDisabled}}
       >
         {{#if @icon}}
@@ -42,7 +47,7 @@
           class="pix-select-button__dropdown-icon"
           @icon={{if this.isExpanded "chevron-up" "chevron-down"}}
         />
-      </button>
+      </div>
       <div
         {{popover}}
         class="pix-select__dropdown{{unless this.isExpanded ' pix-select__dropdown--closed'}}"

--- a/addon/components/pix-select.js
+++ b/addon/components/pix-select.js
@@ -59,10 +59,6 @@ export default class PixSelect extends Component {
     return classes.join(' ');
   }
 
-  get isAriaExpanded() {
-    return this.isExpanded ? 'true' : 'false';
-  }
-
   get placeholder() {
     if (!this.args.value) return this.args.placeholder;
     const option = this.args.options.find((option) => option.value === this.args.value);

--- a/addon/styles/_pix-select.scss
+++ b/addon/styles/_pix-select.scss
@@ -91,7 +91,7 @@
 
   position: relative;
   display: flex;
-  gap: var(--pix-spacing-4x);
+  gap: var(--pix-spacing-3x);
   align-items: center;
   justify-content: space-between;
   width: 100%;


### PR DESCRIPTION
## :christmas_tree: Problème

Aujourd'hui, les lecteurs d'écran indiquent le Select comme un bouton condensé.

De plus lorsqu'on clique (et qu'il est développé), il faut encore descendre sur la liste puis faire entrée (sur Windows en tout cas) pour pouvoir modifier la valeur de la liste.

## :gift: Proposition

Suivre les [recommandations faites par le W3C](https://www.w3.org/WAI/ARIA/apg/patterns/combobox/examples/combobox-select-only/) :

- Notre ancien bouton devient une `div` avec un `role="combobox"` que l'on peut focus grâce à un `tabindex="0"`. 
- Pour qu'il soit bien accessible, cette `div` a aussi les attributs :
  - `aria-expanded` : pour désigner si la liste des options est affichée ou non
  - `aria-haspop="listbox"` : qui précise qu'il y a une liste d'options associée
  - `aria-controls` : pour indiquer l'ID de la liste des options associées
  - `aria-labelledby` : pour se lier au label associé

## :star2: Remarques

Plus complexe, à terme, si nous trouvons une solution : focus la bonne option lorsque l'utilisateur commence à taper du texte à l'activation de la combobox.

## :santa: Pour tester

Tester [le composant sur Pix UI](https://ui-pr680.review.pix.fr/?path=/docs/form-select--docs)
