### PR TITLE
[BUGFIX] Retirer le padding gauche / droite du bouton tertiaire (PIX-13037)

### DIFF
--- a/addon/styles/_pix-button-base.scss
+++ b/addon/styles/_pix-button-base.scss
@@ -104,6 +104,8 @@
   }
 
   &--tertiary {
+    padding-right: 0;
+    padding-left: 0;
     color: var(--pix-neutral-800);
     text-decoration: underline;
     background-color: transparent;


### PR DESCRIPTION
## :christmas_tree: Problème
Lors du changement de design des boutons, nous avons oublié de retiré l'espacement gache droite du bouton tertiaire

## :gift: Proposition
retirer ces paddings afin que le bouton ait l'aspect désiré

## :star2: Remarques
RAS

Vérification ICI : 
https://ui-pr681.review.pix.fr/?path=/docs/basics-button--docs