### PR TITLE
[BUGFIX] Utiliser les rôles adéquats au sein du composant `PixMultiSelect`.

### DIFF
--- a/addon/components/pix-multi-select.hbs
+++ b/addon/components/pix-multi-select.hbs
@@ -64,11 +64,11 @@
       {{popover}}
       class="pix-multi-select-list {{unless this.isExpanded 'pix-multi-select-list--hidden'}}"
       id={{this.listId}}
-      role="menu"
+      role="listbox"
     >
       {{#if (gt this.results.length 0)}}
         {{#each this.results as |option|}}
-          <li class="pix-multi-select-list__item" role="menuitem">
+          <li class="pix-multi-select-list__item" role="option">
             <PixCheckbox
               @id={{concat this.multiSelectId "-" option.value}}
               @checked={{option.checked}}


### PR DESCRIPTION
## :boom: BREAKING_CHANGES
Les rôles constituant le composant `PixMultiSelect` ayant changés, les tests qui se basaient dessus doivent être modifiés.

## :christmas_tree: Problème

Le composant `PixMultiSelect` est actuellement une liste dont le rôle est `menu` constituée d'éléments dont le rôle est `menu-item`.
Cela n'est pas correct d'un point de vue sémantique et offre une mauvaise expérience aux personnes utilisant un lecteur d'écran.

## :gift: Proposition
On remplace le rôle `menu` par `listbox`.
On remplace le rôle `menu-item` par `option`.

## :star2: Remarques

Ces changements rendent cohérents les composants `PixMultiSelect` et `PixSelect`.

## :santa: Pour tester
Se rendre sur le composant `PixMultiSelect`.
Constater, avec l'inspecteur, que les rôles des différents éléments de la liste déroulante sont bons.