### PR TITLE
[FEATURE] Supprimer l'option compact du composant PixTag (PIX-11127).

### DIFF
--- a/addon/components/pix-collapsible.hbs
+++ b/addon/components/pix-collapsible.hbs
@@ -22,7 +22,7 @@
 
     <span class="pix-collapsible-title__container">
       {{#if @tagContent}}
-        <PixTag @compact={{false}} @color={{@tagColor}}>
+        <PixTag @color={{@tagColor}}>
           {{@tagContent}}
         </PixTag>
       {{/if}}

--- a/addon/components/pix-tag.js
+++ b/addon/components/pix-tag.js
@@ -2,10 +2,9 @@ import Component from '@glimmer/component';
 
 export default class PixTag extends Component {
   get classes() {
-    const { color, compact } = this.args;
+    const { color } = this.args;
     const classes = [];
     if (color) classes.push(`pix-tag--${color}`);
-    if (compact) classes.push(`pix-tag--compact`);
     return classes.join(' ');
   }
 }

--- a/addon/styles/_pix-tag.scss
+++ b/addon/styles/_pix-tag.scss
@@ -12,13 +12,6 @@
   border: 1px solid transparent;
   border-radius: 0.95rem;
 
-  &--compact {
-    @extend %pix-body-xs;
-
-    line-height: inherit;
-    text-transform: uppercase;
-  }
-
   &--grey-light,
   &--neutral {
     color: var(--pix-neutral-900);

--- a/app/stories/pix-tag.mdx
+++ b/app/stories/pix-tag.mdx
@@ -9,11 +9,7 @@ Un `Tag` est un type de `Chips` qui permet de mettre en avant une information ou
 
 > Il est possible de surcharger le style d'un `<PixTag>` via l'attribut `class` ainsi que de passer n'importe quel attribut sur sa `div` wrapper (par exemple, un `aria-label`)
 
-Tag
 <Story of={ComponentStories.tag} height={60} />
-
-Tag compact
-<Story of={ComponentStories.compactTag} height={60} />
 
 ## Usage
 
@@ -23,9 +19,6 @@ Par défaut:
 
 Customiser la couleur du tag:
 <PixTag @color="purple"> This is a purple tag </PixTag>
-
-Tag Compact
-<PixTag @compact="{{true}}" @color="blue"> This is a compact tag </PixTag>
 ```
 
 ## Arguments

--- a/app/stories/pix-tag.stories.js
+++ b/app/stories/pix-tag.stories.js
@@ -3,7 +3,7 @@ import { hbs } from 'ember-cli-htmlbars';
 export default {
   title: 'Basics/Tag',
   render: (args) => ({
-    template: hbs`<PixTag @color={{this.color}} @compact={{this.compact}}>
+    template: hbs`<PixTag @color={{this.color}}>
   Contenu du tag
 </PixTag>`,
     context: args,
@@ -19,19 +19,7 @@ export default {
       },
       options: ['neutral', 'secondary', 'tertiary', 'success', 'error', 'orga'],
     },
-    compact: {
-      name: 'compact',
-      description: 'Tag compact ou non',
-      type: { name: 'boolean', required: false },
-      table: { defaultValue: { summary: false } },
-    },
   },
 };
 
 export const tag = {};
-
-export const compactTag = {
-  args: {
-    compact: true,
-  },
-};

--- a/tests/integration/components/pix-tag-test.js
+++ b/tests/integration/components/pix-tag-test.js
@@ -19,19 +19,9 @@ module('Integration | Component | pix-tag', function (hooks) {
     assert.ok(pixTagElement.classList.contains('pix-tag--primary'));
   });
 
-  test('it renders a compact tag', async function (assert) {
-    await render(hbs`<PixTag @compact={{true}} />`);
-
-    const pixTagElement = this.element.querySelector('.pix-tag');
-    assert.ok(pixTagElement.classList.contains('pix-tag--compact'));
-  });
-
   test('it renders with attributes override', async function (assert) {
-    await render(hbs`<PixTag @color='secondary' aria-label='world' />`);
+    const screen = await render(hbs`<PixTag @color='secondary' aria-label='world' />`);
 
-    const pixTagElement = this.element.querySelector('.pix-tag');
-    // TODO: Fix this the next time the file is edited.
-    // eslint-disable-next-line qunit/no-assert-equal
-    assert.equal(pixTagElement.getAttribute('aria-label'), 'world');
+    assert.dom(screen.getByLabelText('world')).exists();
   });
 });


### PR DESCRIPTION
## :christmas_tree: Problème
Des tags compacts ont été utilisés par le passé. Maintenant il faut généraliser l’utilisation des tags basic et remplacer tous les tags compact qui pourraient encore exister car le composant Pix UI "Tag Compact" n’existe pas côté design system.

## :gift: Proposition
Supprimer l'option `compact` du composant `PixTag`.

## :star2: Remarques
J'en ai profité pour mettre à jour les tests du `PixTag` et d'utiliser un `getByLabelText`.
La PR https://github.com/1024pix/pix/pull/9359 supprime tous les usages de l'option `compact` dans les app.

## :santa: Pour tester
Se rendre sur le composant `PixTag` et constater qu'il n'y a plus de mention de `compact`.
Tests et CI ✅ 