### PR TITLE
[BUGFIX] retarde l'appel à hideTootltip

### DIFF
--- a/addon/components/pix-tooltip.js
+++ b/addon/components/pix-tooltip.js
@@ -30,7 +30,7 @@ export default class PixTooltip extends Component {
 
   @action
   hideTooltip() {
-    this.isTooltipVisible = false;
+    setTimeout(() => (this.isTooltipVisible = false));
   }
 
   @action

--- a/tests/dummy/app/controllers/tooltip-page.js
+++ b/tests/dummy/app/controllers/tooltip-page.js
@@ -1,11 +1,7 @@
 import Controller from '@ember/controller';
-import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
 
-export default class ModalPage extends Controller {
-  @tracked showModal = false;
-  title = "Qu'est-ce qu'une modale ?";
-
+export default class TooltipPage extends Controller {
   @action
-  onCloseButtonClick() {}
+  onAction() {}
 }

--- a/tests/dummy/app/templates/tooltip-page.hbs
+++ b/tests/dummy/app/templates/tooltip-page.hbs
@@ -27,3 +27,18 @@
     </:tooltip>
   </PixTooltip>
 </PixBlock>
+
+<PixBlock style="margin: 3vmin; padding: 3vmin;">
+  <PixTooltip @id="tooltip-button">
+    <:triggerElement>
+      <PixButton @triggerAction={{this.onAction}}>
+        Label
+      </PixButton>
+    </:triggerElement>
+
+    <:tooltip>
+      Lorem ipsum dolor sit amet, consectetur adipiscing elit. Ut egestas molestie mauris vel
+      viverra.
+    </:tooltip>
+  </PixTooltip>
+</PixBlock>


### PR DESCRIPTION
 
## :christmas_tree: Problème
Suite à la PR#673 sur le tooltip, des erreurs ont survenues lors de l'exécution de tests sur Pix. En cause, le fait que la propriété tracked isTooltipVisible soit modifié plusieurs fois lors d'une meme event loop. 

## :gift: Proposition
On retarde l'éxecution de hideTooltip pour éviter de modifier le propriété dans un même event loop

## :star2: Remarques
On profite de la PR pour modifier les infos de la page dans l'app de test

## :santa: Pour tester
- CI au vert
- importer le code de la branche dans pix et ci au vert 
