### PR TITLE
[TECH] Ajoute le support node@v22

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -88,7 +88,7 @@
         "webpack": "^5.75.0"
       },
       "engines": {
-        "node": "^20.15.1"
+        "node": "^20 || ^22"
       }
     },
     "node_modules/@1024pix/ember-testing-library": {

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "license": "MIT",
   "author": "GIP Pix",
   "engines": {
-    "node": "^20.15.1"
+    "node": "^20 || ^22"
   },
   "ember": {
     "edition": "octane"


### PR DESCRIPTION
## :jack_o_lantern: Problème
Pix UI ne supporte pas Node.js en version 22 qui deviens LTS en octobre.

## :bat: Proposition
Ajouter le support de Node 22 pour ne pas bloquer l'install dans les projets qui utilisent cette lib.

## :spider_web: Remarques
J'ai été assez permissif sur les versions, en espérant qu'on ait pas les mêmes regressions qu'on avait eu sur des versions mineures de Node il y a quelques années 😬.

## :ghost: Pour tester
Pour l'instant rien ne change, Scalingo ne supporte pas encore Node 22. J'ai quand même testé en local par aquis de conscience et Storybook se lance correctement.
