### PR TITLE
[BUGFIX] Corrige le scroll involontaire dans une page avec plusieurs modales (PIX-13529)

### DIFF
--- a/app/modifiers/trap-focus.js
+++ b/app/modifiers/trap-focus.js
@@ -12,6 +12,7 @@ export default modifier(function trapFocus(element, [isOpen]) {
   } else if (sourceActiveElement) {
     allowPageScrolling();
     focusElement(sourceActiveElement, element);
+    sourceActiveElement = null;
   }
 
   element.addEventListener('keydown', (event) => {


### PR DESCRIPTION
## :christmas_tree: Problème
Dans une page contenant plusieurs modales, l'ouverture d'une première modale rentre en conflit avec l'ouverture d'une seconde. Ainsi lors de l'ouverture de la seconde, la page parente va scroller vers le bouton qui a permis d'ouvrir la première...

https://github.com/user-attachments/assets/c55507d3-2795-486b-a996-36200be6ee76

Dans le code, on stocke l'élément HTML ayant déclenché le trap focus. Lorsqu'on stoppe le trap focus, on redonne le focus sur cet élément. Cet élément n'est pas nettoyé pendant cette fermeture, donc on redonne le focus à ce mauvais élément quand on ouvre une autre modale.

## :gift: Proposition
Nettoyer l'élément source lors de l'arrêt du trap focus.

## :star2: Remarques
RAS

## :santa: Pour tester
Vérifier que la Modal et la Sidebar fonctionnent toujours correctement.

Brancher sur Modulix avec 
```shell
npm i -D "git://github.com/1024pix/pix-ui#fix-modal-page-scroll"
```

Et vérifier la correction sur http://localhost:4200/modules/bien-ecrire-son-adresse-mail/passage.

Disponible temporairement sur https://app-pr9708.review.pix.fr/modules/bien-ecrire-son-adresse-mail/passage.