### PR TITLE
[TECH] Ne pas ouvrir de nouvel onglet au lancement de Storybook en développement

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "build-ember": "ember build --environment=production",
     "serve-ember": "ember serve",
     "build-storybook": "ember build && cp -v CNAME dist && storybook build",
-    "serve-storybook": "storybook dev --port 9001",
+    "serve-storybook": "storybook dev --port 9001 --no-open",
     "clean": "rm -rf dist node_modules",
     "deploy-storybook": "storybook-to-ghpages",
     "lint": "npm-run-all --aggregate-output --parallel --continue-on-error 'lint:!(fix)'",


### PR DESCRIPTION
## :christmas_tree: Problème
Quand on lance Storybook en local, une fenêtre s'ouvre automatiquement dans le navigateur. C'est ok quand c'est la première fois qu'on le lance, mais on est régulièrement obligé de relancer Storybook pour constater les modifications, donc on fini avec plein d'onglets ouverts...

## :gift: Proposition
Ne pas ouvrir automatiquement cet onglet au lancement de l'environnement de dev.

## :star2: Remarques
RAS

## :santa: Pour tester
Vérifier que `npm run dev` n'ouvre pas de nouvel onglet.
