### PR TITLE
[BUGFIX] Corrige la couleur de texte du bouton secondary hover

### DIFF
--- a/addon/styles/_pix-button-base.scss
+++ b/addon/styles/_pix-button-base.scss
@@ -83,7 +83,7 @@
 
     &:not([aria-disabled="true"]) {
       &:hover {
-        color: var(--pix-neutral-700);
+        color: var(--pix-primary-700);
         background-color: var(--pix-primary-100);
       }
 


### PR DESCRIPTION
## :christmas_tree: Problème
Dans [cette PR](https://github.com/1024pix/pix/pull/9762), @AndreiaPena relève :

> Le bouton "Rester" sur la modale en hover n'a pas le même comportement que les autres boutons du même style.
> Le texte passe en blanc.

On utilise une couleur inexistante au hover sur le texte du bouton secondary, le texte prend donc la couleur la plus proche dans la pile de sélecteurs CSS...

## :gift: Proposition
Utiliser une couleur existante, de préférence celle recommandée sur [Figma](https://www.figma.com/design/8RJ3aCSfdeQ8AZZVBBYKS8/Design-System?node-id=112-196&t=3h2Ss3PCvbCzqDE8-0).

## :star2: Remarques
RAS

## :santa: Pour tester
Vérifier que le bouton secondary utilise une couleur de texte existante au hover.
