### PR TITLE
[BUGFIX] Ajouter une couleur de fond sur `PixIconButton` `withBackground` au hover

### DIFF
--- a/addon/styles/_pix-icon-button.scss
+++ b/addon/styles/_pix-icon-button.scss
@@ -35,6 +35,19 @@
 
   &--background {
     background-color: var(--pix-neutral-20);
+
+    &:hover:enabled {
+      background-color: var(--pix-neutral-100);
+    }
+
+    &:focus:enabled {
+      background-color: var(--pix-neutral-800);
+    }
+
+    &:active:enabled {
+      color: var(--pix-neutral-0);
+      background-color: var(--pix-neutral-500);
+    }
   }
 
   &--small {


### PR DESCRIPTION
## :christmas_tree: Problème
Sur le composant `PixIconButton` avec un fond non transparent (variant `withBackground`, utilisée dans la `PixModal` notamment), il n'y a aucun changement visible lors du `hover`.

## :gift: Proposition
Pour la variante `withBackground`, différencier l'état hover des autres états.

## :star2: Remarques
RAS

## :santa: Pour tester
Vérifier par exemple dans la `PixModal` que le bouton de fermeture a bien 4 états différenciables : de base, hover, active (lors du clic), focus.
