### PR TITLE
[BUGFIX] Permettre le focus sur les `variants` `tile` `isDisabled` avec un `state`

### DIFF
--- a/addon/components/pix-label-wrapped.hbs
+++ b/addon/components/pix-label-wrapped.hbs
@@ -1,9 +1,9 @@
 <label for={{@for}} class={{this.className}} ...attributes>
   {{#if this.hasError}}
-    <FaIcon @icon="circle-xmark" />
+    <FaIcon @icon="circle-xmark" class="pix-label-wrapped__state-icon" />
   {{/if}}
   {{#if this.hasSuccess}}
-    <FaIcon @icon="circle-check" />
+    <FaIcon @icon="circle-check" class="pix-label-wrapped__state-icon" />
   {{/if}}
 
   {{yield to="inputElement"}}

--- a/addon/components/pix-radio-button.js
+++ b/addon/components/pix-radio-button.js
@@ -5,17 +5,6 @@ import { warn } from '@ember/debug';
 import { formatMessage } from '../translations';
 
 export default class PixRadioButton extends Component {
-  constructor() {
-    super(...arguments);
-
-    warn(
-      'PixRadioButton: @state attribute should be used along with @isDisabled attribute.',
-      this.stateWarning,
-      {
-        id: 'pix-ui.radio-button.state.cant-be-used-without-is-disabled',
-      },
-    );
-  }
   text = 'pix-radio-button';
 
   get stateWarning() {

--- a/addon/styles/_pix-checkbox.scss
+++ b/addon/styles/_pix-checkbox.scss
@@ -117,7 +117,6 @@
 
       &.pix-checkbox__input--state {
         position: absolute;
-        visibility: hidden;
       }
     }
   }

--- a/addon/styles/_pix-label-wrapped.scss
+++ b/addon/styles/_pix-label-wrapped.scss
@@ -10,7 +10,7 @@
     padding: var(--pix-spacing-3x) var(--pix-spacing-4x);
     background: var(--pix-neutral-0);
     border: 1px solid var(--pix-neutral-100);
-    border-radius: 4px;
+    border-radius: 8px;
 
     &:focus-within {
       border: 1px solid var(--pix-primary-500);

--- a/addon/styles/_pix-label-wrapped.scss
+++ b/addon/styles/_pix-label-wrapped.scss
@@ -41,6 +41,15 @@
           color: var(--pix-error-700);
         }
 
+        & .pix-label-wrapped__state-icon {
+          z-index: 1;
+          width: 1rem;
+          height: 1rem;
+          padding: 0;
+          background-color: var(--state-background-color);
+          border: 0;
+        }
+
         // stylelint-disable-next-line no-duplicate-selectors
         & {
           background: var(--state-background-color);

--- a/addon/styles/_pix-radio-button.scss
+++ b/addon/styles/_pix-radio-button.scss
@@ -89,7 +89,6 @@
 
       &.pix-radio-button__input--state {
         position: absolute;
-        visibility: hidden;
       }
     }
   }

--- a/tests/integration/components/pix-radio-button-test.js
+++ b/tests/integration/components/pix-radio-button-test.js
@@ -104,31 +104,6 @@ module('Integration | Component | pix-radio-button', function (hooks) {
         .exists();
     });
 
-    module('when @isDisabled is false', function () {
-      test(`it should not be possible to add a state`, async function (assert) {
-        // given
-        this.set('isDisabled', false);
-        this.set('state', 'success');
-
-        // when
-        await render(
-          hbs`<PixRadioButton checked @isDisabled={{this.isDisabled}} @state={{this.state}}><:label>Bonne réponse
-    !</:label></PixRadioButton>`,
-        );
-
-        // then
-        sandbox.assert.calledWith(
-          EmberDebug.warn,
-          'PixRadioButton: @state attribute should be used along with @isDisabled attribute.',
-          false,
-          {
-            id: 'pix-ui.radio-button.state.cant-be-used-without-is-disabled',
-          },
-        );
-        assert.ok(true);
-      });
-    });
-
     test(`it should read error state info if given`, async function (assert) {
       // given
       this.set('isDisabled', true);


### PR DESCRIPTION
## :christmas_tree: Problème
Quand on place `visibility: hidden` sur un `input` ne permet pas de prendre le focus.

## :gift: Proposition
Une autre approche pour permettre le focus sur les input Checkbox et Radio.

## :star2: Remarques
Aussi :
- ajustement border-radius des variant tile,
- suppression d'un log qui poppe tout le temps. Le temps de trouver mieux...

## :santa: Pour tester
Radio Button : 
1. On pouvait focus sur les [`disabled` "normaux"](https://ui-pr719.review.pix.fr/?path=/story/form-inputs-radio-button-variant-tile--checked-is-disabled-variant-tile).
2. Vérifier que ça fonctionne sur [le state success](https://ui-pr719.review.pix.fr/?path=/story/form-inputs-radio-button-variant-tile--is-disabled-is-success-variant-tile).
3. Vérifier que ça fonctionne sur [le state error](https://ui-pr719.review.pix.fr/?path=/story/form-inputs-radio-button-variant-tile--is-disabled-is-error-variant-tile).

Checkbox : 
1. On pouvait focus sur les [`disabled` "normaux"](https://ui-pr719.review.pix.fr/?path=/story/form-inputs-checkbox-variant-tile--checked-is-disabled-variant-tile).
2. Vérifier que ça fonctionne sur [le state success](https://ui-pr719.review.pix.fr/?path=/story/form-inputs-checkbox-variant-tile--is-disabled-is-success-variant-tile).
3. Vérifier que ça fonctionne sur [le state error](https://ui-pr719.review.pix.fr/?path=/story/form-inputs-checkbox-variant-tile--is-disabled-is-error-variant-tile).