### PR TITLE
[TECH] Ne plus embarquer les .mdx / stories.js (PIX-14450)

### DIFF
--- a/package.json
+++ b/package.json
@@ -141,11 +141,11 @@
   },
   "files": [
     "addon/",
-    "app/",
+    "app/components",
+    "app/modifiers",
+    "app/services",
     "config/icons.js",
-    "public/",
-    "scripts/migrate-colors-scss-vars-to-css-vars.sh",
-    "scripts/migrate-spacing-scss-vars-to-css-vars.sh"
+    "public/"
   ],
   "storybook-deployer": {
     "commitMessage": "Deploy Storybook [skip ci]"


### PR DESCRIPTION
## :christmas_tree: Problème
On embarque des fichiers dans le package npm alors que l'on ne devrait pas

## :gift: Proposition
les retirer

## :star2: Remarques
RAS

## :santa: Pour tester
CI au vert et vérifier que le package  build bien sur Orga / Certif ou MonPix