### PR TITLE
Revert "[BUMP] Update dependency ember-resolver to v13 (dossier racine)"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -61,7 +61,7 @@
         "ember-load-initializers": "^2.1.2",
         "ember-page-title": "^8.0.0",
         "ember-qunit": "^8.0.0",
-        "ember-resolver": "^13.0.0",
+        "ember-resolver": "^12.0.0",
         "ember-sinon": "^5.0.0",
         "ember-source": "^4.0.1",
         "ember-source-channel-url": "^3.0.0",
@@ -20354,9 +20354,9 @@
       }
     },
     "node_modules/ember-resolver": {
-      "version": "13.0.1",
-      "resolved": "https://registry.npmjs.org/ember-resolver/-/ember-resolver-13.0.1.tgz",
-      "integrity": "sha512-+F0lX8P9pBwE1hf8PMhe7ftT3f9PQSQwIXPN1qc9Aiij5V/GDVTdd+j4+CSj6tCHlf6ylADGxs4c6mofs/sDvQ==",
+      "version": "12.0.1",
+      "resolved": "https://registry.npmjs.org/ember-resolver/-/ember-resolver-12.0.1.tgz",
+      "integrity": "sha512-U+ZBdbEHMhmvcZly1xhZKwqeH5/igjT93p9bbD6x+mQVg7hm4jrsQA4jsxHu3BqgL5MmqOVx0gtAuYEWV1x2MQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -103,7 +103,7 @@
     "ember-load-initializers": "^2.1.2",
     "ember-page-title": "^8.0.0",
     "ember-qunit": "^8.0.0",
-    "ember-resolver": "^13.0.0",
+    "ember-resolver": "^12.0.0",
     "ember-sinon": "^5.0.0",
     "ember-source": "^4.0.1",
     "ember-source-channel-url": "^3.0.0",


### PR DESCRIPTION
Revert de la PR car storybook ne fonctionne plus en local depuis cette montée en version.