### PR TITLE
[BUGFIX] Corriger le chemin du sprite.svg (PIX-14493)

### DIFF
--- a/addon/components/pix-icon.hbs
+++ b/addon/components/pix-icon.hbs
@@ -4,5 +4,5 @@
   aria-hidden={{this.ariaHidden}}
   ...attributes
 >
-  <use href="../@1024pix/pix-ui/svg/pix-sprite.svg#{{this.iconName}}" />
+  <use href="/@1024pix/pix-ui/svg/pix-sprite.svg#{{this.iconName}}" />
 </svg>


### PR DESCRIPTION
## :christmas_tree: Problème
le chemin vers le sprite pose problème dans certaines app ou il ne va pas récupérer les sources dans le bon fichier

## :gift: Proposition
Retirer les `..` qui  interfère avec l'emplacement ou sont utiliser le PixIcon


## :santa: Pour tester
Vérifier que l'affichage des icones est OK sur un test dans une route sur certif/orga ou app