### PR TITLE
[TECH] Affiche toutes les icônes dans la story de PixIcon

### DIFF
--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -1,3 +1,5 @@
+import '../app/styles/global.css';
+
 const preview = {
   parameters: {
     layout: 'centered',
@@ -33,11 +35,11 @@ const preview = {
             'Breaking changes',
             'Faire une release',
             'Architecture',
-            'Storybook'
+            'Storybook',
           ],
         ],
       },
     },
-  }
+  },
 };
 export default preview;

--- a/app/stories/pix-icon.mdx
+++ b/app/stories/pix-icon.mdx
@@ -7,12 +7,12 @@ import * as ComponentStories from './pix-icon.stories';
 
 > Permet d'utiliser les icônes disponible du Design System.
 
-<Story of={ComponentStories.icon} height={60} />
+<Story of={ComponentStories.allIcons} height={1050} />
 
 ## Usage
 
 ```html
-  <PixIcon @name="powerSettings", @plainIcon={{true}} />
+<PixIcon @name="playCircle" @plainIcon="{{true}}" />
 ```
 
 ## Arguments

--- a/app/stories/pix-icon.stories.js
+++ b/app/stories/pix-icon.stories.js
@@ -49,3 +49,34 @@ export const icon = (args) => ({
 />`,
   context: args,
 });
+
+const icons = Object.entries(ICONS).flatMap(([name, icon]) =>
+  icon.plainIcon
+    ? [
+        { iconName: name, variant: false },
+        { iconName: name, variant: true },
+      ]
+    : { iconName: name, variant: false },
+);
+
+export const allIcons = (args) => {
+  return {
+    template: hbs`<ul class='icon-list'>
+  {{#each this.icons as |icon|}}
+    <li class='icon-list__cell'>
+      <PixIcon
+        @name={{icon.iconName}}
+        @plainIcon={{icon.variant}}
+        @alternativeText={{icon.iconName}}
+        @ariaHidden={{true}}
+      />
+      <p class='icon-name'>{{icon.iconName}}&nbsp;{{if icon.variant '(plain)'}}</p>
+    </li>
+  {{/each}}
+</ul>`,
+    context: args,
+  };
+};
+
+allIcons.bind({});
+allIcons.args = { icons };

--- a/app/styles/global.css
+++ b/app/styles/global.css
@@ -1,0 +1,24 @@
+/* on utilise un fichier css car on a pas de loader scss */
+.icon-list {
+  display: grid;
+  grid-template-columns: repeat(9, 1fr);
+  gap: .4rem;
+}
+
+.icon-list__cell {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  height:60px;
+  padding-bottom: .3rem;
+}
+
+.icon-list__cell svg {
+  width: 2rem;
+  height: 2rem;
+}
+
+.icon-name {
+  color:var(--pix-neutral-800);
+  font-size: .75rem
+}


### PR DESCRIPTION
## :christmas_tree: Problème
C'est pénible de ne pas avoir la liste de toutes les icônes disponibles dans la story du composant.

## :gift: Proposition
On affiche toutess les icônes dispo

## :star2: Remarques
J'aime travailler avec storybook
![image](https://github.com/user-attachments/assets/6db4b1c8-fbd5-4447-b08c-051fda4e96a7)


## :santa: Pour tester
Afficher la story de PixIcon