### PR TITLE
[BUGFIX] Permettre de surcharger l'attribut aria-disabled sur PixButton (PIX-14785)

### DIFF
--- a/addon/components/pix-button.hbs
+++ b/addon/components/pix-button.hbs
@@ -2,9 +2,9 @@
   type={{this.type}}
   class={{this.className}}
   {{on "click" this.triggerAction}}
-  ...attributes
   disabled={{this.isDisabled}}
   aria-disabled="{{this.isDisabled}}"
+  ...attributes
 >
   {{#if this.isLoading}}
     <div class="loader loader--{{this.loadingColor}}">

--- a/addon/components/pix-input-code.hbs
+++ b/addon/components/pix-input-code.hbs
@@ -4,7 +4,6 @@
     <legend>{{this.legend}}</legend>
     {{#each this.numberOfIterations as |i|}}
       <input
-        ...attributes
         id="code-input-{{i}}"
         type="{{this.inputType}}"
         aria-label="{{this.ariaLabel}} {{i}}"
@@ -18,6 +17,7 @@
         {{on "input" (fn this.handleCodeInput i)}}
         {{on "paste" (fn this.handlePaste i)}}
         {{on "focus" (fn this.handleFocus i)}}
+        ...attributes
       />
     {{/each}}
   </fieldset>


### PR DESCRIPTION
## :christmas_tree: Problème
Actuellement, il n’est pas possible de surcharger les attributs disabled et aria-disabled à cause de la déclaration du ...attributes avant ces champs sur [PixButton](https://github.com/1024pix/pix-ui/blob/dev/addon/components/pix-button.hbs#L5) 

Cela est problématique dans le cas où on voudrait juste mettre un aria-disabled par exemple pour un bouton de type `submit` (https://kittygiraudel.com/2024/03/29/on-disabled-and-aria-disabled-attributes/).

## :gift: Proposition
Déplacer le …attributes après la déclaration de tous les attributs.

## :star2: Remarques
Une repasse a été faites sur les autres composants pour vérifier que le ...attributes est bien déclaré à la fin.

## :santa: Pour tester
- CI au vert 
- Vérifier sur la RA, que les composants PixButton et PixInputCode s'affichent bien !