### PR TITLE
[DOC] Réparer le lien dans le README qui mène vers la documentation pour la création d'un nouveau composant

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Plus d'informations sur les [tags git ici](https://git-scm.com/book/fr/v2/Les-ba
 
 * `ember g pix-component <nom_du_composant>`
 
-Plus d'informations sur [la création de composant ici](/?path=/docs/create-component.stories.mdx).
+Plus d'informations sur [la création de composant ici](./docs/create-component.mdx).
 
 
 ##### Lancement de storybook en local <a id="Storybook"></a>


### PR DESCRIPTION
## :christmas_tree: Problème
Le lien vers la documentation de création d'un nouveau composant ne menait nulle part.

## :gift: Proposition
Corriger le lien.

## :star2: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :santa: Pour tester
Cliquer sur le lien dans le README et vérifier qu'il mène quelque part
