### PR TITLE
[BUGFIX] Le focus de Pix Select ne fonctionne pas dans tous les cas (PIX-14876)

### DIFF
--- a/addon/components/pix-select.js
+++ b/addon/components/pix-select.js
@@ -37,6 +37,10 @@ export default class PixSelect extends Component {
         element.style.setProperty('--pix-select-width', `${selectWidth}rem`);
       });
     }
+
+    this.elementHelper.waitForElement(`container-${this.selectId}`).then((element) => {
+      this.rootElement = element;
+    });
   }
 
   get displayDefaultOption() {
@@ -151,11 +155,11 @@ export default class PixSelect extends Component {
   focus() {
     if (this.isExpanded) {
       if (this.args.value) {
-        document.querySelector("[aria-selected='true']").focus();
+        this.rootElement.querySelector("[aria-selected='true']").focus();
       } else if (this.args.isSearchable) {
         document.getElementById(this.searchId).focus();
       } else if (this.displayDefaultOption) {
-        document.querySelector("[aria-selected='true']").focus();
+        this.rootElement.querySelector("[aria-selected='true']").focus();
       }
     }
   }

--- a/tests/integration/components/pix-select-test.js
+++ b/tests/integration/components/pix-select-test.js
@@ -391,6 +391,34 @@ module('Integration | Component | PixSelect', function (hooks) {
         // then
         assert.dom(select).isFocused();
       });
+
+      test("it should focus first element of Pix Select even when there's an aria-selected=true somewhere", async function (assert) {
+        // given
+        const screen = await render(
+          hbs`<div class='tab-interface'>
+  <div role='tablist' aria-label='Sample Tabs'>
+    <span role='tab' aria-selected='true' aria-controls='panel-1' id='tab-1' tabindex='0'>
+      Je ne dois pas être focus !
+    </span>
+  </div>
+</div>
+<PixSelect @options={{this.options}} @placeholder={{this.placeholder}}><:label
+  >{{this.label}}</:label></PixSelect>`,
+        );
+
+        // when
+        await screen.getByLabelText('Mon menu déroulant').focus();
+
+        await userEvent.keyboard('[ArrowDown]');
+
+        await screen.findByRole('listbox');
+        fireEvent(document.querySelector('.pix-select__dropdown'), new Event('transitionend'));
+
+        const option = screen.getByRole('option', { name: 'Choisissez une option' });
+
+        // then
+        assert.dom(option).isFocused();
+      });
     });
   });
 


### PR DESCRIPTION
## :christmas_tree: Problème
Sur PixEditor, on a voulu mettre des PixSelect sur la page d'édition d'épreuve.
Bug remarqué (sur notre branche en développement du coup, lorsqu'on a voulu remplacer de vieux composants ember-power-select par du pixui):
- Aller sur la page d'édition d'épreuve
- Scroller un peu vers le bas jusqu'à arriver au PixSelect (oui oui c'est important que le pixselect soit plus bas et qu'il faille scroller vous allez voir)
- Cliquer sur le PixSelect pour choisir son option
- Constater que l'ascenceur remonte jusqu'en haut de la page !

En fait, l'implémentation de prise de focus du PixSelect passait par l'usage d'un querySelector qui balayait très large sur tout le `document` :
`document.querySelector("[aria-selected=true]");`

Le problème c'est que côté PixEditor, on a le text area de la consigne de l'épreuve qui a des éléments avec l'attribut aria-selected à true, et donc le code de PixSelect met le focus sur le mauvais élément.

## :gift: Proposition
Améliorer le scope dans les selecteurs.

## :star2: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :santa: Pour tester
On a ajouté un test en espèrant que ça suffise !
