### PR TITLE
[BUGFIX] Éviter de `throw` si l'élément `aria-selected` de `PixSelect` n'existe plus ou pas encore (PIX-15018)

### DIFF
--- a/addon/components/pix-select.js
+++ b/addon/components/pix-select.js
@@ -155,11 +155,11 @@ export default class PixSelect extends Component {
   focus() {
     if (this.isExpanded) {
       if (this.args.value) {
-        this.rootElement.querySelector("[aria-selected='true']").focus();
+        this.rootElement.querySelector("[aria-selected='true']")?.focus();
       } else if (this.args.isSearchable) {
         document.getElementById(this.searchId).focus();
       } else if (this.displayDefaultOption) {
-        this.rootElement.querySelector("[aria-selected='true']").focus();
+        this.rootElement.querySelector("[aria-selected='true']")?.focus();
       }
     }
   }

--- a/addon/components/pix-select.js
+++ b/addon/components/pix-select.js
@@ -37,10 +37,6 @@ export default class PixSelect extends Component {
         element.style.setProperty('--pix-select-width', `${selectWidth}rem`);
       });
     }
-
-    this.elementHelper.waitForElement(`container-${this.selectId}`).then((element) => {
-      this.rootElement = element;
-    });
   }
 
   get displayDefaultOption() {
@@ -152,15 +148,16 @@ export default class PixSelect extends Component {
   }
 
   @action
-  focus() {
-    if (this.isExpanded) {
-      if (this.args.value) {
-        this.rootElement.querySelector("[aria-selected='true']")?.focus();
-      } else if (this.args.isSearchable) {
-        document.getElementById(this.searchId).focus();
-      } else if (this.displayDefaultOption) {
-        this.rootElement.querySelector("[aria-selected='true']")?.focus();
-      }
+  focus(event) {
+    if (!event.target) return;
+    if (!this.isExpanded) return;
+
+    if (this.args.value) {
+      event.target.querySelector("[aria-selected='true']")?.focus();
+    } else if (this.args.isSearchable) {
+      event.target.querySelector(`#${this.searchId}`)?.focus();
+    } else if (this.displayDefaultOption) {
+      event.target.querySelector("[aria-selected='true']")?.focus();
     }
   }
 }


### PR DESCRIPTION
## :christmas_tree: Problème
Dans l'action `focus`, on ne vérifie pas si l'élément `[aria-selected=true]` existe avant d'appeler la méthode `focus()` dessus.
Il se peut que cet élément n'existe pas encore ou plus du tout, principalement dans des tests.
On suppose que ces tests interagissent trop rapidement avec le composant.

## :gift: Proposition
Vérifier si le résultat du `querySelector` est `null` avant de l'utiliser.
Ne plus se baser sur le `rootElement` juste pour être sûrs.

## :star2: Remarques
RAS

## :santa: Pour tester
Vérifier si les tests flaky de pix-admin sont réparés? 👀
