### PR TITLE
[BREAKING] Corriger l'affichage du label en cas d'icône sur PixCollapsible

### DIFF
--- a/addon/components/pix-collapsible.hbs
+++ b/addon/components/pix-collapsible.hbs
@@ -8,16 +8,17 @@
     aria-expanded={{if this.isUnCollapsed "true" "false"}}
     ...attributes
   >
-    {{#if @iconName}}
-      <PixIcon
-        class="pix-collapsible-title__icon"
-        @name={{@iconName}}
-        @plainIcon={{@plainIcon}}
-        @ariaHidden={{true}}
-      />
-    {{/if}}
 
-    <span>
+    <span class="pix-collapsible-title__container">
+      {{#if @iconName}}
+        <PixIcon
+          class="pix-collapsible-title__icon"
+          @name={{@iconName}}
+          @plainIcon={{@plainIcon}}
+          @ariaHidden={{true}}
+        />
+      {{/if}}
+
       {{yield to="title"}}
     </span>
 
@@ -40,7 +41,7 @@
     aria-hidden={{if this.isCollapsed "true" "false"}}
   >
     {{#if this.isContentRendered}}
-      {{yield}}
+      {{yield to="content"}}
     {{/if}}
   </div>
 </div>

--- a/addon/components/pix-collapsible.js
+++ b/addon/components/pix-collapsible.js
@@ -18,13 +18,6 @@ export default class PixCollapsible extends Component {
     return this.hasUnCollapsedOnce;
   }
 
-  get title() {
-    if (!this.args.title || !this.args.title.trim()) {
-      throw new Error('ERROR in PixCollapsible component, @title param is not provided');
-    }
-    return this.args.title;
-  }
-
   @action
   toggleCollapsible() {
     this.isCollapsed = !this.isCollapsed;

--- a/app/stories/pix-collapsible.mdx
+++ b/app/stories/pix-collapsible.mdx
@@ -10,6 +10,11 @@ Par défaut le contenu est masqué et cliquer sur le libellé permet de montrer 
 
 > Il est possible de cumuler les `PixCollapsible` de sorte à former un accordéon, il suffit de les mettre dans une même div parente.
 
+Ce composant possède deux `yield` :
+
+- `:title`, destiné à accueillir le label de l'accordéon
+- `:content`, destiné à accueillir le contenu lorsque l'accordéon est déroulé
+
 
 <Story of={ComponentStories.collapsible} height={150} />
 
@@ -25,8 +30,11 @@ Les paramètres `tagContent` et `tagColor` permettent d'afficher un `Pix Tag` pr
 ## Usage
 
 ```html
-<PixCollapsible @title="Titre du contenu à dérouler en cliquant" @iconTitle="user">
-  <p>Contenu du PixCollapsible</p>
+<PixCollapsible @iconName="users">`
+  <:title>Titre du contenu à dérouler en cliquant</:title>
+  <:content>
+    <div>Contenu du PixCollapsible</div>
+  </:content>
 </PixCollapsible>
 ```
 

--- a/app/stories/pix-collapsible.stories.js
+++ b/app/stories/pix-collapsible.stories.js
@@ -4,15 +4,10 @@ import { ICONS } from '../../addon/helpers/icons';
 export default {
   title: 'Others/Collapsible',
   argTypes: {
-    title: {
-      name: 'title',
-      description: 'Intitulé du contenu du PixCollapsible',
-      type: { name: 'string', required: true },
-    },
     iconName: {
       name: 'iconName',
       description: "Ajoute l'icône donnée en paramètre avant le titre du PixCollapsible",
-      type: { name: 'string', required: true },
+      type: { name: 'string', required: false },
       control: { type: 'select' },
       options: Object.keys(ICONS),
     },
@@ -52,9 +47,9 @@ const Template = (args) => {
   <:title>
     {{this.title}}
   </:title>
-  <:default>
+  <:content>
     <div>Contenu du PixCollapsible</div>
-  </:default>
+  </:content>
 </PixCollapsible>`,
     context: args,
   };
@@ -73,27 +68,27 @@ export const multipleCollapsible = (args) => {
     <:title>
       Titre A
     </:title>
-    <:default>
+    <:content>
       <div>Contenu A</div>
-    </:default>
+    </:content>
   </PixCollapsible>
 
   <PixCollapsible @iconName={{this.iconName}} @plainIcon={{this.plainIcon}}>
     <:title>
       Titre B
     </:title>
-    <:default>
+    <:content>
       <div>Contenu B</div>
-    </:default>
+    </:content>
   </PixCollapsible>
 
   <PixCollapsible @iconName={{this.iconName}} @plainIcon={{this.plainIcon}}>
     <:title>
       Titre C
     </:title>
-    <:default>
+    <:content>
       <div>Contenu C</div>
-    </:default>
+    </:content>
   </PixCollapsible>
 </div>`,
     context: args,
@@ -114,9 +109,9 @@ export const collapsibleWithTag = (args) => {
     <:title>
       Titre A
     </:title>
-    <:default>
+    <:content>
       <div>Contenu A</div>
-    </:default>
+    </:content>
   </PixCollapsible>
 
   <PixCollapsible
@@ -128,9 +123,9 @@ export const collapsibleWithTag = (args) => {
     <:title>
       Titre B
     </:title>
-    <:default>
+    <:content>
       <div>Contenu B</div>
-    </:default>
+    </:content>
   </PixCollapsible>
 </div>`,
     context: args,

--- a/tests/integration/components/pix-collapsible-test.js
+++ b/tests/integration/components/pix-collapsible-test.js
@@ -2,7 +2,6 @@ import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { render, clickByText } from '@1024pix/ember-testing-library';
 import { hbs } from 'ember-cli-htmlbars';
-import createGlimmerComponent from '../../helpers/create-glimmer-component';
 
 module('Integration | Component | PixCollapsible', function (hooks) {
   setupRenderingTest(hooks);
@@ -13,9 +12,9 @@ module('Integration | Component | PixCollapsible', function (hooks) {
   <:title>
     Titre de mon élément déroulable
   </:title>
-  <:default>
+  <:content>
     <p>Contenu de mon élément</p>
-  </:default>
+  </:content>
 </PixCollapsible>`);
 
     // then
@@ -29,9 +28,9 @@ module('Integration | Component | PixCollapsible', function (hooks) {
   <:title>
     Titre de mon élément déroulable
   </:title>
-  <:default>
+  <:content>
     <p>Contenu de mon élément</p>
-  </:default>
+  </:content>
 </PixCollapsible>`);
     await clickByText('Titre de mon élément déroulable');
 
@@ -40,29 +39,15 @@ module('Integration | Component | PixCollapsible', function (hooks) {
     assert.dom(screen.queryByText('Contenu de mon élément')).isVisible();
   });
 
-  test('it should not show PixCollapsible if title is not provided', async function (assert) {
-    // given
-    const componentParams = { title: '  ' };
-    const component = createGlimmerComponent('pix-collapsible', componentParams);
-
-    // when & then
-    const expectedError = new Error(
-      'ERROR in PixCollapsible component, @title param is not provided',
-    );
-    assert.throws(function () {
-      component.title;
-    }, expectedError);
-  });
-
   test('it should not destroy content when uncollapsed then collapsed again', async function (assert) {
     // when
     const screen = await render(hbs`<PixCollapsible aria-label='collapsible label'>
   <:title>
     Titre de mon élément déroulable
   </:title>
-  <:default>
+  <:content>
     <p>Contenu de mon élément</p>
-  </:default>
+  </:content>
 </PixCollapsible>`);
     await clickByText('Titre de mon élément déroulable');
     await clickByText('Titre de mon élément déroulable');


### PR DESCRIPTION
## :boom: BREAKING_CHANGES
Changement de comportement pour le PixCollapsible, yield `content` à la place de `default`.

## :christmas_tree: Problème
Lorsque l'icône est ajouté dans le title du composant, le label se plaçait au centre


https://github.com/user-attachments/assets/cad3d9bd-7266-467b-94c9-2b10f96c9812



## :gift: Proposition
Mettre l'icône dans la même span que le label

La v47 introduit le bug d'affichage. La montée de version est mise en pause coté Certif en attendant ce fix.

## :star2: Remarques
J'ai nommé le yield du contenu du composant.

## :santa: Pour tester
Aller sur la doc de PixCollapsible et jouer avec le composant
