### PR TITLE
[BUGFIX] Remplacer le alt par la balise title du svg (PIX-15105)

### DIFF
--- a/addon/components/pix-icon.hbs
+++ b/addon/components/pix-icon.hbs
@@ -1,10 +1,15 @@
-<svg
-  xmlns="http://www.w3.org/2000/svg"
-  alt={{this.alternativeText}}
-  aria-hidden={{this.ariaHidden}}
-  role="img"
-  class="pix-icon"
-  ...attributes
->
-  <use href="/@1024pix/pix-ui/svg/pix-sprite.svg#{{this.iconName}}" />
-</svg>
+{{#let (unique-id) as |titleId|}}
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    aria-hidden={{this.ariaHidden}}
+    role="img"
+    class="pix-icon"
+    aria-describedby={{if this.title titleId}}
+    ...attributes
+  >
+    {{#if this.title}}
+      <title id={{titleId}}>{{this.title}}</title>
+    {{/if}}
+    <use href="/@1024pix/pix-ui/svg/pix-sprite.svg#{{this.iconName}}" />
+  </svg>
+{{/let}}

--- a/addon/components/pix-icon.js
+++ b/addon/components/pix-icon.js
@@ -3,8 +3,12 @@ import { warn } from '@ember/debug';
 import { ICONS } from '@1024pix/pix-ui/helpers/icons';
 
 export default class PixIcon extends Component {
-  get alternativeText() {
-    return this.args.alternativeText || '';
+  get title() {
+    warn('PixIcon: @alternativeText is deprecated use @title instead', !this.args.alternativeText, {
+      id: 'pix-ui.icon.alternativeText.deprecated',
+    });
+
+    return this.args.title || this.args.alternativeText || null;
   }
 
   get ariaHidden() {

--- a/app/stories/pix-icon.stories.js
+++ b/app/stories/pix-icon.stories.js
@@ -23,7 +23,13 @@ export default {
     },
     alternativeText: {
       name: 'alternativeText',
-      description: "Permet d'ajouter un texte alternatif pour illustrer l'icône si besoin",
+      description:
+        "DEPRECATED: Permet d'ajouter un texte alternatif pour illustrer l'icône si besoin",
+      type: { name: 'string', required: false },
+    },
+    title: {
+      name: 'title',
+      description: "Permet d'ajouter un texte title pour illustrer l'icône si besoin",
       type: { name: 'string', required: false },
     },
     ariaHidden: {
@@ -45,6 +51,7 @@ export const icon = (args) => ({
   @name={{this.name}}
   @plainIcon={{this.plainIcon}}
   @alternativeText={{this.alternativeText}}
+  @title={{this.title}}
   @ariaHidden={{this.ariaHidden}}
 />`,
   context: args,
@@ -67,7 +74,7 @@ export const allIcons = (args) => {
       <PixIcon
         @name={{icon.iconName}}
         @plainIcon={{icon.variant}}
-        @alternativeText={{icon.iconName}}
+        @title={{icon.iconName}}
         @ariaHidden={{true}}
       />
       <p class='icon-name'>{{icon.iconName}}&nbsp;{{if icon.variant '(plain)'}}</p>

--- a/tests/integration/components/pix-icons-test.js
+++ b/tests/integration/components/pix-icons-test.js
@@ -1,0 +1,16 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@1024pix/ember-testing-library';
+import { hbs } from 'ember-cli-htmlbars';
+
+module('Integration | Component | PixIcons', function (hooks) {
+  setupRenderingTest(hooks);
+
+  test('it renders the default PixIcons title', async function (assert) {
+    // when
+    const screen = await render(hbs`<PixIcon @title='my-title' @icon='help' />`);
+
+    // then
+    assert.ok(screen.getByRole('img', { name: 'my-title' }));
+  });
+});


### PR DESCRIPTION
## :christmas_tree: Problème
le alt n'est pas la meilleur manière de donner un title à notre svg

## :gift: Proposition
Utiliser la balise title ( ISO FontAwesome lors de l'usage d'un title qui permet un survol de l'icône avec le texte)

## :star2: Remarques
Pas de mofication de signature par rapport au field alternativeText
Ajout d'un aria describeBy dans le cas ou un title est affiché

## :santa: Pour tester
CI au vert, lors de l'ajout d'un title vérifier qu'au survol on voit bien le texte