### PR TITLE
[BUGFIX] Ne pas surcharger le PixIcon via le composant Tooltip (PIX-15123)

### DIFF
--- a/addon/styles/_pix-icon.scss
+++ b/addon/styles/_pix-icon.scss
@@ -1,4 +1,5 @@
 .pix-icon {
   width: 1.5rem;
   height: 1.5rem;
+  fill: currentcolor;
 }

--- a/addon/styles/_pix-tooltip.scss
+++ b/addon/styles/_pix-tooltip.scss
@@ -7,12 +7,7 @@
   &__trigger-element {
     display: block;
     width: 100%;
-
-    > svg {
-      width: 1rem;
-      height: 1rem;
-      fill:var(--pix-neutral-500);
-    }
+    color: var(--pix-neutral-500);
   }
 
   &__trigger-element:hover + .pix-tooltip__content {
@@ -54,11 +49,6 @@
   transition: opacity 0.3s;
   pointer-events: none;
   fill: var(--pix-neutral-0);
-
-  > .pix-icon {
-    width: 1rem;
-    height: 1rem;
-  }
 
   &--inline {
     white-space: nowrap;

--- a/app/stories/pix-tooltip.stories.js
+++ b/app/stories/pix-tooltip.stories.js
@@ -104,7 +104,7 @@ const TemplateWithIconElement = (args) => {
     template: hbs`<PixTooltip @id={{this.id}} @isInline='true'>
   <:triggerElement>
     {{! template-lint-disable no-inline-styles }}
-    <PixIcon class='external-link' @name='openNew' style='widh:2.5rem;height:2.5rem' />
+    <PixIcon class='external-link' @name='openNew' style='width:1.5rem;height:1.5rem' />
   </:triggerElement>
 
   <:tooltip>


### PR DESCRIPTION
## :christmas_tree: Problème
On surcharge actuellement le pix-icon / ou directement le svg dans le composant PixTooltip, ce qui pose des soucis dans le cas où nous voudrions une icône avec une couleur/taille différente avec une tooltip

## :gift: Proposition
Retirer ces surcharges qui seront à faire dans le layout au besoin

## :santa: Pour tester
CI au vert