### PR TITLE
[BUGFIX] Ajouter des ariaHidden sur les PixIcon décorative (PIX-15154)

### DIFF
--- a/addon/components/pix-banner.hbs
+++ b/addon/components/pix-banner.hbs
@@ -1,6 +1,11 @@
 {{#if this.displayBanner}}
   <div class="pix-banner pix-banner--{{this.type}}" role="alert" ...attributes>
-    <PixIcon @name={{this.icon}} @plainIcon={{true}} @ariaHidden="true" class="pix-banner__icon" />
+    <PixIcon
+      @name={{this.icon}}
+      @plainIcon={{true}}
+      @ariaHidden={{true}}
+      class="pix-banner__icon"
+    />
     <div>
       {{yield}}
       {{#if this.displayAction}}

--- a/addon/components/pix-button.hbs
+++ b/addon/components/pix-button.hbs
@@ -17,6 +17,7 @@
     {{#if @iconBefore}}
       <PixIcon
         class="pix-button__icon pix-button__icon--before"
+        @ariaHidden={{true}}
         @name={{@iconBefore}}
         @plainIcon={{@plainIconBefore}}
       />
@@ -26,6 +27,7 @@
       <PixIcon
         class="pix-button__icon pix-button__icon--after"
         @name={{@iconAfter}}
+        @ariaHidden={{true}}
         @plainIcon={{@plainIconAfter}}
       />
     {{/if}}

--- a/addon/components/pix-collapsible.hbs
+++ b/addon/components/pix-collapsible.hbs
@@ -30,6 +30,7 @@
       {{/if}}
       <PixIcon
         class="pix-collapsible-title-container__toggle-icon"
+        @ariaHidden={{true}}
         @name="{{if this.isCollapsed 'chevronBottom' 'chevronTop'}}"
       />
     </span>

--- a/addon/components/pix-input-password.hbs
+++ b/addon/components/pix-input-password.hbs
@@ -44,10 +44,18 @@
       />
 
       {{#if this.hasError}}
-        <PixIcon @name="close" class="pix-input-password__icon pix-input-password__error-icon" />
+        <PixIcon
+          @name="close"
+          @ariaHidden={{true}}
+          class="pix-input-password__icon pix-input-password__error-icon"
+        />
       {{/if}}
       {{#if this.hasSuccess}}
-        <PixIcon @name="check" class="pix-input-password__icon pix-input-password__success-icon" />
+        <PixIcon
+          @name="check"
+          @ariaHidden={{true}}
+          class="pix-input-password__icon pix-input-password__success-icon"
+        />
       {{/if}}
     </div>
 

--- a/addon/components/pix-input.hbs
+++ b/addon/components/pix-input.hbs
@@ -24,10 +24,10 @@
       />
 
       {{#if this.hasError}}
-        <PixIcon @name="close" class="pix-input__error-icon" />
+        <PixIcon @name="close" class="pix-input__error-icon" @ariaHidden={{true}} />
       {{/if}}
       {{#if this.hasSuccess}}
-        <PixIcon @name="check" class="pix-input__success-icon" />
+        <PixIcon @name="check" class="pix-input__success-icon" @ariaHidden={{true}} />
       {{/if}}
     </div>
 

--- a/addon/components/pix-multi-select.hbs
+++ b/addon/components/pix-multi-select.hbs
@@ -20,7 +20,7 @@
 
     {{#if @isSearchable}}
       <span {{reference}} class={{this.headerClassName}}>
-        <PixIcon @name="search" class="pix-multi-select-header__search-icon" />
+        <PixIcon @name="search" class="pix-multi-select-header__search-icon" @ariaHidden={{true}} />
 
         <input
           class="pix-multi-select-header__search-input"
@@ -56,6 +56,7 @@
           class="pix-multi-select-header__dropdown-icon
             {{if this.isExpanded ' pix-multi-select-header__dropdown-icon--expand'}}"
           @name={{if this.isExpanded "chevronTop" "chevronBottom"}}
+          @ariaHidden={{true}}
         />
       </button>
     {{/if}}

--- a/addon/components/pix-search-input.hbs
+++ b/addon/components/pix-search-input.hbs
@@ -11,7 +11,7 @@
   </PixLabel>
 
   <div class="pix-search-input__input-container">
-    <PixIcon @name="search" />
+    <PixIcon @name="search" @ariaHidden={{true}} />
     <input
       id={{this.id}}
       class="pix-search-input__input"

--- a/addon/components/pix-select.hbs
+++ b/addon/components/pix-select.hbs
@@ -33,13 +33,19 @@
         aria-disabled={{@isDisabled}}
       >
         {{#if @iconName}}
-          <PixIcon @name={{@iconName}} @plainIcon={{@plainIcon}} class="pix-select-button__icon" />
+          <PixIcon
+            @name={{@iconName}}
+            @plainIcon={{@plainIcon}}
+            @ariaHidden={{true}}
+            class="pix-select-button__icon"
+          />
         {{/if}}
 
         <span class="pix-select-button__text">{{this.placeholder}}</span>
 
         <PixIcon
           class="pix-select-button__dropdown-icon"
+          @ariaHidden={{true}}
           @name={{if this.isExpanded "chevronTop" "chevronBottom"}}
         />
       </button>
@@ -50,7 +56,7 @@
       >
         {{#if @isSearchable}}
           <div class="pix-select__search">
-            <PixIcon class="pix-select-search__icon" @name="search" />
+            <PixIcon class="pix-select-search__icon" @name="search" @ariaHidden={{true}} />
             <label class="screen-reader-only" for={{this.searchId}}>{{@searchLabel}}</label>
             <input
               class="pix-select-search__input"

--- a/tests/integration/components/pix-select-test.js
+++ b/tests/integration/components/pix-select-test.js
@@ -663,18 +663,6 @@ module('Integration | Component | PixSelect', function (hooks) {
   });
 
   module('#icon', function () {
-    module('when no icon name is provided', function () {
-      test('does not display any icon', async function (assert) {
-        // given & when
-        await render(
-          hbs`<PixSelect @options={{this.options}}><:label>{{this.label}}</:label></PixSelect>`,
-        );
-
-        // then
-        assert.dom('.fa-earth-europe').doesNotExist();
-      });
-    });
-
     module('when an icon name is provided', function () {
       test('displays an icon', async function (assert) {
         // given & when
@@ -682,7 +670,7 @@ module('Integration | Component | PixSelect', function (hooks) {
           hbs`<PixSelect @iconName='globe' @options={{this.options}}><:label>{{this.label}}</:label></PixSelect>`,
         );
 
-        const svg = screen.getAllByRole('img')[0].innerHTML;
+        const svg = screen.getAllByRole('img', { hidden: true })[0].innerHTML;
         // then
         assert.true(svg.includes('#globe'));
       });


### PR DESCRIPTION
## :christmas_tree: Problème
Suite à la migration sur mon-pix, on a vu que certains PixIcon n'ont pas d'ariaHidden alors que l'on devrait

## :gift: Proposition
Ajouter les ariaHidden qui sont nécessaire

## :star2: Remarques
Ajouter en Tech Time un linter accessiblité ? afin de remonter le souci au plus vite

## :santa: Pour tester
CI au vert