### PR TITLE
[FEATURE] Améliorer la barre de progression (PIX-15260)

### DIFF
--- a/addon/components/pix-progress-gauge.hbs
+++ b/addon/components/pix-progress-gauge.hbs
@@ -1,4 +1,8 @@
-<div class="progress-gauge {{this.themeMode}} {{this.colorClass}}" ...attributes>
+<div
+  class="progress-gauge {{this.themeMode}} {{this.colorClass}}"
+  aria-hidden={{if @isDecorative "true"}}
+  ...attributes
+>
   {{#unless @hidePercentage}}
     <div class="progress-gauge__text" role="presentation">{{this.percentageValue}}</div>
   {{/unless}}

--- a/addon/components/pix-progress-gauge.hbs
+++ b/addon/components/pix-progress-gauge.hbs
@@ -1,5 +1,7 @@
 <div class="progress-gauge {{this.themeMode}} {{this.colorClass}}" ...attributes>
-  <div class="progress-gauge__text" role="presentation">{{this.percentageValue}}</div>
+  {{#unless @hidePercentage}}
+    <div class="progress-gauge__text" role="presentation">{{this.percentageValue}}</div>
+  {{/unless}}
   <label for={{this.id}} class="screen-reader-only">{{@label}}</label>
   <progress
     class="progress-gauge__bar"

--- a/addon/components/pix-progress-gauge.js
+++ b/addon/components/pix-progress-gauge.js
@@ -20,7 +20,9 @@ export default class PixProgressGauge extends Component {
   }
 
   get label() {
-    if (!this.args.label || !this.args.label.trim()) {
+    const thereIsNoLabel = !this.args.label || !this.args.label.trim();
+
+    if (thereIsNoLabel && !this.args.isDecorative) {
       throw new Error('ERROR in PixProgressGauge component, @label param is not provided.');
     }
     return this.args.label;

--- a/app/stories/pix-progress-gauge.mdx
+++ b/app/stories/pix-progress-gauge.mdx
@@ -32,6 +32,7 @@ Démonstration d'une barre de progression blanche en dark mode avec un sous titr
   @color="sucess"
   @themeMode="dark"
   @subTitle="Un sous titre"
+  @hidePercentage=false
 />
 ```
 

--- a/app/stories/pix-progress-gauge.mdx
+++ b/app/stories/pix-progress-gauge.mdx
@@ -9,7 +9,7 @@ import * as ComponentStories from './pix-progress-gauge.stories';
 
 Permet d'afficher un barre de progression sur un barème de 100%. Des paramètres existent pour changer le mode (dark ou light) ou la couleur du composant.
 
-> **⚠️** **Il est nécessaire d'avoir un `label` pour rendre le composant accessible !**
+> **⚠️** **Il est nécessaire d'avoir un `label` pour rendre le composant accessible, sauf si le composant est utilisé uniquement pour de la décoration. Dans ce cas, mettre le paramètre `@isDecorative` à `true`.**
 
 <Story of={ComponentStories.Default} height={60} />
 
@@ -33,6 +33,7 @@ Démonstration d'une barre de progression blanche en dark mode avec un sous titr
   @themeMode="dark"
   @subTitle="Un sous titre"
   @hidePercentage=false
+  @isDecorative={{true}}
 />
 ```
 

--- a/app/stories/pix-progress-gauge.stories.js
+++ b/app/stories/pix-progress-gauge.stories.js
@@ -46,6 +46,13 @@ export default {
       type: { name: 'boolean', required: false },
       table: { defaultValue: { summary: 'false' } },
     },
+    isDecorative: {
+      name: 'isDecorative',
+      description:
+        'Indiquer que la barre de progression est utilisée pour de la présentation et doit être ignorée par les lecteurs d’écran',
+      type: { name: 'boolean', required: false },
+      table: { defaultValue: { summary: 'false' } },
+    },
   },
 };
 

--- a/app/stories/pix-progress-gauge.stories.js
+++ b/app/stories/pix-progress-gauge.stories.js
@@ -40,6 +40,12 @@ export default {
       type: { name: 'string', required: false },
       table: { defaultValue: { summary: 'null' } },
     },
+    hidePercentage: {
+      name: 'hidePercentage',
+      description: 'Cacher le pourcentage affiché à gauche de la barre de progression',
+      type: { name: 'boolean', required: false },
+      table: { defaultValue: { summary: 'false' } },
+    },
   },
 };
 
@@ -114,4 +120,23 @@ darkModeProgressGauge.args = {
   color: 'primary',
   themeMode: 'dark',
   subtitle: 'Avancement',
+};
+
+export const WithoutPercentage = (args) => {
+  return {
+    template: hbs`<PixProgressGauge
+  @value={{this.value}}
+  @color={{this.color}}
+  @themeMode={{this.themeMode}}
+  @subtitle={{this.subtitle}}
+  @label={{this.label}}
+  @hidePercentage={{this.hidePercentage}}
+/>`,
+    context: args,
+  };
+};
+WithoutPercentage.args = {
+  value: '50',
+  color: 'primary',
+  hidePercentage: true,
 };

--- a/tests/integration/components/pix-progress-gauge-test.js
+++ b/tests/integration/components/pix-progress-gauge-test.js
@@ -156,7 +156,7 @@ module('Integration | Component | progress-gauge', function (hooks) {
     });
   });
 
-  module('Attibutes @subtitle', function () {
+  module('Attributes @subtitle', function () {
     test('it does not render the progress gauge sub-title', async function (assert) {
       // given & when
       await render(hbs`<PixProgressGauge @value='50' />`);

--- a/tests/integration/components/pix-progress-gauge-test.js
+++ b/tests/integration/components/pix-progress-gauge-test.js
@@ -69,6 +69,16 @@ module('Integration | Component | progress-gauge', function (hooks) {
         component.label;
       }, expectedError);
     });
+
+    test('it should not throw an error if there is no label and if @isDecorative is true', async function (assert) {
+      // given & when
+      const componentParams = { label: null, isDecorative: true };
+      const component = createGlimmerComponent('pix-progress-gauge', componentParams);
+
+      // then
+      component.label;
+      assert.ok(true);
+    });
   });
 
   module('Attributes @color', function () {
@@ -207,6 +217,16 @@ module('Integration | Component | progress-gauge', function (hooks) {
 
       // then
       assert.dom('.progress-gauge__text').doesNotExist();
+    });
+  });
+
+  module('Attributes @isDecorative', () => {
+    test('it sets gauge aria-hidden to "true"', async function (assert) {
+      // when
+      await render(hbs`<PixProgressGauge @value='50' @isDecorative='true' />`);
+
+      // then
+      assert.dom('.progress-gauge').hasAria('hidden', 'true');
     });
   });
 });

--- a/tests/integration/components/pix-progress-gauge-test.js
+++ b/tests/integration/components/pix-progress-gauge-test.js
@@ -28,12 +28,12 @@ module('Integration | Component | progress-gauge', function (hooks) {
       // given & when
       const screen = await render(hbs`<PixProgressGauge @value='50' />`);
 
+      const localizedPercentage = Number(50 / 100).toLocaleString(navigator.language, {
+        style: 'percent',
+      });
+
       // then
-      const frenchLocale = String(navigator.language).toLowerCase() === 'fr-fr';
-      assert.strictEqual(
-        screen.getByRole('presentation').innerText,
-        frenchLocale ? '50\xA0%' : '50%',
-      );
+      assert.strictEqual(screen.getByRole('presentation').innerText, localizedPercentage);
     });
 
     test('it renders the progress gauge with correct width never exceed 100%', async function (assert) {
@@ -173,6 +173,40 @@ module('Integration | Component | progress-gauge', function (hooks) {
       // then
       const componentElement = this.element.querySelector('.progress-gauge__sub-title');
       assert.strictEqual(componentElement.textContent.trim(), 'toto');
+    });
+  });
+
+  module('Attributes @hidePercentage', function () {
+    test('it renders the progress gauge percentage by default', async function (assert) {
+      // when
+      const screen = await render(hbs`<PixProgressGauge @value='50' />`);
+
+      const localizedPercentage = Number(50 / 100).toLocaleString(navigator.language, {
+        style: 'percent',
+      });
+
+      // then
+      assert.dom(screen.getByRole('presentation', { hidden: true })).hasText(localizedPercentage);
+    });
+
+    test('it renders the progress gauge percentage when attribute is false', async function (assert) {
+      // when
+      const screen = await render(hbs`<PixProgressGauge @value='50' @hidePercentage={{false}} />`);
+      const localizedPercentage = Number(50 / 100).toLocaleString(navigator.language, {
+        style: 'percent',
+      });
+
+      // then
+
+      assert.dom(screen.getByRole('presentation', { hidden: true })).hasText(localizedPercentage);
+    });
+
+    test('it does not render the progress gauge percentage when attribute is true', async function (assert) {
+      // when
+      await render(hbs`<PixProgressGauge @value='50' @hidePercentage={{true}} />`);
+
+      // then
+      assert.dom('.progress-gauge__text').doesNotExist();
     });
   });
 });


### PR DESCRIPTION
## :christmas_tree: Problème

Dans les modules d'apprentissage Pix, nous voulons afficher une barre de progression (`PixProgressGauge`) sans le pourcentage, et pouvoir la masquer aux lecteurs d'écran car elle est uniquement décorative.

![Capture d’écran 2024-11-12 à 17 41 51](https://github.com/user-attachments/assets/f5b90135-1f79-434d-980f-4ae49c4c219a)

Maquette dispo ici : https://www.figma.com/design/47MuKB1wXoLEgMal06idN3/R%26D-DevComp?node-id=2718-4576&node-type=canvas&t=6YIdJvyGAJy1jfwe-0

## :gift: Proposition

Créer deux nouveaux attributes pour `PixProgressGauge`
- `@hidePercentage` pour permettre le masquage du pourcentage
- `@isDecorative` pour masquer le composant aux lecteurs d'écran

## :star2: Remarques

Pas de _breaking changes_ à prévoir car les deux nouveaux attributs ont `false` pour valeur par défaut et préservent le comportement existant s'ils ne sont pas renseignés.

## :santa: Pour tester

1. Ouvrir storybook : https://ui-pr759.review.pix.fr/?path=/docs/utiliser-pix-ui-installation--docs
2. Afficher le composant ProgressGauge
3. Activer le paramètre hidePercentage et vérifier que le pourcentage n'est plus affiché à gauche de la barre
4. Activer le paramètre isDecorative et vérifier que le champ label n'est plus à remplir obligatoirement
