### PR TITLE
[BUGFIX] Corriger l'affichage des icônes sur les composants (PIX-15304)

### DIFF
--- a/addon/styles/_pix-banner.scss
+++ b/addon/styles/_pix-banner.scss
@@ -32,7 +32,6 @@
   &--information {
     color: var(--pix-info-700);
     background-color: var(--pix-info-50);
-    fill: var(--pix-info-700);
 
     .pix-icon-button {
       background-color: var(--pix-info-50);
@@ -52,7 +51,6 @@
   &--warning {
     color: var(--pix-warning-700);
     background-color: var(--pix-warning-50);
-    fill: var(--pix-warning-700);
 
     .pix-icon-button {
       background-color: var(--pix-warning-50);
@@ -72,7 +70,6 @@
   &--error {
     color: var(--pix-error-700);
     background-color: var(--pix-error-50);
-    fill: var(--pix-error-700);
 
     .pix-icon-button {
       background-color: var(--pix-error-50);
@@ -92,18 +89,15 @@
   &--communication {
     color: var(--pix-neutral-0);
     background-color: var(--pix-primary-500);
-    fill: var(--pix-neutral-0);
 
     &-orga {
       color: var(--pix-neutral-0);
       background-color: var(--pix-orga-500);
-      fill: var(--pix-neutral-0);
     }
 
     &-certif {
       color: var(--pix-neutral-0);
       background-color: var(--pix-certif-500);
-      fill: var(--pix-neutral-0);
     }
   }
 }

--- a/addon/styles/_pix-banner.scss
+++ b/addon/styles/_pix-banner.scss
@@ -34,6 +34,7 @@
     background-color: var(--pix-info-50);
 
     .pix-icon-button {
+      color: currentcolor;
       background-color: var(--pix-info-50);
 
       &:hover:enabled,
@@ -53,6 +54,7 @@
     background-color: var(--pix-warning-50);
 
     .pix-icon-button {
+      color: currentcolor;
       background-color: var(--pix-warning-50);
 
       &:hover:enabled,
@@ -72,6 +74,7 @@
     background-color: var(--pix-error-50);
 
     .pix-icon-button {
+      color: currentcolor;
       background-color: var(--pix-error-50);
 
       &:hover:enabled,
@@ -90,14 +93,45 @@
     color: var(--pix-neutral-0);
     background-color: var(--pix-primary-500);
 
-    &-orga {
-      color: var(--pix-neutral-0);
-      background-color: var(--pix-orga-500);
-    }
+    .pix-icon-button {
+      color: currentcolor;
 
-    &-certif {
-      color: var(--pix-neutral-0);
-      background-color: var(--pix-certif-500);
+      &:hover:enabled,
+      &:focus:enabled,
+      &:active:enabled {
+        background-color: var(--pix-primary-300);
+      }
     }
   }
-}
+
+    &--communication-orga {
+      color: var(--pix-neutral-0);
+      background-color: var(--pix-orga-500);
+
+      .pix-icon-button {
+        color: currentcolor;
+
+        &:hover:enabled,
+        &:focus:enabled,
+        &:active:enabled {
+          background-color: var(--pix-communication-light);
+        }
+      }
+    }
+
+    &--communication-certif {
+      color: var(--pix-neutral-0);
+      background-color: var(--pix-certif-500);
+
+      .pix-icon-button {
+        color: currentcolor;
+
+        &:hover:enabled,
+        &:focus:enabled,
+        &:active:enabled {
+          background-color: var(--pix-content-light);
+        }
+      }
+    }
+  }
+

--- a/addon/styles/_pix-button-base.scss
+++ b/addon/styles/_pix-button-base.scss
@@ -30,7 +30,6 @@
   &--primary {
     color: var(--pix-neutral-0);
     background-color: var(--pix-primary-500);
-    fill: var(--pix-neutral-0);
 
     &:not([aria-disabled="true"]) {
       &:hover {
@@ -54,13 +53,11 @@
   &--primary-bis {
     color: var(--pix-neutral-900);
     background-color: var(--pix-secondary-500);
-    fill: var(--pix-neutral-900);
 
     &:not([aria-disabled="true"]) {
       &:hover {
         color: var(--pix-neutral-0);
         background-color: var(--pix-secondary-700);
-        fill: var(--pix-neutral-0);
       }
 
       &:focus,
@@ -69,14 +66,12 @@
         background-color: var(--pix-secondary-700);
         outline: 1px solid var(--pix-neutral-0);
         outline-offset: -4px;
-        fill: var(--pix-neutral-0);
       }
 
       &:active {
         color: var(--pix-neutral-0);
         background-color: var(--pix-secondary-900);
         outline: none;
-        fill: var(--pix-neutral-0);
       }
     }
   }
@@ -85,7 +80,6 @@
     color: var(--pix-primary-700);
     background-color: transparent;
     border: 2px solid var(--pix-primary-700);
-    fill: var(--pix-primary-700);
 
     &:not([aria-disabled="true"]) {
       &:hover {
@@ -115,7 +109,6 @@
     color: var(--pix-neutral-800);
     text-decoration: underline;
     background-color: transparent;
-    fill: var(--pix-neutral-800);
 
     &:not([aria-disabled="true"]) {
       &:hover,
@@ -133,7 +126,6 @@
   &--success {
     color: var(--pix-neutral-0);
     background-color: var(--pix-success-500);
-    fill: var(--pix-neutral-0);
 
     &:not([aria-disabled="true"]) {
       &:hover {
@@ -157,7 +149,6 @@
   &--error {
     color: var(--pix-neutral-0);
     background-color: var(--pix-error-500);
-    fill: var(--pix-neutral-0);
 
     &:not([aria-disabled="true"]) {
       &:hover {

--- a/addon/styles/_pix-collapsible.scss
+++ b/addon/styles/_pix-collapsible.scss
@@ -38,7 +38,6 @@
   font-size: 1rem;
   line-height: 1.25;
   border: none;
-  fill: var(--pix-neutral-800);
 
   &:hover,
   &[aria-expanded='true'] {
@@ -59,7 +58,7 @@
 
   &__icon {
     margin-right: var(--pix-spacing-2x);
-    fill: var(--pix-neutral-500);
+    color: var(--pix-neutral-500);
   }
 }
 

--- a/addon/styles/_pix-icon-button.scss
+++ b/addon/styles/_pix-icon-button.scss
@@ -6,12 +6,12 @@
   min-width: 2.375rem;
   height: 2.375rem;
   padding: 0;
+  color: var(--pix-neutral-800);
   background-color: transparent;
   border: none;
   border-radius: 50%;
   outline: none;
   cursor: pointer;
-  fill: var(--pix-neutral-800);
 
   &__icon {
     width: 1.35rem;
@@ -34,16 +34,16 @@
   }
 
   &:focus:enabled {
+    color: var(--pix-neutral-0);
     background-color: var(--pix-neutral-800);
     outline: 1px solid var(--pix-neutral-0);
     outline-offset: -3px;
-    fill: var(--pix-neutral-0);
   }
 
   &:active:enabled {
+    color: var(--pix-neutral-800);
     background-color: var(--pix-neutral-100);
     outline: 0;
-    fill: var(--pix-neutral-800);
   }
 
   &--background {

--- a/addon/styles/_pix-indicator-card.scss
+++ b/addon/styles/_pix-indicator-card.scss
@@ -17,31 +17,31 @@
 
     &--grey,
     &--neutral {
+      color: var(--pix-neutral-500);
       background-color: var(--pix-neutral-20);
-      fill: var(--pix-neutral-500);
     }
 
     &--blue,
     &--primary {
+      color: var(--pix-primary-700);
       background-color: var(--pix-primary-10);
-      fill: var(--pix-primary-700);
     }
 
     &--green,
     &--success {
+      color: var(--pix-success-700);
       background-color: var(--pix-success-50);
-      fill: var(--pix-success-700);
     }
 
     &--purple,
     &--tertiary {
+      color: var(--pix-tertiary-900);
       background-color: var(--pix-tertiary-100);
-      fill: var(--pix-tertiary-900);
     }
 
     &--warning {
+      color: var(--pix-warning-700);
       background-color: var(--pix-warning-50);
-      fill: var(--pix-warning-700);
     }
   }
 
@@ -93,6 +93,6 @@
     width: 1rem;
     height:1rem;
     margin: 0 var(--pix-spacing-2x);
-    fill: var(--pix-neutral-500);
+    color: var(--pix-neutral-500);
   }
 }

--- a/addon/styles/_pix-input-password.scss
+++ b/addon/styles/_pix-input-password.scss
@@ -69,8 +69,8 @@
     width: 1rem;
     height: 1rem;
     padding: 2px;
+    color: var(--pix-neutral-0);
     border-radius: 50%;
-    fill: var(--pix-neutral-0);
   }
 
   &__error-icon {

--- a/addon/styles/_pix-label-wrapped.scss
+++ b/addon/styles/_pix-label-wrapped.scss
@@ -32,7 +32,6 @@
           --state-border-color: var(--pix-success-300);
 
           color: var(--pix-success-700);
-          fill: var(--pix-success-700);
         }
 
         &.pix-label-wrapped--state-error {
@@ -40,7 +39,6 @@
           --state-border-color: var(--pix-error-500);
 
           color: var(--pix-error-700);
-          fill: var(--pix-error-700);
         }
 
         & .pix-label-wrapped__state-icon {

--- a/addon/styles/_pix-message.scss
+++ b/addon/styles/_pix-message.scss
@@ -13,30 +13,25 @@
   &.pix-message--info {
     color: var(--pix-info-700);
     background-color: var(--pix-info-50);
-    fill: var(--pix-info-700);
   }
 
   &.pix-message--alert {
     color: var(--pix-error-700);
     background-color: var(--pix-error-50);
-    fill: var(--pix-info-700);
   }
 
   &.pix-message--error {
     color: var(--pix-error-700);
     background-color: var(--pix-error-50);
-    fill: var(--pix-error-700);
   }
 
   &.pix-message--success {
     color: var(--pix-success-700);
     background-color: var(--pix-success-50);
-    fill: var(--pix-success-700);
   }
 
   &.pix-message--warning {
     color: var(--pix-warning-700);
     background-color: var(--pix-warning-50);
-    fill: var(--pix-warning-700);
   }
 }

--- a/addon/styles/_pix-multi-select.scss
+++ b/addon/styles/_pix-multi-select.scss
@@ -33,7 +33,7 @@
   }
 
   &__search-icon {
-    fill: var(--pix-neutral-900);
+    color: var(--pix-neutral-900);
   }
 
   &__title {
@@ -58,8 +58,8 @@
   &__dropdown-icon {
     @extend %pix-body-s;
 
+    color: var(--pix-neutral-900);
     pointer-events: none;
-    fill: var(--pix-neutral-900);
   }
 }
 

--- a/addon/styles/_pix-select.scss
+++ b/addon/styles/_pix-select.scss
@@ -103,7 +103,7 @@
   cursor: pointer;
 
   &__icon {
-    fill: var(--pix-neutral-900);
+    color: var(--pix-neutral-900);
   }
 
   &--error {
@@ -119,8 +119,8 @@
   &__dropdown-icon {
     @extend %pix-body-s;
 
+    color: var(--pix-neutral-900);
     pointer-events: none;
-    fill: var(--pix-neutral-900);
   }
 }
 
@@ -198,6 +198,6 @@
 
   &__icon {
     margin: auto var(--pix-spacing-1x);
-    fill: var(--pix-neutral-100)
+    color: var(--pix-neutral-100)
   }
 }

--- a/addon/styles/_pix-toast.scss
+++ b/addon/styles/_pix-toast.scss
@@ -49,7 +49,7 @@
 }
 
 .pix-toast__icon {
-  fill: var(--pix-neutral-0);
+  color: var(--pix-neutral-0);
 
   &--error {
     background-color: var(--pix-error-700);
@@ -74,12 +74,12 @@
 
 .pix-toast__close-button {
   &--error {
-    fill: var(--pix-error-700);
+    color: var(--pix-error-700);
 
     &:hover:enabled,
     &:active:enabled, {
+      color: var(--pix-neutral-0);
       background-color: var(--pix-error-700);
-      fill: var(--pix-neutral-0);
     }
 
     &:focus:enabled {
@@ -88,12 +88,12 @@
   }
 
   &--success {
-    fill: var(--pix-success-700);
+    color: var(--pix-success-700);
 
     &:hover:enabled,
     &:active:enabled, {
+      color: var(--pix-neutral-0);
       background-color: var(--pix-success-700);
-      fill: var(--pix-neutral-0);
     }
 
     &:focus:enabled {
@@ -102,12 +102,12 @@
   }
 
   &--information {
-    fill: var(--pix-info-700);
+    color: var(--pix-info-700);
 
     &:hover:enabled,
     &:active:enabled, {
+      color: var(--pix-neutral-0);
       background-color: var(--pix-info-700);
-      fill: var(--pix-neutral-0);
     }
 
     &:focus:enabled {
@@ -116,12 +116,12 @@
   }
 
   &--warning {
-    fill: var(--pix-warning-700);
+    color: var(--pix-warning-700);
 
     &:hover:enabled,
     &:active:enabled, {
+      color: var(--pix-neutral-0);
       background-color: var(--pix-warning-700);
-      fill: var(--pix-neutral-0);
     }
 
     &:focus:enabled {

--- a/addon/styles/_pix-toast.scss
+++ b/addon/styles/_pix-toast.scss
@@ -78,8 +78,8 @@
 
     &:hover:enabled,
     &:active:enabled, {
-      color: var(--pix-neutral-0);
-      background-color: var(--pix-error-700);
+      color: currentcolor;
+      background-color: var(--pix-error-100);
     }
 
     &:focus:enabled {
@@ -92,8 +92,8 @@
 
     &:hover:enabled,
     &:active:enabled, {
-      color: var(--pix-neutral-0);
-      background-color: var(--pix-success-700);
+      color: currentcolor;
+      background-color: var(--pix-success-100);
     }
 
     &:focus:enabled {
@@ -106,8 +106,8 @@
 
     &:hover:enabled,
     &:active:enabled, {
-      color: var(--pix-neutral-0);
-      background-color: var(--pix-info-700);
+      color: currentcolor;
+      background-color: var(--pix-info-100);
     }
 
     &:focus:enabled {
@@ -120,8 +120,8 @@
 
     &:hover:enabled,
     &:active:enabled, {
-      color: var(--pix-neutral-0);
-      background-color: var(--pix-warning-700);
+      color: currentcolor;
+      background-color: var(--pix-warning-100);
     }
 
     &:focus:enabled {

--- a/addon/styles/_pix-toggle.scss
+++ b/addon/styles/_pix-toggle.scss
@@ -40,13 +40,11 @@
   &__on {
     color: var(--pix-neutral-800);
     font-weight: var(--pix-font-normal);
-    fill: var(--pix-neutral-800);
   }
 
   &__off {
     color: var(--pix-neutral-20);
     background-color: var(--pix-neutral-800);
-    fill: var(--pix-neutral-20);
   }
 
   &--pressed {
@@ -55,14 +53,12 @@
         color: var(--pix-neutral-20);
         font-weight: inherit;
         background-color: var(--pix-neutral-800);
-        fill: var(--pix-neutral-20);
       }
 
       &__off {
         color: var(--pix-neutral-800);
         font-weight: var(--pix-font-normal);
         background-color: transparent;
-        fill: var(--pix-neutral-800);
       }
     }
   }

--- a/addon/styles/_pix-tooltip.scss
+++ b/addon/styles/_pix-tooltip.scss
@@ -48,7 +48,6 @@
   opacity: 0;
   transition: opacity 0.3s;
   pointer-events: none;
-  fill: var(--pix-neutral-0);
 
   &--inline {
     white-space: nowrap;


### PR DESCRIPTION

## :christmas_tree: Problème
Les icônes sur le composant toast ne s’affichent pas ou il y a un effet lors du hover comme on peut le voir sur la capture : 
<img width="565" alt="Capture d’écran 2024-11-14 à 11 46 08" src="https://github.com/user-attachments/assets/0b5b2d71-1cd4-40dd-85d8-7199b23c91ce">

C'est aussi le cas sur d'autres composants

## :gift: Proposition
Corriger cela en utilisant la propriété `color` plutôt que `fill` 

## :star2: Remarques
RAS

## :santa: Pour tester
Vérifier, sur la RA de Pix UI, que les icônes ont bien le bon affichage 😄 
