### PR TITLE
[FEATURE] Organiser les composants comme dans Figma (PIX-14598)

### DIFF
--- a/.storybook/manager.js
+++ b/.storybook/manager.js
@@ -3,4 +3,7 @@ import storybookCustomTheme from './storybook-custom-theme';
 
 addons.setConfig({
   theme: storybookCustomTheme,
+  sidebar: {
+    showRoots: true,
+  },
 });

--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -25,23 +25,35 @@ const preview = {
     options: {
       storySort: {
         order: [
-          'Utiliser Pix UI',
-          ['Installation', 'Utiliser un composant'],
-          'Développement',
+          'CHANGELOG',
+          'Pix UI',
           [
-            'Design System',
-            'Créer un composant',
-            'Bonnes pratiques',
-            'Breaking changes',
-            'Faire une release',
-            'Architecture',
-            'Storybook',
+            'Installation',
+            'Utiliser un composant',
+            'Développement',
+            [
+              'Design System',
+              'Créer un composant',
+              'Bonnes pratiques',
+              'Breaking changes',
+              'Faire une release',
+              'Architecture',
+              'Storybook',
+            ],
           ],
+          'Design Tokens',
+          'Actions',
+          'Forms',
+          'Navigation',
+          'Feedback',
+          'Data display',
+          'Overlay',
+          'Other',
         ],
       },
     },
   },
 
-  tags: ['autodocs']
+  tags: ['autodocs'],
 };
 export default preview;

--- a/app/components/pix-checkbox.js
+++ b/app/components/pix-checkbox.js
@@ -1,1 +1,4 @@
+// WORKAROUND: necessary for storybook to resolve the import
+import '@formatjs/intl';
+
 export { default } from '@1024pix/pix-ui/components/pix-checkbox';

--- a/app/components/pix-radio-button.js
+++ b/app/components/pix-radio-button.js
@@ -1,1 +1,4 @@
+// WORKAROUND: necessary for storybook to resolve the import
+import '@formatjs/intl';
+
 export { default } from '@1024pix/pix-ui/components/pix-radio-button';

--- a/app/stories/form-example.mdx
+++ b/app/stories/form-example.mdx
@@ -1,11 +1,10 @@
 import { Meta, Story, Canvas } from '@storybook/addon-docs';
-import * as stories from './form.stories';
+import * as ComponentStories from './form-example.stories';
 
-<Meta of={stories} />
+<Meta of={ComponentStories} />
 
 # Formulaire avec les composants Pix UI
 
 Un formulaire complet avec les composants Pix UI :
 
-<Story of={stories.form} height={700} />
-
+<Story of={ComponentStories.form} height={700} />

--- a/app/stories/form-example.stories.js
+++ b/app/stories/form-example.stories.js
@@ -2,7 +2,7 @@ import { hbs } from 'ember-cli-htmlbars';
 import { action } from '@storybook/addon-actions';
 
 export default {
-  title: 'Form/Exemple de formulaire',
+  title: 'Forms/Exemple de formulaire',
 };
 
 export const form = (args) => {

--- a/app/stories/pix-background-header.stories.js
+++ b/app/stories/pix-background-header.stories.js
@@ -1,7 +1,7 @@
 import { hbs } from 'ember-cli-htmlbars';
 
 export default {
-  title: 'Layout/Background Header',
+  title: 'Other/Background Header',
 };
 
 export const backgroundHeader = (args) => {

--- a/app/stories/pix-banner.stories.js
+++ b/app/stories/pix-banner.stories.js
@@ -1,7 +1,7 @@
 import { hbs } from 'ember-cli-htmlbars';
 
 export default {
-  title: 'Notification/Banner',
+  title: 'Feedback/Banner',
   argTypes: {
     actionLabel: {
       name: 'actionLabel',

--- a/app/stories/pix-block.stories.js
+++ b/app/stories/pix-block.stories.js
@@ -1,7 +1,7 @@
 import { hbs } from 'ember-cli-htmlbars';
 
 export default {
-  title: 'Layout/Block',
+  title: 'Other/Contenu',
   argTypes: {
     shadow: {
       name: 'shadow',

--- a/app/stories/pix-button-link.stories.js
+++ b/app/stories/pix-button-link.stories.js
@@ -1,7 +1,7 @@
 import { hbs } from 'ember-cli-htmlbars';
 
 export default {
-  title: 'Basics/ButtonLink',
+  title: 'Actions/ButtonLink',
 
   argTypes: {
     href: {

--- a/app/stories/pix-button-upload.stories.js
+++ b/app/stories/pix-button-upload.stories.js
@@ -2,7 +2,7 @@ import { hbs } from 'ember-cli-htmlbars';
 import { action } from '@storybook/addon-actions';
 
 export default {
-  title: 'Basics/ButtonUpload',
+  title: 'Actions/ButtonUpload',
   argTypes: {
     id: {
       name: 'id',

--- a/app/stories/pix-button.stories.js
+++ b/app/stories/pix-button.stories.js
@@ -2,7 +2,7 @@ import { hbs } from 'ember-cli-htmlbars';
 import { ICONS } from '../../addon/helpers/icons';
 
 export default {
-  title: 'Basics/Button',
+  title: 'Actions/Button',
   argTypes: {
     type: {
       name: 'type',

--- a/app/stories/pix-checkbox-variant-tile.stories.js
+++ b/app/stories/pix-checkbox-variant-tile.stories.js
@@ -2,7 +2,7 @@ import { hbs } from 'ember-cli-htmlbars';
 import pixCheckboxStories from './pix-checkbox.stories.js';
 
 export default {
-  title: 'Form/Inputs/Checkbox/Variant Tile',
+  title: 'Forms/Checkbox/Variant Tile',
   argTypes: {
     variant: {
       name: 'variant',

--- a/app/stories/pix-checkbox.stories.js
+++ b/app/stories/pix-checkbox.stories.js
@@ -1,7 +1,7 @@
 import { hbs } from 'ember-cli-htmlbars';
 
 export default {
-  title: 'Form/Inputs/Checkbox',
+  title: 'Forms/Checkbox',
   argTypes: {
     id: {
       name: 'id',

--- a/app/stories/pix-collapsible.stories.js
+++ b/app/stories/pix-collapsible.stories.js
@@ -2,7 +2,7 @@ import { hbs } from 'ember-cli-htmlbars';
 import { ICONS } from '../../addon/helpers/icons';
 
 export default {
-  title: 'Others/Collapsible',
+  title: 'Data display/Collapsible',
   argTypes: {
     iconName: {
       name: 'iconName',

--- a/app/stories/pix-filter-banner.stories.js
+++ b/app/stories/pix-filter-banner.stories.js
@@ -2,7 +2,7 @@ import { hbs } from 'ember-cli-htmlbars';
 import { action } from '@storybook/addon-actions';
 
 export default {
-  title: 'Form/Filter banner',
+  title: 'Other/Filter banner',
   argTypes: {
     title: {
       name: 'title',

--- a/app/stories/pix-filterable-and-searchable-select.stories.js
+++ b/app/stories/pix-filterable-and-searchable-select.stories.js
@@ -2,7 +2,7 @@ import { hbs } from 'ember-cli-htmlbars';
 import { action } from '@storybook/addon-actions';
 
 export default {
-  title: 'Form/Filterable and searchable select',
+  title: 'Other/Filterable and searchable select',
   argTypes: {
     label: {
       name: 'label',

--- a/app/stories/pix-icon-button.stories.js
+++ b/app/stories/pix-icon-button.stories.js
@@ -3,7 +3,7 @@ import { action } from '@storybook/addon-actions';
 import { ICONS } from '../../addon/helpers/icons';
 
 export default {
-  title: 'Basics/Icon button',
+  title: 'Actions/Icon button',
   argTypes: {
     ariaLabel: {
       name: 'ariaLabel',

--- a/app/stories/pix-icon.stories.js
+++ b/app/stories/pix-icon.stories.js
@@ -2,7 +2,7 @@ import { hbs } from 'ember-cli-htmlbars';
 import { ICONS } from '../../addon/helpers/icons.js';
 
 export default {
-  title: 'Others/Icon',
+  title: 'Design Tokens/Icon',
   argTypes: {
     name: {
       name: 'name',

--- a/app/stories/pix-indicator-card.stories.js
+++ b/app/stories/pix-indicator-card.stories.js
@@ -2,7 +2,7 @@ import { hbs } from 'ember-cli-htmlbars';
 import { ICONS } from '../../addon/helpers/icons.js';
 
 export default {
-  title: 'Others/Indicator Card',
+  title: 'Other/Indicator Card',
   argTypes: {
     title: {
       name: 'Title',

--- a/app/stories/pix-input-code.stories.js
+++ b/app/stories/pix-input-code.stories.js
@@ -1,7 +1,7 @@
 import { hbs } from 'ember-cli-htmlbars';
 
 export default {
-  title: 'Form/Inputs/Code',
+  title: 'Forms/Code',
   argTypes: {
     ariaLabel: {
       name: 'ariaLabel',

--- a/app/stories/pix-input-password.stories.js
+++ b/app/stories/pix-input-password.stories.js
@@ -1,7 +1,7 @@
 import { hbs } from 'ember-cli-htmlbars';
 
 export default {
-  title: 'Form/Inputs/Password',
+  title: 'Forms/Password',
   argTypes: {
     id: {
       name: 'id',

--- a/app/stories/pix-input.stories.js
+++ b/app/stories/pix-input.stories.js
@@ -1,7 +1,7 @@
 import { hbs } from 'ember-cli-htmlbars';
 
 export default {
-  title: 'Form/Inputs/Input',
+  title: 'Forms/Input',
   argTypes: {
     id: {
       name: 'id',

--- a/app/stories/pix-label.stories.js
+++ b/app/stories/pix-label.stories.js
@@ -1,7 +1,7 @@
 import { hbs } from 'ember-cli-htmlbars';
 
 export default {
-  title: 'Form/Label',
+  title: 'Forms/Label',
   argTypes: {
     for: {
       name: 'for',

--- a/app/stories/pix-message.stories.js
+++ b/app/stories/pix-message.stories.js
@@ -1,7 +1,7 @@
 import { hbs } from 'ember-cli-htmlbars';
 
 export default {
-  title: 'Notification/Message',
+  title: 'Feedback/Message',
   render: (args) => ({
     template: hbs`<PixMessage @type={{this.type}} @withIcon={{this.withIcon}}>
   Ceci est un message

--- a/app/stories/pix-modal.stories.js
+++ b/app/stories/pix-modal.stories.js
@@ -1,7 +1,7 @@
 import { hbs } from 'ember-cli-htmlbars';
 
 export default {
-  title: 'Basics/Modal',
+  title: 'Overlay/Modal',
   render: (args) => ({
     template: hbs`<PixModal
   @showModal={{this.showModal}}

--- a/app/stories/pix-multi-select.stories.js
+++ b/app/stories/pix-multi-select.stories.js
@@ -2,7 +2,7 @@ import { hbs } from 'ember-cli-htmlbars';
 import { action } from '@storybook/addon-actions';
 
 export default {
-  title: 'Form/Multi Select',
+  title: 'Forms/Multi Select',
   render: (args) => ({
     template: hbs`{{! template-lint-disable no-forbidden-elements }}
 <style>

--- a/app/stories/pix-navigation.stories.js
+++ b/app/stories/pix-navigation.stories.js
@@ -1,7 +1,7 @@
 import { hbs } from 'ember-cli-htmlbars';
 
 export default {
-  title: 'Layout/Navigation',
+  title: 'Navigation/Navigation',
   argTypes: {
     variant: {
       description: 'Variante de la navigation',

--- a/app/stories/pix-pagination.stories.js
+++ b/app/stories/pix-pagination.stories.js
@@ -1,7 +1,7 @@
 import { hbs } from 'ember-cli-htmlbars';
 
 export default {
-  title: 'Basics/Pagination',
+  title: 'Navigation/Pagination',
   render: (args) => ({
     template: hbs`<PixPagination
   @pagination={{this.pagination}}

--- a/app/stories/pix-progress-gauge.stories.js
+++ b/app/stories/pix-progress-gauge.stories.js
@@ -1,7 +1,7 @@
 import { hbs } from 'ember-cli-htmlbars';
 
 export default {
-  title: 'Others/Progress Gauge',
+  title: 'Data display/Progress Gauge',
   argTypes: {
     value: {
       name: 'value',

--- a/app/stories/pix-radio-button-variant-tile.stories.js
+++ b/app/stories/pix-radio-button-variant-tile.stories.js
@@ -2,7 +2,7 @@ import { hbs } from 'ember-cli-htmlbars';
 import pixRadioButtonStories from './pix-radio-button.stories.js';
 
 export default {
-  title: 'Form/Inputs/Radio Button/Variant Tile',
+  title: 'Forms/Radio Button/Variant Tile',
   argTypes: {
     variant: {
       name: 'variant',

--- a/app/stories/pix-radio-button.stories.js
+++ b/app/stories/pix-radio-button.stories.js
@@ -1,7 +1,7 @@
 import { hbs } from 'ember-cli-htmlbars';
 
 export default {
-  title: 'Form/Inputs/Radio Button',
+  title: 'Forms/Radio Button',
   argTypes: {
     id: {
       name: 'id',

--- a/app/stories/pix-return-to.stories.js
+++ b/app/stories/pix-return-to.stories.js
@@ -1,7 +1,7 @@
 import { hbs } from 'ember-cli-htmlbars';
 
 export default {
-  title: 'Basics/Return To',
+  title: 'Other/Return To',
   render: (args) => ({
     template: hbs`<PixReturnTo
   @route='profile'

--- a/app/stories/pix-search-input.stories.js
+++ b/app/stories/pix-search-input.stories.js
@@ -2,7 +2,7 @@ import { hbs } from 'ember-cli-htmlbars';
 import { action } from '@storybook/addon-actions';
 
 export default {
-  title: 'Others/SearchInput',
+  title: 'Forms/SearchInput',
   argTypes: {
     id: {
       name: 'id',

--- a/app/stories/pix-select.stories.js
+++ b/app/stories/pix-select.stories.js
@@ -3,7 +3,7 @@ import { action } from '@storybook/addon-actions';
 import { ICONS } from '../../addon/helpers/icons';
 
 export default {
-  title: 'Form/Select',
+  title: 'Forms/Select',
   argTypes: {
     options: {
       name: 'options',

--- a/app/stories/pix-selectable-tag.stories.js
+++ b/app/stories/pix-selectable-tag.stories.js
@@ -1,7 +1,7 @@
 import { hbs } from 'ember-cli-htmlbars';
 
 export default {
-  title: 'basics/Tag/Selectable Tag',
+  title: 'Data display/Tag/Selectable Tag',
   argTypes: {
     label: {
       name: 'label',

--- a/app/stories/pix-sidebar.stories.js
+++ b/app/stories/pix-sidebar.stories.js
@@ -1,7 +1,7 @@
 import { hbs } from 'ember-cli-htmlbars';
 
 export default {
-  title: 'Basics/Sidebar',
+  title: 'Navigation/Sidebar',
   argTypes: {
     showSidebar: {
       name: 'showSidebar',

--- a/app/stories/pix-stars.stories.js
+++ b/app/stories/pix-stars.stories.js
@@ -1,7 +1,7 @@
 import { hbs } from 'ember-cli-htmlbars';
 
 export default {
-  title: 'Others/PixStars',
+  title: 'Data display/PixStars',
   argTypes: {
     count: {
       name: 'count',

--- a/app/stories/pix-tag.stories.js
+++ b/app/stories/pix-tag.stories.js
@@ -1,7 +1,7 @@
 import { hbs } from 'ember-cli-htmlbars';
 
 export default {
-  title: 'Basics/Tag',
+  title: 'Data display/Tag',
   render: (args) => ({
     template: hbs`<PixTag @color={{this.color}}>
   Contenu du tag

--- a/app/stories/pix-textarea.stories.js
+++ b/app/stories/pix-textarea.stories.js
@@ -1,7 +1,7 @@
 import { hbs } from 'ember-cli-htmlbars';
 
 export default {
-  title: 'Form/Textarea',
+  title: 'Forms/Textarea',
   argTypes: {
     id: {
       name: 'id',

--- a/app/stories/pix-toast.stories.js
+++ b/app/stories/pix-toast.stories.js
@@ -1,7 +1,7 @@
 import { hbs } from 'ember-cli-htmlbars';
 
 export default {
-  title: 'Notification/Toast',
+  title: 'Feedback/Toast',
   argTypes: {
     toast: {
       name: 'toast',

--- a/app/stories/pix-toggle.stories.js
+++ b/app/stories/pix-toggle.stories.js
@@ -2,7 +2,7 @@ import { hbs } from 'ember-cli-htmlbars';
 import { action } from '@storybook/addon-actions';
 
 export default {
-  title: 'Basics/Toggle',
+  title: 'Navigation/Toggle',
   argTypes: {
     label: {
       name: 'label',

--- a/app/stories/pix-tooltip.stories.js
+++ b/app/stories/pix-tooltip.stories.js
@@ -1,7 +1,7 @@
 import { hbs } from 'ember-cli-htmlbars';
 
 export default {
-  title: 'Basics/Tooltip',
+  title: 'Overlay/Tooltip',
   argTypes: {
     id: {
       name: 'id',

--- a/docs/architecture.mdx
+++ b/docs/architecture.mdx
@@ -1,6 +1,6 @@
 import { Meta } from '@storybook/blocks';
 
-<Meta title="Développement/Architecture" />
+<Meta title="Pix UI/Développement/Architecture" />
 
 # Architecture du projet Pix UI
 

--- a/docs/breaking-changes.mdx
+++ b/docs/breaking-changes.mdx
@@ -1,6 +1,6 @@
 import { Meta } from '@storybook/blocks';
 
-<Meta title="Développement/Breaking changes" />
+<Meta title="Pix UI/Développement/Breaking changes" />
 
 # Breaking changes dans Pix UI
 

--- a/docs/colors-palette.mdx
+++ b/docs/colors-palette.mdx
@@ -1,15 +1,15 @@
 import { Meta, ColorPalette, ColorItem } from '@storybook/blocks';
 
-<Meta title="Utiliser Pix UI/Design Tokens/Palette de couleurs" />
+<Meta title="Design Tokens/Palette de couleurs" />
 
 # Palette de couleurs
 
- > Pour infos :
- >
- > Cette page permet de connaitre les couleurs qui sont disponibles dans `Pix-UI`. [Figma](https://www.figma.com/file/8RJ3aCSfdeQ8AZZVBBYKS8/Design-System-Pix?node-id=16%3A2) reste la source de vérité des couleurs du design system de `Pix`.
- >
- > Les variables css présentes dans le fichier `_colors.scss` reprennent les noms des symboles utilisés sur les maquettes dans Figma,
- > on préconise d'utiliser ses noms de variables plutôt que le code hexa.
+> Pour infos :
+>
+> Cette page permet de connaitre les couleurs qui sont disponibles dans `Pix-UI`. [Figma](https://www.figma.com/file/8RJ3aCSfdeQ8AZZVBBYKS8/Design-System-Pix?node-id=16%3A2) reste la source de vérité des couleurs du design system de `Pix`.
+>
+> Les variables css présentes dans le fichier `_colors.scss` reprennent les noms des symboles utilisés sur les maquettes dans Figma,
+> on préconise d'utiliser ses noms de variables plutôt que le code hexa.
 
 #### SOLID
 
@@ -155,51 +155,51 @@ import { Meta, ColorPalette, ColorItem } from '@storybook/blocks';
   <ColorItem
     title="Primary Pix App"
     subtitle="$pix-primary-app-gradient"
-    colors={{ PrimaryPixApp: 'linear-gradient(91.59deg, #3d68ff 0%, #8845ff 100%)'}}
+    colors={{ PrimaryPixApp: 'linear-gradient(91.59deg, #3d68ff 0%, #8845ff 100%)' }}
   />
   <ColorItem
     title="Secondary Pix App"
     subtitle="$pix-secondary-app-gradient"
-    colors={{ SecondaryPixAppGradient: 'linear-gradient(91.59deg, #fedc41 0%, #ff9f00 100%)'}}
+    colors={{ SecondaryPixAppGradient: 'linear-gradient(91.59deg, #fedc41 0%, #ff9f00 100%)' }}
   />
   <ColorItem
     title="Primary Certif"
     subtitle="$pix-primary-certif-gradient"
-    colors={{ PrimaryCertif: 'linear-gradient(91.59deg, #52d987 0%, #1a8c89 100%)'}}
+    colors={{ PrimaryCertif: 'linear-gradient(91.59deg, #52d987 0%, #1a8c89 100%)' }}
   />
   <ColorItem
     title="Primary Orga"
     subtitle="$pix-primary-orga-gradient"
-    colors={{ PrimaryOrga: 'linear-gradient(91.59deg, #00ddff 0%, #0095c0 100%)'}}
-   />
-   <ColorItem
-     title="Secondary Orga"
-     subtitle="$pix-primary-secondary-gradient"
-     colors={{SecondaryOrga: 'linear-gradient(91.59deg, #0d7dc4 0%, #213371 100%)'}}
-   />
-   <ColorItem
-     title="Domain Information"
-     subtitle="$pix-information-gradient"
-     colors={{DomainInformation: 'linear-gradient(180deg, #f24645 0%, #f1a141 100%)'}}
-   />
-   <ColorItem
-     title="Domain Content"
-     subtitle="$pix-content-gradient"
-     colors={{DomainContent: 'linear-gradient(180deg, #1a8c89 0%, #52d987 100%)'}}
-   />
-   <ColorItem
-     title="Domain Communication"
-     subtitle="$pix-communication-gradient"
-     colors={{DomainCommunication: 'linear-gradient(180deg, #3d68ff 0%, #12a3ff 100%)'}}
-   />
-   <ColorItem
-     title="Domain Security"
-     subtitle="$pix-security-gradient"
-     colors={{DomainSecurity: 'linear-gradient(180deg, #ac008d 0%, #ff3f94 100%)'}}
-   />
-   <ColorItem
-     title="Domain Environment"
-     subtitle="$pix-environment-gradient"
-     colors={{DomainEnvironment: 'linear-gradient(180deg, #5e2563 0%, #564da6 100%)'}}
-   />
+    colors={{ PrimaryOrga: 'linear-gradient(91.59deg, #00ddff 0%, #0095c0 100%)' }}
+  />
+  <ColorItem
+    title="Secondary Orga"
+    subtitle="$pix-primary-secondary-gradient"
+    colors={{ SecondaryOrga: 'linear-gradient(91.59deg, #0d7dc4 0%, #213371 100%)' }}
+  />
+  <ColorItem
+    title="Domain Information"
+    subtitle="$pix-information-gradient"
+    colors={{ DomainInformation: 'linear-gradient(180deg, #f24645 0%, #f1a141 100%)' }}
+  />
+  <ColorItem
+    title="Domain Content"
+    subtitle="$pix-content-gradient"
+    colors={{ DomainContent: 'linear-gradient(180deg, #1a8c89 0%, #52d987 100%)' }}
+  />
+  <ColorItem
+    title="Domain Communication"
+    subtitle="$pix-communication-gradient"
+    colors={{ DomainCommunication: 'linear-gradient(180deg, #3d68ff 0%, #12a3ff 100%)' }}
+  />
+  <ColorItem
+    title="Domain Security"
+    subtitle="$pix-security-gradient"
+    colors={{ DomainSecurity: 'linear-gradient(180deg, #ac008d 0%, #ff3f94 100%)' }}
+  />
+  <ColorItem
+    title="Domain Environment"
+    subtitle="$pix-environment-gradient"
+    colors={{ DomainEnvironment: 'linear-gradient(180deg, #5e2563 0%, #564da6 100%)' }}
+  />
 </ColorPalette>

--- a/docs/create-component.mdx
+++ b/docs/create-component.mdx
@@ -1,6 +1,6 @@
 import { Meta } from '@storybook/blocks';
 
-<Meta title="Développement/Créer un composant" />
+<Meta title="Pix UI/Développement/Créer un composant" />
 
 # Créer un composant et sa story
 
@@ -65,8 +65,8 @@ export default {
       control: { type: 'select' },
       options: ['info', 'success', 'warning', 'alert'],
     },
-  }
-}
+  },
+};
 
 // Ici on instancie l'aperçu du composant dans la doc
 export const message = (args) => {
@@ -84,7 +84,7 @@ export const message = (args) => {
 `````markdown
 {/_ pix-message.stories.mdx _/}
 import { Meta, Story, ArgTypes } from '@storybook/blocks';
-import * as ComponentStories from './pix-message.stories';
+import \* as ComponentStories from './pix-message.stories';
 
 {/_ Titre de la section affichée dans le menu de storybook _/}
 

--- a/docs/design-system.mdx
+++ b/docs/design-system.mdx
@@ -1,6 +1,6 @@
 import { Meta } from '@storybook/blocks';
 
-<Meta title="Développement/Design System" />
+<Meta title="Pix UI/Développement/Design System" />
 
 # Design System
 

--- a/docs/design-tokens.mdx
+++ b/docs/design-tokens.mdx
@@ -1,6 +1,6 @@
 import { Meta } from '@storybook/blocks';
 
-<Meta title="Utiliser Pix UI/Design Tokens/ Utilisation" />
+<Meta title="Design Tokens/Utilisation" />
 
 # Design Tokens
 

--- a/docs/good-practices-a11y.mdx
+++ b/docs/good-practices-a11y.mdx
@@ -1,7 +1,7 @@
 import { Meta } from '@storybook/blocks';
 import accessibilityImage from './assets/accessibility-storybook.png';
 
-<Meta title="Développement/Bonnes pratiques/Accessibilité" />
+<Meta title="Pix UI/Développement/Bonnes pratiques/Accessibilité" />
 
 # Bonnes pratiques d'accessibilité
 

--- a/docs/good-practices-design.mdx
+++ b/docs/good-practices-design.mdx
@@ -1,6 +1,6 @@
 import { Meta } from '@storybook/blocks';
 
-<Meta title="Développement/Bonnes pratiques/Design" />
+<Meta title="Pix UI/Développement/Bonnes pratiques/Design" />
 
 # Bonnes pratiques design
 
@@ -9,7 +9,7 @@ import { Meta } from '@storybook/blocks';
 - les **noms de branches** commencent par `pix-ui`.
 
 - Les **noms des fichiers** suivent l'exemple de la pix-tooltip.
-  _Par exemple, pour les styles, on recomandera de rajouter `_` devant le nom du fichier pour indiquer que c'est un ["fichier partiel Sass"](https://sass-lang.com/guide#topic-4)._
+  _Par exemple, pour les styles, on recomandera de rajouter `_` devant le nom du fichier pour indiquer que c'est un ["fichier partiel Sass"](https://sass-lang.com/guide#topic-4).\_
 
 - Les **noms des composants** commencent par `Pix` et sont écrit en _PascalCase_.
   _Par exemple, un composant bouton devient : `PixButton`._
@@ -59,4 +59,4 @@ Exemple d'un composant déprécié :
 </PixSelect>
 ```
 
-Autres détails d'un breaking change sur la page [Installation](/?path=/docs/utiliser-pix-ui-installation--page).
+Autres détails d'un breaking change sur la page [Pix UI/Installation](/?path=/docs/utiliser-pix-ui-installation--page).

--- a/docs/good-practices-responsive.mdx
+++ b/docs/good-practices-responsive.mdx
@@ -1,6 +1,6 @@
 import { Meta } from '@storybook/blocks';
 
-<Meta title="Développement/Bonnes pratiques/Responsive" />
+<Meta title="Pix UI/Développement/Bonnes pratiques/Responsive" />
 
 # Bonnes pratiques responsive
 

--- a/docs/good-practices-style-css.mdx
+++ b/docs/good-practices-style-css.mdx
@@ -1,6 +1,6 @@
 import { Meta } from '@storybook/blocks';
 
-<Meta title="Développement/Bonnes pratiques/Style CSS" />
+<Meta title="Pix UI/Développement/Bonnes pratiques/Style CSS" />
 
 # Style CSS / SCSS
 

--- a/docs/good-practices-tests.mdx
+++ b/docs/good-practices-tests.mdx
@@ -1,6 +1,6 @@
 import { Meta } from '@storybook/blocks';
 
-<Meta title="Développement/Bonnes pratiques/Tests" />
+<Meta title="Pix UI/Développement/Bonnes pratiques/Tests" />
 
 # Bonnes pratiques de test
 

--- a/docs/make-a-release.mdx
+++ b/docs/make-a-release.mdx
@@ -1,6 +1,6 @@
 import { Meta } from '@storybook/blocks';
 
-<Meta title="Développement/Faire une release" />
+<Meta title="Pix UI/Développement/Faire une release" />
 
 # Faire une release
 

--- a/docs/pix-design-tokens-dev.mdx
+++ b/docs/pix-design-tokens-dev.mdx
@@ -1,6 +1,6 @@
 import { Meta } from '@storybook/blocks';
 
-<Meta title="Développement/Pix Design Tokens" />
+<Meta title="Pix UI/Développement/Pix Design Tokens" />
 
 # Design Tokens
 

--- a/docs/shadow.mdx
+++ b/docs/shadow.mdx
@@ -1,6 +1,6 @@
 import { Meta } from '@storybook/blocks';
 
-<Meta title="Utiliser Pix UI/Design Tokens/Ombres" />
+<Meta title="Design Tokens/Ombres" />
 
 # Ombres
 

--- a/docs/spacing.mdx
+++ b/docs/spacing.mdx
@@ -1,6 +1,6 @@
 import { Meta } from '@storybook/blocks';
 
-<Meta title="Utiliser Pix UI/Design Tokens/Espacements" />
+<Meta title="Design Tokens/Espacements" />
 
 # Espacements
 

--- a/docs/storybook.mdx
+++ b/docs/storybook.mdx
@@ -1,6 +1,6 @@
 import { Meta } from '@storybook/blocks';
 
-<Meta title="Développement/Storybook" />
+<Meta title="Pix UI/Développement/Storybook" />
 
 # Déploiement de Storybook
 

--- a/docs/test-pix-ui-locally.mdx
+++ b/docs/test-pix-ui-locally.mdx
@@ -1,6 +1,6 @@
 import { Meta } from '@storybook/blocks';
 
-<Meta title="Développement/Tester localement Pix UI dans un app" />
+<Meta title="Pix UI/Développement/Tester localement Pix UI dans un app" />
 
 # Tester localement Pix UI dans un app
 
@@ -30,6 +30,7 @@ Pour cela, dans le répertoire de l'application Pix UI, éxecuter la commande:
 ```shell
 npm pack
 ```
+
 cela va creer une archive `.tgz` de la librairie
 
 Se déplacer dans le répertoire de l'application dans laquelle l'on veut tester la librairie
@@ -38,6 +39,7 @@ puis installer la version compilée localement :
 ```shell
 npm install --save-dev "file:../../pix-ui/1024pix-pix-ui-<X.Y.Z>.tgz"
 ```
+
 on notera la présence de `file:` suivi du chemin vers l'archive.
 
 Puis lancer l'application

--- a/docs/typography.mdx
+++ b/docs/typography.mdx
@@ -1,6 +1,6 @@
 import { Meta, Markdown, Unstyled } from '@storybook/blocks';
 
-<Meta title="Utiliser Pix UI/Design Tokens/Typographie" />
+<Meta title="Design Tokens/Typographie" />
 
 # Typographie
 

--- a/docs/update-sprites.mdx
+++ b/docs/update-sprites.mdx
@@ -1,10 +1,11 @@
 import { Meta } from '@storybook/blocks';
 
-<Meta title="Développement/Mis à jour du sprite.svg" />
+<Meta title="Pix UI/Développement/Mis à jour du sprite.svg" />
 
 # Mise à jour du Sprites SVG
 
 ## Récupérer le ZIP
+
 Télécharger le `.zip` fourni par l'équipe Design contenant le delta/mis à jour des nouvelles icônes
 
 Copier les nouvelles icônes fournies par le design dans le dossier `./svgs/icons`

--- a/docs/use-component.mdx
+++ b/docs/use-component.mdx
@@ -1,6 +1,6 @@
 import { Meta } from '@storybook/blocks';
 
-<Meta title="Utiliser Pix UI/Utiliser un composant" />
+<Meta title="Pix UI/Utiliser un composant" />
 
 # Utiliser un composant
 

--- a/docs/use-install.mdx
+++ b/docs/use-install.mdx
@@ -1,6 +1,6 @@
 import { Meta } from '@storybook/blocks';
 
-<Meta title="Utiliser Pix UI/Installation" />
+<Meta title="Pix UI/Installation" />
 
 # Installer l'addon Pix UI
 

--- a/docs/use-utility-classes.mdx
+++ b/docs/use-utility-classes.mdx
@@ -1,6 +1,6 @@
 import { Meta } from '@storybook/blocks';
 
-<Meta title="Utiliser Pix UI/Classes CSS utilitaires" />
+<Meta title="Design Tokens/Classes CSS utilitaires" />
 
 # Classes CSS utilitaires
 


### PR DESCRIPTION
## :christmas_tree: Problème

Les catégories storybook des composants ne suivent pas la catégorisation définie dans le design système.

## :gift: Proposition

Placer les composants dans les bonnes catégories (organisation définie par le design, voir le ticket PIX-14598 associé)

## :star2: Remarques

1. La documentation a été regroupée sous une catégorie Pix UI
2. Correction de bugs dans le storybook lié à la lib `@formatjs/intl`

## :santa: Pour tester

Voir le storybook https://ui-pr762.review.pix.fr
