### PR TITLE
[BUGFIX] Améliorer le style d'un PixInput avec état (PIX-15196).

### DIFF
--- a/addon/styles/_pix-input.scss
+++ b/addon/styles/_pix-input.scss
@@ -44,17 +44,20 @@
     width: 100%;
     border: 1px solid var(--pix-neutral-500);
 
-    &--error {
-      @extend %pix-form-error-state;
-    }
-
-    &--success {
-      @extend %pix-form-success-state;
-    }
-
     &::placeholder {
       color: var(--pix-neutral-500);
     }
-
   }
+}
+
+.pix-input .pix-input__input--error {
+  @extend %pix-form-error-state;
+
+  padding-right: 2rem;
+}
+
+.pix-input .pix-input__input--success {
+  @extend %pix-form-success-state;
+
+  padding-right: 2rem;
 }


### PR DESCRIPTION
## :christmas_tree: Problème

Lorsque le texte d'un PixInput avec état est trop long, alors l'icône passe par dessus la fin du texte.

## :gift: Proposition

Ajouter un padding permettant au texte de ne pas passer en dessous de l'icône d'état.

## ℹ️ Remarques

J'ai été obligé d'augmenter le poids du sélecteur CSS de l'input avec état pour surcharger le padding.

## :santa: Pour tester

En RA, tester sur les inputs avec états ([success](https://ui-pr763.review.pix.fr/?path=/story/forms-input--success-state) / [error](https://ui-pr763.review.pix.fr/?path=/story/forms-input--error-state)).
