### PR TITLE
[FEATURE] Déplacer l'indicateur de requirement de PixLabel (PIX-15143).

### DIFF
--- a/addon/components/pix-label.hbs
+++ b/addon/components/pix-label.hbs
@@ -1,9 +1,9 @@
 <label for={{@for}} class={{this.className}} ...attributes>
+  {{yield}}
+
   {{#if @requiredLabel}}
     <abbr title={{@requiredLabel}} class="mandatory-mark">*</abbr>
   {{/if}}
-
-  {{yield}}
 
   {{#if @subLabel}}
     <span class="pix-label__sub-label">{{@subLabel}}</span>

--- a/tests/integration/components/pix-filterable-and-searchable-select-test.js
+++ b/tests/integration/components/pix-filterable-and-searchable-select-test.js
@@ -352,7 +352,7 @@ module('Integration | Component | PixFilterableAndSearchableSelect', function (h
 </PixFilterableAndSearchableSelect>`);
 
       // then
-      assert.dom(screen.getByLabelText('* Label de mon big composant trop compliqué')).exists();
+      assert.dom(screen.getByLabelText('Label de mon big composant trop compliqué *')).exists();
     });
   });
 

--- a/tests/integration/components/pix-input-password-test.js
+++ b/tests/integration/components/pix-input-password-test.js
@@ -99,7 +99,7 @@ module('Integration | Component | pix-input-password', function (hooks) {
     );
 
     // then
-    const requiredPasswordInput = screen.getByLabelText('* Mot de passe');
+    const requiredPasswordInput = screen.getByLabelText('Mot de passe *');
     assert.dom(requiredPasswordInput).isRequired();
   });
 
@@ -114,7 +114,7 @@ module('Integration | Component | pix-input-password', function (hooks) {
       await click(screen.getByRole('button', { name: 'Afficher le mot de passe' }));
 
       // then
-      assert.dom(screen.getByLabelText('* Mot de passe')).isFocused();
+      assert.dom(screen.getByLabelText('Mot de passe *')).isFocused();
     });
   });
 });

--- a/tests/integration/components/pix-input-test.js
+++ b/tests/integration/components/pix-input-test.js
@@ -92,7 +92,7 @@ module('Integration | Component | PixInput', function (hooks) {
     );
 
     // then
-    const requiredInput = screen.getByLabelText('* Prénom');
+    const requiredInput = screen.getByLabelText('Prénom *');
     assert.dom(requiredInput).isRequired();
   });
 });

--- a/tests/integration/components/pix-label-test.js
+++ b/tests/integration/components/pix-label-test.js
@@ -53,7 +53,7 @@ module('Integration | Component | PixLabel', function (hooks) {
     );
 
     // then
-    assert.ok(screen.getByLabelText(['*', label].join(' ')));
+    assert.ok(screen.getByLabelText([label, '*'].join(' ')));
   });
 
   test('it still accessible when hidden label', async function (assert) {

--- a/tests/integration/components/pix-select-test.js
+++ b/tests/integration/components/pix-select-test.js
@@ -632,7 +632,7 @@ module('Integration | Component | PixSelect', function (hooks) {
   @placeholder={{this.placeholder}}
   @requiredLabel={{this.requiredLabel}}
 ><:label>{{this.label}}</:label></PixSelect>`);
-      assert.dom(screen.getByLabelText('* Mon menu déroulant')).exists();
+      assert.dom(screen.getByLabelText('Mon menu déroulant *')).exists();
     });
   });
 


### PR DESCRIPTION
## :christmas_tree: Problème

Aujourd’hui, l’astérisque pour signifier à l’utilisateur est positionné à gauche du label principal de PixLabel et ce n’est pas un comportement habituel.

## :gift: Proposition

Placer l’astérisque à droite du label sur le composant PixLabel

## :santa: Pour tester

Visualiser un input ou directement le composant PixLabel en mode `required` sur la RA
