### PR TITLE
[TECH] Mettre à jour les tailles de différentes typographies (PIX-15000).

### DIFF
--- a/addon/styles/pix-design-tokens/_typography.scss
+++ b/addon/styles/pix-design-tokens/_typography.scss
@@ -15,15 +15,19 @@
   --font-size-title: 2rem;
 
   font-size: var(--font-size-title);
-  line-height: 1.3;
+  line-height: 2.625rem;
   letter-spacing: calc(-0.02 * var(--font-size-title));
 
   @include device-is('tablet') {
-    --font-size-title: 2.5rem;
+    --font-size-title: 2.25rem;
+
+    line-height: 2.875rem;
   }
 
   @include device-is('desktop') {
-    --font-size-title: 3rem;
+    --font-size-title: 2.5rem;
+
+    line-height: 3.25rem;
   }
 }
 
@@ -35,16 +39,20 @@
   --letter-spacing-title: -0.02;
 
   font-size: var(--font-size-title);
-  line-height: 1.3;
+  line-height: 2.125rem;
   letter-spacing: calc(var(--letter-spacing-title) * var(--font-size-title));
 
   @include device-is('tablet') {
     --font-size-title: 2rem;
+
+    line-height: 2.625rem;
   }
 
   @include device-is('desktop') {
     --font-size-title: 2.25rem;
     --letter-spacing-title: -0.01;
+
+    line-height: 2.875rem;
   }
 }
 
@@ -55,15 +63,19 @@
   --font-size-title: 1.375rem;
 
   font-size: var(--font-size-title);
-  line-height: 1.3;
+  line-height: 1.75rem;
   letter-spacing: calc(-0.01 * var(--font-size-title));
 
   @include device-is('tablet') {
     --font-size-title: 1.5rem;
+
+    line-height: 2rem;
   }
 
   @include device-is('desktop') {
     --font-size-title: 1.75rem;
+
+    line-height: 2.25rem;
   }
 }
 
@@ -74,7 +86,7 @@
   --font-size-title: 1.25rem;
 
   font-size: var(--font-size-title);
-  line-height: 1.4;
+  line-height: 1.75rem;
   letter-spacing: calc(-0.01 * var(--font-size-title));
 }
 
@@ -106,7 +118,7 @@
   @extend %-pix-body;
 
   font-size: 0.75rem;
-  line-height: 1.5;
+  line-height: 1.125rem;
   letter-spacing: 0.02em;
 }
 
@@ -115,7 +127,7 @@
   @extend %-pix-body;
 
   font-size: 0.875rem;
-  line-height: 1.5;
+  line-height: 1.25rem;
 }
 
 %pix-body-m,
@@ -123,10 +135,11 @@
   @extend %-pix-body;
 
   font-size: 0.875rem;
-  line-height: 1.5;
+  line-height: 1.25rem;
 
   @include device-is('tablet') {
     font-size: 1rem;
+    line-height: 1.5rem;
   }
 }
 
@@ -135,10 +148,11 @@
   @extend %-pix-body;
 
   font-size: 1rem;
-  line-height: 1.5;
+  line-height: 1.5rem;
 
   @include device-is('tablet') {
     font-size: 1.125rem;
+    line-height: 1.625rem;
   }
 }
 


### PR DESCRIPTION
## :christmas_tree: Problème

Les tailles de font ne sont pas les mêmes que celles mentionnées dans [le fichier Figma](https://www.figma.com/design/8RJ3aCSfdeQ8AZZVBBYKS8/Design-System-Nebulix?node-id=24-8).
De ce fait, tous les outils Pix affichent des textes beaucoup trop gros.

## :gift: Proposition

Mettre à jour avec les bonnes tailles

## :santa: Pour tester

Vérifier que les `font-size` et `line-height` correspondent bien au tableau présent sur Figma.
