### PR TITLE
[FEATURE] Regler la taille de la dropdown de pix-select (PIX-14436)

### DIFF
--- a/addon/styles/_pix-select.scss
+++ b/addon/styles/_pix-select.scss
@@ -19,7 +19,7 @@
     z-index: 200;
     width: 100%;
     min-width: fit-content;
-    max-height: 12.5rem;
+    max-height: 12.8rem;
     margin-top: var(--pix-spacing-1x);
     padding: 0;
     overflow-y: auto;


### PR DESCRIPTION
## :christmas_tree: Problème
Il n'est pas claire pour certain utilisateur que l'on peut scroller dans les options d'un `pix-select`.
![image](https://github.com/user-attachments/assets/6459fde4-f299-49cd-b85f-2a641899376d)

## :gift: Proposition
Ajuster la taille de la liste des options afin que le dernier choix nécessitant un scroll soit visible à moitié ce qui indiquerait à l'utilisateur que d'autre options sont disponibles.

## :star2: Remarques
RAS

## :santa: Pour tester
Afficher la dropdown du pix-select.
