### PR TITLE
[TECH] Déplacer l'étoile de gauche à droite sur les radiobutton / checkbox (PIX-XXXXX)

### DIFF
--- a/addon/components/pix-label-wrapped.hbs
+++ b/addon/components/pix-label-wrapped.hbs
@@ -19,11 +19,11 @@
   {{yield to="inputElement"}}
 
   <span class="{{if @screenReaderOnly 'screen-reader-only'}}">
+    {{yield}}
+
     {{#if @requiredLabel}}
       <abbr title={{@requiredLabel}} class="mandatory-mark">*</abbr>
     {{/if}}
-
-    {{yield}}
 
     {{#if @subLabel}}
       <span class="pix-label__sub-label">{{@subLabel}}</span>


### PR DESCRIPTION
## :christmas_tree: Problème
Certaines * sont encore à gauche. 
## :gift: Proposition
On les veut à droite

## :star2: Remarques
RAS

## :santa: Pour tester
Vérifier que sur les radio/checkbox les étoiles sont à gauche.