### PR TITLE
[BUGFIX] Retirer l'usage de waitForElement qui n'est pas nécessaire PixStructureSwitcher (PIX-XXXXX)

### DIFF
--- a/addon/components/pix-structure-switcher.js
+++ b/addon/components/pix-structure-switcher.js
@@ -2,18 +2,11 @@ import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
 import { guidFor } from '@ember/object/internals';
-import { inject as service } from '@ember/service';
-
 export default class PixStructureSwitcher extends Component {
-  @service elementHelper;
-
   constructor(...args) {
     super(...args);
     this.switcherId = 'structure-switcher-' + guidFor(this);
     this.listId = `listbox-${this.switcherId}`;
-    this.elementHelper.waitForElement(`container-${this.switcherId}`).then((element) => {
-      this.rootElement = element;
-    });
   }
 
   @tracked


### PR DESCRIPTION
## :christmas_tree: Problème
l'usage de wiatForelement peut entraîner des soucis de selector.

## :gift: Proposition
Supprimer son usage

## :star2: Remarques
Il a été supprimé précedement. Mais son instanciation n'a pas été nettoyé

## :santa: Pour tester
CI au vert