### PR TITLE
[BUGFIX] Retirer la couleur par défaut de la tooltip

### DIFF
--- a/addon/styles/_pix-tooltip.scss
+++ b/addon/styles/_pix-tooltip.scss
@@ -7,7 +7,6 @@
   &__trigger-element {
     display: block;
     width: 100%;
-    color: var(--pix-neutral-500);
   }
 
   &__trigger-element:hover + .pix-tooltip__content {


### PR DESCRIPTION
## :christmas_tree: Problème
Depuis que le PixIcon prend par défaut la couleur du texte, il est plus nécessaire/voir contraignant de définir cette couleur directement dans le PixTooltip

## :gift: Proposition
Retirer cette couleur qui nous gêne plus qu'autre chose

## :star2: Remarques
RAS

## :santa: Pour tester
CI au vert