### PR TITLE
[FEATURE] Ajouter un composant colonne basique (PIX-14507)

### DIFF
--- a/addon/components/pix-table-basic-column.hbs
+++ b/addon/components/pix-table-basic-column.hbs
@@ -1,0 +1,8 @@
+<PixTableColumn @index={{@index}}>
+  <:header>
+    {{@name}}
+  </:header>
+  <:cell>
+    {{@value}}
+  </:cell>
+</PixTableColumn>

--- a/addon/components/pix-table-basic-column.hbs
+++ b/addon/components/pix-table-basic-column.hbs
@@ -1,4 +1,4 @@
-<PixTableColumn @index={{@index}}>
+<PixTableColumn @context={{@context}} class={{this.typeClass}}>
   <:header>
     {{@name}}
   </:header>

--- a/addon/components/pix-table-basic-column.js
+++ b/addon/components/pix-table-basic-column.js
@@ -1,9 +1,13 @@
 import Component from '@glimmer/component';
+import { warn } from '@ember/debug';
 
 export default class PixTableBasicColumn extends Component {
-  text = 'pix-table-basic-column';
-
   get typeClass() {
+    const correctTypes = ['number', 'text'];
+    const type = this.args.type ?? 'text';
+    warn('PixTableBasicColumn: you need to provide a valid type', correctTypes.includes(type), {
+      id: 'pix-ui.table-basic-column.type.incorrect',
+    });
     if (this.args.type === 'number') {
       return `pix-table-basic-column--number`;
     }

--- a/addon/components/pix-table-basic-column.js
+++ b/addon/components/pix-table-basic-column.js
@@ -2,4 +2,11 @@ import Component from '@glimmer/component';
 
 export default class PixTableBasicColumn extends Component {
   text = 'pix-table-basic-column';
+
+  get typeClass() {
+    if (this.args.type === 'number') {
+      return `pix-table-basic-column--number`;
+    }
+    return '';
+  }
 }

--- a/addon/components/pix-table-basic-column.js
+++ b/addon/components/pix-table-basic-column.js
@@ -1,0 +1,5 @@
+import Component from '@glimmer/component';
+
+export default class PixTableBasicColumn extends Component {
+  text = 'pix-table-basic-column';
+}

--- a/addon/styles/_pix-table-basic-column.scss
+++ b/addon/styles/_pix-table-basic-column.scss
@@ -1,4 +1,5 @@
-.pix-table-basic-column {
-  
-
+td.pix-table-basic-column {
+  &--number{
+    text-align: right;
+  }
 }

--- a/addon/styles/_pix-table-basic-column.scss
+++ b/addon/styles/_pix-table-basic-column.scss
@@ -1,0 +1,4 @@
+.pix-table-basic-column {
+  
+
+}

--- a/addon/styles/_pix-table.scss
+++ b/addon/styles/_pix-table.scss
@@ -1,3 +1,5 @@
+@import 'pix-table-basic-column';
+
 .pix-table {
   width: 100%;
   padding: var(--pix-spacing-4x);

--- a/addon/styles/_pix-table.scss
+++ b/addon/styles/_pix-table.scss
@@ -4,6 +4,7 @@
   width: 100%;
   padding: var(--pix-spacing-4x);
   overflow: auto;
+  background-color: var(--pix-neutral-0);
   border: solid 1px var(--pix-neutral-100);
   border-radius: var(--pix-spacing-2x);
 

--- a/app/components/pix-table-basic-column.js
+++ b/app/components/pix-table-basic-column.js
@@ -1,0 +1,1 @@
+export { default } from '@1024pix/pix-ui/components/pix-table-basic-column';

--- a/app/stories/pix-table-basic-column.mdx
+++ b/app/stories/pix-table-basic-column.mdx
@@ -15,14 +15,19 @@ Un composant enfant du PixTable qui affiche une colonne de type `text` ou `numbe
 ```html
 <PixTable @data={{this.data}} @caption={{this.caption}}>
   <:columns as |row context|>
-    <PixTableColumn @context={{context}}>
-      <:header>
-        Info
-      </:header>
-      <:cell>
-        <PixIcon @name='info' @title={{concat row.name ' a ' row.age ' ans'}} />
-      </:cell>
-    </PixTableColumn>
+    <PixTableBasicColumn
+      @context={{context}}
+      class={{this.typeClass}}
+      @name='Nom'
+      @value={{row.name}}
+    />
+    <PixTableBasicColumn
+      @context={{context}}
+      class={{this.typeClass}}
+      @name='Âge'
+      @value={{row.age}}
+      @type='number'
+    />
   </:columns>
 </PixTable>
 ```

--- a/app/stories/pix-table-basic-column.mdx
+++ b/app/stories/pix-table-basic-column.mdx
@@ -1,0 +1,23 @@
+import { Meta, Story, ArgTypes } from '@storybook/blocks';
+
+import * as ComponentStories from './pix-table-basic-column.stories';
+
+<Meta of={ComponentStories} />
+
+# PixTableBasicColumn
+
+TODO: insert component description
+
+<Story of={ComponentStories.Default} height={60} />
+
+## Usage
+
+```html
+<PixTableBasicColumn
+  <!-- TODO -->
+/>
+```
+
+## Arguments
+
+<ArgTypes />

--- a/app/stories/pix-table-basic-column.mdx
+++ b/app/stories/pix-table-basic-column.mdx
@@ -6,16 +6,25 @@ import * as ComponentStories from './pix-table-basic-column.stories';
 
 # PixTableBasicColumn
 
-TODO: insert component description
+Un composant enfant du PixTable qui affiche une colonne de type `text` ou `number`
 
-<Story of={ComponentStories.Default} height={60} />
+<Story of={ComponentStories.Default} height={400} />
 
 ## Usage
 
 ```html
-<PixTableBasicColumn
-  <!-- TODO -->
-/>
+<PixTable @data={{this.data}} @caption={{this.caption}}>
+  <:columns as |row context|>
+    <PixTableColumn @context={{context}}>
+      <:header>
+        Info
+      </:header>
+      <:cell>
+        <PixIcon @name='info' @title={{concat row.name ' a ' row.age ' ans'}} />
+      </:cell>
+    </PixTableColumn>
+  </:columns>
+</PixTable>
 ```
 
 ## Arguments

--- a/app/stories/pix-table-basic-column.mdx
+++ b/app/stories/pix-table-basic-column.mdx
@@ -17,16 +17,15 @@ Un composant enfant du PixTable qui affiche une colonne de type `text` ou `numbe
   <:columns as |row context|>
     <PixTableBasicColumn
       @context={{context}}
-      class={{this.typeClass}}
+      @type='text'
       @name='Nom'
       @value={{row.name}}
     />
     <PixTableBasicColumn
       @context={{context}}
-      class={{this.typeClass}}
+      @type='number'
       @name='Âge'
       @value={{row.age}}
-      @type='number'
     />
   </:columns>
 </PixTable>

--- a/app/stories/pix-table-basic-column.stories.js
+++ b/app/stories/pix-table-basic-column.stories.js
@@ -35,10 +35,15 @@ const Template = (args) => {
   <:columns as |row context|>
     <PixTableBasicColumn
       @context={{context}}
-      class={{this.typeClass}}
+      @type={{this.nameColumnType}}
       @name='Nom'
       @value={{row.name}}
-      @type={{this.type}}
+    />
+    <PixTableBasicColumn
+      @context={{context}}
+      @type={{this.ageColumnType}}
+      @name='Âge'
+      @value={{row.age}}
     />
   </:columns>
 </PixTable>`,
@@ -59,5 +64,6 @@ Default.args = {
       age: 25,
     },
   ],
-  type: 'number',
+  nameColumnType: 'text',
+  ageColumnType: 'number',
 };

--- a/app/stories/pix-table-basic-column.stories.js
+++ b/app/stories/pix-table-basic-column.stories.js
@@ -1,0 +1,29 @@
+import { hbs } from 'ember-cli-htmlbars';
+
+export default {
+  title: 'TableBasicColumn',
+  // TODO: add component attributes information
+  // select attribute data type from https://storybook.js.org/docs/react/essentials/controls
+  argTypes: {
+    attributeName: {
+      name: 'attribute name',
+      description: 'attribute description',
+      type: { name: 'string', required: false },
+    },
+  },
+};
+
+const Template = (args) => {
+  return {
+    template: hbs`
+      <PixTableBasicColumn
+      />
+    `,
+    context: args,
+  };
+};
+
+export const Default = Template.bind({});
+Default.args = {
+  // TODO
+};

--- a/app/stories/pix-table-basic-column.stories.js
+++ b/app/stories/pix-table-basic-column.stories.js
@@ -1,29 +1,64 @@
 import { hbs } from 'ember-cli-htmlbars';
 
 export default {
-  title: 'TableBasicColumn',
-  // TODO: add component attributes information
+  title: 'Data display/Table/TableBasicColumn',
   // select attribute data type from https://storybook.js.org/docs/react/essentials/controls
   argTypes: {
-    attributeName: {
-      name: 'attribute name',
-      description: 'attribute description',
-      type: { name: 'string', required: false },
+    type: {
+      defaultValue: {
+        summary: 'text',
+      },
+      type: {
+        name: '"text" | "number"',
+      },
+    },
+    name: {
+      name: 'name',
+      description: 'Nom de la colonne',
+      type: { name: 'string', required: true },
+    },
+    value: {
+      name: 'value',
+      description: 'La valeur de la cellule',
+      type: { name: 'string', required: true },
     },
   },
 };
 
 const Template = (args) => {
   return {
-    template: hbs`
-      <PixTableBasicColumn
-      />
-    `,
+    template: hbs`<PixTable @data={{this.data}} @caption={{this.caption}}>
+  <:columns as |row context|>
+    <PixTableBasicColumn
+      @context={{context}}
+      class={{this.typeClass}}
+      @name='Nom'
+      @value={{row.name}}
+    />
+    <PixTableBasicColumn
+      @context={{context}}
+      class={{this.typeClass}}
+      @name='Âge'
+      @value={{row.age}}
+      @type='number'
+    />
+  </:columns>
+</PixTable>`,
     context: args,
   };
 };
 
 export const Default = Template.bind({});
 Default.args = {
-  // TODO
+  caption: 'Description du tableau',
+  data: [
+    {
+      name: 'jean',
+      age: 15,
+    },
+    {
+      name: 'brian',
+      age: 25,
+    },
+  ],
 };

--- a/app/stories/pix-table-basic-column.stories.js
+++ b/app/stories/pix-table-basic-column.stories.js
@@ -8,6 +8,10 @@ export default {
       defaultValue: {
         summary: 'text',
       },
+      options: ['text', 'number'],
+      control: {
+        type: 'select',
+      },
       type: {
         name: '"text" | "number"',
       },
@@ -34,13 +38,7 @@ const Template = (args) => {
       class={{this.typeClass}}
       @name='Nom'
       @value={{row.name}}
-    />
-    <PixTableBasicColumn
-      @context={{context}}
-      class={{this.typeClass}}
-      @name='Âge'
-      @value={{row.age}}
-      @type='number'
+      @type={{this.type}}
     />
   </:columns>
 </PixTable>`,
@@ -61,4 +59,5 @@ Default.args = {
       age: 25,
     },
   ],
+  type: 'number',
 };

--- a/tests/integration/components/pix-table-basic-column-test.js
+++ b/tests/integration/components/pix-table-basic-column-test.js
@@ -1,0 +1,43 @@
+//! template-lint-disable
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@1024pix/ember-testing-library';
+import { hbs } from 'ember-cli-htmlbars';
+
+module('Integration | Component | table-basic-column', function (hooks) {
+  setupRenderingTest(hooks);
+
+  hooks.beforeEach(function () {
+    this.data = [
+      {
+        name: 'jean',
+        description: 'fort au jungle speed',
+        age: 15,
+      },
+      {
+        name: 'brian',
+        description: 'travail au peach pit',
+        age: 25,
+      },
+    ];
+  });
+
+  module('when type is text', function () {
+    test('it renders a text column by default', async function (assert) {
+      // when
+      const screen = await render(
+        hbs`<PixTable @caption='Ceci est le caption de notre table' @data={{this.data}}>
+  <:columns as |row context|>
+    <PixTableBasicColumn @context={{context}} @name="Nom" @value={{row.name}} />
+  </:columns>
+</PixTable>`,
+      );
+
+      // then
+      const cell = screen.queryByRole('cell', { name: 'jean' });
+      const textAlign = window.getComputedStyle(cell).getPropertyValue('text-align');
+      assert.dom(cell).exists();
+      assert.strictEqual(textAlign, 'start');
+    });
+  });
+});

--- a/tests/integration/components/pix-table-basic-column-test.js
+++ b/tests/integration/components/pix-table-basic-column-test.js
@@ -3,6 +3,9 @@ import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { render } from '@1024pix/ember-testing-library';
 import { hbs } from 'ember-cli-htmlbars';
+import sinon from 'sinon';
+
+import EmberDebug from '@ember/debug';
 
 module('Integration | Component | table-basic-column', function (hooks) {
   setupRenderingTest(hooks);
@@ -20,6 +23,48 @@ module('Integration | Component | table-basic-column', function (hooks) {
         age: 25,
       },
     ];
+  });
+
+  module('#warn', function (hooks) {
+    let sandbox;
+    hooks.beforeEach(function () {
+      sandbox = sinon.createSandbox();
+      sandbox.stub(EmberDebug, 'warn');
+    });
+
+    hooks.afterEach(function () {
+      sandbox.restore();
+    });
+
+    test('should warn when provided incorrect type', async function (assert) {
+      this.wrongType = 'wrong type';
+
+      // when
+      await render(
+        hbs`<PixTable @caption='Ceci est le caption de notre table' @data={{this.data}}>
+  <:columns as |row context|>
+    <PixTableBasicColumn
+      @context={{context}}
+      @name='Nom'
+      @value={{row.name}}
+      @type={{this.wrongType}}
+    />
+  </:columns>
+</PixTable>`,
+      );
+
+      // then
+      assert.ok(
+        EmberDebug.warn
+          .getCalls()
+          .find((call) => {
+            return call.args[0] === 'PixTableBasicColumn: you need to provide a valid type';
+          })
+          .calledWith('PixTableBasicColumn: you need to provide a valid type', false, {
+            id: 'pix-ui.table-basic-column.type.incorrect',
+          }),
+      );
+    });
   });
 
   module('when type is text', function () {

--- a/tests/integration/components/pix-table-basic-column-test.js
+++ b/tests/integration/components/pix-table-basic-column-test.js
@@ -28,16 +28,35 @@ module('Integration | Component | table-basic-column', function (hooks) {
       const screen = await render(
         hbs`<PixTable @caption='Ceci est le caption de notre table' @data={{this.data}}>
   <:columns as |row context|>
-    <PixTableBasicColumn @context={{context}} @name="Nom" @value={{row.name}} />
+    <PixTableBasicColumn @context={{context}} @name='Nom' @value={{row.name}} />
   </:columns>
 </PixTable>`,
       );
 
       // then
       const cell = screen.queryByRole('cell', { name: 'jean' });
-      const textAlign = window.getComputedStyle(cell).getPropertyValue('text-align');
       assert.dom(cell).exists();
+      const textAlign = window.getComputedStyle(cell).getPropertyValue('text-align');
       assert.strictEqual(textAlign, 'start');
+    });
+  });
+
+  module('when type is number', function () {
+    test('it renders a number column', async function (assert) {
+      // when
+      const screen = await render(
+        hbs`<PixTable @caption='Ceci est le caption de notre table' @data={{this.data}}>
+  <:columns as |row context|>
+    <PixTableBasicColumn @context={{context}} @name='Âge' @value={{row.age}} @type='number' />
+  </:columns>
+</PixTable>`,
+      );
+
+      // then
+      const cell = screen.queryByRole('cell', { name: '15' });
+      assert.dom(cell).exists();
+      const textAlign = window.getComputedStyle(cell).getPropertyValue('text-align');
+      assert.strictEqual(textAlign, 'right');
     });
   });
 });


### PR DESCRIPTION
## :christmas_tree: Problème
Nous voulons standardiser les colonnes de type `text` et `number` du `pix-table`.

## :gift: Proposition
Création d'un composant `pix-table-basic-column` acceptant les types `text` et `number`.

## :star2: Remarques
Afin de contrôler au maximum l'affichage du contenu de ce composant, on ne donne pas accès aux `yield`s du `PixTableColumn` interne. Ce composant n'accepte donc que des props :
```html
<PixTableBasicColumn @context={{context}} @type="text" @name="Nom" @value={{row.name}} />
```

## :santa: Pour tester
Se rendre sur la [page de documentation](https://ui-pr779.review.pix.fr/?path=/docs/data-display-table-tablebasiccolumn--docs) du composant.
