### PR TITLE
[FEATURE] Modifier les couleurs du PixReturnTo en cas de shade blanc (PIX-11642).

### DIFF
--- a/addon/components/pix-return-to.js
+++ b/addon/components/pix-return-to.js
@@ -1,20 +1,21 @@
 import Component from '@glimmer/component';
+import { warn } from '@ember/debug';
 
 export default class PixReturnTo extends Component {
   text = 'pix-return-to';
-  availableShade = ['black', 'white', 'blue'];
+  availableShades = ['neutral-dark', 'neutral-light'];
   defaultModel = [];
 
   get route() {
     const routeParam = this.args.route;
-    if (routeParam == undefined || routeParam.trim() == '') {
-      throw new Error('ERROR in PixReturnTo component, @route param is not provided');
-    }
+    warn('PixReturnTo: @route param is not provided', routeParam !== undefined, {
+      id: 'pix-ui.returnTo.route.required',
+    });
     return routeParam;
   }
 
   get shade() {
     const shadeParam = this.args.shade;
-    return this.availableShade.includes(shadeParam) ? shadeParam : this.availableShade[0];
+    return this.availableShades.includes(shadeParam) ? shadeParam : this.availableShades[0];
   }
 }

--- a/addon/styles/_pix-return-to.scss
+++ b/addon/styles/_pix-return-to.scss
@@ -23,31 +23,41 @@
     cursor: pointer;
   }
 
-  @mixin coloriseLink($defaultColor, $arrowHoverColor, $arrowBgColor) {
+  @mixin coloriseLink($defaultColor, $focusColor) {
     color: $defaultColor;
 
-    &:focus,
-    &:hover,
+    &:hover {
+      .pix-return-to__icon {
+        color: var(--pix-neutral-900);
+        background-color: var(--pix-neutral-20);
+        border-radius: 50%;
+      }
+    }
+
+    &:focus {
+      .pix-return-to__icon {
+        color: $focusColor;
+        background-color: $defaultColor;
+        border-radius: 50%;
+        outline: 1px solid $focusColor;
+        outline-offset: -3px;
+      }
+    }
+
     &:active {
       .pix-return-to__icon {
-        background-color: $arrowBgColor;
+        color: var(--pix-neutral-900);
+        background-color: var(--pix-neutral-100);
         border-radius: 50%;
-        outline: 1px solid var(--pix-neutral-0);
-        outline-offset: -3px;
-        fill: $arrowHoverColor;
       }
     }
   }
 
-  &--white, &--neutral-light {
-    @include coloriseLink(var(--pix-neutral-20), var(--pix-neutral-0), var(--pix-neutral-20));
+  &--neutral-light {
+    @include coloriseLink(var(--pix-neutral-20), var(--pix-neutral-900));
   }
 
-  &--black, &--neutral-dark {
-    @include coloriseLink(var(--pix-neutral-900), var(--pix-neutral-0), var(--pix-neutral-900));
-  }
-
-  &--blue, &--primary {
-    @include coloriseLink(var(--pix-primary-900), var(--pix-neutral-0), var(--pix-primary-900));
+  &--neutral-dark {
+    @include coloriseLink(var(--pix-neutral-900), var(--pix-neutral-0));
   }
 }

--- a/app/stories/pix-return-to.stories.js
+++ b/app/stories/pix-return-to.stories.js
@@ -32,16 +32,12 @@ export default {
       type: { name: 'string', required: false },
       table: { defaultValue: { summary: 'neutral-dark' } },
       control: { type: 'select' },
-      options: ['neutral-light', 'neutral-dark', 'neutral-primary'],
+      options: ['neutral-light', 'neutral-dark'],
     },
   },
 };
 
-export const returnTo = {
-  args: {
-    shade: 'primary',
-  },
-};
+export const returnTo = {};
 
 export const returnToWithText = {
   args: {

--- a/tests/integration/components/pix-return-to-test.js
+++ b/tests/integration/components/pix-return-to-test.js
@@ -2,9 +2,19 @@ import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { render } from '@1024pix/ember-testing-library';
 import { hbs } from 'ember-cli-htmlbars';
+import EmberDebug from '@ember/debug';
+import sinon from 'sinon';
 
 module('Integration | Component | pix-return-to', function (hooks) {
   setupRenderingTest(hooks);
+
+  hooks.beforeEach(function () {
+    sinon.stub(EmberDebug, 'warn');
+  });
+
+  hooks.afterEach(function () {
+    sinon.restore();
+  });
 
   const RETURN_TO_SELECTOR = '.pix-return-to';
 
@@ -13,22 +23,7 @@ module('Integration | Component | pix-return-to', function (hooks) {
     await render(hbs`<PixReturnTo @route='home'>Home</PixReturnTo>`);
 
     // then
-    const pixReturnToElement = this.element.querySelector(RETURN_TO_SELECTOR);
     assert.contains('Home');
-    assert.ok(
-      pixReturnToElement.classList.toString().includes('pix-return-to pix-return-to--black'),
-    );
-  });
-
-  test('it renders with the given shade', async function (assert) {
-    // when
-    await render(hbs`<PixReturnTo @route='home' @shade='white' />`);
-
-    // then
-    const pixReturnToElement = this.element.querySelector(RETURN_TO_SELECTOR);
-    assert.ok(
-      pixReturnToElement.classList.toString().includes('pix-return-to pix-return-to--white'),
-    );
   });
 
   test('it renders without text', async function (assert) {
@@ -37,8 +32,23 @@ module('Integration | Component | pix-return-to', function (hooks) {
 
     // then
     const pixReturnToElement = this.element.querySelector(RETURN_TO_SELECTOR);
-    // TODO: Fix this the next time the file is edited.
-    // eslint-disable-next-line qunit/no-assert-equal
-    assert.equal(pixReturnToElement.textContent.trim(), '');
+    assert.strictEqual(pixReturnToElement.textContent.trim(), '');
+  });
+
+  test('it warns if route param is undefined', async function (assert) {
+    // when
+    await render(hbs`<PixReturnTo />`);
+
+    // then
+    assert.ok(
+      EmberDebug.warn
+        .getCalls()
+        .find((call) => {
+          return call.args[0] === 'PixReturnTo: @route param is not provided';
+        })
+        .calledWith('PixReturnTo: @route param is not provided', false, {
+          id: 'pix-ui.returnTo.route.required',
+        }),
+    );
   });
 });

--- a/tests/unit/components/pix-return-to-test.js
+++ b/tests/unit/components/pix-return-to-test.js
@@ -8,36 +8,20 @@ module('Unit | Component | pix-return-to', function (hooks) {
   test('its default color is black', function (assert) {
     // given
     const componentParams = { route: 'uneRoute', shade: 'test' };
-    const expectedShade = 'black';
+    const expectedShade = 'neutral-dark';
     const component = createGlimmerComponent('pix-return-to', componentParams);
 
     // when & then
-    // TODO: Fix this the next time the file is edited.
-    // eslint-disable-next-line qunit/no-assert-equal
-    assert.equal(component.shade, expectedShade);
+    assert.strictEqual(component.shade, expectedShade);
   });
 
   test('it can be white', function (assert) {
     // given
-    const componentParams = { route: 'uneRoute', shade: 'white' };
-    const expectedShade = 'white';
+    const componentParams = { route: 'uneRoute', shade: 'neutral-light' };
+    const expectedShade = 'neutral-light';
     const component = createGlimmerComponent('pix-return-to', componentParams);
 
     // when & then
-    // TODO: Fix this the next time the file is edited.
-    // eslint-disable-next-line qunit/no-assert-equal
-    assert.equal(component.shade, expectedShade);
-  });
-
-  test('it throws if route param is undefined or empty', function (assert) {
-    // given
-    const componentParams = { route: '  ' };
-    const expectedError = new Error('ERROR in PixReturnTo component, @route param is not provided');
-    const component = createGlimmerComponent('pix-return-to', componentParams);
-
-    // when & then
-    assert.throws(function () {
-      component.route;
-    }, expectedError);
+    assert.strictEqual(component.shade, expectedShade);
   });
 });


### PR DESCRIPTION
## :christmas_tree: Problème
Actuellement 2 pages coté Pix App utilisent le PixReturnTo avec le shade white mais le hover masque l'icône.

<img width="630" alt="Capture d’écran 2024-03-14 à 12 19 18" src="https://github.com/user-attachments/assets/d24fad4b-c46c-44e6-985a-c6af31cdea81">


## :gift: Proposition
Revoir les couleurs pour ce shade

## :star2: Remarques
Des modifications de naming pour du neutral-* ont été ajouté pour le `shade` mais pas appliqué sur les apps. 

Etant donné que le paramètre `shade` est exclusivement utilisé dans ces 2 pages sur Pix App, je supprime les anciens naming (white et dark pour laisser uniquement les nouveaux)

Ça pourrait faire l'objet d'un BREAKING parce que ça impacte leurs couleurs mais comme ça ne concerne que deux liens, je le l'applique pas.
Je m'assurerais que ces liens appliqueront le bon shade.

## :santa: Pour tester
aller sur le [Pix Return To et mettre le shade en neutral-light](https://ui-pr781.review.pix.fr/?path=/story/other-return-to--return-to-with-text&args=shade:neutral-light&globals=backgrounds.value:!hex(333)).

S'assurer qu'il soit iso avec [le design](https://www.figma.com/design/8RJ3aCSfdeQ8AZZVBBYKS8/Design-System-Nebulix?node-id=4696-22894&node-type=canvas&t=51k3OuTXNAtclBO9-0)
