### PR TITLE
[FEATURE] Permettre de trier les données de `PixTable` (PIX-15560)

### DIFF
--- a/addon/components/pix-table-column.hbs
+++ b/addon/components/pix-table-column.hbs
@@ -1,6 +1,16 @@
 {{#if this.displayHeader}}
-  <th scope="col" ...attributes>
-    {{yield to="header"}}
+  <th scope="col" ...attributes aria-sort={{this.ariaSort}}>
+    <div class="pix-table-header-container">
+      {{yield to="header"}}
+      {{#if this.sortable}}
+        <PixIconButton
+          @ariaLabel={{this.iconLabel}}
+          @iconName={{this.iconName}}
+          @triggerAction={{@onSort}}
+          @size="small"
+        />
+      {{/if}}
+    </div>
   </th>
 {{else}}
   <td ...attributes class={{this.typeClass}}>

--- a/addon/components/pix-table-column.js
+++ b/addon/components/pix-table-column.js
@@ -6,6 +6,69 @@ export default class PixTableColumn extends Component {
     return this.args.context === 'header';
   }
 
+  get sortable() {
+    return Boolean(this.args.onSort);
+  }
+
+  get sortOrder() {
+    if (this.args.sortOrder === undefined) {
+      return undefined;
+    }
+    const correctSortOrders = ['asc', 'desc', null];
+    warn(
+      'PixTableColumn: you need to provide a valid sortOrder',
+      correctSortOrders.includes(this.args.sortOrder),
+      {
+        id: 'pix-ui.table-column.sortOrder.not-valid',
+      },
+    );
+    return this.args.sortOrder;
+  }
+
+  get iconName() {
+    if (!this.sortOrder) {
+      return 'sort';
+    }
+    if (this.sortOrder === 'asc') {
+      return 'sortAsc';
+    }
+    return 'sortDesc';
+  }
+
+  get iconLabel() {
+    warn(
+      'PixTableColumn: parameters `@ariaLabelDefaultSort`, `@ariaLabelSortDesc` and `@ariaLabelSortAsc` are required for sort buttons',
+      ![
+        this.args.ariaLabelDefaultSort,
+        this.args.ariaLabelSortDesc,
+        this.args.ariaLabelSortAsc,
+      ].includes(undefined),
+      {
+        id: 'pix-ui.pix-table-column.sortAriaLabels.required',
+      },
+    );
+    if (!this.sortOrder) {
+      return this.args.ariaLabelDefaultSort;
+    }
+    if (this.sortOrder === 'asc') {
+      return this.args.ariaLabelSortDesc;
+    }
+    return this.args.ariaLabelSortAsc;
+  }
+
+  get ariaSort() {
+    if (!this.sortable) {
+      return undefined;
+    }
+    if (!this.sortOrder) {
+      return 'none';
+    }
+    if (this.sortOrder === 'asc') {
+      return 'ascending';
+    }
+    return 'descending';
+  }
+
   get typeClass() {
     const correctTypes = ['number', 'text'];
     const type = this.args.type ?? 'text';

--- a/addon/components/pix-table-column.js
+++ b/addon/components/pix-table-column.js
@@ -6,6 +6,10 @@ export default class PixTableColumn extends Component {
     return this.args.context === 'header';
   }
 
+  get type() {
+    return this.args.type ?? 'text';
+  }
+
   get sortable() {
     return Boolean(this.args.onSort);
   }
@@ -26,13 +30,14 @@ export default class PixTableColumn extends Component {
   }
 
   get iconName() {
+    const isText = this.type === 'text';
     if (!this.sortOrder) {
-      return 'sort';
+      return isText ? 'sortAz' : 'sort';
     }
     if (this.sortOrder === 'asc') {
-      return 'sortAsc';
+      return isText ? 'sortAzAsc' : 'sortAsc';
     }
-    return 'sortDesc';
+    return isText ? 'sortAzDesc' : 'sortDesc';
   }
 
   get iconLabel() {
@@ -71,8 +76,7 @@ export default class PixTableColumn extends Component {
 
   get typeClass() {
     const correctTypes = ['number', 'text'];
-    const type = this.args.type ?? 'text';
-    warn('PixTableColumn: you need to provide a valid type', correctTypes.includes(type), {
+    warn('PixTableColumn: you need to provide a valid type', correctTypes.includes(this.type), {
       id: 'pix-ui.table-column.type.incorrect',
     });
     if (this.args.type === 'number') {

--- a/addon/styles/_pix-table.scss
+++ b/addon/styles/_pix-table.scss
@@ -32,8 +32,15 @@
       }
     }
 
+    .pix-table-header-container {
+      display: flex;
+      gap: var(--pix-spacing-1x);
+      align-items: center;
+    }
+
     th {
       text-align: start;
+      vertical-align: middle;
     }
 
     td, th {

--- a/app/stories/pix-table-column.mdx
+++ b/app/stories/pix-table-column.mdx
@@ -40,6 +40,40 @@ Une colonne d'un [PixTable](/docs/data-display-table--docs), gère l'affichage d
 </PixTable>
 ```
 
+## Tri
+
+<Story of={ComponentStories.Sorted} height={400} />
+
+```html
+<PixTable @data={{this.data}} @caption={{this.caption}}>
+  <:columns as |row context|>
+    <PixTableColumn @context={{context}}>
+      <:header>
+        Nom
+      </:header>
+      <:cell>
+        {{row.name}}
+      </:cell>
+    </PixTableColumn>
+    <PixTableColumn
+      @context={{context}}
+      @onSort={{this.onNumSort}}
+      @sortOrder={{this.sortOrder}}
+      @ariaLabelDefaultSort={{this.otherArialLabelDefaultSort}}
+      @ariaLabelSortAsc={{this.ariaLabelSortAsc}}
+      @ariaLabelSortDesc={{this.ariaLabelSortDesc}}
+    >
+      <:header>
+        Age
+      </:header>
+      <:cell>
+        {{row.age}}
+      </:cell>
+    </PixTableColumn>
+  </:columns>
+</PixTable>
+```
+
 ## Arguments
 
 <ArgTypes />

--- a/app/stories/pix-table-column.mdx
+++ b/app/stories/pix-table-column.mdx
@@ -47,7 +47,14 @@ Une colonne d'un [PixTable](/docs/data-display-table--docs), gère l'affichage d
 ```html
 <PixTable @data={{this.data}} @caption={{this.caption}}>
   <:columns as |row context|>
-    <PixTableColumn @context={{context}}>
+    <PixTableColumn
+      @context={{context}}
+      @onSort={{this.sortAz}}
+      @sortOrder={{this.sortOrderAz}}
+      @ariaLabelDefaultSort={{this.ariaLabelDefaultSort}}
+      @ariaLabelSortAsc={{this.ariaLabelSortAsc}}
+      @ariaLabelSortDesc={{this.ariaLabelSortDesc}}
+    >
       <:header>
         Nom
       </:header>
@@ -57,9 +64,10 @@ Une colonne d'un [PixTable](/docs/data-display-table--docs), gère l'affichage d
     </PixTableColumn>
     <PixTableColumn
       @context={{context}}
-      @onSort={{this.onNumSort}}
-      @sortOrder={{this.sortOrder}}
-      @ariaLabelDefaultSort={{this.otherArialLabelDefaultSort}}
+      @type="number"
+      @onSort={{this.sortNum}}
+      @sortOrder={{this.sortOrderNum}}
+      @ariaLabelDefaultSort={{this.ariaLabelDefaultSort}}
       @ariaLabelSortAsc={{this.ariaLabelSortAsc}}
       @ariaLabelSortDesc={{this.ariaLabelSortDesc}}
     >

--- a/app/stories/pix-table-column.stories.js
+++ b/app/stories/pix-table-column.stories.js
@@ -8,6 +8,43 @@ export default {
       description: 'Propriété a récupérer depuis le block element `<:columns>` du PixTable parent.',
       type: { name: 'privé', required: true },
     },
+    onSort: {
+      name: 'onSort',
+      description:
+        "Fonction appelée en cas de clic sur le bouton de tri d'une colonne. Sa présence détermine si le bouton de tri est affiché ou non. Le tri est à implémenter soi-même.",
+      type: { name: 'function', required: false },
+    },
+    sortOrder: {
+      name: 'sortOrder',
+      description:
+        "Statut du tri de la colonne. À gérer du côté de l'application.<br> ⚠️ Obligatoire si `@onSort` est utilisé ⚠️",
+      options: ['asc', 'desc', null],
+      control: {
+        type: 'select',
+      },
+      type: {
+        name: '"asc" | "desc" | null',
+        required: false,
+      },
+    },
+    ariaLabelDefaultSort: {
+      name: 'ariaLabelDefaultSort',
+      description:
+        "Label du bouton de tri, lorsqu'aucun tri n'est appliqué.<br>  ⚠️ Obligatoire si `@onSort` est utilisé ⚠️",
+      type: { name: 'string', required: false },
+    },
+    ariaLabelSortAsc: {
+      name: 'ariaLabelSortAsc',
+      description:
+        'Label du bouton de tri (pour trier en ordre ascendant), lorsque le tri descendant est appliqué.<br>  ⚠️ Obligatoire si `@onSort` est utilisé ⚠️',
+      type: { name: 'string', required: false },
+    },
+    ariaLabelSortDesc: {
+      name: 'ariaLabelSortDesc',
+      description:
+        'Label du bouton de tri (pour trier en ordre descendant), lorsque le tri ascendant est appliqué.<br>  ⚠️ Obligatoire si `@onSort` est utilisé ⚠️',
+      type: { name: 'string', required: false },
+    },
     type: {
       defaultValue: {
         summary: 'text',
@@ -73,4 +110,59 @@ Default.args = {
       age: 25,
     },
   ],
+};
+
+const TemplateSort = (args) => {
+  return {
+    template: hbs`<PixTable @data={{this.data}} @caption={{this.caption}}>
+  <:columns as |row context|>
+    <PixTableColumn @context={{context}}>
+      <:header>
+        Nom
+      </:header>
+      <:cell>
+        {{row.name}}
+      </:cell>
+    </PixTableColumn>
+    <PixTableColumn
+      @context={{context}}
+      @onSort={{this.sortNum}}
+      @sortOrder={{this.sortOrder}}
+      @ariaLabelDefaultSort={{this.ariaLabelDefaultSort}}
+      @ariaLabelSortAsc={{this.ariaLabelSortAsc}}
+      @ariaLabelSortDesc={{this.ariaLabelSortDesc}}
+    >
+      <:header>
+        Age
+      </:header>
+      <:cell>
+        {{row.age}}
+      </:cell>
+    </PixTableColumn>
+  </:columns>
+</PixTable>`,
+    context: args,
+  };
+};
+
+export const Sorted = TemplateSort.bind({});
+Sorted.args = {
+  caption: 'Description du tableau',
+  data: [
+    {
+      name: 'jean',
+      age: 15,
+    },
+    {
+      name: 'brian',
+      age: 25,
+    },
+  ],
+  sortNum(a, b) {
+    return a.age - b.age;
+  },
+  sortOrder: 'asc',
+  ariaLabelDefaultSort: 'click pour trier',
+  ariaLabelSortAsc: 'click pour trier en ordre ascendant',
+  ariaLabelSortDesc: 'click pour trier en ordre descendant',
 };

--- a/app/stories/pix-table-column.stories.js
+++ b/app/stories/pix-table-column.stories.js
@@ -116,7 +116,14 @@ const TemplateSort = (args) => {
   return {
     template: hbs`<PixTable @data={{this.data}} @caption={{this.caption}}>
   <:columns as |row context|>
-    <PixTableColumn @context={{context}}>
+    <PixTableColumn
+      @context={{context}}
+      @onSort={{this.sort}}
+      @sortOrder={{this.sortOrder}}
+      @ariaLabelDefaultSort={{this.ariaLabelDefaultSort}}
+      @ariaLabelSortAsc={{this.ariaLabelSortAsc}}
+      @ariaLabelSortDesc={{this.ariaLabelSortDesc}}
+    >
       <:header>
         Nom
       </:header>
@@ -126,7 +133,8 @@ const TemplateSort = (args) => {
     </PixTableColumn>
     <PixTableColumn
       @context={{context}}
-      @onSort={{this.sortNum}}
+      @type='number'
+      @onSort={{this.sort}}
       @sortOrder={{this.sortOrder}}
       @ariaLabelDefaultSort={{this.ariaLabelDefaultSort}}
       @ariaLabelSortAsc={{this.ariaLabelSortAsc}}
@@ -158,9 +166,7 @@ Sorted.args = {
       age: 25,
     },
   ],
-  sortNum(a, b) {
-    return a.age - b.age;
-  },
+  sort() {},
   sortOrder: 'asc',
   ariaLabelDefaultSort: 'click pour trier',
   ariaLabelSortAsc: 'click pour trier en ordre ascendant',

--- a/app/stories/pix-table.stories.js
+++ b/app/stories/pix-table.stories.js
@@ -93,4 +93,7 @@ Default.args = {
       age: 25,
     },
   ],
+  onNameSort: () => {
+    alert('Fonctionnalité seulement disponible en local sur dummy');
+  },
 };

--- a/tests/dummy/app/controllers/table-page.js
+++ b/tests/dummy/app/controllers/table-page.js
@@ -1,0 +1,59 @@
+import Controller from '@ember/controller';
+import { tracked } from '@glimmer/tracking';
+import { action } from '@ember/object';
+
+export default class TablePage extends Controller {
+  @tracked
+  nameSortOrder = null;
+  @tracked
+  numSortOrder = null;
+
+  variant = 'orga';
+
+  @tracked
+  data = [
+    {
+      name: 'jean',
+      description: 'fort au jungle speed',
+      age: 15,
+    },
+    {
+      name: 'brian',
+      description: 'travail au peach pit',
+      age: 25,
+    },
+  ];
+
+  caption = 'Titre de mon tableau';
+
+  @action
+  onNameSort() {
+    this.resetOrders('name');
+    if (this.nameSortOrder === 'asc') {
+      this.data = this.data.sort((a, b) => b.name.localeCompare(a.name));
+      this.nameSortOrder = 'desc';
+    } else {
+      this.data = this.data.sort((a, b) => a.name.localeCompare(b.name));
+      this.nameSortOrder = 'asc';
+    }
+  }
+
+  @action
+  onNumSort() {
+    this.resetOrders('num');
+    if (this.numSortOrder === 'asc') {
+      this.data = this.data.sort((a, b) => b.age - a.age);
+      this.numSortOrder = 'desc';
+    } else {
+      this.data = this.data.sort((a, b) => a.age - b.age);
+      this.numSortOrder = 'asc';
+    }
+  }
+
+  resetOrders(except) {
+    for (const key of ['num', 'name']) {
+      if (key === except) continue;
+      this[`${key}SortOrder`] = null;
+    }
+  }
+}

--- a/tests/dummy/app/router.js
+++ b/tests/dummy/app/router.js
@@ -13,4 +13,5 @@ Router.map(function () {
   this.route('select-page', { path: '/select' });
   this.route('sidebar-page', { path: '/sidebar' });
   this.route('tooltip-page', { path: '/tooltip' });
+  this.route('table-page', { path: '/table' });
 });

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -14,6 +14,7 @@
       <PixNavigationButton @route="select-page" @icon="book">select</PixNavigationButton>
       <PixNavigationButton @route="sidebar-page" @icon="doorOpen">Sidebar</PixNavigationButton>
       <PixNavigationButton @route="tooltip-page" @icon="signpost">tooltip</PixNavigationButton>
+      <PixNavigationButton @route="table-page" @icon="assignment">Table</PixNavigationButton>
 
       <PixNavigationButton href="https://pix.fr" @icon="book">Documentation</PixNavigationButton>
       <PixNavigationButton href="https://pix.fr" title="Pix.fr" @target="_blank" @icon="help">Centre

--- a/tests/dummy/app/templates/table-page.hbs
+++ b/tests/dummy/app/templates/table-page.hbs
@@ -1,0 +1,51 @@
+<PixTable @variant={{this.variant}} @data={{this.data}} @caption={{this.caption}}>
+  <:columns as |row context|>
+    <PixTableColumn
+      @context={{context}}
+      @type="text"
+      @onSort={{this.onNameSort}}
+      @sortOrder={{this.nameSortOrder}}
+    >
+      <:header>
+        Nom
+      </:header>
+      <:cell>
+        {{row.name}}
+      </:cell>
+    </PixTableColumn>
+    <PixTableColumn @context={{context}}>
+      <:header>
+        Description
+      </:header>
+      <:cell>
+        <i>{{row.description}}</i>
+      </:cell>
+    </PixTableColumn>
+    <PixTableColumn
+      @context={{context}}
+      @type="number"
+      @onSort={{this.onNumSort}}
+      @sortOrder={{this.numSortOrder}}
+      class="table__column--small"
+    >
+      <:header>
+        Age
+      </:header>
+      <:cell>
+        {{row.age}}
+      </:cell>
+    </PixTableColumn>
+    <PixTableColumn @context={{context}} class="table__column--small">
+      <:header>
+        Info
+      </:header>
+      <:cell>
+        <PixIcon @name="info" @title={{concat row.name " a " row.age " ans"}} />
+      </:cell>
+    </PixTableColumn>
+  </:columns>
+</PixTable>
+{{! template-lint-disable no-forbidden-elements }}
+<style>
+  .table__column--small { width: 64px; }
+</style>

--- a/tests/integration/components/pix-table-test.js
+++ b/tests/integration/components/pix-table-test.js
@@ -2,6 +2,7 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { render } from '@1024pix/ember-testing-library';
+import { click } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import EmberDebug from '@ember/debug';
 import sinon from 'sinon';
@@ -19,7 +20,12 @@ module('Integration | Component | table', function (hooks) {
       {
         name: 'brian',
         description: 'travail au peach pit',
-        age: 25,
+        age: 14,
+      },
+      {
+        name: 'zoé',
+        description: 'travail aux affaires non classées',
+        age: 70,
       },
     ];
   });
@@ -119,6 +125,146 @@ module('Integration | Component | table', function (hooks) {
     });
   });
 
+  module('#sort', function () {
+    test('it should call @onSort on click', async function (assert) {
+      // given
+      const sortStub = sinon.stub();
+      this.onSort = sortStub;
+
+      const arialLabelDefaultSort = 'default label sort';
+      this.arialLabelDefaultSort = arialLabelDefaultSort;
+
+      // when
+
+      const screen = await render(
+        hbs`<PixTable @caption='Ceci est le caption de notre table' @data={{this.data}}>
+  <:columns as |row context|>
+    <PixTableColumn
+      @context={{context}}
+      @onSort={{this.onSort}}
+      @sortOrder={{null}}
+      @ariaLabelDefaultSort={{this.arialLabelDefaultSort}}
+      @ariaLabelSortAsc='asc label sort'
+      @ariaLabelSortDesc='desc label sort'
+    >
+      <:header>
+        Nom
+      </:header>
+      <:cell>
+        {{row.name}}
+      </:cell>
+    </PixTableColumn>
+  </:columns>
+</PixTable>`,
+      );
+
+      // then
+      await click(await screen.getByRole('button', { name: arialLabelDefaultSort }));
+      assert.ok(sortStub.calledOnce);
+    });
+
+    test('it should display `ariaLabelSortAsc` when sortOrder is `desc`', async function (assert) {
+      // given
+      const sortStub = sinon.stub();
+      this.onSort = sortStub;
+
+      this.sortOrder = 'desc';
+
+      const ariaLabelSortAsc = "clicker pour trié dans l'ordre desc";
+      this.ariaLabelSortAsc = ariaLabelSortAsc;
+
+      // when
+
+      const screen = await render(
+        hbs`<PixTable @caption='Ceci est le caption de notre table' @data={{this.data}}>
+  <:columns as |row context|>
+    <PixTableColumn
+      @context={{context}}
+      @onSort={{this.onSort}}
+      @sortOrder={{this.sortOrder}}
+      @ariaLabelDefaultSort='default label sort'
+      @ariaLabelSortAsc={{this.ariaLabelSortAsc}}
+      @ariaLabelSortDesc='desc label sort'
+    >
+      <:header>
+        Nom
+      </:header>
+      <:cell>
+        {{row.name}}
+      </:cell>
+    </PixTableColumn>
+  </:columns>
+</PixTable>`,
+      );
+
+      // then
+      assert.ok(await screen.getByRole('button', { name: ariaLabelSortAsc }));
+    });
+
+    test('it should display `ariaLabelSortDesc` when sortOrder is `asc`', async function (assert) {
+      // given
+      const sortStub = sinon.stub();
+      this.onSort = sortStub;
+
+      this.sortOrder = 'asc';
+
+      const ariaLabelSortDesc = "clicker pour trié dans l'ordre asc";
+      this.ariaLabelSortDesc = ariaLabelSortDesc;
+
+      // when
+
+      const screen = await render(
+        hbs`<PixTable @caption='Ceci est le caption de notre table' @data={{this.data}}>
+  <:columns as |row context|>
+    <PixTableColumn
+      @context={{context}}
+      @onSort={{this.onSort}}
+      @sortOrder={{this.sortOrder}}
+      @ariaLabelDefaultSort='default label sort'
+      @ariaLabelSortDesc={{this.ariaLabelSortDesc}}
+      @ariaLabelSortAsc='asc label sort'
+    >
+      <:header>
+        Nom
+      </:header>
+      <:cell>
+        {{row.name}}
+      </:cell>
+    </PixTableColumn>
+  </:columns>
+</PixTable>`,
+      );
+
+      // then
+      assert.ok(await screen.getByRole('button', { name: ariaLabelSortDesc }));
+    });
+
+    test('it should not display sortlabel when `@onSort` is not provided', async function (assert) {
+      // given
+      const arialLabelDefaultSort = 'default label sort';
+      this.arialLabelDefaultSort = arialLabelDefaultSort;
+
+      // when
+      const screen = await render(
+        hbs`<PixTable @caption='Ceci est le caption de notre table' @data={{this.data}}>
+  <:columns as |row context|>
+    <PixTableColumn @context={{context}} @ariaLabelDefaultSort={{this.arialLabelDefaultSort}}>
+      <:header>
+        Nom
+      </:header>
+      <:cell>
+        {{row.name}}
+      </:cell>
+    </PixTableColumn>
+  </:columns>
+</PixTable>`,
+      );
+
+      // then
+      assert.notOk(await screen.queryByRole('button', { name: arialLabelDefaultSort }));
+    });
+  });
+
   module('#warn', function (hooks) {
     let sandbox;
     hooks.beforeEach(function () {
@@ -132,7 +278,10 @@ module('Integration | Component | table', function (hooks) {
 
     test('it should warn when @variant is incorrect', async function (assert) {
       // when
-      await render(hbs`<PixTable @caption='A caption' @variant='wrong variant' />`);
+      this.data = [];
+      await render(
+        hbs`<PixTable @data={{this.data}} @caption='A caption' @variant='wrong variant' />`,
+      );
 
       // then
       assert.ok(
@@ -154,9 +303,10 @@ module('Integration | Component | table', function (hooks) {
       );
     });
 
-    test('it should warn when @caption is not provided provided', async function (assert) {
+    test('it should warn when @caption is not provided', async function (assert) {
       // when
-      await render(hbs`<PixTable />`);
+      this.data = [];
+      await render(hbs`<PixTable @data={{this.data}} />`);
 
       // then
       assert.ok(
@@ -169,6 +319,90 @@ module('Integration | Component | table', function (hooks) {
             id: 'pix-ui.pix-table.caption.required',
           }),
       );
+    });
+
+    test('it should warn when @sortOrder is incorrect', async function (assert) {
+      // when
+      this.data = [];
+      this.onSort = () => {};
+      await render(
+        hbs`<PixTable @data={{this.data}} @caption='On sort?'>
+  <:columns as |row context|>
+    <PixTableColumn @context={{context}} @onSort={{this.onSort}} @sortOrder='eeuuuuh' />
+  </:columns>
+</PixTable>`,
+      );
+
+      // then
+      assert.ok(
+        EmberDebug.warn
+          .getCalls()
+          .find((call) => {
+            return call.args[2].id === 'pix-ui.table-column.sortOrder.not-valid';
+          })
+          .calledWith('PixTableColumn: you need to provide a valid sortOrder', false, {
+            id: 'pix-ui.table-column.sortOrder.not-valid',
+          }),
+      );
+    });
+
+    [
+      {
+        ariaLabelDefaultSort: 'tri',
+        ariaLabelSortDesc: 'tri',
+        ariaLabelSortAsc: undefined,
+      },
+      {
+        ariaLabelDefaultSort: 'tri',
+        ariaLabelSortDesc: undefined,
+        ariaLabelSortAsc: 'tri',
+      },
+      {
+        ariaLabelDefaultSort: undefined,
+        ariaLabelSortDesc: 'tri',
+        ariaLabelSortAsc: 'tri',
+      },
+    ].forEach(function (sortAriaLabels) {
+      const [missingLabel] = Object.entries(sortAriaLabels).find(([, value]) => !value);
+      test(`it should warn when ${missingLabel} is not provided`, async function (assert) {
+        // when
+        this.data = [];
+        this.onSort = () => {};
+        this.ariaLabelDefaultSort = sortAriaLabels.ariaLabelDefaultSort;
+        this.ariaLabelSortDesc = sortAriaLabels.ariaLabelSortDesc;
+        this.ariaLabelSortAsc = sortAriaLabels.ariaLabelSortAsc;
+
+        await render(hbs`<PixTable @data={{this.data}} @caption='Mon tableau et pas le tien'>
+  <:columns as |row context|>
+    <PixTableColumn
+      @context={{context}}
+      @onSort={{this.onSort}}
+      @ariaLabelDefaultSort={{this.ariaLabelDefaultSort}}
+      @ariaLabelSortDesc={{this.ariaLabelSortDesc}}
+      @ariaLabelSortAsc={{this.ariaLabelSortAsc}}
+    />
+  </:columns>
+</PixTable>`);
+
+        // then
+        assert.ok(
+          EmberDebug.warn
+            .getCalls()
+            .find((call) => {
+              return (
+                call.args[0] ===
+                'PixTableColumn: parameters `@ariaLabelDefaultSort`, `@ariaLabelSortDesc` and `@ariaLabelSortAsc` are required for sort buttons'
+              );
+            })
+            .calledWith(
+              'PixTableColumn: parameters `@ariaLabelDefaultSort`, `@ariaLabelSortDesc` and `@ariaLabelSortAsc` are required for sort buttons',
+              false,
+              {
+                id: 'pix-ui.pix-table-column.sortAriaLabels.required',
+              },
+            ),
+        );
+      });
     });
   });
 });


### PR DESCRIPTION
## :christmas_tree: Problème
On ne peut pas facilement trier les lignes d'un tableau `PixTable`.

## :gift: Proposition
Ajout de la gestion de l'état du tri du tableau.

## :star2: Remarques
Il existe un dummy `/table` pour qui est motivé de faire tourner cette PR en local.

## :santa: Pour tester
- Se rendre sur [les stories de PixTable](https://ui-pr783.review.pix.fr/?path=/docs/data-display-table--docs) et [ses colonnes](https://ui-pr783.review.pix.fr/?path=/story/data-display-table-tablecolumn--sorted).
- Vérifier que les icônes de tri s'affichent.
- Faire des retours plein d'amour sur cette PR 🫶
