### PR TITLE
[TECH] Suppression de le documentation concernant le type alert dépréciée sur Pix Notification Alert.

### DIFF
--- a/app/stories/pix-notification-alert.mdx
+++ b/app/stories/pix-notification-alert.mdx
@@ -37,10 +37,6 @@ Le bandeau en cas de d'erreur.
 
 <Story of={ComponentStories.error} height={110} />
 
-## Alert
-
-⚠️ Ce type est déprécié, utilisez le type `error` à la place.
-
 ## Usage
 
 Par défaut


### PR DESCRIPTION
## :christmas_tree: Problème
Le type alert, dans le composant Pix NotificationAlert,  a été dépréciée depuis un moment et a été définitivement supprimé en octobre https://github.com/1024pix/pix-ui/pull/731
Mais de la documentation a survécu.

## :gift: Proposition
Supprimer la documentation

## :star2: Remarques
Une PR sera prévu coté repo 1024/pix car le type alert est encore existant sur une poignée de composant.

## :santa: Pour tester
RAS
