### PR TITLE
[FEATURE] Rendre le MultiSelect avec recherche intégralement cliquable (PIX-15635).

### DIFF
--- a/addon/components/pix-multi-select.hbs
+++ b/addon/components/pix-multi-select.hbs
@@ -19,11 +19,15 @@
   <PopperJS @placement={{or @placement "bottom-start"}} as |reference popover|>
 
     {{#if @isSearchable}}
-      <span {{reference}} class={{this.headerClassName}}>
-        <PixIcon @name="search" class="pix-multi-select-header__search-icon" @ariaHidden={{true}} />
+      <span {{reference}} class={{this.mainInputClassName}}>
+        <PixIcon
+          @name="search"
+          class="pix-multi-select-main-input__search-icon"
+          @ariaHidden={{true}}
+        />
 
         <input
-          class="pix-multi-select-header__search-input"
+          class="pix-multi-select-main-input__search-input"
           id={{this.multiSelectId}}
           type="text"
           name={{this.multiSelectId}}
@@ -44,7 +48,7 @@
         aria-expanded={{this.isAriaExpanded}}
         aria-controls={{this.listId}}
         aria-haspopup="menu"
-        class={{this.headerClassName}}
+        class={{this.mainInputClassName}}
         {{on "click" this.toggleDropDown}}
       >
         {{#if (has-block "placeholder")}}
@@ -53,8 +57,8 @@
           {{this.placeholder}}
         {{/if}}
         <PixIcon
-          class="pix-multi-select-header__dropdown-icon
-            {{if this.isExpanded ' pix-multi-select-header__dropdown-icon--expand'}}"
+          class="pix-multi-select-main-input__dropdown-icon
+            {{if this.isExpanded ' pix-multi-select-main-input__dropdown-icon--expand'}}"
           @name={{if this.isExpanded "chevronTop" "chevronBottom"}}
           @ariaHidden={{true}}
         />

--- a/addon/components/pix-multi-select.js
+++ b/addon/components/pix-multi-select.js
@@ -30,13 +30,17 @@ export default class PixMultiSelect extends Component {
     this.options = [...(this.args.options || [])];
   }
 
-  get headerClassName() {
-    const classes = ['pix-multi-select-header'];
+  get mainInputClassName() {
+    let classes = 'pix-multi-select-main-input';
+
+    if (this.args.isSearchable) {
+      classes += ' pix-multi-select-main-input--is-searchable';
+    }
     if (this.args.className) {
-      classes.push(this.args.className);
+      classes += ` ${this.args.className}`;
     }
 
-    return classes.join(' ');
+    return classes;
   }
 
   get multiSelectId() {

--- a/addon/styles/_pix-multi-select.scss
+++ b/addon/styles/_pix-multi-select.scss
@@ -11,7 +11,8 @@
   }
 }
 
-.pix-multi-select-header {
+/* Main input */
+.pix-multi-select-main-input {
   @extend %pix-body-s;
   @extend %pix-form-element-state;
 
@@ -27,42 +28,46 @@
   border: 1px var(--pix-neutral-500) solid;
   border-radius: var(--pix-spacing-1x);
   cursor: pointer;
+}
 
-  &--big {
-    height: 44px;
-  }
+.pix-multi-select-main-input__dropdown-icon {
+  @extend %pix-body-s;
 
-  &__search-icon {
-    color: var(--pix-neutral-900);
-  }
+  color: var(--pix-neutral-900);
+  pointer-events: none;
+}
 
-  &__title {
+// Searchable multiselect
+.pix-multi-select-main-input--is-searchable {
+  padding: 0;
+
+  .pix-multi-select-main-input__search-icon {
     position: absolute;
-    width: 0;
-    height: 0;
-    opacity: 0;
+    top: 50%;
+    left: var(--pix-spacing-3x);
+    z-index: 0;
+    width: var(--pix-spacing-4x);
+    height: var(--pix-spacing-4x);
+    color: var(--pix-neutral-500);
+    transform: translateY(-50%);
   }
 
-  input.pix-multi-select-header__search-input {
-    width: 100%;
-    height: inherit;
-    padding: 0 10px;
-    color: var(--pix-neutral-900);
-    font-size: 0.875rem;
-    background: transparent;
-    border: none;
-    border-radius: 3px;
-    outline: none;
-  }
-
-  &__dropdown-icon {
+  .pix-multi-select-main-input__search-input {
     @extend %pix-body-s;
 
-    color: var(--pix-neutral-900);
-    pointer-events: none;
+    position: relative;
+    z-index: 1;
+    padding: var(--pix-spacing-2x) var(--pix-spacing-3x) var(--pix-spacing-2x) var(--pix-spacing-9x);
+    background-color: transparent;
+    border: none;
+
+    &:focus {
+      outline: none;
+    }
   }
 }
 
+/* Select list */
 .pix-multi-select-list {
   @extend %pix-shadow-sm;
 


### PR DESCRIPTION
## :christmas_tree: Problème

La taille de la zone éditable du PixMultiSelect en version isSearchable est vraiment toute petite comparée à ce qu'on en voit visuellement.
Si on clique en dehors de cette zone, on ne déclenche pas l'input, ce qui est très frustrant.

![image](https://github.com/user-attachments/assets/60304797-419a-4df9-8b41-ccd4c1f73ee4)

## :gift: Proposition

Améliorer le style pour que tout l'input soit cliquable.

## :star2: Remarques

Le composant n'a pas de vraie variante `size` j'ai donc enlevé le style `--big` (qui pourra être traité dans une autre PR).

## :santa: Pour tester

Voir [en RA](https://ui-pr785.review.pix.fr/?path=/docs/forms-multi-select--docs) :
- Constater qu'il n'y a pas de régression visuelle avec la prod
- Vérifier que tout l'input de base est bien cliquable.
