### PR TITLE
[BREAKING] Migrer les variants communications de PixBannerAlert dans PixNotificationAlert (PIX-15547)

### DIFF
--- a/addon/components/pix-notification-alert.js
+++ b/addon/components/pix-notification-alert.js
@@ -4,10 +4,21 @@ const TYPE_INFO = 'info';
 const TYPE_SUCCESS = 'success';
 const TYPE_WARNING = 'warning';
 const TYPE_ERROR = 'error';
+const TYPE_COMMUNICATION = 'communication';
+const TYPE_COMMUNICATION_ORGA = 'communication-orga';
+const TYPE_COMMUNICATION_CERTIF = 'communication-certif';
 
 export default class PixNotificationAlert extends Component {
   get type() {
-    const correctTypes = [TYPE_INFO, TYPE_SUCCESS, TYPE_WARNING, TYPE_ERROR];
+    const correctTypes = [
+      TYPE_INFO,
+      TYPE_SUCCESS,
+      TYPE_WARNING,
+      TYPE_ERROR,
+      TYPE_COMMUNICATION,
+      TYPE_COMMUNICATION_CERTIF,
+      TYPE_COMMUNICATION_ORGA,
+    ];
 
     return correctTypes.includes(this.args.type) ? this.args.type : 'info';
   }
@@ -18,6 +29,9 @@ export default class PixNotificationAlert extends Component {
       [TYPE_SUCCESS]: 'checkCircle',
       [TYPE_WARNING]: 'warning',
       [TYPE_ERROR]: 'error',
+      [TYPE_COMMUNICATION]: 'campaign',
+      [TYPE_COMMUNICATION_CERTIF]: 'campaign',
+      [TYPE_COMMUNICATION_ORGA]: 'campaign',
     };
     return classes[this.type];
   }

--- a/addon/styles/_pix-banner-alert.scss
+++ b/addon/styles/_pix-banner-alert.scss
@@ -87,50 +87,5 @@
       }
     }
   }
-
-  &--communication {
-    color: var(--pix-neutral-0);
-    background-color: var(--pix-primary-500);
-
-    .pix-icon-button {
-      color: currentcolor;
-
-      &:hover:enabled,
-      &:focus:enabled,
-      &:active:enabled {
-        background-color: var(--pix-primary-300);
-      }
-    }
-  }
-
-    &--communication-orga {
-      color: var(--pix-neutral-0);
-      background-color: var(--pix-orga-500);
-
-      .pix-icon-button {
-        color: currentcolor;
-
-        &:hover:enabled,
-        &:focus:enabled,
-        &:active:enabled {
-          background-color: var(--pix-communication-light);
-        }
-      }
-    }
-
-    &--communication-certif {
-      color: var(--pix-neutral-0);
-      background-color: var(--pix-certif-500);
-
-      .pix-icon-button {
-        color: currentcolor;
-
-        &:hover:enabled,
-        &:focus:enabled,
-        &:active:enabled {
-          background-color: var(--pix-content-light);
-        }
-      }
-    }
-  }
+}
 

--- a/addon/styles/_pix-notification-alert.scss
+++ b/addon/styles/_pix-notification-alert.scss
@@ -10,22 +10,22 @@
   border: 1px solid currentcolor;
   border-radius: var(--pix-spacing-1x);
 
-  &.pix-notification-alert--info {
+  &--info {
     color: var(--pix-info-700);
     background-color: var(--pix-info-50);
   }
 
-  &.pix-notification-alert--alert {
+  &--alert {
     color: var(--pix-error-700);
     background-color: var(--pix-error-50);
   }
 
-  &.pix-notification-alert--error {
+  &--error {
     color: var(--pix-error-700);
     background-color: var(--pix-error-50);
   }
 
-  &.pix-notification-alert--success {
+  &--success {
     color: var(--pix-success-700);
     background-color: var(--pix-success-50);
   }
@@ -33,5 +33,53 @@
   &.pix-notification-alert--warning {
     color: var(--pix-warning-700);
     background-color: var(--pix-warning-50);
+  }
+
+  &--communication {
+    color: var(--pix-neutral-0);
+    background-color: var(--pix-primary-500);
+    border-color: var(--pix-primary-500);
+
+    .pix-icon-button {
+      color: currentcolor;
+
+      &:hover:enabled,
+      &:focus:enabled,
+      &:active:enabled {
+        background-color: var(--pix-primary-300);
+      }
+    }
+  }
+
+  &--communication-orga {
+    color: var(--pix-neutral-0);
+    background-color: var(--pix-orga-500);
+    border-color: var(--pix-orga-500);
+
+    .pix-icon-button {
+      color: currentcolor;
+
+      &:hover:enabled,
+      &:focus:enabled,
+      &:active:enabled {
+        background-color: var(--pix-communication-light);
+      }
+    }
+  }
+
+  &--communication-certif {
+    color: var(--pix-neutral-0);
+    background-color: var(--pix-certif-500);
+    border-color: var(--pix-certif-500);
+
+    .pix-icon-button {
+      color: currentcolor;
+
+      &:hover:enabled,
+      &:focus:enabled,
+      &:active:enabled {
+        background-color: var(--pix-content-light);
+      }
+    }
   }
 }

--- a/app/stories/pix-banner-alert.mdx
+++ b/app/stories/pix-banner-alert.mdx
@@ -27,15 +27,6 @@ Bannière pour les erreurs.
 
 <Story of={ComponentStories.error} height={75} />
 
-## Communication
-
-Bannière pour Pix App
-<Story of={ComponentStories.communicationPixApp} height={75} />
-Bannière pour Pix Orga
-<Story of={ComponentStories.communicationPixOrga} height={75} />
-Bannière pour Pix Certif
-<Story of={ComponentStories.communicationPixCertif} height={75} />
-
 ## With Internal Link
 
 Bannière contenant un lien interne.
@@ -61,8 +52,6 @@ Bannière contenant un bouton qui permet de fermer la bannière.
 
 ```html
 <PixBannerAlert> Bannière Info par défaut </PixBannerAlert>
-
-<PixBannerAlert @type="communication"> Bannière Communication pour Pix App </PixBannerAlert>
 
 <PixBannerAlert @type="warning"> Bannière Warning </PixBannerAlert>
 

--- a/app/stories/pix-banner-alert.stories.js
+++ b/app/stories/pix-banner-alert.stories.js
@@ -27,14 +27,7 @@ export default {
       control: {
         type: 'select',
       },
-      options: [
-        'information',
-        'warning',
-        'error',
-        'communication',
-        'communication-orga',
-        'communication-certif',
-      ],
+      options: ['information', 'warning', 'error'],
     },
     canCloseBanner: {
       name: 'canCloseBanner',
@@ -81,21 +74,6 @@ warning.args = {
 export const error = Template.bind({});
 error.args = {
   type: 'error',
-};
-
-export const communicationPixApp = Template.bind({});
-communicationPixApp.args = {
-  type: 'communication',
-};
-
-export const communicationPixOrga = Template.bind({});
-communicationPixOrga.args = {
-  type: 'communication-orga',
-};
-
-export const communicationPixCertif = Template.bind({});
-communicationPixCertif.args = {
-  type: 'communication-certif',
 };
 
 export const withExternalLink = Template.bind({});

--- a/app/stories/pix-notification-alert.mdx
+++ b/app/stories/pix-notification-alert.mdx
@@ -37,6 +37,15 @@ Le bandeau en cas de d'erreur.
 
 <Story of={ComponentStories.error} height={110} />
 
+## Communication
+
+Le bandeau pour Pix App.
+<Story of={ComponentStories.communicationPixApp} height={110} />
+Le bandeau pour Pix Orga.
+<Story of={ComponentStories.communicationPixOrga} height={110} />
+Le bandeau pour Pix Certif.
+<Story of={ComponentStories.communicationPixCertif} height={110} />
+
 ## Usage
 
 Par défaut

--- a/app/stories/pix-notification-alert.stories.js
+++ b/app/stories/pix-notification-alert.stories.js
@@ -19,7 +19,15 @@ export default {
       type: { name: 'string', required: false },
       table: { defaultValue: { summary: 'info' } },
       control: { type: 'select' },
-      options: ['info', 'success', 'warning', 'error'],
+      options: [
+        'info',
+        'success',
+        'warning',
+        'error',
+        'communication',
+        'communication-certif',
+        'communication-orga',
+      ],
     },
     withIcon: {
       name: 'withIcon',
@@ -50,6 +58,27 @@ export const warning = {
 export const success = {
   args: {
     type: 'success',
+    withIcon: true,
+  },
+};
+
+export const communicationPixApp = {
+  args: {
+    type: 'communication',
+    withIcon: true,
+  },
+};
+
+export const communicationPixCertif = {
+  args: {
+    type: 'communication-certif',
+    withIcon: true,
+  },
+};
+
+export const communicationPixOrga = {
+  args: {
+    type: 'communication-orga',
     withIcon: true,
   },
 };

--- a/tests/integration/components/pix-banner-alert-test.js
+++ b/tests/integration/components/pix-banner-alert-test.js
@@ -58,42 +58,6 @@ module('Integration | Component | PixBannerAlert', function (hooks) {
     );
   });
 
-  test('it renders the PixBannerAlert with type communication', async function (assert) {
-    // given
-
-    this.set('type', 'communication');
-
-    //when
-    await render(hbs`<PixBannerAlert @color={{this.color}} @type={{this.type}} />`);
-
-    // then
-    assert.dom('.pix-banner-alert--communication').exists();
-  });
-
-  test('it renders the PixBannerAlert with type communication-orga', async function (assert) {
-    // given
-
-    this.set('type', 'communication-orga');
-
-    //when
-    await render(hbs`<PixBannerAlert @color={{this.color}} @type={{this.type}} />`);
-
-    // then
-    assert.dom('.pix-banner-alert--communication-orga').exists();
-  });
-
-  test('it renders the PixBannerAlert  with type communication-certif', async function (assert) {
-    // given
-
-    this.set('type', 'communication-certif');
-
-    //when
-    await render(hbs`<PixBannerAlert @color={{this.color}} @type={{this.type}} />`);
-
-    // then
-    assert.dom('.pix-banner-alert--communication-certif').exists();
-  });
-
   test('it renders the PixBannerAlert with external url', async function (assert) {
     // given
     this.set('actionUrl', 'www.test.fr/');

--- a/tests/integration/components/pix-notification-alert-test.js
+++ b/tests/integration/components/pix-notification-alert-test.js
@@ -78,4 +78,23 @@ module('Integration | Component | pixNotificationAlert', function (hooks) {
 
     assert.true(icon.innerHTML.includes('#error'));
   });
+
+  ['communication', 'communication-certif', 'communication-orga'].forEach((type) => {
+    test(`it renders with a "campaign" icon for ${type} type`, async function (assert) {
+      // given
+      this.set('type', type);
+
+      // when
+      const screen = await render(
+        hbs`<PixNotificationAlert @type={{this.type}} @withIcon='true' />`,
+      );
+
+      // then
+      const icon = screen.getByRole('img', { hidden: true });
+      const container = screen.getByRole('paragraph');
+
+      assert.true(icon.innerHTML.includes('#campaign'));
+      assert.true(container.classList.contains(`pix-notification-alert--${type}`));
+    });
+  });
 });


### PR DESCRIPTION
## :boom: BREAKING_CHANGES
Les types `communication`, `communication-certif` et `communication-orga` n'existent plus dans `PixBannerAlert`. 
Il faut remplacer les endroits où c'est utilisé par le composant `PixNotificationAlert` avec le type correspondant.


## :christmas_tree: Problème
L'utilisation des variants `communication`, `communication-certif` et `communication-orga` pour `PixBannerAlert` ne sont pas adaptés au comportement du composant. 

## :gift: Proposition
Migrer ces variants dans le composant `PixNotificationAlert` qui est plus adapté dans ce cas là.

## :star2: Remarques
RAS

## :santa: Pour tester
- Aller, dans storybook, sur la page du composant PixBannerAlert : https://ui-pr786.review.pix.fr/?path=/docs/feedback-banner-alert--docs
- Vérifier qu'il n'y a plus de trace des variants `communication*`
- Se rendre ensuite sur la page du composant PixNotificationAlert : https://ui-pr786.review.pix.fr/?path=/docs/feedback-notification-alert--docs
- Tester que les nouveaux variants `communication`, `communication-certif` et `communication-orga` pour le `type` fonctionnent bien 🎉