### PR TITLE
[BUGFIX] removed z-index on inputs that have searchable = true [PIX-15763]

### DIFF
--- a/addon/styles/_pix-multi-select.scss
+++ b/addon/styles/_pix-multi-select.scss
@@ -56,7 +56,6 @@
     @extend %pix-body-s;
 
     position: relative;
-    z-index: 1;
     padding: var(--pix-spacing-2x) var(--pix-spacing-3x) var(--pix-spacing-2x) var(--pix-spacing-9x);
     background-color: transparent;
     border: none;


### PR DESCRIPTION
## :christmas_tree: Problème
Les inputs à l'intérieur du composant des PixMultiSelect dans lequels on peut effectuer une recherche ont un z-index à 1, ce qui fait que le nouveau switcher d'organisations englobe les placeholders s'il y a beaucoup d'organisations. Voir https://1024pix.atlassian.net/browse/PIX-15763

## :gift: Proposition
On enlève le z-index à 1 sans impact sur le code.

## :santa: Pour tester
Tester le comportement des inputs des PixMultiSelect sur lesquels isSearchable = true.