### PR TITLE
[BUGFIX] Modification de l'état defaut du PixButton Tertiary (PIX-15732)

### DIFF
--- a/addon/styles/_pix-button-base.scss
+++ b/addon/styles/_pix-button-base.scss
@@ -106,7 +106,7 @@
   &--tertiary {
     padding-right: 0;
     padding-left: 0;
-    color: var(--pix-neutral-800);
+    color: var(--pix-primary-700);
     text-decoration: underline;
     background-color: transparent;
 


### PR DESCRIPTION
## :christmas_tree: Problème
La contraste en l'état default et pressed n'était pas assez flagrant

## :gift: Proposition
Modifier le token default pour être raccord avec le DS

## :santa: Pour tester
Vérifier que c'est le bon token