### PR TITLE
[TECH] Corriger l'exemple sur la transparence des couleurs côté documentation

### DIFF
--- a/docs/colors-palette.mdx
+++ b/docs/colors-palette.mdx
@@ -15,7 +15,7 @@ import { Meta, ColorPalette, ColorItem } from '@storybook/blocks';
 
 > Pour utiliser la transparence des couleurs, il suffit d'utiliser la valeur "privée" `pix-primary-900-inline` de cette manière :
 >
-> `background-color: rgb(var(--pix-primary-900-inline, 0.5));`
+> `background-color: rgb(var(--pix-primary-900-inline), 0.5);`
 > et vous voilà avec un fond avec la gestion de la transparence
 
 ## SOLID


### PR DESCRIPTION
## :christmas_tree: Problème
L'exemple fourni pour la transparence des couleurs ne fonctionne pas : https://ui.pix.fr/?path=/docs/design-tokens-palette-de-couleurs--docs#transparence

## :gift: Proposition
Corriger la petite faute dessus 😄 

## :star2: Remarques
RAS

## :santa: Pour tester
- Aller sur https://ui-pr811.review.pix.fr/?path=/docs/design-tokens-palette-de-couleurs--docs#transparence
- Vérifier que l'exemple est maintenant correct 🎉 
