### PR TITLE
[FEATURE] Permettre à PixButtonLink d'ajouter des icônes avant et après le label (PIX-16184).

### DIFF
--- a/addon/components/pix-button-link.hbs
+++ b/addon/components/pix-button-link.hbs
@@ -7,10 +7,24 @@
     class={{this.className}}
     ...attributes
   >
-    {{yield}}
+    <PixButtonContent
+      @iconBefore={{@iconBefore}}
+      @iconAfter={{@iconAfter}}
+      @plainIconAfter={{@plainIconAfter}}
+      @plainIconBefore={{@plainIconBefore}}
+    >
+      {{yield}}
+    </PixButtonContent>
   </LinkTo>
 {{else}}
   <a href={{@href}} class={{this.className}} ...attributes>
-    {{yield}}
+    <PixButtonContent
+      @iconBefore={{@iconBefore}}
+      @iconAfter={{@iconAfter}}
+      @plainIconAfter={{@plainIconAfter}}
+      @plainIconBefore={{@plainIconBefore}}
+    >
+      {{yield}}
+    </PixButtonContent>
   </a>
 {{/if}}

--- a/addon/components/pix-button-link.js
+++ b/addon/components/pix-button-link.js
@@ -5,6 +5,6 @@ export default class PixButtonLink extends PixButtonBase {
   defaultParams = {};
 
   get className() {
-    return [...super.baseClassNames, 'pix-button-link'].join(' ');
+    return super.baseClassNames.join(' ');
   }
 }

--- a/addon/components/pix-button.hbs
+++ b/addon/components/pix-button.hbs
@@ -14,22 +14,13 @@
     </div>
     <span class="loader__not-visible-text">{{yield}}</span>
   {{else}}
-    {{#if @iconBefore}}
-      <PixIcon
-        class="pix-button__icon pix-button__icon--before"
-        @ariaHidden={{true}}
-        @name={{@iconBefore}}
-        @plainIcon={{@plainIconBefore}}
-      />
-    {{/if}}
-    {{yield}}
-    {{#if @iconAfter}}
-      <PixIcon
-        class="pix-button__icon pix-button__icon--after"
-        @name={{@iconAfter}}
-        @ariaHidden={{true}}
-        @plainIcon={{@plainIconAfter}}
-      />
-    {{/if}}
+    <PixButtonContent
+      @iconBefore={{@iconBefore}}
+      @iconAfter={{@iconAfter}}
+      @plainIconAfter={{@plainIconAfter}}
+      @plainIconBefore={{@plainIconBefore}}
+    >
+      {{yield}}
+    </PixButtonContent>
   {{/if}}
 </button>

--- a/addon/components/pix-button/pix-button-content.hbs
+++ b/addon/components/pix-button/pix-button-content.hbs
@@ -1,0 +1,17 @@
+{{#if @iconBefore}}
+  <PixIcon
+    class="pix-button__icon pix-button__icon--before"
+    @ariaHidden={{true}}
+    @name={{@iconBefore}}
+    @plainIcon={{@plainIconBefore}}
+  />
+{{/if}}
+{{yield}}
+{{#if @iconAfter}}
+  <PixIcon
+    class="pix-button__icon pix-button__icon--after"
+    @name={{@iconAfter}}
+    @ariaHidden={{true}}
+    @plainIcon={{@plainIconAfter}}
+  />
+{{/if}}

--- a/app/components/pix-button-content.js
+++ b/app/components/pix-button-content.js
@@ -1,0 +1,1 @@
+export { default } from '@1024pix/pix-ui/components/pix-button/pix-button-content';

--- a/app/stories/pix-button-link.mdx
+++ b/app/stories/pix-button-link.mdx
@@ -6,7 +6,7 @@ import * as ComponentStories from './pix-button-link.stories';
 
 # ButtonLink
 
-Affiche un lien avec le style d'un bouton Pix. Il peut être de type HTML ou Route EmberJS.
+Affiche un lien avec le style d'un `PixButton`. Il peut être de type HTML ou Route EmberJS.
 
 Hérite des styles de base de `PixButton` (`variant`, `size`, `isBorderVisible`, `isDisabled`)
 
@@ -20,7 +20,7 @@ Redirige directement les attributs de la balise HTML `<a>` (eg. `target`...).
 <Story of={ComponentStories.htmlLink} />
 
 ```html
-<PixButtonLink @href="https://pix.fr" target="_blank"> Libellé du lien </PixButtonLink>
+<PixButtonLink @href="https://pix.fr" target="_blank" @variant="tertiary"> Libellé du lien </PixButtonLink>
 ```
 
 ## Route EmberJS
@@ -33,6 +33,14 @@ Prend en entrée la propriété `@route` et `@model`.
 Un bouton de route EmberJS peut être désactivé via la propriété `@isDisabled`.
 
 <Story of={ComponentStories.emberLink} />
+
+## Icons
+
+Le bouton avec des icônes `PixIcons` à afficher avant (`@iconBefore`) ou après (`@iconAfter`) le label.
+
+> ℹ️ Accessibilité : dans le cas où les icônes ont une valeur d'information (ex:&nbsp;un bouton `⬅️ Précédent`), il est important d'apporter un aria-label au bouton (ex:&nbsp;"Retour à la page précédente").
+
+<Story of={ComponentStories.icons} height={75} />
 
 ## Arguments
 

--- a/app/stories/pix-button-link.stories.js
+++ b/app/stories/pix-button-link.stories.js
@@ -1,8 +1,9 @@
 import { hbs } from 'ember-cli-htmlbars';
 
+import { ICONS } from '../../addon/helpers/icons';
+
 export default {
   title: 'Actions/ButtonLink',
-
   argTypes: {
     href: {
       name: 'href',
@@ -46,6 +47,38 @@ export default {
         defaultValue: { summary: 'primary' },
       },
     },
+    iconBefore: {
+      name: 'iconBefore',
+      description: `Nom de l'icône à afficher **avant** le label`,
+      type: { name: 'string', required: false },
+      control: { type: 'select' },
+      options: Object.keys(ICONS),
+    },
+    iconAfter: {
+      name: 'iconAfter',
+      description: `Nom de l'icône à afficher **après** le label`,
+      type: { name: 'string', required: false },
+      control: { type: 'select' },
+      options: Object.keys(ICONS),
+    },
+    plainIconBefore: {
+      name: 'plainIconBefore',
+      description: `Change le type de l'icône **avant** le label en fill/plain`,
+      type: { name: 'boolean', required: false },
+      table: {
+        type: { summary: 'boolean' },
+        defaultValue: { summary: 'false' },
+      },
+    },
+    plainIconAfter: {
+      name: 'plainIconAfter',
+      description: `Change le type de l'icône **après** le label fill/plain`,
+      type: { name: 'boolean', required: false },
+      table: {
+        type: { summary: 'boolean' },
+        defaultValue: { summary: 'false' },
+      },
+    },
     size: {
       name: 'size',
       description: 'taille: `large`,`small`',
@@ -85,8 +118,12 @@ export const htmlLink = {
     template: hbs`<PixButtonLink
   @href='https://pix.fr'
   target='NEW'
-  @variant={{this.variant}}
+  @variant='tertiary'
   @size={{this.size}}
+  @iconBefore={{this.iconBefore}}
+  @plainIconBefore={{this.plainIconBefore}}
+  @iconAfter={{this.iconAfter}}
+  @plainIconAfter={{this.plainIconAfter}}
   @isBorderVisible={{this.isBorderVisible}}
   @isDisabled={{this.isDisabled}}
 >
@@ -96,7 +133,7 @@ export const htmlLink = {
   }),
 };
 
-export const emberLink = (args) => {
+const Template = (args) => {
   return {
     template: hbs`<PixButtonLink
   @route=''
@@ -105,10 +142,23 @@ export const emberLink = (args) => {
   @variant={{this.variant}}
   @size={{this.size}}
   @isBorderVisible={{this.isBorderVisible}}
+  @iconBefore={{this.iconBefore}}
+  @plainIconBefore={{this.plainIconBefore}}
+  @iconAfter={{this.iconAfter}}
+  @plainIconAfter={{this.plainIconAfter}}
   @isDisabled={{this.isDisabled}}
 >
   Lien route Ember (LinkTo)
 </PixButtonLink>`,
     context: args,
   };
+};
+
+export const emberLink = Template.bind({});
+
+export const icons = Template.bind({});
+icons.args = {
+  ...emberLink.args,
+  iconBefore: 'add',
+  iconAfter: 'minus',
 };


### PR DESCRIPTION
## :christmas_tree: Problème
`PixButtonLink` ne profite pas des icônes avant et après label, ce que possède `PixButton`.

## :gift: Proposition
Créer un composant `PixButtonContent` pour rassembler la logique des iconBefore et iconAfter autour du label du bouton, plutôt que de le dupliquer dans tous les composants qui en ont besoin.

Ce `PixButtonContent` est donc utilisé sur `PixButton` et `PixButtonLink`

## :santa: Pour tester

- Vérifier la non-régression du PixButton 
- Constater que le PixButtonLink profite des pixIcons