### PR TITLE
[FEATURE] Modifier la liste de élements de type select pour une meilleur distinction des éléments  ( PIX-16335)

### DIFF
--- a/addon/components/pix-select-list.hbs
+++ b/addon/components/pix-select-list.hbs
@@ -1,18 +1,20 @@
 <ul role="listbox" id={{@listId}} class="pix-select_list" ...attributes>
-  <li
-    class="pix-select-list-category__option{{unless
-        @value
-        ' pix-select-list-category__option--selected'
-      }}{{unless @displayDefaultOption ' pix-select-list-category__option--hidden'}}"
-    role="option"
-    tabindex={{if this.isDefaultOptionHidden "-1" "0"}}
-    aria-selected={{if @value "false" "true"}}
-    {{on "click" (fn @onChange @defaultOption)}}
-    {{on-enter-action (fn @onChange @defaultOption)}}
-    {{on-space-action (fn @onChange @defaultOption)}}
-  >
-    {{@defaultOptionValue}}
-  </li>
+  {{#if @displayDefaultOption}}
+    <li
+      class="pix-select-list-category__option{{unless
+          @value
+          ' pix-select-list-category__option--selected'
+        }}"
+      role="option"
+      tabindex={{if this.isDefaultOptionHidden "-1" "0"}}
+      aria-selected={{if @value "false" "true"}}
+      {{on "click" (fn @onChange @defaultOption)}}
+      {{on-enter-action (fn @onChange @defaultOption)}}
+      {{on-space-action (fn @onChange @defaultOption)}}
+    >
+      {{@defaultOptionValue}}
+    </li>
+  {{/if}}
   {{#if this.results}}
     {{#if this.displayCategory}}
       {{#each this.results as |element index|}}

--- a/addon/styles/_pix-select-list.scss
+++ b/addon/styles/_pix-select-list.scss
@@ -1,14 +1,16 @@
 @use "pix-design-tokens/typography";
 
 .pix-select_list {
-  padding: var(--pix-spacing-2x);
-  border-top: 1px solid var(--pix-neutral-20);
-
-  --border-radius-2x: var(--pix-spacing-2x);
-
+  display: flex;
+  flex-direction: column;
+  gap: var(--pix-spacing-1x);
+  padding: var(--pix-spacing-2x) var(--pix-spacing-1x);
 }
 
 .pix-select-list-category {
+  display: flex;
+  flex-direction: column;
+  gap: var(--pix-spacing-1x);
   margin: 0;
   padding: 0;
   list-style: none;
@@ -16,26 +18,30 @@
   &__name {
     @extend %pix-body-s;
 
-    padding: var(--pix-spacing-4x) var(--pix-spacing-6x) var(--pix-spacing-2x) var(--pix-spacing-4x);
-    color: var(--pix-neutral-500);
-    text-transform: uppercase;
+    padding: var(--pix-spacing-1x) var(--pix-spacing-3x);
+    color: var(--pix-neutral-800);
+    font-weight: var(--pix-font-bold);
+    text-transform: capitalize;
+    background-color: var(--pix-neutral-20);
+    border-radius: 0.25rem;
   }
 
   &__option {
     @extend %pix-body-s;
 
     position: relative;
-    padding: var(--pix-spacing-2x) var(--pix-spacing-8x) var(--pix-spacing-2x) var(--pix-spacing-4x);
+    padding: var(--pix-spacing-2x) var(--pix-spacing-10x) var(--pix-spacing-2x) var(--pix-spacing-3x);
     color: var(--pix-neutral-900);
-    border-radius: 8px;
+    border-radius: 0.25rem;
 
-    &:nth-child(even) {
-      background-color: var(--pix-neutral-20);
+    &:hover {
+      background-color: rgba(var(--pix-neutral-100-inline), 0.60);
+      outline: none;
+      cursor: pointer;
     }
 
-    &:hover,
     &:focus {
-      background-color: var(--pix-primary-10);
+      background-color: var(--pix-primary-100);
       outline: none;
       cursor: pointer;
     }
@@ -43,27 +49,14 @@
     svg {
       position: absolute;
       top: 50%;
-      right: var(--pix-spacing-2x);
+      right: var(--pix-spacing-3x);
       transform: translateY(-50%);
-      visibility: hidden;
-      opacity: 0;
     }
 
     &--selected {
-      align-items: center;
+      color: var(--pix-primary-900);
+      font-weight: var(--pix-font-bold);
       background-color: var(--pix-primary-10);
-
-      svg {
-        visibility: visible;
-        opacity: 1;
-      }
-    }
-
-    &--hidden {
-      height: 0;
-      padding-top: 0;
-      padding-bottom: 0;
-      visibility: hidden;
     }
   }
 }

--- a/addon/styles/_pix-select.scss
+++ b/addon/styles/_pix-select.scss
@@ -64,7 +64,7 @@
 
   &__search {
     display: flex;
-    margin: var(--pix-spacing-4x) var(--pix-spacing-6x);
+    margin: var(--pix-spacing-2x) var(--pix-spacing-3x);
     color: var(--pix-neutral-100);
     border-bottom: 2px solid var(--pix-neutral-100);
     border-radius: var(--pix-spacing-1x) var(--pix-spacing-1x) 0 0;

--- a/addon/styles/_pix-structure-switcher.scss
+++ b/addon/styles/_pix-structure-switcher.scss
@@ -72,7 +72,6 @@
     white-space: wrap;
     text-align: left;
     word-break: break-word;
-    border-radius: var(--border-radius-2x);
 
     &:focus:not(.pix-select-list-category__option--selected )  {
       background-color: var(--pix-structure-bg-hover);

--- a/tests/dummy/app/controllers/select-page.js
+++ b/tests/dummy/app/controllers/select-page.js
@@ -18,14 +18,15 @@ export default class SelectPage extends Controller {
 
   get options() {
     return [
-      { value: '1', label: 'Figues' },
-      { value: '3', label: 'Fraises' },
-      { value: '2', label: 'Bananes' },
-      { value: '4', label: 'Mangues' },
-      { value: '5', label: 'Kaki' },
+      { value: '1', label: 'Figues', category: 'rouge' },
+      { value: '3', label: 'Fraises', category: 'rouge' },
+      { value: '2', label: 'Bananes', category: 'jaune' },
+      { value: '4', label: 'Mangues', category: 'jaune' },
+      { value: '5', label: 'Kaki', category: 'vert' },
       {
         value: '6',
         label: 'Asiminier trilobé oblong vert (à ne pas confondre avec la papaye)',
+        category: 'vert'
       },
     ];
   }

--- a/tests/integration/components/pix-select-test.js
+++ b/tests/integration/components/pix-select-test.js
@@ -94,7 +94,6 @@ module('Integration | Component | PixSelect', function (hooks) {
 
       await screen.findByRole('listbox');
       // then
-      assert.strictEqual(screen.queryByText(this.placeholder, { selector: 'li' }).tabIndex, -1);
       assert.strictEqual(screen.queryByRole('option', { name: this.placeholder }), null);
     });
   });

--- a/tests/integration/components/pix-structure-switcher-test.js
+++ b/tests/integration/components/pix-structure-switcher-test.js
@@ -50,7 +50,7 @@ module('Integration | Component | pix-structure-switcher', function (hooks) {
       assert.ok(screen.getByRole('option', { name: 'Tomate' }));
     });
 
-    test('it hides default option', async function (assert) {
+    test('it not display default option', async function (assert) {
       // given
       const screen = await render(
         hbs`<PixStructureSwitcher @label='Changer de structure' @structures={{this.structures}} />`,
@@ -60,12 +60,8 @@ module('Integration | Component | pix-structure-switcher', function (hooks) {
       const button = screen.getByRole('button', { name: 'Changer de structure' });
       await userEvent.click(button);
 
-      const hiddenDefaultOption = await screen.findByRole('option', {
-        selected: true,
-        hidden: true,
-      });
       // then
-      assert.strictEqual(hiddenDefaultOption.tabIndex, -1);
+      assert.notOk(screen.queryByRole('option', { name: 'Changer de structure' }));
     });
   });
 


### PR DESCRIPTION
## :christmas_tree: Problème
la nouvelle list des select pose quelque problème de lecteur. zebra trop peu constrasté avec le selectionné ou non / impression d'élement desactivé

## :gift: Proposition
Supprimer le zebra, accentuer la valeur selectionné par du gras. et revoir quelque marge

## :star2: Remarques
- Suppresion du check visible invisible lors d'une liste fermé
- Suppression de l'element HTML invisible qui ne sert à R lorsque l'option par défaut est caché ( autant la supprimer plutôt que la cacher )

## :santa: Pour tester
CI a u vert et correspondant au DS demandé

Vérifier que la check a disparu : 

https://ui-pr822.review.pix.fr/?path=/story/forms-select--with-icon