### PR TITLE
[FEATURE] Augmenter la taille de du pix-select afin de faire comprendre à l'utilisateur qu'il doit scroller lorsqu'il y a trop d'option (PIX-16230)

### DIFF
--- a/addon/styles/_pix-select.scss
+++ b/addon/styles/_pix-select.scss
@@ -23,7 +23,7 @@
     z-index: 200;
     width: 100%;
     min-width: fit-content;
-    max-height: 12.8rem;
+    max-height: 12rem;
     margin-top: var(--pix-spacing-1x);
     padding: 0;
     overflow-y: auto;


### PR DESCRIPTION
## :christmas_tree: Problème
La dropdown du pix-select à une taille qui ne permet pas de comprendre qu'il faut scroll quand il y a beaucoup d'option.

## :gift: Proposition
Augmenter la taille du dropdown afin de faire apparaître la moitié d'une option afin de faire comprendre à l'utilisateur qu'il doit scroll.

## :star2: Remarques
RAS

## :santa: Pour tester
Se rendre sur la documentation du pix-select et vérifier que la dernière option affichée nous invite à scroller.
