### PR TITLE
[FEATURE] Modifier trap-focus et la sidebar pour pouvoir désactiver le focus après fermeture de la Sidebar (PIX-16400)

### DIFF
--- a/addon/components/pix-sidebar.hbs
+++ b/addon/components/pix-sidebar.hbs
@@ -1,7 +1,7 @@
 <div
   class="pix-sidebar__overlay {{unless @showSidebar ' pix-sidebar__overlay--hidden'}}"
   {{on "click" this.closeAction}}
-  {{trap-focus @showSidebar}}
+  {{trap-focus @showSidebar @focusOnClose}}
   {{on-escape-action @onClose}}
 >
   <div

--- a/app/modifiers/trap-focus.js
+++ b/app/modifiers/trap-focus.js
@@ -2,7 +2,7 @@ import { modifier } from 'ember-modifier';
 
 let sourceActiveElement = null;
 
-export default modifier(function trapFocus(element, [isOpen]) {
+export default modifier(function trapFocus(element, [isOpen, focusOnClose = true]) {
   const [firstFocusableElement] = findFocusableElements(element);
 
   if (isOpen) {
@@ -11,7 +11,10 @@ export default modifier(function trapFocus(element, [isOpen]) {
     focusElement(firstFocusableElement, element);
   } else if (sourceActiveElement) {
     allowPageScrolling();
-    focusElement(sourceActiveElement, element);
+
+    if (focusOnClose) {
+      focusElement(sourceActiveElement, element);
+    }
     sourceActiveElement = null;
   }
 

--- a/app/stories/pix-sidebar.stories.js
+++ b/app/stories/pix-sidebar.stories.js
@@ -25,6 +25,16 @@ export default {
         type: { summary: 'function' },
       },
     },
+    focusOnClose: {
+      name: 'focusOnClose',
+      description:
+        'Après fermeture de la Sidebar, active ou non le focus sur l‘élément qui a déclenché son ouverture',
+      type: { name: 'boolean', required: false },
+      table: {
+        type: { summary: 'boolean' },
+        defaultValue: { summary: true },
+      },
+    },
   },
 };
 
@@ -33,6 +43,7 @@ const Template = (args) => {
     template: hbs`<PixSidebar
   @showSidebar={{this.showSidebar}}
   @title={{this.title}}
+  @focusOnClose={{this.focusOnClose}}
   @onClose={{fn (mut this.showSidebar) (not this.showSidebar)}}
 >
   <:content>
@@ -48,10 +59,10 @@ const Template = (args) => {
         @variant='secondary'
         @isBorderVisible='true'
         @triggerAction={{fn (mut this.showSidebar) (not this.showSidebar)}}
-      >Annuler</PixButton>
-      <PixButton
-        @triggerAction={{fn (mut this.showSidebar) (not this.showSidebar)}}
-      >Valider</PixButton>
+      >Annuler
+      </PixButton>
+      <PixButton @triggerAction={{fn (mut this.showSidebar) (not this.showSidebar)}}>Valider
+      </PixButton>
     </div>
   </:footer>
 </PixSidebar>
@@ -60,7 +71,8 @@ const Template = (args) => {
   <PixButton
     @triggerAction={{fn (mut this.showSidebar) (not this.showSidebar)}}
     style='height:45px'
-  >Ouvrir la sidebar</PixButton>
+  >Ouvrir la sidebar
+  </PixButton>
 </div>`,
     context: args,
   };
@@ -71,4 +83,5 @@ Default.args = {
   showSidebar: true,
   title: 'Filtrer',
   onClose: () => {},
+  focusOnClose: true,
 };


### PR DESCRIPTION
## :christmas_tree: Problème
Dans certains contextes, on utilise la Sidebar pour naviguer dans la page. C'est par exemple le cas dans Modulix.

Par défaut la Sidebar redonne le focus à l'élément qui a permis de l'ouvrir, et ce après l'animation de fermeture. Malheureusement ça prends le dessus sur un focus programmatique dans le cas de figure énoncé au dessus.

## :gift: Proposition
Permettre à la `PixSidebar` via le paramètre `@focusOnClose` de ne pas redonner le focus à sa fermeture. Pas d'impact sur le comportement existant, ce paramètre prends la valeur `true` par défaut.

## :star2: Remarques
RAS

## :santa: Pour tester
Jouer dans Storybook avec les paramètres de la Sidebar. S'assurer que la fermeture -> ouverture -> fermeture donne le focus ou non selon la valeur du paramètre `@focusOnClose`.
