### PR TITLE
[FEATURE] Garder les icones dans les options du pix-select à la même taille (PIX-16568)

### DIFF
--- a/addon/components/pix-select-list.hbs
+++ b/addon/components/pix-select-list.hbs
@@ -52,7 +52,12 @@
             >
 
               {{#if option.icon}}
-                <PixIcon role="presentation" @name={{option.icon}} @title={{option.iconTitle}} />
+                <PixIcon
+                  role="presentation"
+                  @name={{option.icon}}
+                  @title={{option.iconTitle}}
+                  class="pix-icon--no-shrink"
+                />
               {{/if}}
 
               {{option.label}}
@@ -84,7 +89,12 @@
           {{on-space-action (fn @onChange option)}}
         >
           {{#if option.icon}}
-            <PixIcon role="presentation" @name={{option.icon}} @title={{option.iconTitle}} />
+            <PixIcon
+              role="presentation"
+              @name={{option.icon}}
+              @title={{option.iconTitle}}
+              class="pix-icon--no-shrink"
+            />
           {{/if}}
 
           {{option.label}}

--- a/addon/styles/_pix-icon.scss
+++ b/addon/styles/_pix-icon.scss
@@ -2,4 +2,8 @@
   width: 1.5rem;
   height: 1.5rem;
   fill: currentcolor;
+
+  &--no-shrink {
+    flex-shrink: 0;
+  }
 }

--- a/tests/dummy/app/controllers/select-page.js
+++ b/tests/dummy/app/controllers/select-page.js
@@ -27,7 +27,8 @@ export default class SelectPage extends Controller {
       },
       {
         value: '3',
-        label: 'Fraises',
+        label:
+          'Fraises, des bonnes fraises, bien rouge. Tout un gros paquet de fraises, mais beaucoup beaucoup',
         category: 'rouge',
         icon: 'userCircle',
         iconTitle: 'titre icone user',


### PR DESCRIPTION
## :christmas_tree: Problème
Lors d'une PR précédente pour l'ajout d'icônes dans les options d'un Pix-Select, nous n'avions pas fait le test sur tous les navigateurs (Firefox en l'occurrence) et avec une option ayant un texte assez long.
Dans le cas d'un texte long sur Firefox, l'icône était redimensionnée et pouvait devenir toute petite

## :gift: Proposition
Ajouter une classe no-shrink dans le fichier SCSS de Pix-Icon afin de pouvoir utiliser ce modifier quand nous en avons besoin
Notamment dans le cas des options du Pix-Select

## :star2: Remarques
Pour Firefox -> 
Avant : 
![image](https://github.com/user-attachments/assets/2cd15918-61bc-4046-b312-624ef1120f85)

Après :
![image](https://github.com/user-attachments/assets/d8ea9cca-cfaf-45ba-a890-07b8168df108)

## :santa: Pour tester
Essayer en local sur firefox sur `http://localhost:4204/select`
