### PR TITLE
[TECH] Ajouter un addon storybook pour afficher des tags informatifs

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -3,6 +3,7 @@ const config = {
     '@storybook/addon-essentials',
     '@storybook/addon-a11y',
     '@storybook/addon-webpack5-compiler-babel',
+    'storybook-addon-tag-badges',
   ],
 
   stories: ['../docs/**/*.@(mdx|stories.@(mdx))', '../app/*/*.@(mdx|stories.@(js|jsx|ts|tsx))'],

--- a/.storybook/manager.js
+++ b/.storybook/manager.js
@@ -1,4 +1,5 @@
 import { addons } from '@storybook/manager-api';
+import { renderLabel } from 'storybook-addon-tag-badges';
 
 import storybookCustomTheme from './storybook-custom-theme';
 
@@ -6,5 +7,6 @@ addons.setConfig({
   theme: storybookCustomTheme,
   sidebar: {
     showRoots: true,
+    renderLabel,
   },
 });

--- a/app/stories/pix-table.stories.js
+++ b/app/stories/pix-table.stories.js
@@ -2,6 +2,7 @@ import { hbs } from 'ember-cli-htmlbars';
 
 export default {
   title: 'Data display/Table',
+  tags: ['new'],
   // select attribute data type from https://storybook.js.org/docs/react/essentials/controls
   argTypes: {
     data: {

--- a/blueprints/pix-component/files/app/stories/pix-__name__.stories.js
+++ b/blueprints/pix-component/files/app/stories/pix-__name__.stories.js
@@ -2,6 +2,7 @@ import { hbs } from 'ember-cli-htmlbars';
 
 export default {
   title: '<%= classifiedModuleName %>',
+  tags: ['new'], // You can find preconfigured tags list here https://github.com/Sidnioulz/storybook-addon-tag-badges#preconfigured-badges
   // TODO: add component attributes information
   // select attribute data type from https://storybook.js.org/docs/react/essentials/controls
   argTypes: {

--- a/docs/create-component.mdx
+++ b/docs/create-component.mdx
@@ -55,6 +55,8 @@ import { hbs } from 'ember-cli-htmlbars'; // import nécessaire pour 'canvasCont
 
 export default {
   title: 'Docs/Notification Alert',
+  // On peut ajouter un tag qui affichera un badge donnant une information sur le statut du composant (ex: 'new', 'deprecated', ...)
+  tags: ['new'],
   // Ici on définit et on documente les arguments du composant
   argTypes: {
     type: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -83,6 +83,7 @@
         "qunit-dom": "^3.4.0",
         "sass": "^1.83.1",
         "storybook": "^8.4.7",
+        "storybook-addon-tag-badges": "^1.4.0",
         "stylelint": "^16.13.2",
         "svg-sprite": "^2.0.4",
         "svgo": "^3.3.2",
@@ -7277,15 +7278,17 @@
       "license": "MIT"
     },
     "node_modules/@storybook/icons": {
-      "version": "1.2.12",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@storybook/icons/-/icons-1.3.2.tgz",
+      "integrity": "sha512-t3xcbCKkPvqyef8urBM0j/nP6sKtnlRkVgC+8JTbTAZQjaTmOjes3byEgzs89p4B/K6cJsg9wLW2k3SknLtYJw==",
       "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=14.0.0"
       },
       "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
-        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0"
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta"
       }
     },
     "node_modules/@storybook/react-dom-shim": {
@@ -34355,6 +34358,22 @@
         "prettier": {
           "optional": true
         }
+      }
+    },
+    "node_modules/storybook-addon-tag-badges": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/storybook-addon-tag-badges/-/storybook-addon-tag-badges-1.4.0.tgz",
+      "integrity": "sha512-ecVwNVT4zIpnB14ltXCTHsWqykW2lgiHrDJW1VeblI3+aU9uMaSZG0zuey+r3vehMeODADnRNrcdk6sN9MAmBA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@storybook/icons": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "peerDependencies": {
+        "storybook": "^8.4.0"
       }
     },
     "node_modules/string_decoder": {

--- a/package.json
+++ b/package.json
@@ -130,6 +130,7 @@
     "qunit-dom": "^3.4.0",
     "sass": "^1.83.1",
     "storybook": "^8.4.7",
+    "storybook-addon-tag-badges": "^1.4.0",
     "stylelint": "^16.13.2",
     "svg-sprite": "^2.0.4",
     "svgo": "^3.3.2",


### PR DESCRIPTION
## :christmas_tree: Problème

Sur storybook, il est difficile d'**avoir en évidence** les **composants obsolètes**, qu'on ne veut plus voir utilisés, ainsi que les **nouveaux composants**.

## :gift: Proposition

Ajouter l'addon [storybook-addon-tag-badges](https://github.com/Sidnioulz/storybook-addon-tag-badges) (présenté dans le [blog officiel](https://storybook.js.org/blog/storybook-tags/#tag-badges-addon)).

Cela permet d'**ajouter ce genre de tags** :

<img width="357" alt="image" src="https://github.com/user-attachments/assets/17af294e-dc63-44fa-be48-c4d78f36e95e" />


## :santa: Pour tester

Ouvrir [storybook en RA](https://ui-pr830.review.pix.fr/) et constater la présence de 2 tags informatifs dans la liste des composants.
