### PR TITLE
[BREAKING] Rendre le bouton pour ouvrir la barre de navigation accessible (PIX-16754)

### DIFF
--- a/addon/components/pix-navigation.hbs
+++ b/addon/components/pix-navigation.hbs
@@ -8,7 +8,13 @@
         aria-expanded={{this.navigationMenuOpened}}
         @iconBefore={{if this.navigationMenuOpened "close" "menu"}}
         @triggerAction={{this.toggleNavigationMenu}}
-      >{{@menuLabel}}</PixButton>
+      >
+        {{#if this.navigationMenuOpened}}
+          {{@closeLabel}}
+        {{else}}
+          {{@openLabel}}
+        {{/if}}
+      </PixButton>
     </div>
   </header>
   <nav

--- a/app/stories/pix-app-layout.stories.js
+++ b/app/stories/pix-app-layout.stories.js
@@ -21,7 +21,11 @@ export const AppLayout = (args) => {
   return {
     template: hbs`<PixAppLayout @variant={{this.variant}}>
   <:navigation>
-    <PixNavigation @navigationAriaLabel={{this.navigationAriaLabel}} @menuLabel='Menu'>
+    <PixNavigation
+      @navigationAriaLabel={{this.navigationAriaLabel}}
+      @openLabel='Ouvrir le menu'
+      @closeLabel='Fermer le menu'
+    >
       <:brand>
         <a href='/'>
           <img src='/pix-orga.svg' alt='pix orga' />

--- a/app/stories/pix-navigation.mdx
+++ b/app/stories/pix-navigation.mdx
@@ -14,14 +14,14 @@ Le composant `<PixNavigation/>` comporte 3 placeholders
 Ce composant doit être utilisé avec le composant `<PixAppLayout>` afin de pouvoir occuper tout la hauteur de la page et être toujours visible.
 
 En complément, les composants `<PixNavigationButton/>` et `<PixNavigationSeparator/>` permettent de composer la navigation souhaitée.
-Il est possible de definir le label ARIA de la navigation principale avec l'attribut `@navigationAriaLabel` et le label du Menu avec `@menuLabel`.
+Il est possible de definir le label ARIA de la navigation principale avec l'attribut `@navigationAriaLabel`, le label du Menu fermé avec `@closeLabel` et le label du menu ouvert avec `@openLabel`.
 
 ## Usage
 
 ```html
 <PixAppLayout @variant="orga">
   <:navigation>
-    <PixNavigation @navigationAriaLabel="navigation principale" @menuLabel="Menu">
+    <PixNavigation @navigationAriaLabel="navigation principale" @openLabel="Ouvrir le menu" @closeLabel="Fermer le menu">
       <:brand>
           <!-- Affichage du bloc identité -->
           <a href="/">

--- a/app/stories/pix-navigation.stories.js
+++ b/app/stories/pix-navigation.stories.js
@@ -10,14 +10,19 @@ export default {
   },
   args: {
     navigationAriaLabel: 'Navigation Principale',
-    menuLabel: 'Menu',
+    openLabel: 'Ouvrir le menu',
+    closeLabel: 'Fermer le menu',
   },
 };
 
 export const Navigation = (args) => {
   return {
     template: hbs`<PixAppLayout @variant='primary'>
-  <PixNavigation @navigationAriaLabel={{this.navigationAriaLabel}} @menuLabel={{this.menuLabel}}>
+  <PixNavigation
+    @navigationAriaLabel={{this.navigationAriaLabel}}
+    @openLabel={{this.openLabel}}
+    @closeLabel={{this.closeLabel}}
+  >
     <:brand>
       <a href='/'>
         <img src='/pix-orga.svg' alt='pix orga' />

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -2,7 +2,11 @@
 
 <PixAppLayout @variant="orga">
   <:navigation>
-    <PixNavigation @menuLabel="Menu" @navigationAriaLabel="navigation principale">
+    <PixNavigation
+      @openLabel="Ouvrir le menu"
+      @closeLabel="Fermer le menu"
+      @navigationAriaLabel="navigation principale"
+    >
       <:brand>
         <a href="/">
           <img src="/pix-orga.svg" alt="pix orga" />

--- a/tests/integration/components/pix-navigation-test.js
+++ b/tests/integration/components/pix-navigation-test.js
@@ -58,7 +58,7 @@ module('Integration | Component | pix-navigation', function (hooks) {
     test('it hides the burger menu', async function (assert) {
       // when
       const screen = await render(
-        hbs`<PixNavigation @navigationAriaLabel='label' @menuLabel='menu' />`,
+        hbs`<PixNavigation @navigationAriaLabel='label' @openLabel='open' @closeLabel='close' />`,
       );
       assert.notOk(screen.queryByRole('button', { name: 'menu' }));
     });


### PR DESCRIPTION
## :boom: BREAKING_CHANGES
Dans le composant PixNavigation, l'attribut "menuLabel" est remplacé par:
- "openLabel": le label lorsque le menu est fermé,
- "closeLabel": Le label lorsque le menu est ouvert.

## :christmas_tree: Problème
Pour le composant PixNavigation, on avait un simple attribut menuLabel, qui permettait d'avoir un label sur le menu, mais pas de savoir s'il était ouvert ou fermé.

## :gift: Proposition
Ajouter 2 paramètres à la place de menuLabel. Le openLabel sera le label à afficher lorsque la barre est fermée et closeLabel lorsqu'elle sera ouverte.

## :star2: Remarques
On a pas mis des noms par défaut aux boutons.

## :santa: Pour tester
- Se rendrer sur l'app,
- Constater lorsque la barre est repliée, qu'il est indiqué "Ouvrir la barre",
- Cliquer sur le bouton,
- Constater que le message devient "Fermer la barre" et que la barre de navigation s'est ouverte.
