### PR TITLE
[BUGFIX] Réparer le mode condensé de PixTable

### DIFF
--- a/addon/components/pix-table.hbs
+++ b/addon/components/pix-table.hbs
@@ -1,5 +1,5 @@
-<div class="pix-table" ...attributes>
-  <table class={{this.tableClass}}>
+<div class={{this.tableClass}} ...attributes>
+  <table>
     <caption class="screen-reader-only">{{this.caption}}</caption>
     <thead class={{this.headerClass}}>
       <tr>

--- a/addon/components/pix-table.js
+++ b/addon/components/pix-table.js
@@ -24,6 +24,7 @@ export default class PixTable extends Component {
   }
 
   get tableClass() {
+    const tableClass = ['pix-table'];
     warn(
       'PixTable: @condensed must be a boolean, default undefined',
       [true, false, undefined].includes(this.args.condensed),
@@ -32,9 +33,10 @@ export default class PixTable extends Component {
       },
     );
     if (this.args.condensed) {
-      return 'pix-table__condensed';
+      tableClass.push('pix-table--condensed');
     }
-    return null;
+
+    return tableClass.join(' ');
   }
 
   get headerClass() {

--- a/addon/styles/_pix-table.scss
+++ b/addon/styles/_pix-table.scss
@@ -11,12 +11,6 @@
 
   @extend %pix-body-s;
 
-  &__condensed {
-    th, td {
-      padding: var(--pix-spacing-2x) var(--pix-spacing-4x);
-    }
-  }
-
   &__clickable-row {
     cursor: pointer;
 
@@ -79,6 +73,14 @@
 
       &:last-child {
         border-radius: 0 var(--pix-spacing-2x) var(--pix-spacing-2x) 0;
+      }
+    }
+  }
+
+  &--condensed {
+    table {
+      th, td {
+        padding: var(--pix-spacing-2x) var(--pix-spacing-4x);
       }
     }
   }

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -19,7 +19,7 @@ const miscFiles = [
   '.circleci/**',
   '.github/**',
   '.template-lintrc.js',
-  'tests/dummy/**'
+  'tests/dummy/**',
 ];
 const emberTryFiles = [
   '.node_modules.ember-try/*',

--- a/tests/integration/components/pix-table-test.js
+++ b/tests/integration/components/pix-table-test.js
@@ -127,7 +127,7 @@ module('Integration | Component | table', function (hooks) {
   module('#condensed', function () {
     test('it should not be condensed by default', async function (assert) {
       // when
-      await render(
+      const screen = await render(
         hbs`<PixTable @caption='Ceci est le caption de notre table' @data={{this.data}}>
   <:columns as |row context|>
     <PixTableColumn @context={{context}}>
@@ -161,7 +161,9 @@ module('Integration | Component | table', function (hooks) {
       );
 
       // then
-      assert.notOk(this.element.querySelector('table').getAttribute('class'));
+      const mainElement = screen.getByRole('table').closest('div');
+
+      assert.strictEqual(mainElement.classList.value, 'pix-table');
     });
 
     test('it should be condensed', async function (assert) {
@@ -169,7 +171,7 @@ module('Integration | Component | table', function (hooks) {
       this.condensed = true;
 
       // when
-      await render(
+      const screen = await render(
         hbs`<PixTable
   @caption='Ceci est le caption de notre table'
   @data={{this.data}}
@@ -207,10 +209,9 @@ module('Integration | Component | table', function (hooks) {
       );
 
       // then
-      assert.strictEqual(
-        this.element.querySelector('table').getAttribute('class'),
-        'pix-table__condensed',
-      );
+      const mainElement = screen.getByRole('table').closest('div');
+
+      assert.strictEqual(mainElement.classList.value, 'pix-table pix-table--condensed');
     });
   });
 


### PR DESCRIPTION
## :christmas_tree: Problème
Suite à quelque correctif, un bug c'est glissé dans la feuille de style pour surcharger le pix table par un mode condensé

## :gift: Proposition
Le réparer

## :star2: Remarques
RAS

## :santa: Pour tester
Aller sur le PixTable, et vérifier que le mode condensé est ok