### PR TITLE
[FEATURE] Mise à jour des couleurs de tags (PIX-16939)

### DIFF
--- a/addon/styles/_pix-tag.scss
+++ b/addon/styles/_pix-tag.scss
@@ -15,25 +15,29 @@
   border-radius: 0.95rem;
 
   &--grey-light,
-  &--neutral {
+  &--neutral,
+  &--grey {
     color: var(--pix-neutral-900);
-    background-color: var(--pix-neutral-20);
+    background-color: var(--pix-neutral-100);
   }
 
   &--yellow-light,
-  &--secondary {
+  &--secondary,
+  &--yellow {
     color: var(--pix-secondary-900);
     background-color: var(--pix-secondary-100);
   }
 
-  &--purple-light,
-  &--tertiary {
+  &--purple-light, 
+  &--tertiary, 
+  &--blue {
     color: var(--pix-tertiary-900);
     background-color: var(--pix-tertiary-100);
   }
 
   &--green-light,
-  &--success {
+  &--success, 
+  &--green {
     color: var(--pix-success-900);
     background-color: var(--pix-success-100);
   }
@@ -43,25 +47,30 @@
     background-color: var(--pix-error-100);
   }
 
+  &--purple {
+    color: var(--pix-primary-900);
+    background-color: var(--pix-primary-100);
+  }
+
+  &--dark {
+    color: var(--pix-neutral-0);
+    background-color: var(--pix-neutral-800);
+  } 
+
+  &--blue-light {
+    color: var(--pix-primary-900);
+    background-color: var(--pix-info-50);
+  }
+
+  &--white {
+    color: var(--pix-neutral-900);
+    background-color: var(--pix-neutral-0);
+  }
+
   &--orga {
+       /** Deprecated color **/
     color: var(--pix-orga-50);
     background-color: var(--pix-orga-500);
-  }
-
-  &--green {
-    /** Deprecated color **/
-    background-color: var(--pix-success-700);
-  }
-
-  &--purple {
-    /** Deprecated color **/
-    background-color: var(--pix-tertiary-900);
-  }
-
-  &--yellow {
-    /** Deprecated color **/
-    color: var(--pix-neutral-900);
-    background-color: var(--pix-warning-500);
   }
 
   &--orange {
@@ -73,10 +82,5 @@
     /** Deprecated color **/
     color: var(--pix-warning-900);
     background-color: var(--pix-warning-100);
-  }
-
-  &--grey {
-    color: var(--pix-neutral-20);
-    background-color: var(--pix-neutral-500);
   }
 }

--- a/app/stories/pix-tag.stories.js
+++ b/app/stories/pix-tag.stories.js
@@ -17,7 +17,17 @@ export default {
       control: {
         type: 'select',
       },
-      options: ['neutral', 'secondary', 'tertiary', 'success', 'error', 'orga'],
+      options: [
+        'grey',
+        'yellow',
+        'purple',
+        'blue',
+        'green',
+        'error',
+        'dark',
+        'white',
+        'blue-light',
+      ],
     },
   },
 };


### PR DESCRIPTION

## :christmas_tree: Problème
Les couleurs de tags ne sont plus cohérentes, certains tags ne se voient plus avec la mise à jour dans les tableaux. D'autres couleurs ne sont pas encore dispos

## :gift: Proposition
Mettre à jour les couleurs 
https://www.figma.com/design/8RJ3aCSfdeQ8AZZVBBYKS8/Design-System-Nebulix?node-id=258-1795&m=dev

## :star2: Remarques
Certaines classes ont été dépréciées, certaines classes ont été ajoutées pour uniformiser les nommages mais les anciennes n'ont pas été supprimées. 

## :santa: Pour tester
Vérifier que les options dispos pour le composant dans storybook sont cohérentes avec figma 
Vérifier que les couleurs sont les bonnes 
🫰 