### PR TITLE
[FEATURE] Ajout d'un variant environment pour PixBannerAlert (PIX-16912)

### DIFF
--- a/addon/components/pix-banner-alert.js
+++ b/addon/components/pix-banner-alert.js
@@ -4,6 +4,7 @@ import { tracked } from '@glimmer/tracking';
 const TYPE_INFO = 'information';
 const TYPE_ERROR = 'error';
 const TYPE_WARNING = 'warning';
+const TYPE_ENVIRONMENT = 'environment';
 const TYPE_COMMUNICATION = 'communication';
 const TYPE_COMMUNICATION_ORGA = 'communication-orga';
 const TYPE_COMMUNICATION_CERTIF = 'communication-certif';
@@ -12,6 +13,7 @@ const types = [
   TYPE_INFO,
   TYPE_ERROR,
   TYPE_WARNING,
+  TYPE_ENVIRONMENT,
   TYPE_COMMUNICATION,
   TYPE_COMMUNICATION_ORGA,
   TYPE_COMMUNICATION_CERTIF,
@@ -21,6 +23,7 @@ const icons = {
   [TYPE_INFO]: 'info',
   [TYPE_ERROR]: 'error',
   [TYPE_WARNING]: 'warning',
+  [TYPE_ENVIRONMENT]: 'displaySettings',
   [TYPE_COMMUNICATION]: 'campaign',
   [TYPE_COMMUNICATION_ORGA]: 'campaign',
   [TYPE_COMMUNICATION_CERTIF]: 'campaign',

--- a/addon/styles/_pix-banner-alert.scss
+++ b/addon/styles/_pix-banner-alert.scss
@@ -87,5 +87,25 @@
       }
     }
   }
+
+  &--environment {
+    color: var(--pix-primary-700);
+    background-color: var(--pix-primary-10);
+
+    .pix-icon-button {
+      color: currentcolor;
+      background-color: var(--pix-primary-10);
+
+      &:hover:enabled,
+      &:focus:enabled,
+      &:active:enabled {
+        background-color: var(--pix-primary-100);
+      }
+
+      &:focus:enabled {
+        outline-color: var(--pix-primary-700);
+      }
+    }
+  }
 }
 

--- a/app/stories/pix-banner-alert.mdx
+++ b/app/stories/pix-banner-alert.mdx
@@ -27,6 +27,12 @@ Bannière pour les erreurs.
 
 <Story of={ComponentStories.error} height={75} />
 
+## Environment
+
+Bannière pour les informations d'environnement de tests internes Pix.
+
+<Story of={ComponentStories.environment} height={75} />
+
 ## With Internal Link
 
 Bannière contenant un lien interne.

--- a/app/stories/pix-banner-alert.stories.js
+++ b/app/stories/pix-banner-alert.stories.js
@@ -27,7 +27,7 @@ export default {
       control: {
         type: 'select',
       },
-      options: ['information', 'warning', 'error', 'environmnent'],
+      options: ['information', 'warning', 'error', 'environment'],
     },
     canCloseBanner: {
       name: 'canCloseBanner',

--- a/app/stories/pix-banner-alert.stories.js
+++ b/app/stories/pix-banner-alert.stories.js
@@ -27,7 +27,7 @@ export default {
       control: {
         type: 'select',
       },
-      options: ['information', 'warning', 'error'],
+      options: ['information', 'warning', 'error', 'environmnent'],
     },
     canCloseBanner: {
       name: 'canCloseBanner',
@@ -74,6 +74,11 @@ warning.args = {
 export const error = Template.bind({});
 error.args = {
   type: 'error',
+};
+
+export const environment = Template.bind({});
+error.args = {
+  type: 'environment',
 };
 
 export const withExternalLink = Template.bind({});

--- a/app/stories/pix-banner-alert.stories.js
+++ b/app/stories/pix-banner-alert.stories.js
@@ -77,7 +77,7 @@ error.args = {
 };
 
 export const environment = Template.bind({});
-error.args = {
+environment.args = {
   type: 'environment',
 };
 


### PR DESCRIPTION
## :christmas_tree: Problème
La bannerAlert précisant qu'il s'agit d'une page destinée à usage uniquement de tests internes Pix utilise actuellement le type 'warning' et ne permet pas de les différencier des alertes devant réellement utiliser le type 'warning'. 

## :gift: Proposition
Ajouter un variat 'environment' avec une autre icone et couleur

## :star2: Remarques


## :santa: Pour tester
Vérifier que la couleur et l'icone correspondent bien au tableau présent sur Figma.