### PR TITLE
[FEATURE] Ajouter la banner dans le layout du PixAppLayout (PIX-16649)

### DIFF
--- a/addon/components/pix-app-layout.hbs
+++ b/addon/components/pix-app-layout.hbs
@@ -1,5 +1,12 @@
 <div class={{this.classNames}} ...attributes>
-  {{yield to="navigation"}}
-  {{yield to="main"}}
-  {{yield to="footer"}}
+  <section
+    class="pix-app-layout__banner"
+    id="pix-layout-banner-container"
+    {{on-window-resize this.handleMarginContainerNavigation}}
+  >
+    {{yield to="banner"}}
+  </section>
+  <div class="pix-app-layout__navigation">{{yield to="navigation"}}</div>
+  <div class="pix-app-layout__main">{{yield to="main"}}</div>
+  <div class="pix-app-layout__footer">{{yield to="footer"}}</div>
 </div>

--- a/addon/components/pix-app-layout.js
+++ b/addon/components/pix-app-layout.js
@@ -1,8 +1,33 @@
 import { VARIANTS } from '@1024pix/pix-ui/helpers/variants';
 import { warn } from '@ember/debug';
+import { service } from '@ember/service';
 import Component from '@glimmer/component';
-
 export default class PixAppLayout extends Component {
+  @service elementHelper;
+
+  constructor(...args) {
+    super(...args);
+
+    this.elementHelper.waitForElement('pix-layout-banner-container').then((elementList) => {
+      this.#computeMarginTopElement(elementList);
+    });
+  }
+
+  #computeMarginTopElement(bannerContainer) {
+    const baseFontRemRatio = Number(
+      getComputedStyle(document.querySelector('html')).fontSize.match(/\d+(\.\d+)?/)[0],
+    );
+    const bannerHeight = bannerContainer.getBoundingClientRect().height;
+    const top = bannerHeight / baseFontRemRatio;
+
+    const layoutElement = document.querySelector('.pix-app-layout');
+    layoutElement.style.setProperty('--pix-app-layout-top', `${top}rem`);
+  }
+
+  handleMarginContainerNavigation = (element) => {
+    this.#computeMarginTopElement(element);
+  };
+
   get variant() {
     const value = this.args.variant ?? 'primary';
     warn(

--- a/addon/components/pix-navigation.js
+++ b/addon/components/pix-navigation.js
@@ -8,6 +8,7 @@ export default class PixMNavigation extends Component {
     super(...args);
     this._navigationId = 'navigation-' + guidFor(this);
   }
+
   @tracked
   navigationMenuOpened = false;
 

--- a/addon/styles/_pix-app-layout.scss
+++ b/addon/styles/_pix-app-layout.scss
@@ -3,29 +3,72 @@
 .pix-app-layout {
   display: grid;
   grid-template-areas:
-  "navigation main main"
-  "navigation footer  footer";
-  grid-template-rows: 1fr min-content;
+    "banner banner"
+    "navigation main"
+    "navigation footer";
+  grid-template-rows: min-content 1fr;
   grid-template-columns: min-content 1fr;
-  gap: var(--pix-spacing-6x);
   min-height: 100dvh;
-  padding: var(--pix-spacing-6x);
-
-  & > *:first-child {
-    grid-area: navigation;
-  }
-
-  & > *:nth-child(2) {
-    grid-area: main;
-  }
-
-  & > *:nth-child(3) {
-    grid-area: footer;
-  }
 
   @include breakpoints.device-is('mobile') {
-    display: block
+    display: flex;
+    flex-direction: column;
   }
+
+  &__banner {
+    position: sticky;
+    top: 0;
+    z-index: 3;
+    grid-area: banner;
+  }
+
+  &__navigation {
+    position: sticky;
+    bottom: var(--pix-spacing-6x);
+    z-index: 1;
+    grid-area: navigation;
+    min-height: calc(100vh - var(--pix-spacing-6x));
+    margin: auto 0 0;
+    padding: calc(var(--pix-app-layout-top) + var(--pix-spacing-6x)) 0 0 var(--pix-spacing-6x);
+
+    @include breakpoints.device-is('mobile') {
+      position: unset;
+      z-index: auto;
+      min-height: auto;
+      padding: var(--pix-spacing-2x) var(--pix-spacing-2x) 0 var(--pix-spacing-2x);
+    }
+  }
+
+  &__main, &__footer {
+    width: 100%;
+    max-width: 93rem;
+    margin: 0 auto;
+    padding: 0 var(--pix-spacing-6x);
+
+    @include breakpoints.device-is('mobile') {
+      padding: 0 var(--pix-spacing-2x);
+    }
+  }
+
+  &__main {
+    grid-area: main;
+    padding-top: var(--pix-spacing-6x);
+
+    @include breakpoints.device-is('mobile') {
+      padding-top: var(--pix-spacing-2x);
+    }
+  }
+
+  &__footer {
+    grid-area: footer;
+    padding-bottom: var(--pix-spacing-6x);
+
+    @include breakpoints.device-is('mobile') {
+      padding-bottom: var(--pix-spacing-2x);
+    }
+  }
+
+
 
   &--admin {
     background-color: var(--pix-primary-10);

--- a/addon/styles/_pix-navigation.scss
+++ b/addon/styles/_pix-navigation.scss
@@ -6,34 +6,25 @@
   --bg-color-active: rgb(var(--pix-neutral-100-inline), 30%);
   --pix-navigation-width:  15rem;
 
-  position: sticky;
-  bottom: var(--pix-spacing-6x);
-  z-index: 1;
   display: flex;
   flex-direction: column;
   gap:var(--pix-spacing-6x);
   align-items: stretch;
   justify-content: space-between;
   width: var(--pix-navigation-width);
-  height: auto;
-  min-height: calc(100vh - var(--pix-spacing-6x) * 2);
-
-  // using a margin top / bottom allow user to discover rapidly
-  // the part of sidebar that is above the fold
-  margin-top: auto;
+  min-height: calc(100vh - var(--pix-app-layout-top) - 2 * var(--pix-spacing-6x));
   padding: var(--pix-spacing-6x) var(--pix-spacing-4x);
   color: var(--pix-navigation-text-color);
   background-color: var(--pix-navigation-color);
   border-radius: var(--pix-spacing-6x);
 
-
   @include breakpoints.device-is('mobile') {
-    position: static;
     flex-direction: column;
     align-items: stretch;
     width: 100%;
     max-width: none;
     min-height: auto;
+    margin-top: 0;
     padding: 0;
 
     &--opened {
@@ -49,7 +40,6 @@
 
     img {
       display: block;
-      width: 132px;
       height: 48px;
       margin:0 auto;
     }

--- a/app/modifiers/on-window-resize.js
+++ b/app/modifiers/on-window-resize.js
@@ -1,0 +1,12 @@
+import { modifier } from 'ember-modifier';
+
+export default modifier(function onWindowResize(element, [action]) {
+  const actionWithElement = () => action(element);
+
+  window.addEventListener('resize', actionWithElement);
+  actionWithElement();
+
+  return () => {
+    window.removeEventListener('resize', actionWithElement);
+  };
+});

--- a/app/stories/pix-app-layout.mdx
+++ b/app/stories/pix-app-layout.mdx
@@ -15,6 +15,7 @@ Le composant `<PixAppLayout/>` comporte 3 placeholders
 
 ```html
 <PixAppLayout @variant="orga">
+  <:banner>Sticky Banner Sticky</:banner>
   <:navigation>
     <PixNavigation @navigationAriaLabel="navigation principale"> </PixNavigation>
   </:navigation>

--- a/app/stories/pix-app-layout.stories.js
+++ b/app/stories/pix-app-layout.stories.js
@@ -26,6 +26,12 @@ export default {
 export const AppLayout = (args) => {
   return {
     template: hbs`<PixAppLayout @variant={{this.variant}}>
+  <:banner>
+  <PixBannerAlert @type="warning">
+      WARNING ceci n'est pas un exercice | WARNING ceci n'est pas un exercice | WARNING ceci n'est
+      pas un exercice | WARNING ceci n'est pas un exercice | WARNING ceci n'est pas un exercice !
+    </PixBannerAlert>
+  </:banner>
   <:navigation>
     <PixNavigation
       @navigationAriaLabel={{this.navigationAriaLabel}}

--- a/app/stories/pix-app-layout.stories.js
+++ b/app/stories/pix-app-layout.stories.js
@@ -17,6 +17,27 @@ export default {
         required: false,
       },
     },
+    banner: {
+      name: '<:banner>',
+      description:
+        'Permet de positionner les banners des applications en haut du layout en position sticky',
+      type: { name: 'block content', required: false },
+    },
+    navigation: {
+      name: '<:navigation>',
+      description: 'insère la navigation à son emplacement définit par le layout',
+      type: { name: 'block content', required: false },
+    },
+    main: {
+      name: '<:main>',
+      description: 'Insère le contenu principale de la page dans son emplacement dédié',
+      type: { name: 'block content', required: true },
+    },
+    footer: {
+      name: '<:footer>',
+      description: "Insère le footer de l'application en bas de page",
+      type: { name: 'block content', required: false },
+    },
   },
   args: {
     variant: 'primary',

--- a/tests/acceptance/pix-modal-page-test.js
+++ b/tests/acceptance/pix-modal-page-test.js
@@ -11,6 +11,7 @@ module('Acceptance | PixModalPageTest', function (hooks) {
   test('Should redirect to link', async function (assert) {
     // given
     const screen = await visit('/modal');
+
     await click(screen.getByRole('button', { name: 'Ouvrir la modale' }));
     await waitForDialog();
 

--- a/tests/dummy/app/router.js
+++ b/tests/dummy/app/router.js
@@ -15,4 +15,5 @@ Router.map(function () {
   this.route('tooltip-page', { path: '/tooltip' });
   this.route('table-page', { path: '/table' });
   this.route('gauge-page', { path: '/gauge' });
+  this.route('layout-page', { path: '/layout' });
 });

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -1,6 +1,13 @@
 {{page-title "Dummy"}}
-
 <PixAppLayout @variant="orga">
+  <:banner>
+    <PixBannerAlert @type="warning">
+      WARNING ceci n'est pas un exercice | WARNING ceci n'est pas un exercice | WARNING ceci n'est
+      pas un exercice | WARNING ceci n'est pas un exercice | WARNING ceci n'est pas un exercice |
+      WARNING ceci n'est pas un exercice | WARNING ceci n'est pas un exercice | WARNING ceci n'est
+      pas un exercice | WARNING ceci n'est pas un exercice | WARNING ceci n'est pas un exercice
+    </PixBannerAlert>
+  </:banner>
   <:navigation>
     <PixNavigation
       @openLabel="Ouvrir le menu"

--- a/tests/dummy/app/templates/layout-page.hbs
+++ b/tests/dummy/app/templates/layout-page.hbs
@@ -1,29 +1,27 @@
-<main>
-  <svg width="100%" height="400" xmlns="http://www.w3.org/2000/svg">
-    <rect width="100%" height="400" fill="IndianRed" />
-  </svg>
+<svg width="100%" height="400" xmlns="http://www.w3.org/2000/svg">
+  <rect width="100%" height="400" fill="IndianRed" />
+</svg>
 
-  <svg width="100%" height="400" xmlns="http://www.w3.org/2000/svg">
-    <rect width="100%" height="400" fill="DeepPink" />
-  </svg>
+<svg width="100%" height="400" xmlns="http://www.w3.org/2000/svg">
+  <rect width="100%" height="400" fill="DeepPink" />
+</svg>
 
-  <svg width="100%" height="400" xmlns="http://www.w3.org/2000/svg">
-    <rect width="100%" height="400" fill="Khaki" />
-  </svg>
+<svg width="100%" height="400" xmlns="http://www.w3.org/2000/svg">
+  <rect width="100%" height="400" fill="Khaki" />
+</svg>
 
-  <svg width="100%" height="400" xmlns="http://www.w3.org/2000/svg">
-    <rect width="100%" height="400" fill="RebeccaPurple" />
-  </svg>
+<svg width="100%" height="400" xmlns="http://www.w3.org/2000/svg">
+  <rect width="100%" height="400" fill="RebeccaPurple" />
+</svg>
 
-  <svg width="100%" height="400" xmlns="http://www.w3.org/2000/svg">
-    <rect width="100%" height="400" fill="YellowGreen" />
-  </svg>
+<svg width="100%" height="400" xmlns="http://www.w3.org/2000/svg">
+  <rect width="100%" height="400" fill="YellowGreen" />
+</svg>
 
-  <svg width="100%" height="400" xmlns="http://www.w3.org/2000/svg">
-    <rect width="100%" height="400" fill="LightCoral" />
-  </svg>
+<svg width="100%" height="400" xmlns="http://www.w3.org/2000/svg">
+  <rect width="100%" height="400" fill="LightCoral" />
+</svg>
 
-  <svg width="100%" xmlns="http://www.w3.org/2000/svg">
-    <rect width="100%" height="400" fill="PowderBlue" />
-  </svg>
-</main>
+<svg width="100%" xmlns="http://www.w3.org/2000/svg">
+  <rect width="100%" height="400" fill="PowderBlue" />
+</svg>

--- a/tests/dummy/app/templates/layout-page.hbs
+++ b/tests/dummy/app/templates/layout-page.hbs
@@ -1,0 +1,29 @@
+<main>
+  <svg width="100%" height="400" xmlns="http://www.w3.org/2000/svg">
+    <rect width="100%" height="400" fill="IndianRed" />
+  </svg>
+
+  <svg width="100%" height="400" xmlns="http://www.w3.org/2000/svg">
+    <rect width="100%" height="400" fill="DeepPink" />
+  </svg>
+
+  <svg width="100%" height="400" xmlns="http://www.w3.org/2000/svg">
+    <rect width="100%" height="400" fill="Khaki" />
+  </svg>
+
+  <svg width="100%" height="400" xmlns="http://www.w3.org/2000/svg">
+    <rect width="100%" height="400" fill="RebeccaPurple" />
+  </svg>
+
+  <svg width="100%" height="400" xmlns="http://www.w3.org/2000/svg">
+    <rect width="100%" height="400" fill="YellowGreen" />
+  </svg>
+
+  <svg width="100%" height="400" xmlns="http://www.w3.org/2000/svg">
+    <rect width="100%" height="400" fill="LightCoral" />
+  </svg>
+
+  <svg width="100%" xmlns="http://www.w3.org/2000/svg">
+    <rect width="100%" height="400" fill="PowderBlue" />
+  </svg>
+</main>

--- a/tests/integration/components/pix-app-layout-test.js
+++ b/tests/integration/components/pix-app-layout-test.js
@@ -9,12 +9,12 @@ module('Integration | Component | pix-app-layout', function (hooks) {
     test(`it add the correct className from ${variant}`, async function (assert) {
       // when
       this.variant = variant;
-      const screen = await render(
+      await render(
         hbs`<PixAppLayout @variant={{this.variant}}><:main>Hello</:main></PixAppLayout>`,
       );
       // then
       assert.strictEqual(
-        screen.getByText(/Hello/).getAttribute('class'),
+        this.element.querySelector('.pix-app-layout').classList.value,
         `pix-app-layout pix-app-layout--${variant}`,
       );
     });


### PR DESCRIPTION
## :christmas_tree: Problème
lorsque des PixBannerAlert apparaissent, il peut subvenir des "problèmes" d'affichage ou d'accès à certains lien, Parceque la banner ne fait pas partie du layout principale.

## :gift: Proposition
Autoriser le PixAppLayout à prendre un nouveau yield pour y insérer les banner

## :star2: Remarques
A voir ce que l'on souhaite faire avec les banner alert. mais il semblerait que ce soit un peu tricky de faire fonctionner les les deux composants en mode sticky. En gardant un accès visible à tout les liens. 
Certainement à revoir la gestion des padding etc... 

## :santa: Pour tester
Lancer la branche en local pour accèder au Dummy de la page table. et voir le fonctionnement? 

https://orga-pr11692.review.pix.fr/campagnes/les-miennes