### PR TITLE
[FEATURE] ajoute  un type de colonne `checkbox` (pix-16845)

### DIFF
--- a/addon/components/pix-table-column.js
+++ b/addon/components/pix-table-column.js
@@ -75,12 +75,15 @@ export default class PixTableColumn extends Component {
   }
 
   get typeClass() {
-    const correctTypes = ['number', 'text'];
+    const correctTypes = ['number', 'text', 'checkbox'];
     warn('PixTableColumn: you need to provide a valid type', correctTypes.includes(this.type), {
       id: 'pix-ui.table-column.type.incorrect',
     });
     if (this.args.type === 'number') {
       return `pix-table-column--number`;
+    }
+    if (this.args.type === 'checkbox') {
+      return `pix-table-column--checkbox`;
     }
     return '';
   }

--- a/addon/styles/_pix-table-column.scss
+++ b/addon/styles/_pix-table-column.scss
@@ -1,5 +1,9 @@
 .pix-table-column {
-  &--number{
+  &--number {
     text-align: left;
+  }
+
+  &--checkbox {
+    width: 3.25rem;
   }
 }

--- a/app/stories/pix-table-column.stories.js
+++ b/app/stories/pix-table-column.stories.js
@@ -49,7 +49,7 @@ export default {
       defaultValue: {
         summary: 'text',
       },
-      options: ['text', 'number'],
+      options: ['text', 'number', 'checkbox'],
       control: {
         type: 'select',
       },
@@ -84,6 +84,28 @@ const Template = (args) => {
   return {
     template: hbs`<PixTable @data={{this.data}} @caption={{this.caption}}>
   <:columns as |row context|>
+    <PixTableColumn @context={{context}} @type='checkbox'>
+      <:header>
+        <PixCheckbox
+          @id='select-all-{{row.id}}'
+          @checked={{row.checked}}
+          @screenReaderOnly={{true}}
+          @size='small'
+        >
+          <:label>Sélectionner toutes les lignes</:label>
+        </PixCheckbox>
+      </:header>
+      <:cell>
+        <PixCheckbox
+          @id={{row.id}}
+          @checked={{row.checked}}
+          @screenReaderOnly={{true}}
+          @size='small'
+        >
+          <:label>Sélectionner {{row.nom}}</:label>
+        </PixCheckbox>
+      </:cell>
+    </PixTableColumn>
     <PixTableColumn @context={{context}} @isMainRow={{this.isMainRow}}>
       <:header>
         Nom
@@ -111,10 +133,12 @@ Default.args = {
   caption: 'Description du tableau',
   data: [
     {
+      id: '1',
       name: 'jean',
       age: 15,
     },
     {
+      id: '2',
       name: 'brian',
       age: 25,
     },

--- a/tests/dummy/app/templates/table-page.hbs
+++ b/tests/dummy/app/templates/table-page.hbs
@@ -5,6 +5,28 @@
   @onRowClick={{this.onClick}}
 >
   <:columns as |row context|>
+    <PixTableColumn @context={{context}} @type="checkbox">
+      <:header>
+        <PixCheckbox
+          @id="select-all-{{row.id}}"
+          @checked={{row.checked}}
+          @screenReaderOnly={{true}}
+          @size="small"
+        >
+          <:label>Sélectionner toutes les lignes</:label>
+        </PixCheckbox>
+      </:header>
+      <:cell>
+        <PixCheckbox
+          @id={{row.id}}
+          @checked={{row.checked}}
+          @screenReaderOnly={{true}}
+          @size="small"
+        >
+          <:label>Sélectionner {{row.nom}}</:label>
+        </PixCheckbox>
+      </:cell>
+    </PixTableColumn>
     <PixTableColumn
       @context={{context}}
       @type="text"


### PR DESCRIPTION
 
## :christmas_tree: Problème
lorsqu'une table a une colonne avec des checkbox, la largeur est trop importante. on souhaite diminuer la largeur utilisée.

## :gift: Proposition
On crée un nouveau type de colonne "checkbox" qui diminue la largeur utilisée.

## :star2: Remarques
ras

## :santa: Pour tester
- afficher la story des colonnes de table et vérifié, via l'inspecteur, que la largeur occupée est 52px
-
