### PR TITLE
[BUGFIX] Placer les banières d'alerte dans une balise header

### DIFF
--- a/addon/components/pix-banner-alert.hbs
+++ b/addon/components/pix-banner-alert.hbs
@@ -1,5 +1,5 @@
 {{#if this.displayBanner}}
-  <div class="pix-banner-alert pix-banner-alert--{{this.type}}" role="alert" ...attributes>
+  <header class="pix-banner-alert pix-banner-alert--{{this.type}}" role="alert" ...attributes>
     <PixIcon
       @name={{this.icon}}
       @plainIcon={{true}}
@@ -34,5 +34,5 @@
         />
       </div>
     {{/if}}
-  </div>
+  </header>
 {{/if}}


### PR DESCRIPTION
## :christmas_tree: Problème
Les PixBannerAlert affiche un message mais ne sont pas placées dans des balise de banière tels que:
```html
<header></header>
```

## :gift: Proposition
Remplacer la balise div par une balise header.

## :star2: Remarques
On pourrait garder le div et rajouter le header.

## :santa: Pour tester
> _Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc._
