### PR TITLE
[FEATURE] Utiliser PixBlock pour le PixIndicatorCard (PIX-16975)

### DIFF
--- a/addon/components/pix-indicator-card.hbs
+++ b/addon/components/pix-indicator-card.hbs
@@ -1,4 +1,4 @@
-<section class="indicator-card" ...attributes>
+<PixBlock @variant="orga" class="indicator-card" role="region" ...attributes>
   {{#if @isLoading}}
     <p class="screen-reader-only">{{@loadingMessage}}</p>
     <div class="indicator-card__icon" aria-hidden="true"></div>
@@ -44,4 +44,4 @@
       </p>
     </dl>
   {{/if}}
-</section>
+</PixBlock>

--- a/addon/styles/_pix-indicator-card.scss
+++ b/addon/styles/_pix-indicator-card.scss
@@ -2,21 +2,17 @@
 @use "pix-design-tokens/shadows";
 
 .indicator-card {
-  @extend %pix-shadow-xs;
-
   display: flex;
   width: 100%;
   min-height: 112px;
   padding: 0;
-  background-color: var(--pix-neutral-0);
-  border-radius: 8px;
 
   &__icon-wrapper {
     display: flex;
     align-items: center;
     justify-content: center;
     min-width: 96px;
-    border-radius: 8px 0 0 8px;
+    border-radius: 7px 0 0 7px;
 
     &--grey,
     &--neutral {


### PR DESCRIPTION
## :christmas_tree: Problème
Le style de fond des PixIndicatorCard n'est plus bon. Et doit être changé indépendament des autres éléments à chaque fois

## :gift: Proposition
Utiliser le PixBlock pour définir le style de fond et le rendre plus facilement modifiable dans le temps

## :star2: Remarques
- Le PixIndicatorCard était auparavant une section alors que le PixBlock est une div. J'ai donc ajouté un aria-role. N'hésitez pas à réagir sur la meilleur manière de faire car je ne suis pas 100% convaincue de la mienne
## :santa: Pour tester
- aller voir PixIndicatorCard, voir qu'il est joli et possède encore tous ses éléments