### PR TITLE
[FEATURE] Composant gauge (pix-16946)

### DIFF
--- a/addon/components/pix-gauge.hbs
+++ b/addon/components/pix-gauge.hbs
@@ -1,0 +1,98 @@
+<svg
+  xmlns:svg="http://www.w3.org/2000/svg"
+  xmlns="http://www.w3.org/2000/svg"
+  viewBox={{this.viewBox}}
+  version="1.1"
+  preserveAspectRatio="none"
+  class="result-level-gauge {{if @isSmall 'result-level-gauge__small'}}"
+  role="progressbar"
+  aria-valuenow={{this.formatNumber this.reachedLevel}}
+  aria-valuemin={{0}}
+  aria-valuemax={{this.formatNumber this.maxLevel}}
+  aria-valuetext={{this.label}}
+  aria-label={{this.label}}
+>
+  <title {{this.label}}></title>
+
+  {{! gauge grey background}}
+  <rect
+    y={{22}}
+    width="100%"
+    height={{this.backgroundHeight}}
+    rx={{this.greyGaugeRx}}
+    class="result-level-gauge__background"
+  />
+
+  <g transform="translate(4, 0)">
+    {{! template-lint-disable no-inline-styles style-concatenation }}
+    {{! gauge white max level}}
+    <rect
+      y={{26}}
+      width="calc(calc(100% - 8px) * {{this.maxLevelPourcentage}})"
+      height={{this.whiteAndPurpleGaugesHeight}}
+      rx={{this.whiteAndPurpleGaugeRx}}
+      class="result-level-gauge__max-bar"
+    />
+    {{#unless this.hideValues}}
+      <g style="transform: translate(calc(calc(100% - 8px) * {{this.maxLevelPourcentage}}))">
+        <text
+          y={{this.statsFontHeight}}
+          x="0"
+          dx={{-10}}
+          dy={{26}}
+          class="result-level-gauge__max-value"
+          aria-hidden={{this.hideValues}}
+        >{{this.formatNumber @maxLevel}}</text>
+      </g>
+    {{/unless}}
+    {{! mean purple level }}
+    <rect
+      y={{26}}
+      width="max(calc(calc(100% - 8px) * {{this.reachedLevelPercentage}}), 44px)"
+      height={{this.whiteAndPurpleGaugesHeight}}
+      rx={{this.whiteAndPurpleGaugeRx}}
+      class="result-level-gauge__mean-bar"
+    />
+    {{#unless this.hideValues}}
+      <g
+        style="transform: translate(max(calc(calc(100% - 8px) * {{this.reachedLevelPercentage}}), 44px))"
+      >
+        <text
+          y={{this.statsFontHeight}}
+          x="0"
+          dx={{-10}}
+          dy={{26}}
+          class="result-level-gauge__mean-value"
+          aria-hidden={{this.hideValues}}
+        >{{this.formatNumber @reachedLevel}}</text>
+      </g>
+    {{/unless}}
+    {{! level labels }}
+    {{#unless @isSmall}}
+      {{#each @stepLabels as |stepLabel index|}}
+        <g style="transform: translate(calc(calc(100% - 8px) * {{this.stepLabelX index}}))">
+          <text
+            y={{15}}
+            class="result-level-gauge__rank
+              {{if (this.isLevelActive index) 'result-level-gauge__rank--active'}}"
+          >{{stepLabel}}</text>
+        </g>
+        {{#unless (eq index 0)}}
+          <g style="transform: translate(calc(100% * {{this.stepLineX index}}))">
+            <line
+              x1="0"
+              y1={{7}}
+              x2="0"
+              y2="74.6641"
+              stroke-width={{2}}
+              stroke-linecap="round"
+              stroke-dasharray="2 8"
+              class="result-level-gauge__separator"
+              role="separator"
+            />
+          </g>
+        {{/unless}}
+      {{/each}}
+    {{/unless}}
+  </g>
+</svg>

--- a/addon/components/pix-gauge.js
+++ b/addon/components/pix-gauge.js
@@ -1,0 +1,96 @@
+import { warn } from '@ember/debug';
+import Component from '@glimmer/component';
+export default class PixGauge extends Component {
+  get label() {
+    warn('PixGauge: @label must be defined', !this.args.label, {
+      id: 'pix-ui.gauge.label.not-defined',
+    });
+    return this.args.label;
+  }
+
+  get reachedLevel() {
+    warn(
+      'PixGauge: @reachedLevel must be between 0 and 8',
+      this.args.reachedLevel <= 8 || this.args.reachedLevel >= 0,
+      {
+        id: 'pix-ui.gauge.reachedLevel.not-defined',
+      },
+    );
+    return this.args.reachedLevel;
+  }
+
+  get maxLevel() {
+    warn(
+      'PixGauge: @maxLevel must be between 1 and 8',
+      this.args.maxLevel <= 8 || this.args.maxLevel >= 1,
+      {
+        id: 'pix-ui.gauge.maxLevel.not-defined',
+      },
+    );
+    return this.args.maxLevel;
+  }
+
+  get hideValues() {
+    return this.args.hideValues ?? false;
+  }
+
+  get maxLevelPourcentage() {
+    return this.maxLevel / 8;
+  }
+  get viewBox() {
+    if (this.args.isSmall) {
+      return '0 22 200 32';
+    }
+    return '0 0 100% 70';
+  }
+
+  get reachedLevelPercentage() {
+    return this.reachedLevel / 8;
+  }
+
+  get whiteAndPurpleGaugeRx() {
+    return this.args.isSmall ? 12 : 20;
+  }
+
+  get whiteAndPurpleGaugesHeight() {
+    return this.args.isSmall ? 24 : 40;
+  }
+
+  // background
+  get greyGaugeRx() {
+    return this.args.isSmall ? 16 : 24;
+  }
+
+  get backgroundHeight() {
+    return this.args.isSmall ? 32 : 48;
+  }
+
+  get statsFontHeight() {
+    return this.args.isSmall ? 18 : 26;
+  }
+
+  isLevelActive = (index) => {
+    if (this.reachedLevel === 0 && index === 0) return true;
+    const step = 8 / this.args.stepLabels.length;
+    return index * step < this.reachedLevel && this.reachedLevel <= (index + 1) * step;
+  };
+
+  stepLabelX = (index) => {
+    const stepStart = 1 / this.args.stepLabels.length;
+    return `${stepStart * index + (1 / 2) * stepStart}`;
+  };
+
+  stepLineX = (index) => {
+    const stepStart = 1 / this.args.stepLabels.length;
+    return `${stepStart * index}`;
+  };
+
+  formatNumber = (str) => {
+    const num = Number(str);
+    const oneDigitNum = num.toFixed(1);
+    if (oneDigitNum.toString().endsWith('0')) {
+      return Math.ceil(oneDigitNum);
+    }
+    return oneDigitNum;
+  };
+}

--- a/addon/styles/_pix-gauge.scss
+++ b/addon/styles/_pix-gauge.scss
@@ -1,0 +1,69 @@
+@use "pix-design-tokens/fonts";
+@use "pix-design-tokens/typography";
+
+.result-level-gauge {
+  display: block;
+  width: 100%;
+  height: 4.375rem;
+  margin-bottom: var(--pix-spacing-2x);
+
+  &__rank {
+    font-size: .625rem;
+    font-family: fonts.$font-roboto;
+    text-transform: uppercase;
+    fill: var(--pix-neutral-900);
+    text-anchor: middle;
+
+    &--active {
+      font-weight: var(--pix-font-bold);
+    }
+  }
+
+  &__mean-bar {
+    fill: var(--pix-primary-300);
+  }
+
+  &__max-bar {
+    fill: var(--pix-neutral-0);
+  }
+
+  &__background {
+    fill: rgba(var(--pix-neutral-900-inline), 0.1);
+  }
+
+  &__mean-value {
+    @extend %pix-body-l;
+
+    font-weight: var(--pix-font-bold);
+    fill: var(--pix-primary-10);
+    text-anchor: end;
+  }
+
+  &__max-value {
+    @extend %pix-body-l;
+
+    fill: var(--pix-neutral-800);
+    text-anchor: end;
+  }
+
+  &__separator {
+    transform: translate(-4px, 0);
+    stroke: var(--pix-primary-100);
+  }
+
+  // Modifier for small version of the gauge
+  &__small {
+    width: 200px;
+    height: 2rem;
+
+    &__mean-value {
+      font-weight: var(--pix-font-bold);
+
+      @extend %pix-body-s;
+    }
+
+    &__max-value {
+      @extend %pix-body-s;
+    }
+  }
+}

--- a/addon/styles/addon.scss
+++ b/addon/styles/addon.scss
@@ -47,7 +47,7 @@
 @use 'pix-structure-switcher';
 @use 'pix-code';
 @use 'pix-tabs';
-
+@use 'pix-gauge';
 
 // at the end so it can override it's children scss
 @use 'pix-filterable-and-searchable-select';

--- a/app/components/pix-gauge.js
+++ b/app/components/pix-gauge.js
@@ -1,0 +1,4 @@
+// WORKAROUND: necessary for storybook to resolve the import
+import '@formatjs/intl';
+
+export { default } from '@1024pix/pix-ui/components/pix-gauge';

--- a/app/stories/pix-gauge.mdx
+++ b/app/stories/pix-gauge.mdx
@@ -1,0 +1,26 @@
+import { Meta, Story, ArgTypes } from '@storybook/blocks';
+import * as ComponentStories from './pix-gauge.stories';
+
+<Meta of={ComponentStories} />
+
+# PixGauge
+
+Le composant `<PixGauge/>` prend en arguments
+
+- `stepLabels`: un tableau avec les noms des niveaux, ex ["Novice", "Intermédiaire", "Avancé", "Expert"];
+- `label`: le titre du svg lisible par le lecteur d'écran
+- `isSmall` : un booléen, par défaut à false, à passer à true si on veut cacher les labels de description des niveaux au-dessus de la jauge ainsi que les séparateurs, et avoir la jauge en plus petite taille (voir ci-dessous)
+- `hideValues` : un booléen, par défaut à false, qui permet de ne pas afficher les valeurs numériques.
+- `maxLevel`: un nombre, le niveau maximum atteignable par la jauge (jauge blanche)
+- `reachedLevel` : un nombre, le niveau atteint (jauge violette)
+
+## Usage
+
+```html
+<PixGauge @label="Niveau atteint de ...
+  sur un niveau maximum atteignable de ..." @reachedLevel={{1}} @maxLevel={{4}} @isSmall={{true}} @stepLabels={{array "Novice" "Intermédiaire" "Avancé" "Expert"}}>
+```
+
+## Arguments
+
+<ArgTypes of={ComponentStories} />

--- a/app/stories/pix-gauge.stories.js
+++ b/app/stories/pix-gauge.stories.js
@@ -1,0 +1,53 @@
+import { hbs } from 'ember-cli-htmlbars';
+
+export default {
+  title: 'Data display/Gauge',
+  argTypes: {
+    label: {
+      description: "Titre à renseigner pour les lecteurs d'écran",
+      type: { name: 'string', required: true },
+    },
+    stepLabels: {
+      description:
+        'Labels pour les différents niveaux (ex: Novice / Intermédiaire / Avancé / Expert)',
+      type: { name: 'array', required: false },
+    },
+    isSmall: {
+      description:
+        'A passer à true pour passer la jauge en taille "mini" + pour cacher les labels de niveaux et les séparateurs',
+      type: { name: 'boolean', required: false },
+    },
+    hiveValues: {
+      description: 'A passer à true pour cacher les valeurs numériques',
+      type: { name: 'boolean', required: false },
+    },
+    maxLevel: {
+      description: 'Niveau maximum atteignable',
+      type: { name: 'number', required: true },
+    },
+    reachedLevel: {
+      description: 'Niveau atteint',
+      type: { name: 'number', required: false },
+    },
+  },
+  args: {
+    stepLabels: ['Novice', 'Intermédiaire', 'Avancé', 'Expert'],
+    isSmall: false,
+    hideValues: false,
+    maxLevel: 4,
+    reachedLevel: 1,
+  },
+};
+
+export const PixGauge = (args) => {
+  return {
+    template: hbs`<PixGauge
+  @stepLabels={{this.stepLabels}}
+  @isSmall={{this.isSmall}}
+  @hideValues={{this.hideValues}}
+  @maxLevel={{this.maxLevel}}
+  @reachedLevel={{this.reachedLevel}}
+/>`,
+    context: args,
+  };
+};

--- a/tests/dummy/app/router.js
+++ b/tests/dummy/app/router.js
@@ -14,4 +14,5 @@ Router.map(function () {
   this.route('sidebar-page', { path: '/sidebar' });
   this.route('tooltip-page', { path: '/tooltip' });
   this.route('table-page', { path: '/table' });
+  this.route('gauge-page', { path: '/gauge' });
 });

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -20,6 +20,7 @@
         <PixNavigationButton @route="sidebar-page" @icon="doorOpen">Sidebar</PixNavigationButton>
         <PixNavigationButton @route="tooltip-page" @icon="signpost">tooltip</PixNavigationButton>
         <PixNavigationButton @route="table-page" @icon="assignment">Table</PixNavigationButton>
+        <PixNavigationButton @route="gauge-page" @icon="barsUp">gauge</PixNavigationButton>
         <PixNavigationButton href="https://pix.fr" @icon="book">Documentation</PixNavigationButton>
         <PixNavigationButton
           href="https://pix.fr"

--- a/tests/dummy/app/templates/gauge-page.hbs
+++ b/tests/dummy/app/templates/gauge-page.hbs
@@ -1,0 +1,45 @@
+<PixGauge
+  @stepLabels={{array "Novice" "Intermédiaire" "Avancé" "Expert"}}
+  @reachedLevel={{6.3}}
+  @maxLevel={{8}}
+  @label="niveau atteind de 6.3 sur un maximum de 8"
+/>
+
+<PixGauge
+  @stepLabels={{array "Novice" "Intermédiaire" "Avancé" "Expert"}}
+  @reachedLevel={{0.51}}
+  @maxLevel={{8}}
+  @label="niveau atteind de 4 sur un maximum de 8"
+/>
+
+<PixGauge
+  @stepLabels={{array "Novice" "Intermédiaire" "Avancé" "Expert"}}
+  @reachedLevel={{0}}
+  @maxLevel={{8}}
+  @label="niveau atteind de 4 sur un maximum de 8"
+/>
+
+<PixGauge
+  @stepLabels={{array "Novice" "Intermédiaire" "Avancé" "Expert"}}
+  @isSmall={{true}}
+  @reachedLevel={{4}}
+  @maxLevel={{8}}
+  @label="niveau atteind de 4 sur un maximum de 8"
+/>
+
+<PixGauge
+  @stepLabels={{array "Novice" "Intermédiaire" "Avancé" "Expert"}}
+  @hideValues={{true}}
+  @reachedLevel={{4}}
+  @maxLevel={{8}}
+  @label="niveau atteind de 4 sur un maximum de 8"
+/>
+
+<PixGauge
+  @stepLabels={{array "Novice" "Intermédiaire" "Avancé" "Expert"}}
+  @isSmall={{true}}
+  @hideValues={{true}}
+  @reachedLevel={{4}}
+  @maxLevel={{8}}
+  @label="niveau atteind de 4 sur un maximum de 8"
+/>

--- a/tests/integration/components/pix-gauge-test.js
+++ b/tests/integration/components/pix-gauge-test.js
@@ -1,0 +1,133 @@
+import { render } from '@1024pix/ember-testing-library';
+import { hbs } from 'ember-cli-htmlbars';
+import { setupRenderingTest } from 'ember-qunit';
+import { module, test } from 'qunit';
+
+module('Integration | Component | pix-gauge', function (hooks) {
+  setupRenderingTest(hooks);
+
+  module('Big mode', function () {
+    test('it renders the correct visual for average and max levels', async function (assert) {
+      // when
+      const screen = await render(
+        hbs`<PixGauge
+  @label='Niveau atteint de 1 sur un niveau maximum atteignable de 3'
+  @reachedLevel={{1}}
+  @maxLevel={{3}}
+  @stepLabels={{array 'Novice' 'Intermédiaire' 'Avancé' 'Expert'}}
+/>`,
+      );
+
+      const generalGauge = screen.getByRole('progressbar', {
+        name: /Niveau atteint de 1 sur un niveau maximum atteignable de 3/,
+      });
+      const reachedLevelTextElement = screen.getByText('1');
+      const maxLevelTextElement = screen.getByText('3');
+
+      // then
+      assert.ok(generalGauge);
+      assert.ok(reachedLevelTextElement);
+      assert.ok(maxLevelTextElement);
+    });
+
+    test('it does not render mean level bar when average level is between 0 and 0.25', async function (assert) {
+      // when
+      const screen = await render(
+        hbs`<PixGauge
+  @label='Niveau atteint de ...
+  sur un niveau maximum atteignable de ...'
+  @reachedLevel={{0.57}}
+  @maxLevel={{3}}
+  @stepLabels={{array 'Novice' 'Intermédiaire' 'Avancé' 'Expert'}}
+/>`,
+      );
+      // then
+      assert.notOk(screen.queryByText('1'));
+    });
+
+    test('it renders the content of the labels and of the separators if isSmall prop is not filled in', async function (assert) {
+      // when
+      const screen = await render(
+        hbs`<PixGauge
+  @label='Niveau atteint de ...
+  sur un niveau maximum atteignable de ...'
+  @reachedLevel={{1}}
+  @maxLevel={{3}}
+  @stepLabels={{array 'Novice' 'Intermédiaire' 'Avancé' 'Expert'}}
+/>`,
+      );
+      // then
+      assert.ok(screen.queryByText('Novice'));
+      assert.ok(screen.queryByText('Intermédiaire'));
+      assert.ok(screen.queryByText('Avancé'));
+      assert.ok(screen.queryByText('Expert'));
+    });
+    test('it hide values when hideValues is true', async function (assert) {
+      // when
+      const screen = await render(
+        hbs`<PixGauge
+  @label='Niveau atteint de ...
+  sur un niveau maximum atteignable de ...'
+  @reachedLevel={{1}}
+  @maxLevel={{3}}
+  @hideValues={{true}}
+  @stepLabels={{array 'Novice' 'Intermédiaire' 'Avancé' 'Expert'}}
+/>`,
+      );
+      // then
+      assert.notOk(screen.queryByLabelText('1'));
+      assert.notOk(screen.queryByLabelText('3'));
+    });
+  });
+  module('Small mode', function () {
+    test('it renders the correct visual for average and max levels', async function (assert) {
+      // when
+      const screen = await render(
+        hbs`<PixGauge
+  @label='Niveau atteint de 1 sur un niveau maximum atteignable de 3'
+  @reachedLevel={{1}}
+  @maxLevel={{3}}
+  @stepLabels={{array 'Novice' 'Intermédiaire' 'Avancé' 'Expert'}}
+/>`,
+      );
+
+      const generalGauge = screen.getByRole('progressbar', {
+        name: /Niveau atteint de 1 sur un niveau maximum atteignable de 3/,
+      });
+      const reachedLevelTextElement = screen.getByText('1');
+      const maxLevelTextElement = screen.getByText('3');
+
+      // then
+      assert.ok(generalGauge);
+      assert.ok(reachedLevelTextElement);
+      assert.ok(maxLevelTextElement);
+    });
+
+    test('it renders the mean level bar when average level is lesser than 0', async function (assert) {
+      // when
+      const screen = await render(
+        hbs`<PixGauge @isSmall={{true}} @reachedLevel={{0.75}} @maxLevel={{3}} />`,
+      );
+      // then
+      assert.ok(screen.queryByText('0.8'));
+    });
+
+    test('it does not renders content of the labels and the separators if hideValues is true', async function (assert) {
+      // when
+      const screen = await render(
+        hbs`<PixGauge
+  @hideValues={{true}}
+  @isSmall={{true}}
+  @reachedLevel={{1}}
+  @maxLevel={{3}}
+  @stepLabels={{array 'novice' 'expert'}}
+/>`,
+      );
+      // then
+      assert.notOk(screen.queryByText('1'));
+      assert.notOk(screen.queryByText('3'));
+      assert.notOk(screen.queryByLabelText('novice'));
+      assert.notOk(screen.queryByLabelText('expert'));
+    });
+  });
+});


### PR DESCRIPTION
## :christmas_tree: Problème
Côté Pix Orga, on avait besoin d'une jauge de progression pour notre nouvelle page d'Analyse des résultats de campagne. 
Après discussion avec @pierrepougetpix, on a vu que ce composant pouvait être réutilisé dans d'autres contextes (comme celui de la certification). 

## :gift: Proposition
On crée un composant <ResultLevelGauge> qui, visuellement, fonctionne en quarts (chaque section représente 25% de la barre). Ce composant prend un "reachedLevel" (niveau atteint, représenté par la barre violette) et un "maxLevel" (niveau maximum atteignable, représenté par la barre blanche). 
Il est à l'origine pensé pour prendre des niveaux en paramètres (1 étant le plus petit et 8 le niveau maximum) et les transformer en pourcentage, mais on pourrait éventuellement le transformer pour prendre directement un pourcentage en prop.
On a la possibilité d'utiliser un variant de cette jauge : plus petit, sans séparateurs visuels et sans labels au-dessus de la jauge(mode "isSmall").

## :star2: Remarques
Côté Pix Orga, il faudra lui passer un tableau dans la prop "stepLabels" avec les clés de traduction pour pouvoir afficher les labels au-dessus de la jauge. 

TODO

- [x] Arrondi étrange à fixer pour les rect : rx à 12 pour la jauge interne, à 16 pour le gris
- [x] Vérifier que toutes les valeurs sont bien en tokens du DS -> vu avec le design, c'est OK si toutes les valeurs sont pas forcément en token (c'était important seulement pour certaines valeurs)
- [x] Entre 0 et 1, le visuel doit être équivalent à si mon niveau est à 1 (mais on affiche la valeur quand même)
- [ ] Les traits des séparateurs doivent dépasser en bas
- [x] Revérifier les labels en local quand isSmall est à false (pas visibles sur Storybook)

## :santa: Pour tester
Essayer la story sur Storybook avec différentes valeurs de moyennes / de maximum.