### PR TITLE
[FEATURE] Changement de la couleur de fond pour la nav PixAdmin (PIX-17216)

### DIFF
--- a/addon/styles/_pix-app-layout.scss
+++ b/addon/styles/_pix-app-layout.scss
@@ -27,6 +27,13 @@
     display: block
   }
 
+  &--admin {
+    background-color: var(--pix-primary-10);
+
+    --pix-navigation-color: var(--pix-primary-900);
+    --pix-navigation-text-color: var(--pix-neutral-0);
+  }
+
   &--orga {
     background-color: var(--pix-orga-50);
 


### PR DESCRIPTION
## :christmas_tree: Problème
La navigation affiche la couleur de fond destinée à Pix App

## :gift: Proposition
Ajout d'une classe pour admin qui affiche la couleur de fond pix-primary-900

## :santa: Pour tester
Vérifier que la couleur est bien la bonne