### PR TITLE
[FEATURE] Ajustement des marges internes des cellules de PixTable (PIX-17220)

### DIFF
--- a/addon/styles/_pix-table.scss
+++ b/addon/styles/_pix-table.scss
@@ -71,7 +71,7 @@
 
 
     td, th {
-      padding: var(--pix-spacing-6x) var(--pix-spacing-4x);
+      padding: var(--pix-spacing-4x) var(--pix-spacing-4x);
 
       &:first-child {
         border-radius: var(--pix-spacing-2x) 0 0 var(--pix-spacing-2x);
@@ -86,7 +86,7 @@
   &--condensed {
     table {
       th, td {
-        padding: var(--pix-spacing-2x) var(--pix-spacing-4x);
+        padding: .5rem var(--pix-spacing-4x);
       }
     }
   }


### PR DESCRIPTION
## :christmas_tree: Problème
Après implémentation dans les différents outils, le rendu des tableau est trop lourd, les marges internes sont trop importantes

## :gift: Proposition
Réduction des marges internes pour réduire la hauteur de la cellule

## :santa: Pour tester
Tester sur un tableau à plusieurs lignes (type PixOrga ou Admin).
Tester le mode condensed

Sur une cellule classique de texte, les hauteurs doivent être : 
- mode normal : 52px
- mode condensed : 36px