### PR TITLE
[BUGFIX] Ne faire apparaître le texte de PixNaviation qu'au lecteur d'écran

### DIFF
--- a/addon/components/pix-navigation.hbs
+++ b/addon/components/pix-navigation.hbs
@@ -9,11 +9,13 @@
         @iconBefore={{if this.navigationMenuOpened "close" "menu"}}
         @triggerAction={{this.toggleNavigationMenu}}
       >
-        {{#if this.navigationMenuOpened}}
-          {{@closeLabel}}
-        {{else}}
-          {{@openLabel}}
-        {{/if}}
+        <span class="screen-reader-only">
+          {{#if this.navigationMenuOpened}}
+            {{@closeLabel}}
+          {{else}}
+            {{@openLabel}}
+          {{/if}}
+        </span>
       </PixButton>
     </div>
   </header>

--- a/addon/components/pix-navigation.js
+++ b/addon/components/pix-navigation.js
@@ -1,3 +1,4 @@
+import { warn } from '@ember/debug';
 import { action } from '@ember/object';
 import { guidFor } from '@ember/object/internals';
 import Component from '@glimmer/component';
@@ -7,6 +8,13 @@ export default class PixMNavigation extends Component {
   constructor(...args) {
     super(...args);
     this._navigationId = 'navigation-' + guidFor(this);
+    warn(
+      'PixNavigation: @openLabel and @closeLabel are required',
+      this.args.openLabel && this.args.closeLabel,
+      {
+        id: 'pix-navigation.open-close-labels',
+      },
+    );
   }
 
   @tracked

--- a/app/stories/pix-navigation.stories.js
+++ b/app/stories/pix-navigation.stories.js
@@ -7,6 +7,14 @@ export default {
       description: 'Variante de la navigation',
       type: { name: 'string', required: true },
     },
+    openLabel: {
+      description: 'Label à afficher lorsque la navbar est fermée.',
+      type: { name: 'string', required: true },
+    },
+    closeLabel: {
+      description: 'Label à afficher lorsque la navbar est ouverte.',
+      type: { name: 'string', required: true },
+    },
   },
   args: {
     navigationAriaLabel: 'Navigation Principale',


### PR DESCRIPTION
## :christmas_tree: Problème
Actuellement, on affichait le texte sous le bouton pour ouvrir la navbar. Or, on ne veut pas de texte.

## :gift: Proposition
Mettre un screen-reader-only avec un span.

## :star2: Remarques
RAS

## :santa: Pour tester
- Se rendre sur la story de PIxNavigation,
- Inspécter le bouton pour vérifier que l'élément "Ouvrir le menu" est présent,
- Vérifier qu'il n'y a pas de texte affiché!