### PR TITLE
[BUGFIX] Corriger l'affichage de la nav bar en mobile

### DIFF
--- a/addon/styles/_pix-app-layout.scss
+++ b/addon/styles/_pix-app-layout.scss
@@ -35,6 +35,7 @@
       position: unset;
       z-index: auto;
       min-height: auto;
+      margin: unset;
       padding: var(--pix-spacing-2x) var(--pix-spacing-2x) 0 var(--pix-spacing-2x);
     }
   }
@@ -55,6 +56,7 @@
     padding-top: var(--pix-spacing-6x);
 
     @include breakpoints.device-is('mobile') {
+      margin-bottom: auto;
       padding-top: var(--pix-spacing-2x);
     }
   }


### PR DESCRIPTION
## :christmas_tree: Problème
la nav bar ne se positionne pas correctement en mobile

## :gift: Proposition
Corriger ce positionnement

## :star2: Remarques
RAS

## :santa: Pour tester
Aller sur PixOrga et vérifier que c'est ok sur cette PR 

https://github.com/1024pix/pix/pull/11692