### PR TITLE
[TECH] Permettre l'utilisation de fichiers .gjs (PIX-17355).

### DIFF
--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,6 +1,7 @@
 {
   "printWidth": 100,
   "singleQuote": true,
+  "templateSingleQuote": false,
   "overrides": [
     {
       "files": "*.hbs",
@@ -8,5 +9,8 @@
         "singleQuote": false
       }
     }
+  ],
+  "plugins": [
+    "prettier-plugin-ember-template-tag"
   ]
 }

--- a/.template-lintrc.js
+++ b/.template-lintrc.js
@@ -12,4 +12,12 @@ module.exports = {
     },
   },
   ignore: ['blueprints/**'],
+  overrides: [
+    {
+      files: ['**/*.gjs'],
+      rules: {
+        prettier: 'off',
+      },
+    },
+  ],
 };

--- a/addon/components/pix-tag.gjs
+++ b/addon/components/pix-tag.gjs
@@ -7,4 +7,10 @@ export default class PixTag extends Component {
     if (color) classes.push(`pix-tag--${color}`);
     return classes.join(' ');
   }
+
+  <template>
+    <div class="pix-tag {{this.classes}}" ...attributes>
+      {{yield}}
+    </div>
+  </template>
 }

--- a/addon/components/pix-tag.hbs
+++ b/addon/components/pix-tag.hbs
@@ -1,3 +1,0 @@
-<div class="pix-tag {{this.classes}}" ...attributes>
-  {{yield}}
-</div>

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
         "ember-lifeline": "^7.0.0",
         "ember-modifier": "^4.2.0",
         "ember-popperjs": "^3.0.0",
+        "ember-template-imports": "^4.3.0",
         "ember-truth-helpers": "^4.0.0"
       },
       "devDependencies": {
@@ -62,7 +63,7 @@
         "ember-resolver": "^12.0.0",
         "ember-sinon": "^5.0.0",
         "ember-source": "^5.11.0",
-        "ember-template-lint": "^7.0.1",
+        "ember-template-lint": "^7.0.2",
         "ember-template-lint-plugin-prettier": "^5.0.0",
         "ember-try": "^3.0.0",
         "eslint": "^9.21.0",
@@ -79,6 +80,7 @@
         "lodash": "^4.17.21",
         "npm-run-all2": "^7.0.0",
         "prettier": "^3.5.3",
+        "prettier-plugin-ember-template-tag": "^2.0.5",
         "qunit": "^2.23.1",
         "qunit-dom": "^3.4.0",
         "sass": "^1.83.1",
@@ -18670,10 +18672,30 @@
         "node": ">=8"
       }
     },
+    "node_modules/ember-template-imports": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ember-template-imports/-/ember-template-imports-4.3.0.tgz",
+      "integrity": "sha512-jZ5D6KLKU8up/AynZltmKh4lkXBPgTGSPgomprI/55XvIVqn42UNUpEz7ra/mO3QiGODDZOUesbggPe49i38sQ==",
+      "license": "MIT",
+      "dependencies": {
+        "broccoli-stew": "^3.0.0",
+        "content-tag": "^3.0.0",
+        "ember-cli-version-checker": "^5.1.2"
+      },
+      "engines": {
+        "node": "16.* || >= 18"
+      }
+    },
+    "node_modules/ember-template-imports/node_modules/content-tag": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/content-tag/-/content-tag-3.1.2.tgz",
+      "integrity": "sha512-Z+MGhZfnFFKzYC+pUTWXnoDYhfiXP9ojZe3JbwsYufmDuoeq2EvuDyeFAJ/RnKokUwz5s9bQhDOrbvSYRShcrQ==",
+      "license": "MIT"
+    },
     "node_modules/ember-template-lint": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/ember-template-lint/-/ember-template-lint-7.0.1.tgz",
-      "integrity": "sha512-rFGrioqtoHyWGig6PsURQYL797Hj1u9Wbn8ZyTO3H0NUNrRgPOX+2Gu9uTrmnf+KWry/2GB+yok6OY7mVSygIA==",
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/ember-template-lint/-/ember-template-lint-7.0.2.tgz",
+      "integrity": "sha512-3YhHVLqD48GK1M9ZXf3L+eH2800FYCtvENCLzazgiAlU50towMKCV9Dy+lF9XlXzQZSJZzxR16IGCgv8rkiesw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -31860,6 +31882,31 @@
       "engines": {
         "node": ">=6.0.0"
       }
+    },
+    "node_modules/prettier-plugin-ember-template-tag": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/prettier-plugin-ember-template-tag/-/prettier-plugin-ember-template-tag-2.0.5.tgz",
+      "integrity": "sha512-G9lbK3wmryIBSzqBKKoy254v7hIjqzqYpqWxi9NvOxcxNtwLyrC1u9NLJJFm+x9blzqHQOzKGOseVnbLtEwEbg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.23.6",
+        "content-tag": "^3.1.2",
+        "prettier": "^3.1.1"
+      },
+      "engines": {
+        "node": "18.* || >= 20"
+      },
+      "peerDependencies": {
+        "prettier": ">= 3.0.0"
+      }
+    },
+    "node_modules/prettier-plugin-ember-template-tag/node_modules/content-tag": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/content-tag/-/content-tag-3.1.2.tgz",
+      "integrity": "sha512-Z+MGhZfnFFKzYC+pUTWXnoDYhfiXP9ojZe3JbwsYufmDuoeq2EvuDyeFAJ/RnKokUwz5s9bQhDOrbvSYRShcrQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/pretty-error": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
     "ember-lifeline": "^7.0.0",
     "ember-modifier": "^4.2.0",
     "ember-popperjs": "^3.0.0",
+    "ember-template-imports": "^4.3.0",
     "ember-truth-helpers": "^4.0.0"
   },
   "devDependencies": {
@@ -109,7 +110,7 @@
     "ember-resolver": "^12.0.0",
     "ember-sinon": "^5.0.0",
     "ember-source": "^5.11.0",
-    "ember-template-lint": "^7.0.1",
+    "ember-template-lint": "^7.0.2",
     "ember-template-lint-plugin-prettier": "^5.0.0",
     "ember-try": "^3.0.0",
     "eslint": "^9.21.0",
@@ -126,6 +127,7 @@
     "lodash": "^4.17.21",
     "npm-run-all2": "^7.0.0",
     "prettier": "^3.5.3",
+    "prettier-plugin-ember-template-tag": "^2.0.5",
     "qunit": "^2.23.1",
     "qunit-dom": "^3.4.0",
     "sass": "^1.83.1",


### PR DESCRIPTION
## :christmas_tree: Problème

Jusqu'à présent, nous n'utilisions que le combo de fichier hbs/js pour la création de composants.
Cela nous contraignait pas mal pour les imports explicites d'utilitaires.

## :gift: Proposition

- Importer les packages nécessaires à l'utilisation des fichiers .gjs
- Réaliser une première transition de format de fichier pour un composant simple (ici PixTag)

## :santa: Pour tester

S'assurer que tout fonctionne toujours bien pour le composant [PixTag](https://ui-pr855.review.pix.fr/?path=/story/data-display-tag--tag).
