### PR TITLE
[BUGFIX] Réparer les problèmes liés à l'overflow du PixTable

### DIFF
--- a/addon/styles/_pix-table.scss
+++ b/addon/styles/_pix-table.scss
@@ -5,6 +5,10 @@
   min-width: 100%;
   overflow: auto;
 
+  @include breakpoints.device-is('desktop') {
+    overflow: unset;
+  }
+
   @extend %pix-body-s;
 
   &__clickable-row {


### PR DESCRIPTION
## :christmas_tree: Problème
Les tooltips et les menus flottants par-dessus PixTable (ex: titre de colonne avec une tooltip, ou bouton d'action) sont tronqués à cause de l'overflow : auto.

## :gift: Proposition
En attendant un fix plus général, permettre à l'utilisateur de voir correctement ses tooltips sur les tableaux en passant l'overflow en visible à partir de la taille desktop.

## :santa: Pour tester
Pull la branche et la lancer en local.
Vérifier que les tooltips à l'intérieur du tableau de la page dummy passent bien au-dessus du cadre, et que la taille en mobile du PixTable s'adapte bien.