### PR TITLE
[FEATURE] Supprimer l'utilisation de withBackground dans PixIconButton (PIX-17289)

### DIFF
--- a/addon/components/pix-icon-button.hbs
+++ b/addon/components/pix-icon-button.hbs
@@ -1,7 +1,6 @@
 <button
   type="button"
-  class="pix-icon-button pix-icon-button--{{this.size}}
-    {{if @withBackground ' pix-icon-button--background'}}"
+  class="pix-icon-button pix-icon-button--{{this.size}}"
   {{on "click" this.triggerAction}}
   ...attributes
 >

--- a/addon/styles/_pix-icon-button.scss
+++ b/addon/styles/_pix-icon-button.scss
@@ -46,10 +46,6 @@
     outline: 0;
   }
 
-  &--background {
-    background-color: var(--pix-neutral-20);
-  }
-
   &--small {
     width: 2rem;
     min-width: 2rem;

--- a/app/stories/pix-icon-button.mdx
+++ b/app/stories/pix-icon-button.mdx
@@ -19,12 +19,6 @@ Le bouton en version small. (big étant la valeur par défaut)
 
 <Story of={ComponentStories.size} height={60} />
 
-## With Background
-
-Le bouton avec le fond grisé.
-
-<Story of={ComponentStories.withBackground} height={60} />
-
 ## Disabled
 
 Exemple avec le bouton disabled
@@ -54,7 +48,6 @@ Bouton de fermeture
   @ariaLabel="L'action du bouton"
   @iconName="add"
   @triggerAction="{{triggerAction}}"
-  @withBackground="{{true}}"
 />
 ```
 
@@ -66,7 +59,6 @@ Bouton d'action
   @iconName="ChevronRight"
   @triggerAction="{{triggerAction}}"
   @size="small"
-  @withBackground="{{true}}"
 />
 ```
 

--- a/app/stories/pix-icon-button.stories.js
+++ b/app/stories/pix-icon-button.stories.js
@@ -32,15 +32,6 @@ export default {
       description: 'Fonction à appeler au clic du bouton',
       type: { required: true },
     },
-    withBackground: {
-      name: 'withBackground',
-      description: 'Affichage du fond grisé',
-      type: { name: 'boolean', required: false },
-      table: {
-        type: { summary: 'boolean' },
-        defaultValue: { summary: 'false' },
-      },
-    },
     size: {
       name: 'size',
       description: 'Size: `small`',
@@ -62,7 +53,6 @@ const Template = (args) => {
   @iconName={{this.icon}}
   @iconPrefix={{this.iconPrefix}}
   @triggerAction={{this.triggerAction}}
-  @withBackground={{this.withBackground}}
   @size={{this.size}}
   disabled={{this.disabled}}
   aria-disabled={{this.disabled}}
@@ -84,13 +74,6 @@ export const size = Template.bind({});
 size.args = {
   ...Default.args,
   size: 'small',
-  triggerAction,
-};
-
-export const withBackground = Template.bind({});
-withBackground.args = {
-  ...Default.args,
-  withBackground: true,
   triggerAction,
 };
 


### PR DESCRIPTION
## :boom: BREAKING_CHANGES
Suppression de l'argument `withBackground` dans le composant `PixIconButton`.

## :christmas_tree: Problème
L'utilisation de l'argument `withBackground` de PixIconButton est deprecated.

## :gift: Proposition
Enlever cet argument

## :star2: Remarques
RAS

## :santa: Pour tester
- Vérifier que la story `withBackground` (https://ui.pix.fr/?path=/story/actions-icon-button--with-background) n'apparaît plus et qu'il n'apparaît plus dans storybook.
- Vérifier qu'il n'y a plus d'utilisations de withBackground dans le code 😄 
