### PR TITLE
[TECH] Renommer la section PixBlock (PIX-16869)

### DIFF
--- a/app/stories/pix-block.stories.js
+++ b/app/stories/pix-block.stories.js
@@ -3,7 +3,7 @@ import { hbs } from 'ember-cli-htmlbars';
 import { VARIANTS } from '../../addon/helpers/variants.js';
 
 export default {
-  title: 'Other/Contenu',
+  title: 'Other/Block',
   argTypes: {
     variant: {
       name: 'variant',


### PR DESCRIPTION
## :christmas_tree: Problème
Sur storybook, la story correspondant à PixBlock s'appelle Other/Contenu. Cela pose des problèmes car le nommage est différent du composant ce qui rend difficile la recherche.

## :gift: Proposition
Renommer le titre de la section/story en Other/Block

## :star2: Remarques
RAS

## :santa: Pour tester
- Aller sur la RA, sur la section Other/Block : https://ui-pr859.review.pix.fr/?path=/docs/other-block--docs
- Vérifier que la section a miantenant le bon nommage 😄 
