### PR TITLE
[FEATURE] Ajouter un attribut qui permet de supprimer les padding du PixBlock(PIX-17352)

### DIFF
--- a/addon/components/pix-block.hbs
+++ b/addon/components/pix-block.hbs
@@ -1,4 +1,7 @@
-<div class="pix-block {{concat 'pix-block--' this.variant}}" ...attributes>
+<div
+  class="pix-block {{concat 'pix-block--' this.variant}}{{if @condensed ' pix-block--condensed'}}"
+  ...attributes
+>
 
   {{yield}}
 

--- a/addon/styles/_pix-block.scss
+++ b/addon/styles/_pix-block.scss
@@ -24,4 +24,8 @@
     padding: var(--pix-spacing-3x);
     border: solid 1px var(--pix-primary-100);
   }
+
+  &--condensed {
+    padding: 0;
+  }
 }

--- a/app/stories/pix-block.stories.js
+++ b/app/stories/pix-block.stories.js
@@ -22,14 +22,20 @@ export default {
         required: false,
       },
     },
+    condensed: {
+      name: 'condensed',
+      description: 'Permet d‘enlever le padding',
+      control: { type: 'boolean' },
+    },
   },
 };
 
 const Template = (args) => {
   return {
-    template: hbs`<PixBlock @variant={{this.variant}}>
-      {{this.information}}
-</PixBlock>`,
+    template: hbs`
+      <PixBlock @variant={{this.variant}} @condensed={{this.condensed}}>
+        {{this.information}}
+      </PixBlock>`,
     context: args,
   };
 };
@@ -56,4 +62,11 @@ export const admin = Template.bind({});
 admin.args = {
   variant: 'admin',
   information: 'Pour Pix Admin',
+};
+
+export const condensed = Template.bind({});
+condensed.args = {
+  variant: 'primary',
+  condensed: true,
+  information: 'Primary Condensed',
 };

--- a/tests/integration/components/pix-block-test.js
+++ b/tests/integration/components/pix-block-test.js
@@ -11,7 +11,7 @@ module('Integration | Component | pix-block', function (hooks) {
 
   test('it renders the PixBlock', async function (assert) {
     // when
-    await render(hbs`<PixBlock @variant='certif'>
+    await render(hbs`<PixBlock @variant='certif' @condensed={{false}}>
   Je suis un beau bloc
 </PixBlock>`);
     const blockElement = this.element.querySelector(BLOCK_SELECTOR);
@@ -53,6 +53,33 @@ module('Integration | Component | pix-block', function (hooks) {
         warnStub.calledWithExactly(
           'WARNING: PixBlock: @variant "PIX APP" should be primary, orga, certif, admin',
         ),
+      );
+    });
+  });
+
+  module('when @condensed parameter is true', function (hooks) {
+    let warnStub;
+
+    hooks.beforeEach(function () {
+      warnStub = sinon.stub(console, 'warn');
+    });
+
+    hooks.afterEach(function () {
+      warnStub.restore();
+    });
+
+    test('it renders the condensed PixBlock', async function (assert) {
+      // when
+      await render(hbs`<PixBlock @condensed={{true}}>
+  Je suis un beau bloc
+</PixBlock>`);
+      const blockElement = this.element.querySelector(BLOCK_SELECTOR);
+
+      // then
+      assert.contains('Je suis un beau bloc');
+      assert.strictEqual(
+        blockElement.className,
+        'pix-block pix-block--primary pix-block--condensed',
       );
     });
   });


### PR DESCRIPTION
## :christmas_tree: Problème
On ne veut pas de padding dans certains PixBlock existant (ex. dans PixApp, les carte de contenus formatifs utilisent PixBlock et ne veulent pas de padding)

## :gift: Proposition
Ajouter un attribut @condensed , non requis. qui permet de supprimer le padding (padding à 0) du PixBlock

## :star2: Remarques
RAS

## :santa: Pour tester
- Ouvrir Storybook
- Afficher la story "Condensed" pour voir le rendu du pixBlock sans padding.
