### PR TITLE
[FEATURE] Ajouter le type tag au composant pix-table-column (PIX-16963)

### DIFF
--- a/addon/components/pix-table-column.js
+++ b/addon/components/pix-table-column.js
@@ -75,7 +75,7 @@ export default class PixTableColumn extends Component {
   }
 
   get typeClass() {
-    const correctTypes = ['number', 'text', 'checkbox'];
+    const correctTypes = ['number', 'text', 'checkbox', 'tag'];
     warn('PixTableColumn: you need to provide a valid type', correctTypes.includes(this.type), {
       id: 'pix-ui.table-column.type.incorrect',
     });
@@ -84,6 +84,9 @@ export default class PixTableColumn extends Component {
     }
     if (this.args.type === 'checkbox') {
       return `pix-table-column--checkbox`;
+    }
+    if (this.args.type === 'tag') {
+      return `pix-table-column--tag`;
     }
     return '';
   }

--- a/addon/styles/_pix-table-column.scss
+++ b/addon/styles/_pix-table-column.scss
@@ -1,20 +1,15 @@
-.pix-table-column {
-  &--number {
-    text-align: left;
-  }
+td.pix-table-column {
+    &--number {
+      text-align: left;
+    }
 
-  &--checkbox {
-    width: 3.25rem;
-  }
-}
+    &--checkbox {
+      width: 3.25rem;
+    }
 
-.pix-table .pix-table-column--tag {
-  padding-top: 0.875rem;
-  padding-bottom: 0.875rem;
-  text-align: left;
-
-  &--condensed {
-    padding-top: 0.375rem;
-    padding-bottom: 0.375rem;
+    &--tag {
+      padding-top: 0.875rem;
+      padding-bottom: 0.875rem;
+      text-align: left;
+    }
   }
-}

--- a/addon/styles/_pix-table-column.scss
+++ b/addon/styles/_pix-table-column.scss
@@ -7,3 +7,14 @@
     width: 3.25rem;
   }
 }
+
+.pix-table .pix-table-column--tag {
+  padding-top: 0.875rem;
+  padding-bottom: 0.875rem;
+  text-align: left;
+
+  &--condensed {
+    padding-top: 0.375rem;
+    padding-bottom: 0.375rem;
+  }
+}

--- a/addon/styles/_pix-table.scss
+++ b/addon/styles/_pix-table.scss
@@ -42,8 +42,9 @@
   table {
     width: 100%;
     border-collapse: collapse;
+  }
 
-    tbody > tr:nth-of-type(even):not(.pix-table__clickable-row:hover, .pix-table__clickable-row:focus, .pix-table__clickable-row:active) {
+   tbody > tr:nth-of-type(even):not(.pix-table__clickable-row:hover, .pix-table__clickable-row:focus, .pix-table__clickable-row:active) {
       background-color: rgba(var(--pix-neutral-20-inline), 0.80);
     }
 
@@ -93,13 +94,15 @@
         border-radius: 0 var(--pix-spacing-2x) var(--pix-spacing-2x) 0;
       }
     }
-  }
 
   &--condensed {
-    table {
-      th, td {
-        padding: .5rem var(--pix-spacing-4x);
-      }
+    th, td {
+      padding: .5rem var(--pix-spacing-4x);
+    }
+
+    td.pix-table-column--tag {
+        padding-top: 0.375rem;
+        padding-bottom: 0.375rem;
     }
   }
 }

--- a/app/stories/pix-table-column.mdx
+++ b/app/stories/pix-table-column.mdx
@@ -82,6 +82,9 @@ Une colonne d'un [PixTable](/docs/data-display-table--docs), gère l'affichage d
 </PixTable>
 ```
 
+## Variant tag
+<Story of={ComponentStories.Tag} height={400} />
+
 ## Arguments
 
 <ArgTypes />

--- a/app/stories/pix-table-column.stories.js
+++ b/app/stories/pix-table-column.stories.js
@@ -49,12 +49,12 @@ export default {
       defaultValue: {
         summary: 'text',
       },
-      options: ['text', 'number', 'checkbox'],
+      options: ['text', 'number', 'checkbox', 'tag'],
       control: {
         type: 'select',
       },
       type: {
-        name: '"text" | "number"',
+        name: '"text" | "number" | "tag"',
         description: 'Defini le style avec lequel nous afficherons la colonne',
       },
     },

--- a/app/stories/pix-table-column.stories.js
+++ b/app/stories/pix-table-column.stories.js
@@ -205,3 +205,33 @@ Sorted.args = {
   ariaLabelSortAsc: 'click pour trier en ordre ascendant',
   ariaLabelSortDesc: 'click pour trier en ordre descendant',
 };
+
+const templateTag = (args) => {
+  return {
+    template: hbs`<PixTable @data={{this.data}} @caption={{this.caption}}>
+  <:columns as |row context|>
+    <PixTableColumn @context={{context}} @type='tag'>
+      <:header>
+        tag
+      </:header>
+      <:cell>
+        <PixTag>{{row.tag}}</PixTag>
+      </:cell>
+    </PixTableColumn>
+  </:columns>
+</PixTable>`,
+    context: args,
+  };
+};
+export const Tag = templateTag.bind({});
+Tag.args = {
+  caption: 'Description du tableau',
+  data: [
+    {
+      tag: 'tag1',
+    },
+    {
+      tag: 'tag2',
+    },
+  ],
+};

--- a/app/stories/pix-table-column.stories.js
+++ b/app/stories/pix-table-column.stories.js
@@ -122,6 +122,14 @@ const Template = (args) => {
         {{row.age}}
       </:cell>
     </PixTableColumn>
+    <PixTableColumn @context={{context}} @type='tag'>
+      <:header>
+        Hobby
+      </:header>
+      <:cell>
+        <PixTag>{{row.hobby}}</PixTag>
+      </:cell>
+    </PixTableColumn>
   </:columns>
 </PixTable>`,
     context: args,
@@ -136,11 +144,13 @@ Default.args = {
       id: '1',
       name: 'jean',
       age: 15,
+      hobby: 'Couture',
     },
     {
       id: '2',
       name: 'brian',
       age: 25,
+      hobby: 'Tricot',
     },
   ],
 };

--- a/app/stories/pix-table.stories.js
+++ b/app/stories/pix-table.stories.js
@@ -96,6 +96,14 @@ const Template = (args) => {
         {{row.age}}
       </:cell>
     </PixTableColumn>
+    <PixTableColumn @context={{context}} @type='tag'>
+      <:header>
+        tag
+      </:header>
+      <:cell>
+        <PixTag>{{row.tag}}</PixTag>
+      </:cell>
+    </PixTableColumn>
   </:columns>
 </PixTable>
 {{! template-lint-disable no-forbidden-elements}}
@@ -115,11 +123,13 @@ Default.args = {
       name: 'jean',
       description: 'fort au jungle speed',
       age: 15,
+      tag: 'tag1',
     },
     {
       name: 'brian',
       description: 'travail au peach pit',
       age: 25,
+      tag: 'tag2',
     },
   ],
   onNameSort: () => {

--- a/tests/dummy/app/templates/table-page.hbs
+++ b/tests/dummy/app/templates/table-page.hbs
@@ -70,6 +70,16 @@
         <PixIcon @name="info" @title={{concat row.name " a " row.age " ans"}} />
       </:cell>
     </PixTableColumn>
+    <PixTableColumn @context={{context}} @type="tag">
+      <:header>
+        Tag
+      </:header>
+      <:cell>
+        <PixTag>
+          Un tag
+        </PixTag>
+      </:cell>
+    </PixTableColumn>
   </:columns>
 </PixTable>
 {{! template-lint-disable no-forbidden-elements }}


### PR DESCRIPTION
## :christmas_tree: Problème
On souhaite ajouter un type dans le compososant pix-table-column. Ce type qui est tag, servira à mettre des pix-tag dans le tableau.

## :gift: Proposition
Ajouter le type tag avec le css demandé.

## :star2: Remarques
RAS

## :santa: Pour tester
- Se rendre sur la page de stories,
- Aller sur la story de PixTableColumn,
- Constater qu'un élément tag est présent.