### PR TITLE
[BUGFIX] Correction de la couleur du PixOverlay (PIX-17528)

### DIFF
--- a/addon/styles/_pix-overlay.scss
+++ b/addon/styles/_pix-overlay.scss
@@ -3,7 +3,7 @@
   z-index: 1000;
   inset: 0;
   overflow-y: auto;
-  background-color: rgba(var(--pix-primary-700-inline), 0.3);
+  background-color: rgba(var(--pix-neutral-800-inline), 0.4);
   transition: all 0.3s ease-in-out;
 
   &--hidden {


### PR DESCRIPTION
## :christmas_tree: Problème
C'est violet, et on n'en veut pas

## :gift: Proposition
Gris is the new Violet

## :star2: Remarques
RAS

## :santa: Pour tester
Vérifier que l'overlay est bien neutral