### PR TITLE
[BUGFIX] Afficher les catégories du `PixSelect` quand les @options sont asynchrones (PIX-NOTIKÉ)

### DIFF
--- a/addon/components/pix-select-list.js
+++ b/addon/components/pix-select-list.js
@@ -1,9 +1,7 @@
 import Component from '@glimmer/component';
 
 export default class PixSelectList extends Component {
-  constructor(...args) {
-    super(...args);
-
+  get displayCategory() {
     const categories = [];
 
     this.args.options.forEach((element) => {
@@ -11,7 +9,7 @@ export default class PixSelectList extends Component {
         categories.push(element.category);
       }
     });
-    this.displayCategory = categories.length > 0;
+    return categories.length > 0;
   }
 
   get isDefaultOptionHidden() {


### PR DESCRIPTION
## :christmas_tree: Problème
Nous voulons afficher les catégories du PixSelect sur des données qui ne sont pas encore chargées au premier rendu du composant PixSelect.
Le comportement actuel fait les catégories ne s'affichent pas si la donnée initiale ne contient pas d'option avec une catégorie.

## :gift: Proposition
Rendre réactif le booléen `displayCategory`.

## :star2: Remarques
Est-ce que certaines applications ont déjà rencontré ce comportement ?

## :santa: Pour tester
Tests OK
