### PR TITLE
[FEATURE] Corriger le soucis de scroll horizontal sur les app (PIX-17808)

### DIFF
--- a/addon/styles/_pix-app-layout.scss
+++ b/addon/styles/_pix-app-layout.scss
@@ -42,7 +42,7 @@
 
   &__main, &__footer {
     width: 100%;
-    max-width: 93rem;
+    max-width: min(calc(100vw - 2 * var(--pix-spacing-6x)), 93rem);
     margin: 0 auto;
     padding: 0 var(--pix-spacing-6x);
 


### PR DESCRIPTION
## :christmas_tree: Problème
scroll horizontal par exemple sur Pix Orga quand contenu trop large
## :gift: Proposition
mieux calculer le max-width de la width

## :star2: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :santa: Pour tester
- installer cette version de pixUI en local sur pix Orga
- aller sur la page d'analyse d'une campagne avec un nom mega long
- 🎉 ça marche
