### PR TITLE
[TECH] Ajout d'une méthode dans le PixToast service pour supprimer toutes les notifications (PIX-17822)

### DIFF
--- a/addon/services/pix-toast.js
+++ b/addon/services/pix-toast.js
@@ -1,14 +1,18 @@
 import { warn } from '@ember/debug';
 import Service from '@ember/service';
 import { tracked } from '@glimmer/tracking';
-
+/**
+ * @export
+ * @class ToastService
+ * @extends {Service}
+ */
 export default class ToastService extends Service {
   @tracked content = [];
 
   /**
    * Creates and returns a new toast notification.
-   * @param{string} message content to display
-   * @param{'error' | 'information' | 'success' | 'warning'} type type of toast notification
+   * @param {string} message content to display
+   * @param {'error' | 'information' | 'success' | 'warning'} type type of toast notification
    * @returns {EmberObject | void}
    */
   addNotification({ message, type }) {
@@ -36,7 +40,7 @@ export default class ToastService extends Service {
 
   /**
    * Check if toast already exist in content array
-   * @param{{message: string, type: string}} toast
+   * @param {{message: string, type: string}} toast
    * @returns {boolean}
    */
   exists(toast) {
@@ -59,7 +63,7 @@ export default class ToastService extends Service {
 
   /**
    * Creates and returns a new success toast notification.
-   * @param{string} message content to display
+   * @param {string} message content to display
    * @returns {EmberObject | void}
    */
   sendSuccessNotification({ message }) {
@@ -71,7 +75,7 @@ export default class ToastService extends Service {
 
   /**
    * Creates and returns a new information toast notification.
-   * @param{string} message content to display
+   * @param {string} message content to display
    * @returns {EmberObject | void}
    */
   sendInformationNotification({ message }) {
@@ -83,7 +87,7 @@ export default class ToastService extends Service {
 
   /**
    * Creates and returns a new warning toast notification.
-   * @param{string} message content to display
+   * @param {string} message content to display
    * @returns {EmberObject | void}
    */
   sendWarningNotification({ message }) {
@@ -95,8 +99,8 @@ export default class ToastService extends Service {
 
   /**
    * Remove toast notification from content list
-   * @param{{message: string, type: string}} toast toast to remove
-   * @returns {EmberObject | void}
+   * @param {{message: string, type: string}} toast toast to remove
+   * @returns {void}
    */
   removeNotification(toast) {
     if (!toast) return;
@@ -104,5 +108,16 @@ export default class ToastService extends Service {
     this.content = this.content.filter(
       (value) => toast.message !== value.message || toast.type !== value.type,
     );
+  }
+
+  /**
+   * Remove all toast notification from content list
+   * @param {void}
+   * @returns {void}
+   */
+  removeAllNotifications() {
+    if (this.content.length === 0) return;
+
+    this.content = [];
   }
 }

--- a/tests/unit/services/pix-toast-test.js
+++ b/tests/unit/services/pix-toast-test.js
@@ -266,4 +266,38 @@ module('Unit | Service | toast', function (hooks) {
       });
     });
   });
+
+  module('#removeAllNotifications', function () {
+    test('Removes all notification from content array', function (assert) {
+      // given
+      const message = 'message';
+      const notificationToBeRemove = {
+        message,
+        type: 'success',
+      };
+      const errorNotification = {
+        message,
+        type: 'error',
+      };
+      const informationNotification = {
+        message,
+        type: 'information',
+      };
+      const warningNotification = {
+        message,
+        type: 'warning',
+      };
+
+      toastService.addNotification(notificationToBeRemove);
+      toastService.addNotification(errorNotification);
+      toastService.addNotification(informationNotification);
+      toastService.addNotification(warningNotification);
+
+      // when
+      toastService.removeAllNotifications();
+
+      // then
+      assert.strictEqual(toastService.content.length, 0);
+    });
+  });
 });


### PR DESCRIPTION
## :christmas_tree: Problème
Lorsque l'on change de page sur une application, nous conservons tout les toast précedemment définit

## :gift: Proposition
Ajouter une méthode pour supprimer tout les toast que nous pourrons appeler dans le router sur le onRouteChange. et voilà

## :star2: Remarques
RAS

## :santa: Pour tester
CI au vert. 