### PR TITLE
[BUGFIX] Corriger l'erreur d'accessibilité sur le lien externe de la PixBannerAlert (PIX-A11Y)

### DIFF
--- a/addon/components/pix-banner-alert.hbs
+++ b/addon/components/pix-banner-alert.hbs
@@ -17,7 +17,7 @@
             rel="noopener noreferrer"
           >
             {{@actionLabel}}
-            <PixIcon @name="openNew" class="external-link" />
+            <PixIcon @name="openNew" class="external-link" @ariaHidden={{true}} />
           </a>
         {{else}}
           <LinkTo class="pix-banner-alert__action" @route={{@actionUrl}}>{{@actionLabel}}</LinkTo>


### PR DESCRIPTION
## :christmas_tree: Problème
Axe retourne une erreur lorsqu'un svg ne porte pas d'information, il doit être caché. ce qui n'est pas le cas ici

## :gift: Proposition
ajouter le aria-hidden

## :star2: Remarques
RAS

## :santa: Pour tester
CI au vert. 