### PR TITLE
[FEATURE] Ajout d'un argument `isDisabled` sur PixMultiSelect

### DIFF
--- a/addon/components/pix-multi-select.hbs
+++ b/addon/components/pix-multi-select.hbs
@@ -38,6 +38,7 @@
           aria-expanded={{this.isAriaExpanded}}
           aria-controls={{this.listId}}
           aria-haspopup="menu"
+          disabled={{@isDisabled}}
         />
       </span>
     {{else}}
@@ -49,6 +50,7 @@
         aria-controls={{this.listId}}
         aria-haspopup="menu"
         class={{this.mainInputClassName}}
+        disabled={{@isDisabled}}
         {{on "click" this.toggleDropDown}}
       >
         {{#if (has-block "placeholder")}}

--- a/app/stories/pix-multi-select.mdx
+++ b/app/stories/pix-multi-select.mdx
@@ -32,6 +32,10 @@ Si vous utilisez le `PixMultiSelect` sans vouloir afficher le label, il faudra r
 
 <Story of={ComponentStories.multiSelectWithYield} height={330} />
 
+## Disabled
+
+<Story of={ComponentStories.multiSelectDisabled} height={330} />
+
 ## Usage
 
 ```html
@@ -44,6 +48,7 @@ Si vous utilisez le `PixMultiSelect` sans vouloir afficher le label, il faudra r
   @emptyMessage="{{emptyMessage}}"
   @className="{{className}}"
   @options="{{options}}"
+  @isDisabled="{{isDisabled}}"
 >
   <:label>{{label}}</:label>
   <:default as |option|>{{option.label}}</:default>

--- a/app/stories/pix-multi-select.stories.js
+++ b/app/stories/pix-multi-select.stories.js
@@ -26,6 +26,7 @@ export default {
   @strictSearch={{this.strictSearch}}
   @values={{this.values}}
   @options={{this.options}}
+  @isDisabled={{this.isDisabled}}
 >
   <:label>{{this.label}}</:label>
   <:default as |option|>{{option.label}}</:default>
@@ -166,6 +167,11 @@ export default {
       },
       control: { type: 'boolean' },
     },
+    isDisabled: {
+      name: 'isDisabled',
+      description: 'Permet de désactiver le champ',
+      type: { name: 'boolean', required: false },
+    },
   },
 };
 
@@ -207,6 +213,7 @@ export const multiSelectWithChildComponent = (args) => {
   @subLabel={{this.subLabel}}
   @inlineLabel={{this.inlineLabel}}
   @screenReaderOnly={{this.screenReaderOnly}}
+  @isDisabled={{this.isDisabled}}
 >
   <:label>{{this.label}}</:label>
   <:default as |option|>
@@ -256,6 +263,26 @@ export const multiSelectWithId = {
     label: undefined,
     id: 'custom',
     isSearchable: false,
+  },
+};
+
+export const multiSelectDisabled = {
+  args: {
+    ...Default.args,
+    label: undefined,
+    id: 'custom',
+    isSearchable: false,
+    isDisabled: true,
+  },
+};
+
+export const multiSelectSearchableDisabled = {
+  args: {
+    ...Default.args,
+    isSearchable: true,
+    strictSearch: true,
+    emptyMessage: 'Aucune option trouvée',
+    isDisabled: true,
   },
 };
 

--- a/tests/integration/components/pix-multi-select-test.js
+++ b/tests/integration/components/pix-multi-select-test.js
@@ -844,6 +844,37 @@ module('Integration | Component | multi-select', function (hooks) {
       assert.strictEqual(listElement2[0].labels[0].innerText.trim(), 'Tomate');
       assert.strictEqual(listElement2[2].labels[0].innerText.trim(), 'Oignon');
     });
+    test('should be disabled', async function (assert) {
+      // given
+      this.label = 'multiSelectLabel';
+      this.options = DEFAULT_OPTIONS;
+      this.values = ['2'];
+      this.onChange = () => {};
+      this.emptyMessage = 'no result';
+      this.placeholder = 'MultiSelectTest';
+      this.id = 'id-MultiSelectTest';
+      this.isSearchable = true;
+      this.placeholder = 'Placeholder test';
+      this.isDisabled = true;
+
+      // when
+      const screen = await render(hbs`<PixMultiSelect
+  @isSearchable={{this.isSearchable}}
+  @values={{this.values}}
+  @onChange={{this.onChange}}
+  @placeholder={{this.placeholder}}
+  @id={{this.id}}
+  @emptyMessage={{this.emptyMessage}}
+  @showOptionsOnInput={{true}}
+  @options={{this.options}}
+  @isDisabled={{this.isDisabled}}
+>
+  <:label>{{this.label}}</:label>
+  <:default as |option|>{{option.label}}</:default>
+</PixMultiSelect>`);
+      // then
+      assert.true(screen.queryByRole('textbox').disabled);
+    });
   });
 
   module('custom class name', function () {
@@ -903,6 +934,38 @@ module('Integration | Component | multi-select', function (hooks) {
 
       // then
       assert.dom(screen.getByLabelText('multiSelectLabel')).isFocused();
+    });
+  });
+
+  module('disabled', function () {
+    test('it renders a disabled select', async function (assert) {
+      // given
+      this.label = 'multiSelectLabel';
+      this.options = DEFAULT_OPTIONS;
+      this.values = [];
+      this.onChange = () => {};
+      this.emptyMessage = 'no result';
+      this.placeholder = 'MultiSelectTest';
+      this.id = 'id-MultiSelectTest';
+      this.isDisabled = true;
+
+      // when
+      const screen = await render(hbs`<PixMultiSelect
+  @values={{this.values}}
+  @onChange={{this.onChange}}
+  @placeholder={{this.placeholder}}
+  @id={{this.id}}
+  @emptyMessage={{this.emptyMessage}}
+  @options={{this.options}}
+  @isDisabled={{this.isDisabled}}
+>
+  <:label>{{this.label}}</:label>
+  <:default as |option|>{{option.label}}</:default>
+
+</PixMultiSelect>`);
+
+      // then
+      assert.true(screen.queryByRole('button').disabled);
     });
   });
 });


### PR DESCRIPTION
## :christmas_tree: Problème
`PixMultiSelect` ne peut pas être disabled quand on l'utilise dans une appli

## :gift: Proposition
Ajout de `isDisabled`, déjà présent sur d'autres input

## :star2: Remarques
RAS

## :santa: Pour tester
- Composant SB OK
- Tests OK