### PR TITLE
[FEATURE] Ajouter le variant tagDate au composant PixTableColumn (PIX-16964)

### DIFF
--- a/addon/components/pix-table-column.hbs
+++ b/addon/components/pix-table-column.hbs
@@ -20,6 +20,9 @@
   {{else}}
     <td class={{this.typeClass}} ...attributes>
       {{yield to="cell"}}
+      {{#if (has-block "subCell")}}
+        <p>{{yield to="subCell"}}</p>
+      {{/if}}
     </td>
   {{/if}}
 {{/if}}

--- a/addon/components/pix-table-column.js
+++ b/addon/components/pix-table-column.js
@@ -75,7 +75,7 @@ export default class PixTableColumn extends Component {
   }
 
   get typeClass() {
-    const correctTypes = ['number', 'text', 'checkbox', 'tag'];
+    const correctTypes = ['number', 'text', 'checkbox', 'tag', 'tagDate'];
     warn('PixTableColumn: you need to provide a valid type', correctTypes.includes(this.type), {
       id: 'pix-ui.table-column.type.incorrect',
     });
@@ -87,6 +87,9 @@ export default class PixTableColumn extends Component {
     }
     if (this.args.type === 'tag') {
       return `pix-table-column--tag`;
+    }
+    if (this.args.type === 'tagDate') {
+      return `pix-table-column--tag-date`;
     }
     return '';
   }

--- a/addon/styles/_pix-table-column.scss
+++ b/addon/styles/_pix-table-column.scss
@@ -1,3 +1,5 @@
+@use "pix-design-tokens/typography";
+
 td.pix-table-column {
     &--number {
       text-align: left;
@@ -12,4 +14,21 @@ td.pix-table-column {
       padding-bottom: 0.875rem;
       text-align: left;
     }
+
+  &--tag-date {
+    padding-top: var(--pix-spacing-1x);
+    padding-bottom: var(--pix-spacing-1x);
+
+    .pix-tag {
+      text-align: left;
+    }
+
+    p {
+      @extend %pix-body-xs;
+
+      margin-top: 0.125rem;
+      color: var(--pix-neutral-900);
+      text-align: center;
+    }
+  }
   }

--- a/app/stories/pix-table-column.mdx
+++ b/app/stories/pix-table-column.mdx
@@ -85,6 +85,9 @@ Une colonne d'un [PixTable](/docs/data-display-table--docs), gère l'affichage d
 ## Variant tag
 <Story of={ComponentStories.Tag} height={400} />
 
+## Variant tag + date
+<Story of={ComponentStories.TagDate} height={400} />
+
 ## Arguments
 
 <ArgTypes />

--- a/app/stories/pix-table-column.stories.js
+++ b/app/stories/pix-table-column.stories.js
@@ -49,12 +49,12 @@ export default {
       defaultValue: {
         summary: 'text',
       },
-      options: ['text', 'number', 'checkbox', 'tag'],
+      options: ['text', 'number', 'checkbox', 'tag', 'tagDate'],
       control: {
         type: 'select',
       },
       type: {
-        name: '"text" | "number" | "tag"',
+        name: '"text" | "number" | "tag" | "tagDate"',
         description: 'Defini le style avec lequel nous afficherons la colonne',
       },
     },
@@ -242,6 +242,40 @@ Tag.args = {
     },
     {
       tag: 'tag2',
+    },
+  ],
+};
+
+// TODO sépare
+const templateTagDate = (args) => {
+  return {
+    template: hbs`<PixTable @data={{this.data}} @caption={{this.caption}}>
+  <:columns as |row context|>
+    <PixTableColumn @context={{context}} @type='tagDate'>
+      <:header>
+        tag + date
+      </:header>
+      <:cell>
+        <PixTag>{{row.tag}}</PixTag>
+          <subCell>{{row.date}}</subCell>
+      </:cell>
+    </PixTableColumn>
+  </:columns>
+</PixTable>`,
+    context: args,
+  };
+};
+export const TagDate = templateTagDate.bind({});
+TagDate.args = {
+  caption: 'Description du tableau',
+  data: [
+    {
+      tag: 'tag1',
+      date: '01/01/1970',
+    },
+    {
+      tag: 'tag2',
+      date: '02/02/1980',
     },
   ],
 };

--- a/app/stories/pix-table-column.stories.js
+++ b/app/stories/pix-table-column.stories.js
@@ -257,8 +257,8 @@ const templateTagDate = (args) => {
       </:header>
       <:cell>
         <PixTag>{{row.tag}}</PixTag>
-          <subCell>{{row.date}}</subCell>
       </:cell>
+      <:subCell>{{row.date}}</:subCell>
     </PixTableColumn>
   </:columns>
 </PixTable>`,

--- a/tests/dummy/app/templates/table-page.hbs
+++ b/tests/dummy/app/templates/table-page.hbs
@@ -88,8 +88,8 @@
         <PixTag>
           Un tag
         </PixTag>
-        <subCell>01/01/1970</subCell>
       </:cell>
+      <:subCell>01/01/1970</:subCell>
     </PixTableColumn>
   </:columns>
 </PixTable>

--- a/tests/dummy/app/templates/table-page.hbs
+++ b/tests/dummy/app/templates/table-page.hbs
@@ -80,6 +80,17 @@
         </PixTag>
       </:cell>
     </PixTableColumn>
+    <PixTableColumn @context={{context}} @type="tagDate">
+      <:header>
+        Tag + date
+      </:header>
+      <:cell>
+        <PixTag>
+          Un tag
+        </PixTag>
+        <subCell>01/01/1970</subCell>
+      </:cell>
+    </PixTableColumn>
   </:columns>
 </PixTable>
 {{! template-lint-disable no-forbidden-elements }}


### PR DESCRIPTION
## :christmas_tree: Problème
On souhaite supporter un nouveau type tagDate.

## :gift: Proposition
Ajouter le support du type et le style demandé.

## :star2: Remarques
RAS.

## :santa: Pour tester
- Se rendre sur le storybook,
- Aller sur le composant PixTableColumn,
- Constater que le variant tagDate est prrésent et respecte le format attendu dans le ticket.