### PR TITLE
[BUGFIX] Supprimer l'attribut disabled des PixButton (PIX-8819)

### DIFF
--- a/addon/components/pix-button.hbs
+++ b/addon/components/pix-button.hbs
@@ -2,7 +2,6 @@
   type={{this.type}}
   class={{this.className}}
   {{on "click" this.triggerAction}}
-  disabled={{this.isDisabled}}
   aria-disabled="{{this.isDisabled}}"
   ...attributes
 >

--- a/addon/components/pix-button.js
+++ b/addon/components/pix-button.js
@@ -1,15 +1,43 @@
+import { warn } from '@ember/debug';
 import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
 
 import PixButtonBase from './pix-button-base';
-
 export default class PixButton extends PixButtonBase {
   text = 'pix-button';
   defaultModel = [];
 
   @tracked isTriggering = false;
 
+  constructor(...args) {
+    super(...args);
+
+    const isTriggerFunctionExistOnTypedifferentOfSubmit =
+      this.args.type !== 'submit' && typeof this.args.triggerAction === 'function';
+    const isTriggerFunctionExistOrNullOnTypeSubmit =
+      this.args.type === 'submit' &&
+      (typeof this.args.triggerAction === 'function' ||
+        this.args.triggerAction === undefined ||
+        this.args.triggerAction === null);
+
+    warn(
+      'PixButton: @triggerAction attribute should be a function',
+      isTriggerFunctionExistOnTypedifferentOfSubmit || isTriggerFunctionExistOrNullOnTypeSubmit,
+      {
+        id: 'pix-ui.button.action.not-function',
+      },
+    );
+  }
+
   get isLoading() {
+    warn(
+      'PixButton: @isLoading attribute should be a boolean.',
+      [true, false, undefined, null].includes(this.args.isLoading),
+      {
+        id: 'pix-ui.button.is-loading.not-boolean',
+      },
+    );
+
     return this.args.isLoading || this.isTriggering;
   }
 
@@ -22,7 +50,15 @@ export default class PixButton extends PixButtonBase {
   }
 
   get isDisabled() {
-    return this.isLoading || this.args.isDisabled;
+    warn(
+      'PixButton: @isDisabled attribute should be a boolean.',
+      [true, false, undefined, null].includes(this.args.isDisabled),
+      {
+        id: 'pix-ui.button.is-disabled.not-boolean',
+      },
+    );
+
+    return this.isLoading || this.args.isDisabled ? 'true' : null;
   }
 
   get className() {
@@ -32,9 +68,7 @@ export default class PixButton extends PixButtonBase {
   @action
   async triggerAction(params) {
     if (this.isDisabled || (this.type === 'submit' && !this.args.triggerAction)) return;
-    if (!this.args.triggerAction) {
-      throw new Error('@triggerAction params is required for PixButton !');
-    }
+
     try {
       this.isTriggering = true;
       await this.args.triggerAction(params);

--- a/tests/integration/components/pix-button-test.js
+++ b/tests/integration/components/pix-button-test.js
@@ -1,41 +1,32 @@
 import { render } from '@1024pix/ember-testing-library';
+import { click } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { setupRenderingTest } from 'ember-qunit';
 import { module, test } from 'qunit';
 import sinon from 'sinon';
 
-import clickByLabel from '../../helpers/click-by-label';
-
-module('Integration | Component | button', function (hooks) {
+module('Integration | Component | PixButton', function (hooks) {
   setupRenderingTest(hooks);
-
   const COMPONENT_SELECTOR = '.pix-button';
 
   test('it renders the default PixButton', async function (assert) {
     // when
-    await render(hbs`<PixButton>
+    const screen = await render(hbs`<PixButton>
   Mon bouton
 </PixButton>`);
 
     // then
-    const componentElement = this.element.querySelector(COMPONENT_SELECTOR);
-    assert.contains('Mon bouton');
-    // TODO: Fix this the next time the file is edited.
-    // eslint-disable-next-line qunit/no-assert-equal
-    assert.equal(componentElement.type, 'button');
+    assert.ok(screen.getByRole('button', { name: 'Mon bouton' }));
   });
 
   test('it renders the PixButton component with the given type', async function (assert) {
     // when
-    await render(hbs`<PixButton @type='submit'>
+    const screen = await render(hbs`<PixButton @type='submit'>
   Mon bouton
 </PixButton>`);
 
     // then
-    const componentElement = this.element.querySelector(COMPONENT_SELECTOR);
-    // TODO: Fix this the next time the file is edited.
-    // eslint-disable-next-line qunit/no-assert-equal
-    assert.equal(componentElement.type, 'submit');
+    assert.dom(screen.getByRole('button', { name: 'Mon bouton' })).hasAttribute('type', 'submit');
   });
 
   test('it renders the PixButton component with isDisabled attribute', async function (assert) {
@@ -46,13 +37,13 @@ module('Integration | Component | button', function (hooks) {
     });
 
     //when
-    await render(hbs`<PixButton @isDisabled={{true}} @triggerAction={{this.triggerAction}} aria-label='button label'>
+    const screen =
+      await render(hbs`<PixButton @isDisabled={{true}} @triggerAction={{this.triggerAction}}>
   Mon bouton
 </PixButton>`);
 
     // then
-    const componentElement = this.element.querySelector(COMPONENT_SELECTOR);
-    assert.true(componentElement.disabled);
+    assert.dom(screen.getByText('Mon bouton')).hasAttribute('aria-disabled', 'true');
   });
 
   test('it should call the action', async function (assert) {
@@ -63,25 +54,25 @@ module('Integration | Component | button', function (hooks) {
     });
 
     //when
-    await render(
-      hbs`<PixButton @triggerAction={{this.triggerAction}} aria-label='button label' />`,
+    const screen = await render(
+      hbs`<PixButton @triggerAction={{this.triggerAction}}>Mon bouton</PixButton>`,
     );
 
-    await clickByLabel('button label');
+    await click(screen.getByRole('button', { name: 'Mon bouton' }));
 
     // then
-    const componentElement = this.element.querySelector(COMPONENT_SELECTOR);
     assert.strictEqual(this.count, 2);
-    assert.false(componentElement.disabled);
+    assert.ok(screen.getByRole('button', { name: 'Mon bouton' }));
   });
 
   module('when type is submit, if no trigger action is defined', () => {
     test('if clicked, it should do nothing', async function (assert) {
       // given
-      await render(hbs`<PixButton @type='submit' aria-label='button label' />`);
+      const screen = await render(
+        hbs`<PixButton @triggerAction={{this.triggerAction}} @type='submit'>Mon bouton</PixButton>`,
+      );
 
-      //  when
-      await clickByLabel('button label');
+      await click(screen.getByRole('button', { name: 'Mon bouton' }));
 
       // then
       const componentElement = this.element.querySelector(COMPONENT_SELECTOR);
@@ -112,10 +103,10 @@ module('Integration | Component | button', function (hooks) {
       });
 
       // when
-      await render(
-        hbs`<PixButton @triggerAction={{this.triggerAction}} aria-label='button label' />`,
+      const screen = await render(
+        hbs`<PixButton @triggerAction={{this.triggerAction}}>Mon bouton</PixButton>`,
       );
-      await clickByLabel('button label');
+      await click(screen.getByRole('button', { name: 'Mon bouton' }));
 
       // then
       const loadingComponent = this.element.querySelector('.loader');


### PR DESCRIPTION
## :christmas_tree: Problème
Actuellement nous avons les deux attributs de posé sur le PixButton disabled ET aria-disabled

## :gift: Proposition
Supprimer l'ajout du disabled. il peut toujours être ajouter à la main côté layout grâce au ...attributes, si le besoin se fait ressentir dans un contexte précis.

## :star2: Remarques
Utilisation des warn plutôt que des throw d'erreur (qui sont supprimé à la compilation contrairement au throw qui n'a rien à faire en build de production )

## :santa: Pour tester
Vérifier que le button a bien l'état disabled. et qu'il n'appel pas la fonction passé en paramètre lorsqu'il est dans cet état. le bouton reste foccusable. 