### PR TITLE
[TECH] Augmenter le z-index de la bannière dans le composant PixAppLayout (PIX-18111)

### DIFF
--- a/addon/styles/_pix-app-layout.scss
+++ b/addon/styles/_pix-app-layout.scss
@@ -18,7 +18,7 @@
   &__banner {
     position: sticky;
     top: 0;
-    z-index: 3;
+    z-index: 900;
     grid-area: banner;
   }
 


### PR DESCRIPTION
## :christmas_tree: Problème
Côté modulix, nous avons ajouter un nouvel élément QAB qui empile des cartes. Nous avons géré ça en z-index mais cela pose problème avec la bannière du site car celle-ci a une valeur trop faible.

## :gift: Proposition
Augmenter le z-index de la bannière dans PixAppLayout de 3 à 900. Il faut qu'elle soit inférieure à 1000 (celle de PixOverlay)

## :star2: Remarques
Il faudrait créer un fichier qui contient les z-index de tous les composants et les exporter. 

## :santa: Pour tester
CI au vert ✅ 
