### PR TITLE
[TECH] Rendre l'argument `@options` de `PixMultiSelect` réactif (PIX-18333)

### DIFF
--- a/addon/components/pix-multi-select.js
+++ b/addon/components/pix-multi-select.js
@@ -21,12 +21,25 @@ export default class PixMultiSelect extends Component {
   @tracked isExpanded = false;
   @tracked searchData;
 
-  @tracked options = [];
+  get options() {
+    return [...(this.args.options || [])];
+  }
 
-  constructor(...args) {
-    super(...args);
+  get hasValues() {
+    return this.args.values && Array.isArray(this.args.values);
+  }
 
-    this.options = [...(this.args.options || [])];
+  get displayedOptions() {
+    const optionsWithCheckedStatus = this.options.map((option) => ({
+      ...option,
+      checked: this.hasValues ? this.args.values.includes(option.value) : false,
+    }));
+
+    if (this.args.isSearchable) {
+      return [...optionsWithCheckedStatus.sort(sortOptionsByCheckedFirst)];
+    }
+
+    return optionsWithCheckedStatus;
   }
 
   get mainInputClassName() {
@@ -57,9 +70,9 @@ export default class PixMultiSelect extends Component {
 
   get results() {
     if (this.args.isSearchable && this.searchData) {
-      return this.options.filter(({ label }) => this._search(label));
+      return this.displayedOptions.filter(({ label }) => this._search(label));
     }
-    return this.options;
+    return this.displayedOptions;
   }
 
   get placeholder() {
@@ -75,19 +88,6 @@ export default class PixMultiSelect extends Component {
       return selectedOptionLabels;
     }
     return placeholder;
-  }
-
-  _setDisplayedOptions(selected, shouldSort) {
-    const options = this.options.map((option) => ({
-      ...option,
-      checked: selected ? selected.includes(option.value) : false,
-    }));
-
-    if (shouldSort && this.args.isSearchable) {
-      options.sort(sortOptionsByCheckedFirst);
-    }
-
-    this.options = options;
   }
 
   _search(label) {
@@ -124,7 +124,6 @@ export default class PixMultiSelect extends Component {
   showDropDown() {
     if (this.isExpanded) return;
     this.isExpanded = true;
-    this._setDisplayedOptions(this.args.values, true);
   }
 
   @action
@@ -144,9 +143,6 @@ export default class PixMultiSelect extends Component {
       ? event.target.value
       : removeCapitalizeAndDiacritics(event.target.value);
     this.isExpanded = true;
-    if (!event.target.value) {
-      this._setDisplayedOptions(this.args.values, true);
-    }
   }
 
   get className() {

--- a/tests/acceptance/pix-select-page-test.js
+++ b/tests/acceptance/pix-select-page-test.js
@@ -1,0 +1,34 @@
+import { visit } from '@1024pix/ember-testing-library';
+import { click } from '@ember/test-helpers';
+import userEvent from '@testing-library/user-event';
+import { setupApplicationTest } from 'ember-qunit';
+import { module, test } from 'qunit';
+
+module('Acceptance | PixSelectPageTest', function (hooks) {
+  setupApplicationTest(hooks);
+
+  module('PixMultiSelect', function () {
+    test('displayed options should be reactive', async function (assert) {
+      // given
+      const screen = await visit('/select');
+
+      // when
+      await screen.getByLabelText('Kebab').focus();
+      await userEvent.keyboard('[ArrowDown]');
+      await screen.findByRole('menu');
+
+      assert.strictEqual(screen.getAllByRole('menuitem').length, 3);
+      await userEvent.keyboard('[Escape]');
+
+      await click(screen.getByRole('button', { name: 'Ajouter une option' }));
+
+      // then
+      await screen.getByLabelText('Kebab').focus();
+      await userEvent.keyboard('[ArrowDown]');
+      await screen.findByRole('menu');
+
+      assert.strictEqual(screen.getAllByRole('menuitem').length, 4);
+      assert.ok(screen.getByRole('menuitem', { name: 'Harissa (NEW)' }));
+    });
+  });
+});

--- a/tests/dummy/app/controllers/select-page.js
+++ b/tests/dummy/app/controllers/select-page.js
@@ -5,6 +5,12 @@ import { action } from '@ember/object';
 export default class SelectPage extends Controller {
   @tracked selectedOption = null;
   @tracked structure = this.structures[1];
+  @tracked multiValues = [];
+  @tracked multiOptions = [
+    { value: 'a', label: 'Salade'},
+    { value: 'b', label: 'Tomate'},
+    { value: 'c', label: 'Oignons'},
+  ]
 
   @action
   onChange(option) {
@@ -12,8 +18,20 @@ export default class SelectPage extends Controller {
   }
 
   @action
+  onMultiChange(values) {
+    this.multiValues = values;
+  }
+
+  @action
   setStructure(option) {
     this.structure = option;
+  }
+
+  @action
+  addNewMultiOption() {
+    if (this.multiOptions.length > 3) return;
+    const newOption = { value: 'd', label: 'Harissa (NEW)' };
+    this.multiOptions = [...this.multiOptions, newOption]
   }
 
   get options() {

--- a/tests/dummy/app/templates/select-page.hbs
+++ b/tests/dummy/app/templates/select-page.hbs
@@ -11,4 +11,22 @@
   <:label>Label</:label>
 </PixSelect>
 
+<div class="multi-select">
+  <PixMultiSelect
+    @options={{this.multiOptions}}
+    @values={{this.multiValues}}
+    @onChange={{this.onMultiChange}}
+    @isSearchable={{true}}
+    @searchLabel="Rechercher une option"
+    @searchPlaceholder="Euuuuuh"
+    @emptySearchMessage="Aucun résultat"
+    @emptyMessage="Pas d'options"
+    class="full"
+  >
+    <:label>Kebab</:label>
+    <:default as |option|>{{option.label}}</:default>
+  </PixMultiSelect>
+  <PixButton @triggerAction={{this.addNewMultiOption}}>Ajouter une option</PixButton>
+</div>
+
 <PixPagination @pagination={{this.pagination}} />


### PR DESCRIPTION
## :christmas_tree: Problème
Contrairement à `PixSelect`, l'argument `@options` de `PixMultiSelect` n'est pas réactif.
Cela nous pose problème car ce composant est "recherchable", et on voudrait mettre à jour cette liste d'options en fonction de la recherche de l'utilisateur.

## :gift: Proposition
Remplacer `@tracked options` par `get options()`.

## :star2: Remarques
- Je pense n'avoir rien cassé en supprimant la méthode `_setDisplayedOptions()`, elle me semble aussi remplaçable par un getter.
- J'ai ajouté un test d'acceptance pour tester la réactivité (pas réussi à le faire en intégration)

## :santa: Pour tester
- Tests OK