### PR TITLE
[FEATURE] Permettre de personnaliser le filtrage des `PixSelect` et `PixMultiSelect` recherchables (PIX-18385)

### DIFF
--- a/addon/components/pix-multi-select.js
+++ b/addon/components/pix-multi-select.js
@@ -139,9 +139,13 @@ export default class PixMultiSelect extends Component {
 
   @action
   updateSearch(event) {
-    this.searchData = this.args.strictSearch
-      ? event.target.value
-      : removeCapitalizeAndDiacritics(event.target.value);
+    if (this.args.onSearch) {
+      this.args.onSearch(event.target.value);
+    } else {
+      this.searchData = this.args.strictSearch
+        ? event.target.value
+        : removeCapitalizeAndDiacritics(event.target.value);
+    }
     this.isExpanded = true;
   }
 

--- a/addon/components/pix-multi-select.js
+++ b/addon/components/pix-multi-select.js
@@ -1,3 +1,4 @@
+import { warn } from '@ember/debug';
 import { action } from '@ember/object';
 import { guidFor } from '@ember/object/internals';
 import Component from '@glimmer/component';
@@ -20,6 +21,18 @@ function removeCapitalizeAndDiacritics(string) {
 export default class PixMultiSelect extends Component {
   @tracked isExpanded = false;
   @tracked searchData;
+
+  constructor(...args) {
+    super(...args);
+
+    warn(
+      `PixMultiSelect: @strictSearch is deprecated in favour of @onSearch`,
+      !this.args.strictSearch,
+      {
+        id: 'pix-ui.pix-multi-select.strictSearch.deprecated',
+      },
+    );
+  }
 
   get options() {
     return [...(this.args.options || [])];

--- a/addon/components/pix-select-list.js
+++ b/addon/components/pix-select-list.js
@@ -1,22 +1,21 @@
 import Component from '@glimmer/component';
 
 export default class PixSelectList extends Component {
-  constructor(...args) {
-    super(...args);
+  get categories() {
+    const uniqueCategories = new Set(
+      ...this.args.options.map((option) => option.category).filter(Boolean),
+    );
+    return Array.from(uniqueCategories.values());
+  }
 
-    const categories = [];
-
-    this.args.options.forEach((element) => {
-      if (!categories.includes(element.category) && element.category !== undefined) {
-        categories.push(element.category);
-      }
-    });
-    this.displayCategory = categories.length > 0;
+  get displayCategory() {
+    return this.categories.length > 0;
   }
 
   get isDefaultOptionHidden() {
     return !this.args.isExpanded || this.args.hideDefaultOption;
   }
+
   get results() {
     const results = [];
     let options = this.args.options;

--- a/addon/components/pix-select.js
+++ b/addon/components/pix-select.js
@@ -100,6 +100,10 @@ export default class PixSelect extends Component {
 
   @action
   setSearchValue(event) {
+    if (this.args.onSearch) {
+      this.args.onSearch(event.target.value);
+      return;
+    }
     this.searchValue = event.target.value.trim();
   }
 

--- a/app/stories/pix-multi-select.mdx
+++ b/app/stories/pix-multi-select.mdx
@@ -20,6 +20,20 @@ Si vous utilisez le `PixMultiSelect` sans vouloir afficher le label, il faudra r
 
 ## Searchable
 
+> Il est possible de prendre le contrôle sur le filtre effectué par la recherche en utilisant l'argument `@onSearch`.
+Un exemple est disponible dans l'environnement local sur la page `/select`
+```html
+<PixMultiSelect
+  ...
+  @isSearchable={{true}}
+  @options={{customFilteredOptions}}
+  @onSearch={{{updateOptions}}}
+  ...
+>
+  ...
+</PixMultiSelect>
+```
+
 <Story of={ComponentStories.multiSelectSearchable} height={330} />
 
 ## withCustomClass

--- a/app/stories/pix-multi-select.stories.js
+++ b/app/stories/pix-multi-select.stories.js
@@ -81,6 +81,12 @@ export default {
       type: { name: 'boolean', required: false },
       table: { defaultValue: { summary: false } },
     },
+    onSearch: {
+      name: 'onSearch',
+      description:
+        'Une fonction appelée à chaque entrée dans le champ de recherche. Permet de manuellement gérer le filtrage des options. ⚠️ **Désactive le filtrage automatique par défaut des options** ⚠️. Uniquement disponible si ``isSearchable`` est ``true``',
+      type: { name: 'function', required: false },
+    },
     headerClassName: {
       name: 'headerClassName',
       description: 'Cette classe css permet de surcharger le css par défaut du composant.',

--- a/app/stories/pix-multi-select.stories.js
+++ b/app/stories/pix-multi-select.stories.js
@@ -77,7 +77,7 @@ export default {
     strictSearch: {
       name: 'strictSearch',
       description:
-        'Permet de rendre sensible à la casse et au diacritiques lorsque ``isSearchable`` à ``true``',
+        '**DEPRECATED** : Permet de rendre sensible à la casse et au diacritiques lorsque ``isSearchable`` à ``true``',
       type: { name: 'boolean', required: false },
       table: { defaultValue: { summary: false } },
     },

--- a/app/stories/pix-select.mdx
+++ b/app/stories/pix-select.mdx
@@ -35,6 +35,20 @@ Les options sont représentées par un tableau d'objet contenant les propriété
 
 ## WithSearch
 
+> Il est possible de prendre le contrôle sur le filtre effectué par la recherche en utilisant l'argument `@onSearch`.
+Un exemple est disponible dans l'environnement local sur la page `/select`
+```html
+<PixSelect
+  ...
+  @isSearchable={{true}}
+  @options={{customFilteredOptions}}
+  @onSearch={{{updateOptions}}}
+  ...
+>
+  ...
+</PixMultiSelect>
+```
+
 <Story of={ComponentStories.WithSearch} height={200} />
 
 ## WithCategoriesAndSearch

--- a/app/stories/pix-select.stories.js
+++ b/app/stories/pix-select.stories.js
@@ -38,6 +38,12 @@ export default {
         defaultValue: { summary: false },
       },
     },
+    onSearch: {
+      name: 'onSearch',
+      description:
+        'Une fonction appelée à chaque entrée dans le champ de recherche. Permet de manuellement gérer le filtrage des options. ⚠️ **Désactive le filtrage automatique par défaut des options** ⚠️. Uniquement disponible si ``isSearchable`` est ``true``',
+      type: { name: 'function', required: false },
+    },
     id: {
       name: 'id',
       description: 'id généré automatiquement, peut être définit manuellement si besoin',

--- a/tests/acceptance/pix-select-page-test.js
+++ b/tests/acceptance/pix-select-page-test.js
@@ -1,4 +1,4 @@
-import { visit } from '@1024pix/ember-testing-library';
+import { fillByLabel, visit } from '@1024pix/ember-testing-library';
 import { click } from '@ember/test-helpers';
 import userEvent from '@testing-library/user-event';
 import { setupApplicationTest } from 'ember-qunit';
@@ -29,6 +29,19 @@ module('Acceptance | PixSelectPageTest', function (hooks) {
 
       assert.strictEqual(screen.getAllByRole('menuitem').length, 4);
       assert.ok(screen.getByRole('menuitem', { name: 'Harissa (NEW)' }));
+    });
+
+    test('it should filter by custom regex', async function (assert) {
+      // given
+      const screen = await visit('/select');
+
+      // when
+      await fillByLabel('Kebab', '[A-Z]{1}[a-z]{6}');
+      await screen.findByRole('menu');
+
+      // then
+      assert.strictEqual(screen.getAllByRole('menuitem').length, 1);
+      assert.dom(screen.getByRole('menuitem', { name: 'Oignons' })).exists();
     });
   });
 });

--- a/tests/acceptance/pix-select-page-test.js
+++ b/tests/acceptance/pix-select-page-test.js
@@ -44,4 +44,43 @@ module('Acceptance | PixSelectPageTest', function (hooks) {
       assert.dom(screen.getByRole('menuitem', { name: 'Oignons' })).exists();
     });
   });
+
+  module('PixSelect', function () {
+    test('displayed options should be reactive', async function (assert) {
+      // given
+      const screen = await visit('/select');
+
+      // when
+      await screen.getByLabelText('Fruits').focus();
+      await userEvent.keyboard('[ArrowDown]');
+      await screen.findByRole('listbox');
+
+      assert.strictEqual(screen.getAllByRole('option').length, 6);
+      await userEvent.keyboard('[Escape]');
+
+      await click(screen.getByRole('button', { name: 'Ajouter un citron' }));
+
+      // then
+      await screen.getByLabelText('Fruits').focus();
+      await userEvent.keyboard('[ArrowDown]');
+      await screen.findByRole('listbox');
+
+      assert.strictEqual(screen.getAllByRole('option').length, 7);
+      assert.ok(screen.getByRole('option', { name: 'Citron' }));
+    });
+
+    test('it should filter by custom regex', async function (assert) {
+      // given
+      const screen = await visit('/select');
+
+      // when
+      await screen.getByLabelText('Fruits').click();
+      await fillByLabel('Rechercher un fruit', 'K[a-z]{3}');
+      await screen.findByRole('listbox');
+
+      // then
+      assert.strictEqual(screen.getAllByRole('option').length, 1);
+      assert.dom(screen.getByRole('option', { name: 'Kaki' })).exists();
+    });
+  });
 });

--- a/tests/acceptance/pix-select-page-test.js
+++ b/tests/acceptance/pix-select-page-test.js
@@ -66,7 +66,8 @@ module('Acceptance | PixSelectPageTest', function (hooks) {
       await screen.findByRole('listbox');
 
       assert.strictEqual(screen.getAllByRole('option').length, 7);
-      assert.ok(screen.getByRole('option', { name: 'Citron' }));
+      assert.dom(screen.getAllByRole('presentation').at(-1)).hasText('yellow');
+      assert.dom(screen.getByRole('option', { name: 'Citron' })).exists();
     });
 
     test('it should filter by custom regex', async function (assert) {

--- a/tests/dummy/app/controllers/select-page.js
+++ b/tests/dummy/app/controllers/select-page.js
@@ -6,12 +6,38 @@ export default class SelectPage extends Controller {
   @tracked selectedOption = null;
   @tracked structure = this.structures[1];
   @tracked multiValues = [];
+  @tracked options = [
+    {
+      value: '1',
+      label: 'Figues',
+      category: 'rouge',
+      icon: 'accountOff',
+      iconTitle: 'titre icone account',
+    },
+    {
+      value: '3',
+      label:
+        'Fraises, des bonnes fraises, bien rouge. Tout un gros paquet de fraises, mais beaucoup beaucoup',
+      category: 'rouge',
+      icon: 'userCircle',
+      iconTitle: 'titre icone user',
+    },
+    { value: '2', label: 'Bananes', category: 'jaune' },
+    { value: '4', label: 'Mangues', category: 'jaune' },
+    { value: '5', label: 'Kaki', category: 'vert' },
+    {
+      value: '6',
+      label: 'Asiminier trilobé oblong vert (à ne pas confondre avec la papaye)',
+      category: 'vert',
+    },
+  ];
   @tracked multiOptions = [
     { value: 'a', label: 'Salade'},
     { value: 'b', label: 'Tomate'},
     { value: 'c', label: 'Oignons'},
   ]
   @tracked searchValue;
+  @tracked multiSearchValue;
 
   @action
   onChange(option) {
@@ -29,6 +55,13 @@ export default class SelectPage extends Controller {
   }
 
   @action
+  addNewOption() {
+    if (this.options.length > 6) return;
+    const newOption = { value: '7', label: 'Citron', category: 'jaune' };
+    this.options = [...this.options, newOption]
+  }
+
+  @action
   addNewMultiOption() {
     if (this.multiOptions.length > 3) return;
     const newOption = { value: 'd', label: 'Harissa (NEW)' };
@@ -40,38 +73,29 @@ export default class SelectPage extends Controller {
     this.searchValue = search;
   }
 
+  @action
+  onMultiSearch(search) {
+    this.multiSearchValue = search;
+  }
+
   get options() {
-    return [
-      {
-        value: '1',
-        label: 'Figues',
-        category: 'rouge',
-        icon: 'accountOff',
-        iconTitle: 'titre icone account',
-      },
-      {
-        value: '3',
-        label:
-          'Fraises, des bonnes fraises, bien rouge. Tout un gros paquet de fraises, mais beaucoup beaucoup',
-        category: 'rouge',
-        icon: 'userCircle',
-        iconTitle: 'titre icone user',
-      },
-      { value: '2', label: 'Bananes', category: 'jaune' },
-      { value: '4', label: 'Mangues', category: 'jaune' },
-      { value: '5', label: 'Kaki', category: 'vert' },
-      {
-        value: '6',
-        label: 'Asiminier trilobé oblong vert (à ne pas confondre avec la papaye)',
-        category: 'vert',
-      },
-    ];
+    return
   }
 
   get filteredOptions() {
     if (this.searchValue) {
       try {
         const searchRegex = new RegExp(`${this.searchValue}`, 'i')
+        return this.options.filter((option) => option.label.match(searchRegex));
+      } catch {}
+    }
+    return this.options;
+  }
+
+  get filteredMultiOptions() {
+    if (this.multiSearchValue) {
+      try {
+        const searchRegex = new RegExp(`${this.multiSearchValue}`, 'i')
         return this.multiOptions.filter((option) => option.label.match(searchRegex));
       } catch {}
     }

--- a/tests/dummy/app/controllers/select-page.js
+++ b/tests/dummy/app/controllers/select-page.js
@@ -11,6 +11,7 @@ export default class SelectPage extends Controller {
     { value: 'b', label: 'Tomate'},
     { value: 'c', label: 'Oignons'},
   ]
+  @tracked searchValue;
 
   @action
   onChange(option) {
@@ -32,6 +33,11 @@ export default class SelectPage extends Controller {
     if (this.multiOptions.length > 3) return;
     const newOption = { value: 'd', label: 'Harissa (NEW)' };
     this.multiOptions = [...this.multiOptions, newOption]
+  }
+
+  @action
+  onSearch(search) {
+    this.searchValue = search;
   }
 
   get options() {
@@ -60,6 +66,16 @@ export default class SelectPage extends Controller {
         category: 'vert',
       },
     ];
+  }
+
+  get filteredOptions() {
+    if (this.searchValue) {
+      try {
+        const searchRegex = new RegExp(`${this.searchValue}`, 'i')
+        return this.multiOptions.filter((option) => option.label.match(searchRegex));
+      } catch {}
+    }
+    return this.multiOptions;
   }
 
   get pagination() {

--- a/tests/dummy/app/controllers/select-page.js
+++ b/tests/dummy/app/controllers/select-page.js
@@ -57,7 +57,7 @@ export default class SelectPage extends Controller {
   @action
   addNewOption() {
     if (this.options.length > 6) return;
-    const newOption = { value: '7', label: 'Citron', category: 'jaune' };
+    const newOption = { value: '7', label: 'Citron', category: 'yellow' };
     this.options = [...this.options, newOption]
   }
 

--- a/tests/dummy/app/templates/select-page.hbs
+++ b/tests/dummy/app/templates/select-page.hbs
@@ -1,22 +1,27 @@
 <h1>PixSelect</h1>
 
-<PixSelect
-  @options={{this.options}}
-  @onChange={{this.onChange}}
-  @value={{this.selectedOption}}
-  @hideDefaultOption={{true}}
-  @placeholder="Select an option"
-  @isSearchable={{true}}
->
-  <:label>Label</:label>
-</PixSelect>
+<div class="single-select">
+  <PixSelect
+    @options={{this.filteredOptions}}
+    @onChange={{this.onChange}}
+    @value={{this.selectedOption}}
+    @hideDefaultOption={{true}}
+    @placeholder="Select an option"
+    @isSearchable={{true}}
+    @onSearch={{this.onSearch}}
+    @searchLabel="Rechercher un fruit"
+  >
+    <:label>Fruits</:label>
+  </PixSelect>
+  <PixButton @triggerAction={{this.addNewOption}}>Ajouter un citron</PixButton>
+</div>
 
 <div class="multi-select">
   <PixMultiSelect
-    @options={{this.filteredOptions}}
+    @options={{this.filteredMultiOptions}}
     @values={{this.multiValues}}
     @onChange={{this.onMultiChange}}
-    @onSearch={{this.onSearch}}
+    @onSearch={{this.onMultiSearch}}
     @isSearchable={{true}}
     @searchLabel="Rechercher une option"
     @searchPlaceholder="Euuuuuh"

--- a/tests/dummy/app/templates/select-page.hbs
+++ b/tests/dummy/app/templates/select-page.hbs
@@ -13,9 +13,10 @@
 
 <div class="multi-select">
   <PixMultiSelect
-    @options={{this.multiOptions}}
+    @options={{this.filteredOptions}}
     @values={{this.multiValues}}
     @onChange={{this.onMultiChange}}
+    @onSearch={{this.onSearch}}
     @isSearchable={{true}}
     @searchLabel="Rechercher une option"
     @searchPlaceholder="Euuuuuh"

--- a/tests/integration/components/pix-multi-select-test.js
+++ b/tests/integration/components/pix-multi-select-test.js
@@ -875,6 +875,79 @@ module('Integration | Component | multi-select', function (hooks) {
       // then
       assert.true(screen.queryByRole('textbox').disabled);
     });
+
+    module('when @onSearch is passed', function () {
+      test('it should call @onSearch on text input', async function (assert) {
+        // given
+        this.label = 'multiSelectLabel';
+        this.options = DEFAULT_OPTIONS;
+        this.values = [];
+        this.onChange = () => {};
+        this.emptyMessage = 'no result';
+        this.placeholder = 'MultiSelectTest';
+        this.id = 'id-MultiSelectTest';
+        this.isSearchable = true;
+        this.placeholder = 'Placeholder test';
+        this.onSearch = sinon.spy();
+
+        const screen = await render(hbs`<PixMultiSelect
+  @isSearchable={{this.isSearchable}}
+  @values={{this.values}}
+  @onChange={{this.onChange}}
+  @placeholder={{this.placeholder}}
+  @id={{this.id}}
+  @emptyMessage={{this.emptyMessage}}
+  @options={{this.options}}
+  @onSearch={{this.onSearch}}
+>
+  <:label>{{this.label}}</:label>
+  <:default as |option|>{{option.label}}</:default>
+</PixMultiSelect>`);
+
+        // when
+        await fillByLabel('multiSelectLabel', 'tomate');
+        await screen.findByRole('menu');
+
+        // then
+        assert.ok(this.onSearch.calledOnce, 'the search callback should be called once');
+        assert.deepEqual(this.onSearch.args[0], ['tomate']);
+      });
+
+      test('it should not filter options by default', async function (assert) {
+        // given
+        this.label = 'multiSelectLabel';
+        this.options = DEFAULT_OPTIONS;
+        this.values = [];
+        this.onChange = () => {};
+        this.emptyMessage = 'no result';
+        this.placeholder = 'MultiSelectTest';
+        this.id = 'id-MultiSelectTest';
+        this.isSearchable = true;
+        this.placeholder = 'Placeholder test';
+        this.onSearch = sinon.stub();
+
+        const screen = await render(hbs`<PixMultiSelect
+  @isSearchable={{this.isSearchable}}
+  @values={{this.values}}
+  @onChange={{this.onChange}}
+  @placeholder={{this.placeholder}}
+  @id={{this.id}}
+  @emptyMessage={{this.emptyMessage}}
+  @options={{this.options}}
+  @onSearch={{this.onSearch}}
+>
+  <:label>{{this.label}}</:label>
+  <:default as |option|>{{option.label}}</:default>
+</PixMultiSelect>`);
+
+        // when
+        await fillByLabel('multiSelectLabel', 'tomate');
+        await screen.findByRole('menu');
+
+        // then
+        assert.strictEqual(screen.getAllByRole('checkbox').length, this.options.length);
+      });
+    });
   });
 
   module('custom class name', function () {

--- a/tests/integration/components/pix-multi-select-test.js
+++ b/tests/integration/components/pix-multi-select-test.js
@@ -608,6 +608,43 @@ module('Integration | Component | multi-select', function (hooks) {
       assert.contains('no result');
     });
 
+    test('it should give deprecation warning when using @strictSearch', async function (assert) {
+      // given
+      this.label = 'multiSelectLabel';
+      this.options = DEFAULT_OPTIONS;
+      this.values = [];
+      this.onChange = () => {};
+      this.emptyMessage = 'no result';
+      this.placeholder = 'MultiSelectTest';
+      this.id = 'id-MultiSelectTest';
+      this.isSearchable = true;
+      this.strictSearch = true;
+      this.placeholder = 'Placeholder test';
+      const warnStub = sinon.stub(console, 'warn');
+
+      await render(hbs`<PixMultiSelect
+  @isSearchable={{this.isSearchable}}
+  @strictSearch={{this.strictSearch}}
+  @values={{this.values}}
+  @onChange={{this.onChange}}
+  @placeholder={{this.placeholder}}
+  @id={{this.id}}
+  @emptyMessage={{this.emptyMessage}}
+  @options={{this.options}}
+>
+  <:label>{{this.label}}</:label>
+  <:default as |option|>{{option.label}}</:default>
+</PixMultiSelect>`);
+
+      // then
+      assert.ok(
+        warnStub.calledWithExactly(
+          'WARNING: PixMultiSelect: @strictSearch is deprecated in favour of @onSearch',
+        ),
+      );
+      warnStub.restore();
+    });
+
     test('it should display list PixMultiSelect on focus', async function (assert) {
       // given
       this.label = 'multiSelectLabel';

--- a/tests/integration/components/pix-select-test.js
+++ b/tests/integration/components/pix-select-test.js
@@ -619,6 +619,56 @@ module('Integration | Component | PixSelect', function (hooks) {
       await fillIn(await screen.findByRole('textbox', { name: 'Rechercher' }), 'Cheddar');
       assert.ok(screen.getByText('Aucune option'));
     });
+
+    module('when @onSearch is supplied', function () {
+      test('should call @onSearch on search input', async function (assert) {
+        this.isSearchable = true;
+        this.onSearch = sinon.spy();
+
+        await render(hbs`<PixSelect
+  @options={{this.options}}
+  @placeholder={{this.placeholder}}
+  @searchLabel={{this.searchLabel}}
+  @searchPlaceholder={{this.searchPlaceholder}}
+  @isSearchable={{this.isSearchable}}
+  @onSearch={{this.onSearch}}
+>
+  <:label>{{this.label}}</:label>
+</PixSelect>`);
+
+        // when
+        await clickByName('Mon menu déroulant');
+        await fillByLabel('Rechercher', 'Sal');
+
+        assert.ok(this.onSearch.calledOnce);
+        assert.deepEqual(this.onSearch.args[0], ['Sal']);
+      });
+
+      test('should not filter by default', async function (assert) {
+        this.isSearchable = true;
+        this.onSearch = sinon.stub();
+
+        const screen = await render(hbs`<PixSelect
+  @options={{this.options}}
+  @placeholder={{this.placeholder}}
+  @searchLabel={{this.searchLabel}}
+  @searchPlaceholder={{this.searchPlaceholder}}
+  @isSearchable={{this.isSearchable}}
+  @onSearch={{this.onSearch}}
+>
+  <:label>{{this.label}}</:label>
+</PixSelect>`);
+
+        // when
+        await clickByName('Mon menu déroulant');
+        await fillByLabel('Rechercher', 'Sal');
+
+        await screen.findByRole('listbox');
+
+        const filteredOptions = screen.queryAllByRole('option');
+        assert.strictEqual(filteredOptions.length, 4);
+      });
+    });
   });
 
   module('#required', function () {


### PR DESCRIPTION
## :christmas_tree: Problème
Nous avons besoin de filtrer les résultats affichés des selects selon des critères spécifiques (recherche asynchrone, plus poussée que `option.label.includes(search)`).
`PixSelect` et `PixMultiSelect` ne nous permettent pas de prendre la main sur la recherche.

## :gift: Proposition
Mettre à disposition un argument `@onSearch`, qui serait appelé avec la valeur du champ de recherche à chaque entrée utilisateur. 
La présence de cet argument désactiverait le filtre par défaut du composant (smart component -> dumb component).

## :star2: Remarques
Des tests d'acceptance ont été ajoutés afin de tester la réactivité de ces composants. Je n'ai pas réussi à tester ça en intégration.
Dépréciation de l'argument `@strictSearch`.

## :santa: Pour tester
- Tests OK
- En local :
  - Se rendre sur la page `/select`
  - Sur les deux select, réaliser une recherche au format regex (exemple: `^[a-zA-Z]{7}$`).
  - Constater qu'un filtre personnalisé est appliqué.
  - Cliquer sur les boutons pour ajouter des options.
