### PR TITLE
[TECH] Erreur typographique dans la story du `PixSelect`

### DIFF
--- a/app/stories/pix-multi-select.stories.js
+++ b/app/stories/pix-multi-select.stories.js
@@ -250,7 +250,7 @@ export const multiSelectSearchable = {
   args: {
     ...Default.args,
     isSearchable: true,
-    strictSearch: true,
+    strictSearch: false,
     emptyMessage: 'Aucune option trouvée',
   },
 };

--- a/app/stories/pix-select.mdx
+++ b/app/stories/pix-select.mdx
@@ -46,7 +46,7 @@ Un exemple est disponible dans l'environnement local sur la page `/select`
   ...
 >
   ...
-</PixMultiSelect>
+</PixSelect>
 ```
 
 <Story of={ComponentStories.WithSearch} height={200} />


### PR DESCRIPTION
## :christmas_tree: Problème
Il y a une typo sur la story du PixSelect, à cause [d'un villain monsieur](https://github.com/1024pix/pix-ui/pull/889).

## :gift: Proposition
Mieux relire mes PRs.

## :star2: Remarques
Mise à jour de la story "with search" du PixMultiSelect, pour prendre en compte la dépréciation de `@strictSearch`.

## :santa: Pour tester
- Tests OK
- Relire la PR au cas où 👀
