### PR TITLE
[FEATURE] Formater les niveaux de PixGauge en fonction de la locale (PIX-18442)

### DIFF
--- a/addon/components/pix-gauge.js
+++ b/addon/components/pix-gauge.js
@@ -1,5 +1,8 @@
 import { warn } from '@ember/debug';
 import Component from '@glimmer/component';
+
+import { formatNumber } from '../translations';
+
 export default class PixGauge extends Component {
   get label() {
     warn('PixGauge: @label must be defined', !this.args.label, {
@@ -85,12 +88,5 @@ export default class PixGauge extends Component {
     return `${stepStart * index}`;
   };
 
-  formatNumber = (str) => {
-    const num = Number(str);
-    const oneDigitNum = num.toFixed(1);
-    if (oneDigitNum.toString().endsWith('0')) {
-      return Math.ceil(oneDigitNum);
-    }
-    return oneDigitNum;
-  };
+  formatNumber = (str) => formatNumber(this.args.locale ?? 'fr', Number(str).toFixed(1));
 }

--- a/addon/translations/index.js
+++ b/addon/translations/index.js
@@ -9,6 +9,11 @@ export function formatMessage(locale, message, values) {
   return intl.formatMessage({ id: message }, values);
 }
 
+export function formatNumber(locale, value) {
+  const intl = locales[locale] || locales.en;
+  return intl.formatNumber(value);
+}
+
 const locales = {
   fr: createIntl({
     locale: 'fr',

--- a/app/stories/pix-gauge.mdx
+++ b/app/stories/pix-gauge.mdx
@@ -13,12 +13,13 @@ Le composant `<PixGauge/>` prend en arguments
 - `hideValues` : un booléen, par défaut à false, qui permet de ne pas afficher les valeurs numériques.
 - `maxLevel`: un nombre, le niveau maximum atteignable par la jauge (jauge blanche)
 - `reachedLevel` : un nombre, le niveau atteint (jauge violette)
+- `locale` : locale pour le formatage des nombres, par défaut "fr" (e.g. 1.2 / 1,2)
 
 ## Usage
 
 ```html
 <PixGauge @label="Niveau atteint de ...
-  sur un niveau maximum atteignable de ..." @reachedLevel={{1}} @maxLevel={{4}} @isSmall={{true}} @stepLabels={{array "Novice" "Intermédiaire" "Avancé" "Expert"}}>
+  sur un niveau maximum atteignable de ..." @reachedLevel={{1}} @maxLevel={{4}} @isSmall={{true}} @stepLabels={{array "Novice" "Intermédiaire" "Avancé" "Expert"}} @locale="fr" />
 ```
 
 ## Arguments

--- a/app/stories/pix-gauge.stories.js
+++ b/app/stories/pix-gauge.stories.js
@@ -29,6 +29,17 @@ export default {
       description: 'Niveau atteint',
       type: { name: 'number', required: false },
     },
+    locale: {
+      name: 'locale',
+      description: "Permet de formater les niveaux selon la locale de l'utilisateur",
+      type: { name: 'string', required: false },
+      control: { type: 'select' },
+      options: ['fr', 'en', 'es'],
+      table: {
+        type: { summary: 'string' },
+        defaultValue: { summary: 'fr' },
+      },
+    },
   },
   args: {
     stepLabels: ['Novice', 'Intermédiaire', 'Avancé', 'Expert'],
@@ -47,6 +58,7 @@ export const PixGauge = (args) => {
   @hideValues={{this.hideValues}}
   @maxLevel={{this.maxLevel}}
   @reachedLevel={{this.reachedLevel}}
+  @locale={{this.locale}}
 />`,
     context: args,
   };

--- a/tests/dummy/app/templates/gauge-page.hbs
+++ b/tests/dummy/app/templates/gauge-page.hbs
@@ -2,21 +2,29 @@
   @stepLabels={{array "Novice" "Intermédiaire" "Avancé" "Expert"}}
   @reachedLevel={{6.3}}
   @maxLevel={{8}}
-  @label="niveau atteind de 6.3 sur un maximum de 8"
+  @label="niveau atteint de 6.3 sur un maximum de 8"
+/>
+
+<PixGauge
+  @stepLabels={{array "Novice" "Intermédiaire" "Avancé" "Expert"}}
+  @reachedLevel={{6.3}}
+  @maxLevel={{7.2}}
+  @label="Level reached of 6.3 out of a maximum of 7.2"
+  @locale="en"
 />
 
 <PixGauge
   @stepLabels={{array "Novice" "Intermédiaire" "Avancé" "Expert"}}
   @reachedLevel={{0.51}}
   @maxLevel={{8}}
-  @label="niveau atteind de 4 sur un maximum de 8"
+  @label="niveau atteint de 4 sur un maximum de 8"
 />
 
 <PixGauge
   @stepLabels={{array "Novice" "Intermédiaire" "Avancé" "Expert"}}
   @reachedLevel={{0}}
   @maxLevel={{8}}
-  @label="niveau atteind de 4 sur un maximum de 8"
+  @label="niveau atteint de 4 sur un maximum de 8"
 />
 
 <PixGauge
@@ -24,7 +32,7 @@
   @isSmall={{true}}
   @reachedLevel={{4}}
   @maxLevel={{8}}
-  @label="niveau atteind de 4 sur un maximum de 8"
+  @label="niveau atteint de 4 sur un maximum de 8"
 />
 
 <PixGauge
@@ -32,7 +40,7 @@
   @hideValues={{true}}
   @reachedLevel={{4}}
   @maxLevel={{8}}
-  @label="niveau atteind de 4 sur un maximum de 8"
+  @label="niveau atteint de 4 sur un maximum de 8"
 />
 
 <PixGauge
@@ -41,5 +49,5 @@
   @hideValues={{true}}
   @reachedLevel={{4}}
   @maxLevel={{8}}
-  @label="niveau atteind de 4 sur un maximum de 8"
+  @label="niveau atteint de 4 sur un maximum de 8"
 />

--- a/tests/integration/components/pix-gauge-test.js
+++ b/tests/integration/components/pix-gauge-test.js
@@ -62,6 +62,24 @@ module('Integration | Component | pix-gauge', function (hooks) {
       assert.ok(screen.queryByText('Avancé'));
       assert.ok(screen.queryByText('Expert'));
     });
+
+    test('it manages the locale passed as an argument', async function (assert) {
+      // when
+      const screen = await render(
+        hbs`<PixGauge
+  @isSmall={{true}}
+  @reachedLevel={{0.8}}
+  @maxLevel={{3.2}}
+  @stepLabels={{array 'novice' 'expert'}}
+  @locale='en'
+/>`,
+      );
+
+      // then
+      assert.ok(screen.queryByText('0.8'));
+      assert.ok(screen.queryByText('3.2'));
+    });
+
     test('it hide values when hideValues is true', async function (assert) {
       // when
       const screen = await render(
@@ -108,8 +126,9 @@ module('Integration | Component | pix-gauge', function (hooks) {
       const screen = await render(
         hbs`<PixGauge @isSmall={{true}} @reachedLevel={{0.75}} @maxLevel={{3}} />`,
       );
+
       // then
-      assert.ok(screen.queryByText('0.8'));
+      assert.ok(screen.queryByText('0,8'));
     });
 
     test('it does not renders content of the labels and the separators if hideValues is true', async function (assert) {


### PR DESCRIPTION
## :christmas_tree: Problème

L'affichage des niveaux n'est pas internationalisé sur PixGauge (e.g. 1,2 1.2 )  .

## :gift: Proposition
Utiliser la fonction formatNumber de formatJs pour internationaliser l’affichage de ces chiffres. 
Cela implique d’accepter un nouveau paramètre optionnel `locale`.

## :star2: Remarques
La locale est 'fr' par défaut. 

## :santa: Pour tester
Jouer avec la variable locale, constater le changement de l'affichage des niveaux. ( 1.2 != 1,2 )
