### PR TITLE
[FEATURE] Ajouter la possibilité de désactiver un lien (PIX-11536).

### DIFF
--- a/addon/components/pix-button-link.hbs
+++ b/addon/components/pix-button-link.hbs
@@ -5,6 +5,7 @@
     @disabled={{@isDisabled}}
     @query={{if @query @query this.defaultParams}}
     class={{this.className}}
+    aria-disabled="{{@isDisabled}}"
     ...attributes
   >
     <PixButtonContent
@@ -17,7 +18,8 @@
     </PixButtonContent>
   </LinkTo>
 {{else}}
-  <a href={{@href}} class={{this.className}} ...attributes>
+  {{! template-lint-disable no-unsupported-role-attributes }}
+  <a href={{@href}} class={{this.className}} aria-disabled="{{@isDisabled}}" ...attributes>
     <PixButtonContent
       @iconBefore={{@iconBefore}}
       @iconAfter={{@iconAfter}}


### PR DESCRIPTION
## :christmas_tree: Problème
Lors de la désactivation d'un bouton. le css n'est pas mis à jour pour montrer un état désactivé

## :gift: Proposition
Ajouter le aria-disabled pour bénéficier du style disabled

## :star2: Remarques
Ajout d'un template lint disabled. mdn autorise le aria-disabled sur un role link. mais template lint n'est pas content. 

## :santa: Pour tester
Aller sur pix-ui. activer le isDisabled sur le PixButtonLink. Vérifier le bon affichage de l'état désactivé