### PR TITLE
[BUGFIX] Corriger le soucis de scroll horizontal (PIX-17661)

### DIFF
--- a/addon/styles/_pix-app-layout.scss
+++ b/addon/styles/_pix-app-layout.scss
@@ -42,7 +42,7 @@
 
   &__main, &__footer {
     width: 100%;
-    max-width: min(calc(100vw - 2 * var(--pix-spacing-6x)), 93rem);
+    max-width: min(calc(100vw - var(--pix-navigation-width) - 3 * var(--pix-spacing-6x)), 93rem);
     margin: 0 auto;
     padding: 0 var(--pix-spacing-6x);
 

--- a/addon/styles/_pix-navigation.scss
+++ b/addon/styles/_pix-navigation.scss
@@ -1,10 +1,13 @@
 @use "pix-design-tokens/breakpoints";
 @use "pix-design-tokens/typography";
 
+:root {
+  --pix-navigation-width:  15rem;
+}
+
 .pix-navigation {
   --bg-color-focus: rgb(var(--pix-neutral-100-inline), 50%);
   --bg-color-active: rgb(var(--pix-neutral-100-inline), 30%);
-  --pix-navigation-width:  15rem;
 
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
## 🎄 Problème
scroll horizontal par exemple sur Pix Orga quand contenu trop large

## 🎁 Proposition
mieux calculer le max-width de la width

## 🌟 Remarques
Des infos supplémentaires, trucs et astuces ?

## 🎅 Pour tester
installer cette version de pixUI en local sur pix Orga
aller sur la page d'analyse d'une campagne avec un nom mega long
🎉 ça marche
