### PR TITLE
[BUGFIX] Corriger l'apparence de l'application en version mobile (PIX-19200).

### DIFF
--- a/addon/styles/_pix-app-layout.scss
+++ b/addon/styles/_pix-app-layout.scss
@@ -47,6 +47,7 @@
     padding: 0 var(--pix-spacing-6x);
 
     @include breakpoints.device-is('mobile') {
+      max-width: none;
       padding: 0 var(--pix-spacing-2x);
     }
   }


### PR DESCRIPTION
## :christmas_tree: Problème
En version mobile le css `max-width: min(calc(100vw - var(--pix-navigation-width) - 3 * var(--pix-spacing-6x)), 93rem);` fait que le main / footer ne font qu'une petite fraction de la taille disponible ce qui fait peu pour du mobile

## :gift: Proposition
Faire en sorte que l'on prennent toute la place disponible en mobile

## :star2: Remarques
RAS

## :santa: Pour tester
Vérifier sur une app que c'est OK