### PR TITLE
[FEATURE] Ajouter l'attribut isDisabled à PixIconButton (PIX-19373)

### DIFF
--- a/addon/components/pix-icon-button.hbs
+++ b/addon/components/pix-icon-button.hbs
@@ -2,6 +2,7 @@
   type="button"
   class="pix-icon-button pix-icon-button--{{this.size}}"
   {{on "click" this.triggerAction}}
+  aria-disabled="{{this.isDisabled}}"
   ...attributes
 >
   <span class="screen-reader-only">{{this.ariaLabel}}</span>

--- a/addon/components/pix-icon-button.js
+++ b/addon/components/pix-icon-button.js
@@ -13,6 +13,18 @@ export default class PixIconButton extends Component {
     return this.args.color || 'light-grey';
   }
 
+  get isDisabled() {
+    warn(
+      'PixIconButton: @isDisabled attribute should be a boolean.',
+      [true, false, undefined, null].includes(this.args.isDisabled),
+      {
+        id: 'pix-ui.icon-button.is-disabled.not-boolean',
+      },
+    );
+
+    return this.args.isDisabled ? 'true' : null;
+  }
+
   get ariaLabel() {
     warn(
       'PixIconButton: @label attribute should be a string.',
@@ -27,6 +39,8 @@ export default class PixIconButton extends Component {
 
   @action
   triggerAction(params) {
+    if (this.isDisabled) return;
+
     if (this.args.triggerAction) {
       this.args.triggerAction(params);
     }

--- a/addon/styles/_pix-icon-button.scss
+++ b/addon/styles/_pix-icon-button.scss
@@ -23,27 +23,30 @@
     }
   }
 
+  &[aria-disabled='true'],
   &:disabled {
     cursor: not-allowed;
     opacity: 0.5;
   }
 
-  &:hover:enabled {
-    background-color: var(--pix-neutral-20);
-    outline: 0;
-  }
+  &:not([aria-disabled='true']) {
+    &:hover:enabled {
+      background-color: var(--pix-neutral-20);
+      outline: 0;
+    }
 
-  &:focus:enabled {
-    color: var(--pix-neutral-0);
-    background-color: var(--pix-neutral-800);
-    outline: 1px solid var(--pix-neutral-0);
-    outline-offset: -3px;
-  }
+    &:focus:enabled {
+      color: var(--pix-neutral-0);
+      background-color: var(--pix-neutral-800);
+      outline: 1px solid var(--pix-neutral-0);
+      outline-offset: -3px;
+    }
 
-  &:active:enabled {
-    color: var(--pix-neutral-800);
-    background-color: var(--pix-neutral-100);
-    outline: 0;
+    &:active:enabled {
+      color: var(--pix-neutral-800);
+      background-color: var(--pix-neutral-100);
+      outline: 0;
+    }
   }
 
   &--small {

--- a/app/stories/pix-icon-button.mdx
+++ b/app/stories/pix-icon-button.mdx
@@ -21,7 +21,7 @@ Le bouton en version small. (big étant la valeur par défaut)
 
 ## Disabled
 
-Exemple avec le bouton disabled
+Exemple avec le bouton désactivé
 
 <Story of={ComponentStories.disabled} height={60} />
 
@@ -68,8 +68,7 @@ Bouton d'action
 <PixIconButton
   @ariaLabel="L'action du bouton"
   @iconName="add"
-  disabled="{{true}}"
-  aria-disabled="{{true}}"
+  @isDisabled={{true}}
 />
 ```
 

--- a/app/stories/pix-icon-button.stories.js
+++ b/app/stories/pix-icon-button.stories.js
@@ -43,6 +43,15 @@ export default {
         defaultValue: { summary: 'big' },
       },
     },
+    isDisabled: {
+      name: 'isDisabled',
+      type: { name: 'boolean', required: false },
+      control: { type: 'boolean' },
+      table: {
+        type: { summary: 'boolean' },
+        defaultValue: { summary: 'false' },
+      },
+    },
   },
 };
 
@@ -54,8 +63,7 @@ const Template = (args) => {
   @iconPrefix={{this.iconPrefix}}
   @triggerAction={{this.triggerAction}}
   @size={{this.size}}
-  disabled={{this.disabled}}
-  aria-disabled={{this.disabled}}
+  @isDisabled={{this.isDisabled}}
 />`,
     context: args,
   };
@@ -80,6 +88,6 @@ size.args = {
 export const disabled = Template.bind({});
 disabled.args = {
   ...Default.args,
-  disabled: true,
+  isDisabled: true,
   triggerAction,
 };

--- a/tests/dummy/app/controllers/button-page.js
+++ b/tests/dummy/app/controllers/button-page.js
@@ -1,0 +1,9 @@
+import Controller from "@ember/controller";
+import { action } from "@ember/object";
+
+export default class ButtonPage extends Controller {
+	@action
+	onClick() {
+		console.log("CLICKED");
+	}
+}

--- a/tests/dummy/app/router.js
+++ b/tests/dummy/app/router.js
@@ -15,5 +15,6 @@ Router.map(function () {
   this.route('tooltip-page', { path: '/tooltip' });
   this.route('table-page', { path: '/table' });
   this.route('gauge-page', { path: '/gauge' });
+  this.route('button-page', { path: '/button' });
   this.route('layout-page', { path: '/layout' });
 });

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -28,6 +28,7 @@
         <PixNavigationButton @route="tooltip-page" @icon="signpost">tooltip</PixNavigationButton>
         <PixNavigationButton @route="table-page" @icon="assignment">Table</PixNavigationButton>
         <PixNavigationButton @route="gauge-page" @icon="barsUp">gauge</PixNavigationButton>
+        <PixNavigationButton @route="button-page" @icon="lightBulb">Button</PixNavigationButton>
         <PixNavigationButton href="https://pix.fr" @icon="book">Documentation</PixNavigationButton>
         <PixNavigationButton
           href="https://pix.fr"

--- a/tests/dummy/app/templates/button-page.hbs
+++ b/tests/dummy/app/templates/button-page.hbs
@@ -1,0 +1,12 @@
+<PixIconButton
+  @ariaLabel="Mon joli bouton"
+  @iconName="conversionPath"
+  @triggerAction={{this.onClick}}
+/>
+
+<PixIconButton
+  @ariaLabel="Mon joli bouton"
+  @iconName="conversionPath"
+  @triggerAction={{this.onClick}}
+  @isDisabled={{true}}
+/>

--- a/tests/integration/components/pix-icon-button-test.js
+++ b/tests/integration/components/pix-icon-button-test.js
@@ -3,13 +3,9 @@ import { click } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { setupRenderingTest } from 'ember-qunit';
 import { module, test } from 'qunit';
-import { click } from '@ember/test-helpers';
-import clickByLabel from '../../helpers/click-by-label';
 
 module('Integration | Component | icon-button', function (hooks) {
   setupRenderingTest(hooks);
-
-  const COMPONENT_SELECTOR = '.pix-icon-button';
 
   test('it should trigger action if given one', async function (assert) {
     // when
@@ -17,14 +13,14 @@ module('Integration | Component | icon-button', function (hooks) {
     this.set('triggerAction', () => {
       this.count = this.count + 1;
     });
-    await render(
+    const screen = await render(
       hbs`<PixIconButton
   @triggerAction={{this.triggerAction}}
   @ariaLabel='action du bouton'
   @iconName='add'
 />`,
     );
-    await clickByLabel('action du bouton');
+    await click(screen.getByRole('button', { name: 'action du bouton' }));
 
     // then
     assert.strictEqual(this.count, 2);
@@ -35,16 +31,17 @@ module('Integration | Component | icon-button', function (hooks) {
     this.set('triggerAction', () => {});
 
     //when
-    await render(hbs`<PixIconButton
+    const screen = await render(
+      hbs`<PixIconButton
   @triggerAction={{this.triggerAction}}
   @iconName='add'
   disabled={{true}}
-  @ariaLabel="L'action du bouton"
-/>`);
+  @ariaLabel='action du bouton'
+/>`,
+    );
 
     // then
-    const componentElement = this.element.querySelector(COMPONENT_SELECTOR);
-    assert.true(componentElement.disabled);
+    assert.dom(screen.getByRole('button', { name: 'action du bouton' })).isDisabled();
   });
 
   module('When the attribute isDisabled is set to true', function () {
@@ -58,18 +55,18 @@ module('Integration | Component | icon-button', function (hooks) {
       // when
       const screen = await render(
         hbs`<PixIconButton
-          @isDisabled={{true}}
-          @triggerAction={{this.triggerAction}}
-          @ariaLabel='action du bouton'
-        />`,
+  @isDisabled={{true}}
+  @triggerAction={{this.triggerAction}}
+  @ariaLabel='action du bouton'
+/>`,
       );
 
       const iconButton = screen.getByRole('button', {
         name: 'action du bouton',
       });
-      await click(iconButton);
 
       // then
+      await click(iconButton);
       assert.dom(iconButton).hasAria('disabled', 'true');
       assert.strictEqual(this.count, 1);
     });

--- a/tests/integration/components/pix-icon-button-test.js
+++ b/tests/integration/components/pix-icon-button-test.js
@@ -1,8 +1,9 @@
 import { render } from '@1024pix/ember-testing-library';
+import { click } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { setupRenderingTest } from 'ember-qunit';
 import { module, test } from 'qunit';
-
+import { click } from '@ember/test-helpers';
 import clickByLabel from '../../helpers/click-by-label';
 
 module('Integration | Component | icon-button', function (hooks) {
@@ -44,5 +45,33 @@ module('Integration | Component | icon-button', function (hooks) {
     // then
     const componentElement = this.element.querySelector(COMPONENT_SELECTOR);
     assert.true(componentElement.disabled);
+  });
+
+  module('When the attribute isDisabled is set to true', function () {
+    test('it should display the button as disabled and prevent triggerAction', async function (assert) {
+      // given
+      this.set('count', 1);
+      this.set('triggerAction', () => {
+        this.count = this.count + 1;
+      });
+
+      // when
+      const screen = await render(
+        hbs`<PixIconButton
+          @isDisabled={{true}}
+          @triggerAction={{this.triggerAction}}
+          @ariaLabel='action du bouton'
+        />`,
+      );
+
+      const iconButton = screen.getByRole('button', {
+        name: 'action du bouton',
+      });
+      await click(iconButton);
+
+      // then
+      assert.dom(iconButton).hasAria('disabled', 'true');
+      assert.strictEqual(this.count, 1);
+    });
   });
 });


### PR DESCRIPTION
## :christmas_tree: Problème
Contrairement au composant PixButton, il n'y a pas d'attribut @isDisabled pour PixIconButton, permettant d'avoir un icon-button affiché désactivé et accessible.

## :gift: Proposition
Ajouter `@isDisabled` et gérer le design et l'arrêt de triggerAction du bouton en conséquence.

## :star2: Remarques
- On en a profité pour refacto un peu les tests côté PixIconButton.
- On n'a pas touché au comportement de `disabled`, qui existait déjà

## :santa: Pour tester
- Ouvrir la doc du [PixIconButton](https://pix-ui-review-pr902.osc-fr1.scalingo.io/?path=/docs/actions-icon-button--docs&args=isDisabled:!false;plainIcon:!false#disabled)
- Cliquer sur l'iconButton gris et constater qu'aucune action n'est déclenchée
- Utiliser la console développeur pour vérifier la présence du aria-disabled sur le bouton
