### PR TITLE
[TECH] Ajouter un setTimeout afin de ne plus avoir d'erreur sur l'App PixCertif (PIX-XXXX)

### DIFF
--- a/addon/components/pix-app-layout.gjs
+++ b/addon/components/pix-app-layout.gjs
@@ -21,7 +21,9 @@ export default class PixAppLayout extends Component {
   }
 
   handleMarginContainerNavigation = (element) => {
-    this.#computeMarginTopElement(element);
+    setTimeout(() => {
+      this.#computeMarginTopElement(element);
+    }, 0);
   };
 
   get variant() {


### PR DESCRIPTION
## :christmas_tree: Problème
Sur PixCertif les tests de montée de version ne passe pas à cause du resizeObserver ( constat non observé sur les autres App)

## :gift: Proposition
L'ajout d'un setTimeout a 0 permet de ne plus avoir l'erreur sur l'app PixCertif et ne semble pas poser de problème pour la bon fonctionnement des app

## :star2: Remarques
RAS

## :santa: Pour tester
CI au vert. à tester sur le PR https://github.com/1024pix/pix/pull/13218 . et vérifier que le problème n'est plus persistant