### PR TITLE
[FEATURE] Augmenter la taille du texte de l'input a 1rem par défaut (PIX-19572).

### DIFF
--- a/addon/styles/component-state/_form.scss
+++ b/addon/styles/component-state/_form.scss
@@ -1,7 +1,7 @@
 @use "pix-design-tokens/typography";
 
 %pix-input-default {
-  @extend %pix-body-s;
+  @extend %pix-body-l;
 
   padding: var(--pix-spacing-2x) var(--pix-spacing-3x);
   color: var(--pix-neutral-900);


### PR DESCRIPTION
## :christmas_tree: Problème

lorsque la taille du texte dans un input n'est pas de 1rem, sur iOS il y a un zoom. 

## :gift: Proposition
Passer la size a 1rem par défaut

## :star2: Remarques
RAS

## :santa: Pour tester
CI au vert et vérifier que ça ne zoom plus sur tablet mobile