### PR TITLE
[TECH] Tester d'installer chrome en premier pour éviter les erreurs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -75,9 +75,9 @@ jobs:
     working_directory: ~/pix-ui
     resource_class: medium
     steps:
+      - browser-tools/install_chrome
       - attach_workspace:
           at: ~/pix-ui
-      - browser-tools/install_chrome
       - run: npm run test
 
   chromatic-deployment:


### PR DESCRIPTION
## :christmas_tree: Problème
Les tests échouent à cause de Chrome qui ne se lance pas assez vite presque tout le temps.

## :gift: Proposition
Tester de faire que sur le monorepo en installant chrome en premier puis en attachant le workspace. 

## :star2: Remarques
<img width="2856" height="1322" alt="Screenshot 2025-09-26 at 16 11 00" src="https://github.com/user-attachments/assets/46bda036-2727-44d9-84e8-103c7ee94dc8" />

## :santa: Pour tester
> _Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc._
