### PR TITLE
[BUGFIX] Éviter le décalage visuel de l'élément poppant de PixStructureSwitcher 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,7 @@
 
 # system
 .DS_Store
+CLAUDE.md
 
 # ember-try
 /.node_modules.ember-try/

--- a/addon/components/pix-structure-switcher.hbs
+++ b/addon/components/pix-structure-switcher.hbs
@@ -8,7 +8,6 @@
   ...attributes
 >
   <PopperJS @placement="right-end" as |reference popover|>
-
     <PixButton
       {{reference}}
       @size="small"
@@ -18,23 +17,25 @@
       @triggerAction={{this.toggleMenu}}
       aria-expanded={{this.isMenuOpen}}
     >{{@label}}</PixButton>
-    <div
-      {{popover}}
-      class="pix-select__dropdown {{unless this.isMenuOpen 'pix-select__dropdown--closed'}}"
-    >
-      <PixSelectList
-        aria-labelledby={{this.switcherId}}
-        {{on "transitionend" this.focus}}
-        @hideDefaultOption={{true}}
-        @listId={{this.listId}}
-        @selectId={{this.switcherId}}
-        @value={{@value}}
-        @onChange={{this.onSelectListChange}}
-        @defaultOption={{@defaultOption}}
-        @isExpanded={{this.isMenuOpen}}
-        @options={{@structures}}
-        @defaultOptionValue={{@label}}
-      />
-    </div>
+    {{#if this.isMenuOpen}}
+      <div
+        {{popover}}
+        class="pix-select__dropdown {{unless this.isMenuOpen 'pix-select__dropdown--closed'}}"
+      >
+        <PixSelectList
+          aria-labelledby={{this.switcherId}}
+          {{on "transitionend" this.focus}}
+          @hideDefaultOption={{true}}
+          @listId={{this.listId}}
+          @selectId={{this.switcherId}}
+          @value={{@value}}
+          @onChange={{this.onSelectListChange}}
+          @defaultOption={{@defaultOption}}
+          @isExpanded={{this.isMenuOpen}}
+          @options={{@structures}}
+          @defaultOptionValue={{@label}}
+        />
+      </div>
+    {{/if}}
   </PopperJS>
 </div>

--- a/addon/modifiers/on-arrow-down-up-action.js
+++ b/addon/modifiers/on-arrow-down-up-action.js
@@ -1,8 +1,6 @@
 import { modifier } from 'ember-modifier';
 
 export default modifier((element, [elementId, callback, isExpanded]) => {
-  const elementToTarget = document.getElementById(elementId);
-
   element.addEventListener('keydown', handleKeyDown);
 
   return () => {
@@ -19,7 +17,10 @@ export default modifier((element, [elementId, callback, isExpanded]) => {
     event.preventDefault();
 
     const focusElement = () => {
-      const focusableElements = findFocusableElements(elementToTarget);
+      const targetElement = document.getElementById(elementId);
+      if (!targetElement) return;
+
+      const focusableElements = findFocusableElements(targetElement);
 
       const [firstFocusableElement] = focusableElements;
       const lastFocusableElement = focusableElements[focusableElements.length - 1];
@@ -60,15 +61,20 @@ export default modifier((element, [elementId, callback, isExpanded]) => {
     };
 
     if (!isExpanded) {
-      elementToTarget.addEventListener('transitionend', focusElement);
-
       callback(event);
 
-      return () => {
-        elementToTarget.removeEventListener('transitionend', focusElement);
+      const waitForElement = () => {
+        const targetElement = document.getElementById(elementId);
+        if (targetElement) {
+          targetElement.addEventListener('transitionend', focusElement, { once: true });
+        } else {
+          requestAnimationFrame(waitForElement);
+        }
       };
+
+      waitForElement();
     } else {
-      focusElement(elementToTarget);
+      focusElement();
     }
   }
 });

--- a/addon/styles/_pix-structure-switcher.scss
+++ b/addon/styles/_pix-structure-switcher.scss
@@ -35,6 +35,9 @@
     margin-left: calc(-1 * var(--pix-spacing-4x)) !important;
     overflow-y: auto;
     border-radius: 8px;
+    opacity: 0;
+    animation: fade-in-dropdown 150ms ease-in-out forwards;
+    animation-delay: 50ms;
 
     @include breakpoints.device-is('mobile') {
       position: static !important;
@@ -98,5 +101,15 @@
     &:focus {
       color: var(--pix-neutral-800)
     }
+  }
+}
+
+@keyframes fade-in-dropdown {
+  from {
+    opacity: 0;
+  }
+
+  to {
+    opacity: 1;
   }
 }

--- a/tests/integration/components/pix-structure-switcher-test.js
+++ b/tests/integration/components/pix-structure-switcher-test.js
@@ -1,5 +1,4 @@
 import { fireEvent, render } from '@1024pix/ember-testing-library';
-import { waitForElementToBeRemoved } from '@testing-library/dom';
 import userEvent from '@testing-library/user-event';
 import { hbs } from 'ember-cli-htmlbars';
 import { setupRenderingTest } from 'ember-qunit';
@@ -119,7 +118,6 @@ module('Integration | Component | pix-structure-switcher', function (hooks) {
 
       //when
       await userEvent.click(option);
-      await waitForElementToBeRemoved(() => screen.queryByRole('listbox'));
 
       // then
       assert.strictEqual(document.activeElement, button);
@@ -137,6 +135,7 @@ module('Integration | Component | pix-structure-switcher', function (hooks) {
         //  when
         const button = screen.getByRole('button', { name: 'Changer de structure' });
         button.focus();
+
         await userEvent.keyboard('[ArrowUp]');
 
         //then
@@ -231,7 +230,6 @@ module('Integration | Component | pix-structure-switcher', function (hooks) {
         await userEvent.keyboard('[Escape]');
 
         // then
-        await waitForElementToBeRemoved(() => screen.queryByRole('listbox'));
         assert.strictEqual(document.activeElement, button);
       });
 
@@ -255,7 +253,6 @@ module('Integration | Component | pix-structure-switcher', function (hooks) {
 
         // then
         assert.ok(this.onChangeSpy.calledWith({ value: '1', label: 'Salade' }));
-        await waitForElementToBeRemoved(() => screen.queryByRole('listbox'));
         assert.notOk(screen.queryByRole('listbox'));
         assert.strictEqual(document.activeElement, button);
       });
@@ -280,7 +277,6 @@ module('Integration | Component | pix-structure-switcher', function (hooks) {
 
         // then
         assert.ok(this.onChangeSpy.calledWith({ value: '1', label: 'Salade' }));
-        await waitForElementToBeRemoved(() => screen.queryByRole('listbox'));
         assert.notOk(screen.queryByRole('listbox'));
         assert.strictEqual(document.activeElement, button);
       });
@@ -305,7 +301,6 @@ module('Integration | Component | pix-structure-switcher', function (hooks) {
         await userEvent.click(externalButton);
 
         assert.strictEqual(document.activeElement, externalButton);
-        await waitForElementToBeRemoved(() => screen.queryByRole('listbox'));
         assert.notOk(screen.queryByRole('listbox'));
       });
 


### PR DESCRIPTION
## :christmas_tree: Problème

<img width="400" height="463" alt="image" src="https://github.com/user-attachments/assets/487b003d-47b9-4660-8cdc-d661af81b970" />

Dans certains cas (dans le structure switcher de PixCertif par exemple), l'élément poppant apparaissait déconnecté de son bouton de référence.

En scrollant il revenait à sa bonne position, mais ce n’est pas le comportement souhaité.

## :gift: Proposition

- Conditionner l'affichage du contenu "poppant" (ça implique un petit changement dans un des modifiers)
- Activer l'animation "fade-in" en CSS, mais on perd le "fade-out"
- Ne pas avoir d'impact sur PixSelect / Multiselect

## :santa: Pour tester

- Tester le [comportement ici](https://pix-ui-review-pr942.osc-fr1.scalingo.io/iframe.html?globals=&args=&id=navigation-applayout--app-layout&viewMode=story)
(Clic, entrée au clavier et flèches haut et bas)

- Constater qu'il fonctionne mieux [qu'ici](https://ui.pix.fr/iframe.html?globals=&args=&id=navigation-applayout--app-layout&viewMode=story)

