### PR TITLE
[BUGFIX] Afficher la bordure rouge du Select en erreur(PIX-19992)

### DIFF
--- a/addon/styles/_pix-select.scss
+++ b/addon/styles/_pix-select.scss
@@ -101,7 +101,9 @@
     color: var(--pix-neutral-900);
   }
 
-  &--error {
+  // &#{&}--error is equal to => .pix-select-button.pix-select-button--error
+  // https://sass-lang.com/documentation/style-rules/declarations/#interpolation
+  &#{&}--error {
     @extend %pix-form-error-state;
   }
 

--- a/tests/dummy/app/controllers/select-page.js
+++ b/tests/dummy/app/controllers/select-page.js
@@ -6,6 +6,8 @@ export default class SelectPage extends Controller {
   @tracked selectedOption = null;
   @tracked structure = this.structures[1];
   @tracked multiValues = [];
+  @tracked countriesError = true;
+  @tracked selectedCountry = null;
   @tracked options = [
     {
       value: '1',
@@ -45,6 +47,12 @@ export default class SelectPage extends Controller {
   }
 
   @action
+  onChangeCountry(option) {
+    this.selectedCountry = option;
+    this.countriesError = false;
+  }
+
+  @action
   onMultiChange(values) {
     this.multiValues = values;
   }
@@ -77,6 +85,12 @@ export default class SelectPage extends Controller {
   onMultiSearch(search) {
     this.multiSearchValue = search;
   }
+
+  countriesOptions = [
+    { value: '1', label: 'England' },
+    { value: '2', label: 'Cambodgia' },
+    { value: '3', label: 'South Africa' },
+  ];
 
   get options() {
     return

--- a/tests/dummy/app/templates/select-page.hbs
+++ b/tests/dummy/app/templates/select-page.hbs
@@ -1,38 +1,55 @@
+{{! template-lint-disable no-inline-styles }}
+
 <h1>PixSelect</h1>
+<div style="display: flex; flex-direction: column; gap: 2rem;">
+  <div class="single-select">
+    <PixSelect
+      @options={{this.filteredOptions}}
+      @onChange={{this.onChange}}
+      @value={{this.selectedOption}}
+      @hideDefaultOption={{true}}
+      @placeholder="Select an option"
+      @isSearchable={{true}}
+      @onSearch={{this.onSearch}}
+      @searchLabel="Rechercher un fruit"
+    >
+      <:label>Fruits</:label>
+    </PixSelect>
+    <PixButton @triggerAction={{this.addNewOption}}>Ajouter un citron</PixButton>
+  </div>
 
-<div class="single-select">
-  <PixSelect
-    @options={{this.filteredOptions}}
-    @onChange={{this.onChange}}
-    @value={{this.selectedOption}}
-    @hideDefaultOption={{true}}
-    @placeholder="Select an option"
-    @isSearchable={{true}}
-    @onSearch={{this.onSearch}}
-    @searchLabel="Rechercher un fruit"
-  >
-    <:label>Fruits</:label>
-  </PixSelect>
-  <PixButton @triggerAction={{this.addNewOption}}>Ajouter un citron</PixButton>
+  <div class="multi-select">
+    <PixMultiSelect
+      @options={{this.filteredMultiOptions}}
+      @values={{this.multiValues}}
+      @onChange={{this.onMultiChange}}
+      @onSearch={{this.onMultiSearch}}
+      @isSearchable={{true}}
+      @searchLabel="Rechercher une option"
+      @searchPlaceholder="Euuuuuh"
+      @emptySearchMessage="Aucun résultat"
+      @emptyMessage="Pas d'options"
+      class="full"
+    >
+      <:label>Kebab</:label>
+      <:default as |option|>{{option.label}}</:default>
+    </PixMultiSelect>
+    <PixButton @triggerAction={{this.addNewMultiOption}}>Ajouter une option</PixButton>
+  </div>
+
+  <div>
+    <PixSelect
+      @options={{this.countriesOptions}}
+      @onChange={{this.onChangeCountry}}
+      @value={{this.selectedCountry}}
+      @hideDefaultOption={{true}}
+      @placeholder="Select an option"
+      @requiredLabel="Required"
+      @errorMessage={{if this.countriesError "You must select a country"}}
+    >
+      <:label>Countries</:label>
+    </PixSelect>
+  </div>
+
+  <PixPagination @pagination={{this.pagination}} />
 </div>
-
-<div class="multi-select">
-  <PixMultiSelect
-    @options={{this.filteredMultiOptions}}
-    @values={{this.multiValues}}
-    @onChange={{this.onMultiChange}}
-    @onSearch={{this.onMultiSearch}}
-    @isSearchable={{true}}
-    @searchLabel="Rechercher une option"
-    @searchPlaceholder="Euuuuuh"
-    @emptySearchMessage="Aucun résultat"
-    @emptyMessage="Pas d'options"
-    class="full"
-  >
-    <:label>Kebab</:label>
-    <:default as |option|>{{option.label}}</:default>
-  </PixMultiSelect>
-  <PixButton @triggerAction={{this.addNewMultiOption}}>Ajouter une option</PixButton>
-</div>
-
-<PixPagination @pagination={{this.pagination}} />


### PR DESCRIPTION
## :christmas_tree: Problème
Actuellement, lorsque le PixSelect est en erreur, la bordure rouge ne s'affiche pas.

## :gift: Proposition
La classe est bien prévue dans le code, mais à cause du `@extend` de SaSS la propriété CSS pour la couleur rouge de la bordure est créée à la compilation, **APRÈS** la bordure grise d'origine, donc elle n'est pas surchargée.
Trouver une solution de contournement pour forcer le poids CSS dans le sens voulu.


## :santa: Pour tester
- sur la RA, accéder [ici](https://pix-ui-review-pr944.osc-fr1.scalingo.io/?path=/story/forms-select--with-id&args=errorMessage:Error)
- constater la bordure rouge lorsque le champ est en erreur
- supprimer le message d'erreur et constater que la bordure redevient grise

