### PR TITLE
[FEATURE] Créer un variant modulix pour PixAppNavigation (PIX-20100).

### DIFF
--- a/addon/helpers/variants.js
+++ b/addon/helpers/variants.js
@@ -1,1 +1,1 @@
-export const VARIANTS = ['primary', 'orga', 'certif', 'admin'];
+export const VARIANTS = ['primary', 'orga', 'certif', 'admin', 'modulix'];

--- a/addon/styles/_pix-app-layout.scss
+++ b/addon/styles/_pix-app-layout.scss
@@ -100,4 +100,13 @@
     --pix-navigation-color: var(--pix-primary-700);
     --pix-navigation-text-color: var(--pix-neutral-0);
   }
+
+  &--modulix {
+    background-color: var(--pix-neutral-0);
+
+    --pix-navigation-color: var(--pix-primary-10);
+    --pix-navigation-text-color: var(--pix-neutral-800);
+    --pix-navigation-width: 88px;
+    --pix-navigation-mobile-button-color: var(--pix-neutral-800);
+  }
 }

--- a/addon/styles/_pix-button-base.scss
+++ b/addon/styles/_pix-button-base.scss
@@ -184,16 +184,16 @@
 
   &--success {
     color: var(--pix-neutral-0);
-    background-color: var(--pix-success-500);
+    background-color: var(--pix-success-700);
 
     &:not([aria-disabled="true"]) {
       &:hover {
-        background-color: var(--pix-success-700);
+        background-color: var(--pix-success-900);
       }
 
       &:focus,
       &:focus-visible {
-        background-color: var(--pix-success-700);
+        background-color: var(--pix-success-900);
         outline: 1px solid var(--pix-neutral-0);
         outline-offset: -4px;
       }

--- a/addon/styles/_pix-navigation.scss
+++ b/addon/styles/_pix-navigation.scss
@@ -3,6 +3,7 @@
 
 :root {
   --pix-navigation-width:  15rem;
+  --pix-navigation-mobile-button-color: --pix-neutral-0;
 }
 
 .pix-navigation {
@@ -70,6 +71,10 @@
     @include breakpoints.device-is('mobile') {
       display: block;
       margin-left:auto;
+
+      svg {
+        color: var(--pix-navigation-mobile-button-color);
+      }
 
       .pix-button {
         background-color: transparent;

--- a/app/stories/pix-app-layout.mdx
+++ b/app/stories/pix-app-layout.mdx
@@ -6,7 +6,7 @@ import * as ComponentStories from './pix-app-layout.stories';
 # PixAppLayout
 
 Le composant `<PixAppLayout @variant="orga" />` permet d'afficher correctement la navigation principale d'une application.
-C'est ce composant qui va porter la variante de couleur (orga, certif, primary) et qui permettra de mettre à jour les couleurs de la navigation.
+C'est ce composant qui va porter la variante de couleur (orga, certif, primary, admin, modulix) et qui permettra de mettre à jour les couleurs de la navigation.
 Le composant `<PixAppLayout/>` comporte 3 placeholders
 
 - `<:navigation>` dans lequel on mettra la composant `<PixNavigation />`

--- a/tests/integration/components/pix-app-layout-test.js
+++ b/tests/integration/components/pix-app-layout-test.js
@@ -5,7 +5,7 @@ import { module, test } from 'qunit';
 
 module('Integration | Component | pix-app-layout', function (hooks) {
   setupRenderingTest(hooks);
-  ['orga', 'default', 'certif'].forEach(function (variant) {
+  ['orga', 'default', 'certif', 'admin', 'modulix'].forEach(function (variant) {
     test(`it add the correct className from ${variant}`, async function (assert) {
       // when
       this.variant = variant;

--- a/tests/integration/components/pix-block-test.js
+++ b/tests/integration/components/pix-block-test.js
@@ -51,7 +51,7 @@ module('Integration | Component | pix-block', function (hooks) {
       // then
       assert.ok(
         warnStub.calledWithExactly(
-          'WARNING: PixBlock: @variant "PIX APP" should be primary, orga, certif, admin',
+          'WARNING: PixBlock: @variant "PIX APP" should be primary, orga, certif, admin, modulix',
         ),
       );
     });

--- a/tests/integration/components/pix-table-test.js
+++ b/tests/integration/components/pix-table-test.js
@@ -424,7 +424,7 @@ module('Integration | Component | table', function (hooks) {
       // then
       assert.ok(
         warnStub.calledWithExactly(
-          'WARNING: PixTable: @variant "wrong variant" should be primary, orga, certif, admin',
+          'WARNING: PixTable: @variant "wrong variant" should be primary, orga, certif, admin, modulix',
         ),
       );
     });


### PR DESCRIPTION
## :christmas_tree: Problème
Aujourd'hui, les modules nécessitent un menu au format réduit, différent donc du comportement existant du PixNavigation.

## :gift: Proposition
Ajouter un variant `modulix` pour afficher un format réduit + couleurs spécifiques.


> [!IMPORTANT]
> Dans cette PR on modifie la couleur de base du Pix Button success.
En effet, le token success-500 ne fonctionne pas en terme d'A11y dans le bouton, qu'il soit small ou large.
On passe donc au success-700
 
## :santa: Pour tester

Aller voir le menu https://www.figma.com/design/0RcwMBD5KmmbAxVOf2OH0D/Modulix?node-id=866-5275&m=dev
comparer avec storybook, variant `modulix`.
