### PR TITLE
[BREAKING] Tout composant de PixNavigation clicked ferme PixNavigation en Mobile (PIX-20319)

### DIFF
--- a/addon/components/pix-navigation.js
+++ b/addon/components/pix-navigation.js
@@ -26,10 +26,8 @@ export default class PixMNavigation extends Component {
   }
 
   @action
-  handleNavigationClick(event) {
-    if (event.target.nodeName === 'A') {
-      this.navigationMenuOpened = false;
-    }
+  handleNavigationClick() {
+    this.navigationMenuOpened = false;
   }
 
   get navigationId() {

--- a/addon/styles/_pix-navigation.scss
+++ b/addon/styles/_pix-navigation.scss
@@ -91,6 +91,10 @@
         &:active {
           background-color: rgb(var(--pix-neutral-800-inline), 30%);
         }
+
+        .pix-button__icon--before {
+          margin-right: 0;
+        }
       }
     }
   }


### PR DESCRIPTION
## :boom: BREAKING_CHANGES
Tout type de composant cliqué dans la barre de navigation fermera la barre dépliée en Mobile.

## :christmas_tree: Problème
Une condition, dans la fonction handleClick() de pixNavigation, ne permet pas qu'un composant PixButton qui serait clické dans la PixNavigation, ferme également la barre de navigation.
On est contraint de cliquer sur l'icône de fermeture après le click sur le boutton pour fermer la barre de navigation.

## :gift: Proposition
Enlever la condition  pour permettre tout composant cliqué d'entraîner la fermeture de la barre de navigation.

## :star2: Remarques
- On en a profité pour corriger un margin sur le bouton de fermeture de la PixNavigation en affichage Mobile. 

## :santa: Pour tester
- Vérifier que la barre de navigation PixNavigation fonctionne toujours comme avant.
