### PR TITLE
[DOC] Mettre à jour la documentation de release

### DIFF
--- a/docs/make-a-release.mdx
+++ b/docs/make-a-release.mdx
@@ -32,6 +32,8 @@ Le type sémantique de la release est déterminé par le préfixe entre crochets
 `[BREAKING]` va déclencher une release majeure, le préfixe `[FEATURE]` va déclencher une release mineure, tous les
 autres (`[BUGFIX]`, `[BUMP]`, `[DOC]` et `[TECH]` un patch.
 
+⚠ Prenez soin de mettre un espace entre le préfixe et le titre de la PR.
+
 Il est donc important de bien
 [identifier les breaking changes](https://ui.pix.fr/?path=/docs/pix-ui-d%C3%A9veloppement-breaking-changes--docs) dès
 l'étape de la pull request.


### PR DESCRIPTION
## :christmas_tree: Problème
Une PR sans espace entre le préfixe et le titre entraîne des erreurs pour la release de Pix UI.

## :gift: Proposition
Prévenir la population de ce risque.

## :star2: Remarques
On avoue, cette PR à surtout un but autre : faire passer la précédente PR de devcomp :)

## :santa: Pour tester
tout va bien, y'a un espace entre le préfixe et le titre.
