### PR TITLE
[FEATURE] Fermer le menu mobile lors d'un changement de route (PIX-19604).

### DIFF
--- a/addon/components/pix-navigation.hbs
+++ b/addon/components/pix-navigation.hbs
@@ -21,7 +21,7 @@
   </header>
   <nav
     class="pix-navigation__nav"
-    {{on "click" this.handleNavigationClick}}
+    {{on "click" this.closeNavigation}}
     aria-label={{@navigationAriaLabel}}
     id={{this.navigationId}}
   >

--- a/addon/components/pix-navigation.js
+++ b/addon/components/pix-navigation.js
@@ -1,10 +1,13 @@
 import { warn } from '@ember/debug';
 import { action } from '@ember/object';
 import { guidFor } from '@ember/object/internals';
+import { inject as service } from '@ember/service';
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 
 export default class PixMNavigation extends Component {
+  @service router;
+
   constructor(...args) {
     super(...args);
     this._navigationId = 'navigation-' + guidFor(this);
@@ -23,11 +26,18 @@ export default class PixMNavigation extends Component {
   @action
   toggleNavigationMenu() {
     this.navigationMenuOpened = !this.navigationMenuOpened;
+
+    if (this.navigationMenuOpened) {
+      this.router.on('routeDidChange', this.closeNavigation);
+    } else {
+      this.router.off('routeDidChange', this.closeNavigation);
+    }
   }
 
   @action
-  handleNavigationClick() {
+  closeNavigation() {
     this.navigationMenuOpened = false;
+    this.router.off('routeDidChange', this.closeNavigation);
   }
 
   get navigationId() {

--- a/tests/integration/components/pix-navigation-test.js
+++ b/tests/integration/components/pix-navigation-test.js
@@ -1,4 +1,5 @@
 import { render, within } from '@1024pix/ember-testing-library';
+import { click, settled } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { setupRenderingTest } from 'ember-qunit';
 import { module, test } from 'qunit';
@@ -61,6 +62,28 @@ module('Integration | Component | pix-navigation', function (hooks) {
         hbs`<PixNavigation @navigationAriaLabel='label' @openLabel='open' @closeLabel='close' />`,
       );
       assert.notOk(screen.queryByRole('button', { name: 'menu' }));
+    });
+  });
+
+  module('Mobile', function () {
+    test('it should close the menu on route change', async function (assert) {
+      // given
+      const router = this.owner.lookup('service:router');
+
+      const screen = await render(
+        hbs`<PixNavigation @navigationAriaLabel='label' @openLabel='open' @closeLabel='close' />`,
+      );
+
+      // when
+      const openMenuButton = screen.getByText('open').closest('button');
+      await click(openMenuButton);
+
+      router.trigger('routeDidChange');
+      await settled();
+
+      // then
+      assert.ok(screen.getByText('open').closest('button'));
+      assert.notOk(screen.queryByText('close'));
     });
   });
 });


### PR DESCRIPTION
## :christmas_tree: Problème

Sur mobile, le menu ne se referme pas lorsque l’utilisateur clique sur un des bouton.

## :gift: Proposition

- Détecter lorsque la route a changé
- Lorsque ça arrive, déclencher la fermeture du menu

## :santa: Pour tester

- Lancer le projet PixUI en local
- Ne pas aller sur Storybook mais sur le projet Ember qui se lance
- Passer en mode mobile et naviguer via le menu principal
- Constater que le menu se ferme bien quand on change de page
