### PR TITLE
[BUGFIX] Ne pas fermer la barre de navigation lors du clic sur un élément désactivé (PIX-20530)

### DIFF
--- a/addon/components/pix-navigation.js
+++ b/addon/components/pix-navigation.js
@@ -35,9 +35,13 @@ export default class PixMNavigation extends Component {
   }
 
   @action
-  closeNavigation() {
-    this.navigationMenuOpened = false;
-    this.router.off('routeDidChange', this.closeNavigation);
+  closeNavigation(event) {
+    const disabledElement = event?.srcElement?.closest('[aria-disabled=true]');
+
+    if (!disabledElement) {
+      this.navigationMenuOpened = false;
+      this.router.off('routeDidChange', this.closeNavigation);
+    }
   }
 
   get navigationId() {

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -36,6 +36,12 @@
           @target="_blank"
           @icon="help"
         >Centre d'aide</PixNavigationButton>
+        <PixButton
+          aria-disabled="true"
+          @iconBefore="cancel"
+          @isDisabled={{true}}
+          @variant="primary"
+        >Test mobile disabled</PixButton>
       </:navElements>
       <:footer>
         <p>

--- a/tests/integration/components/pix-navigation-test.js
+++ b/tests/integration/components/pix-navigation-test.js
@@ -66,6 +66,38 @@ module('Integration | Component | pix-navigation', function (hooks) {
   });
 
   module('Mobile', function () {
+    module('when a button is disabled on menu', function () {
+      test('it should not close the menu when clicking on this button', async function (assert) {
+        // given
+        const disabledButtonLabel = 'bouton désactivé';
+        this.set('label', disabledButtonLabel);
+
+        // when
+        const screen = await render(
+          hbs`<PixNavigation @navigationAriaLabel='label' @openLabel='open' @closeLabel='close'>
+  <:navElements>
+    <PixButton
+      aria-disabled='true'
+      @iconBefore='cancel'
+      @isDisabled={{true}}
+      @variant='primary'
+    ><span>{{this.label}}</span></PixButton>
+  </:navElements>
+</PixNavigation>`,
+        );
+
+        const openMenuButton = screen.getByText('open').closest('button');
+
+        await click(openMenuButton);
+
+        const spanElement = screen.getByText(this.label);
+        await click(spanElement);
+
+        // then
+        assert.ok(screen.queryByText('close'));
+      });
+    });
+
     test('it should close the menu on route change', async function (assert) {
       // given
       const router = this.owner.lookup('service:router');


### PR DESCRIPTION
## :christmas_tree: Problème
Lorsqu'on a un élément désactivé dans la barre de navigation et qu'on clique dessus, la barre se ferme alors qu'il ne devrait pas y avoir d'impact dessus.

## :gift: Proposition
Corriger cela.

## :star2: Remarques
RAS

## :santa: Pour tester
### En local
- Lancer Pix UI en local
- Aller sur l'app dummy 
- Se mettre en format mobile et cliquer sur le bouton `Test mobile disabled`
- Vérifier que la barre de navigation ne se ferme plus !
