### PR TITLE
[BUGFIX] Activer l'action de fermeture de PixNavigation qu'en mobile

### DIFF
--- a/addon/components/pix-navigation.js
+++ b/addon/components/pix-navigation.js
@@ -38,7 +38,7 @@ export default class PixMNavigation extends Component {
   closeNavigation(event) {
     const disabledElement = event?.srcElement?.closest('[aria-disabled=true]');
 
-    if (!disabledElement) {
+    if (!disabledElement && this.navigationMenuOpened) {
       this.navigationMenuOpened = false;
       this.router.off('routeDidChange', this.closeNavigation);
     }


### PR DESCRIPTION
## :christmas_tree: Problème

Une erreur `You attempted to remove a function listener which did not exist on the instance, which means you may have attempted to remove it before it was added` se déclenchait.

Cela vient du fait que l'action `closeNavigation` de PixNavigation se déclenchait sur desktop au changement de page.

## :gift: Proposition

Déclencher l'action uniquement si le menu est dans un état "toggleable" (sur mobile, avec le burger menu).

## :santa: Pour tester

- Lancer PixUI en local
- Sur le projet Ember qui se lancer (sûrement `http://localhost:4204/`), rester en format desktop
- Cliquer sur les liens du menu
- Aucune erreur n'est censée apparaître dans la console de dev
