### PR TITLE
[TECH] Passage au système de Trusted publishers de npm

### DIFF
--- a/.github/workflows/check-node-version-availability-on-scalingo.yml
+++ b/.github/workflows/check-node-version-availability-on-scalingo.yml
@@ -7,6 +7,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
-      - uses: 1024pix/pix-actions/check-node-version-availability-on-scalingo@v0
+      - uses: 1024pix/pix-actions/check-node-version-availability-on-scalingo@main

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,5 +1,8 @@
 name: release
 
+permissions:
+  id-token: write
+
 on:
   push:
     branches:
@@ -12,13 +15,14 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         with:
           persist-credentials: false
 
-      - uses: actions/setup-node@v5
+      - uses: actions/setup-node@v6
         with:
           node-version-file: 'package.json'
+          registry-url: 'https://registry.npmjs.org'
 
       - run: npm ci
       - run: npm run build
@@ -29,7 +33,6 @@ jobs:
           npmPublish: true
         env:
           GITHUB_TOKEN: ${{ secrets.PIX_SERVICE_ACTIONS_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_PUBLISH_ACCESS_TOKEN }}
 
       - name: Deploy storybook to Github Pages
         run: npm run deploy-storybook -- --ci


### PR DESCRIPTION
## :christmas_tree: Problème

La publication de package npm avec token est déconseillée.
De plus les tokens ont maintenant une durée de vie maximum de 90 jours.

## :gift: Proposition

Passer au système de [Trusted publishers](https://docs.npmjs.com/trusted-publishers) proposé par npm.

## :star2: Remarques

Lié à 1024pix/pix-actions#72

## :santa: Pour tester

Ça a été testé avec succès sur le package `@1024pix/epreuves-components`