### PR TITLE
[FEATURE] Ajouter un attribut isFullWidth sur les composants PixInput et PixSelect (PIX-20616)

### DIFF
--- a/addon/components/pix-input-base.js
+++ b/addon/components/pix-input-base.js
@@ -29,6 +29,19 @@ export default class PixInputBase extends Component {
     return this.args.validationStatus === 'error' ? this.prefix + '-error' : null;
   }
 
+  get rootClassNames() {
+    const classNames = ['pix-input'];
+    if (this.args.inlineLabel) {
+      classNames.push('pix-input--inline');
+    }
+
+    if (this.args.isFullWidth) {
+      classNames.push('pix-input--full-width');
+    }
+
+    return classNames.join(' ');
+  }
+
   get hasError() {
     return this.args.validationStatus === 'error';
   }

--- a/addon/components/pix-input.hbs
+++ b/addon/components/pix-input.hbs
@@ -1,4 +1,4 @@
-<div class="pix-input {{if @inlineLabel ' pix-input--inline'}}">
+<div class={{this.rootClassNames}}>
   {{#if (has-block "label")}}
     <PixLabel
       @for={{this.id}}
@@ -11,7 +11,7 @@
       {{yield to="label"}}
     </PixLabel>
   {{/if}}
-  <div>
+  <div class="pix-input__field-container">
     <div class="pix-input__container">
       <input
         id={{this.id}}

--- a/addon/components/pix-select.hbs
+++ b/addon/components/pix-select.hbs
@@ -1,5 +1,5 @@
 <div
-  class="pix-select {{if @inlineLabel ' pix-select--inline'}}"
+  class={{this.rootClassNames}}
   id="container-{{this.selectId}}"
   {{on-click-outside this.hideDropdown}}
   {{on-arrow-down-up-action this.listId this.showDropdown this.isExpanded}}
@@ -20,13 +20,13 @@
     </PixLabel>
   {{/if}}
 
-  <div>
+  <div class="pix-select__button-container">
     <PopperJS @placement={{or @placement "bottom-start"}} as |reference popover|>
       <button
         {{reference}}
         type="button"
         id={{this.selectId}}
-        class={{this.className}}
+        class={{this.buttonClassName}}
         {{on "click" this.toggleDropdown}}
         aria-expanded={{this.isAriaExpanded}}
         aria-controls={{this.listId}}

--- a/addon/components/pix-select.js
+++ b/addon/components/pix-select.js
@@ -34,13 +34,26 @@ export default class PixSelect extends Component {
     return !this.searchValue && !this.args.hideDefaultOption;
   }
 
-  get className() {
-    const classes = ['pix-select-button'];
+  get buttonClassName() {
+    const buttonClasses = ['pix-select-button'];
     if (this.args.className) {
-      classes.push(this.args.className);
+      buttonClasses.push(this.args.className);
     }
     if (this.args.errorMessage) {
-      classes.push('pix-select-button--error');
+      buttonClasses.push('pix-select-button--error');
+    }
+
+    return buttonClasses.join(' ');
+  }
+
+  get rootClassNames() {
+    const classes = ['pix-select'];
+    if (this.args.inlineLabel) {
+      classes.push('pix-select--inline');
+    }
+
+    if (this.args.isFullWidth) {
+      classes.push('pix-select--full-width');
     }
 
     return classes.join(' ');

--- a/addon/styles/_pix-input.scss
+++ b/addon/styles/_pix-input.scss
@@ -12,8 +12,16 @@
     align-items: center;
   }
 
+  &--full-width {
+    width: 100%;
+  }
+
   &__container {
     position: relative;
+  }
+
+  &__field-container {
+    flex-grow: 1;
   }
 
   svg {

--- a/addon/styles/_pix-label.scss
+++ b/addon/styles/_pix-label.scss
@@ -1,4 +1,4 @@
-@use "pix-design-tokens/typography";
+@use 'pix-design-tokens/typography';
 
 .pix-label {
   display: block;
@@ -22,6 +22,7 @@
   }
 
   &--inline-label {
+    flex-shrink: 0;
     font-weight: var(--pix-font-normal);
   }
 

--- a/addon/styles/_pix-select.scss
+++ b/addon/styles/_pix-select.scss
@@ -16,6 +16,10 @@
     align-items: center;
   }
 
+  &--full-width {
+    width: 100%;
+  }
+
   &__dropdown {
     @extend %pix-shadow-xs;
 
@@ -77,6 +81,10 @@
 
   &__error-message {
     @extend %pix-input-error-message;
+  }
+
+  &__button-container {
+    flex-grow: 1;
   }
 }
 

--- a/app/stories/pix-input.mdx
+++ b/app/stories/pix-input.mdx
@@ -85,6 +85,10 @@ En readonly, l'input n'est pas modifiable, mais il est toujours focusable et est
 
 <Story of={ComponentStories.withoutLabel} height={100} />
 
+## With Is Full Width
+
+<Story of={ComponentStories.withIsFullWidth} height={100} />
+
 ## Usage
 
 ```html

--- a/app/stories/pix-input.stories.js
+++ b/app/stories/pix-input.stories.js
@@ -78,6 +78,15 @@ export default {
       },
       control: { type: 'boolean' },
     },
+    isFullWidth: {
+      name: 'isFullWidth',
+      description: 'Permet au composant de prendre la largeur de son parent',
+      type: { name: 'boolean', required: false },
+      table: {
+        defaultValue: { summary: false },
+      },
+      control: { type: 'boolean' },
+    },
   },
 };
 
@@ -116,6 +125,33 @@ const TemplateWithoutLabel = (args) => {
   @inlineLabel={{this.inlineLabel}}
   @requiredLabel={{this.requiredLabel}}
 />`,
+    context: args,
+  };
+};
+
+const TemplateWithParent = (args) => {
+  return {
+    template: hbs`
+    {{! template-lint-disable no-inline-styles }}
+    <span style="color: blue;">Composant parent</span>
+    <div style="width: 400px; border: 2px solid blue; padding-top: 1rem; padding-bottom: 1rem;">
+      <PixInput
+        @id={{this.id}}
+        @errorMessage={{this.errorMessage}}
+        placeholder='Jeanne, Pierre ...'
+        @validationStatus={{this.validationStatus}}
+        @size={{this.size}}
+        disabled={{this.disabled}}
+        readonly={{this.readonly}}
+        @subLabel={{this.subLabel}}
+        @inlineLabel={{this.inlineLabel}}
+        @requiredLabel={{this.requiredLabel}}
+        @screenReaderOnly={{this.screenReaderOnly}}
+        @isFullWidth={{this.isFullWidth}}
+      >
+        <:label>{{this.label}}</:label>
+      </PixInput>
+    </div>`,
     context: args,
   };
 };
@@ -172,4 +208,13 @@ withRequiredLabel.args = {
 export const withoutLabel = TemplateWithoutLabel.bind({});
 withoutLabel.args = {
   id: 'first-name',
+};
+
+export const withIsFullWidth = TemplateWithParent.bind({});
+withIsFullWidth.args = {
+  id: 'first-name',
+  label: 'Prénom',
+  isFullWidth: true,
+  inlineLabel: false,
+  requiredLabel: 'Champ obligatoire',
 };

--- a/app/stories/pix-select.mdx
+++ b/app/stories/pix-select.mdx
@@ -71,6 +71,12 @@ Si on utilise une option on rajoute une propriété 'icon' celui-ci s'affichera 
 
 <Story of={ComponentStories.WithOptionIcon} />
 
+## WithIsFullWidth
+
+On force le composant à adopter la largeur de son parent.
+
+<Story of={ComponentStories.WithIsFullWidth} />
+
 ## Usage
 
 ```html

--- a/app/stories/pix-select.stories.js
+++ b/app/stories/pix-select.stories.js
@@ -225,6 +225,15 @@ export default {
       },
       control: { type: 'boolean' },
     },
+    isFullWidth: {
+      name: 'isFullWidth',
+      description: 'Permet au composant de prendre la largeur de son parent',
+      type: { name: 'boolean', required: false },
+      table: {
+        defaultValue: { summary: false },
+      },
+      control: { type: 'boolean' },
+    },
   },
 };
 
@@ -254,11 +263,49 @@ const Template = (args) => {
   @size={{this.size}}
   @subLabel={{this.subLabel}}
   @inlineLabel={{this.inlineLabel}}
+  @isFullWidth={{this.isFullWidth}}
   @requiredLabel={{this.requiredLabel}}
   @screenReaderOnly={{this.screenReaderOnly}}
 >
   <:label>{{this.label}}</:label>
 </PixSelect>`,
+    context: args,
+  };
+};
+
+const TemplateWithParent = (args) => {
+  return {
+    template: hbs`
+    {{! template-lint-disable no-inline-styles }}
+    <span style="color: blue;">Composant parent</span>
+  <div style="width: 400px; border: 2px solid blue; padding-top: 1rem; padding-bottom: 1rem;">
+<PixSelect
+    @id={{this.id}}
+    @className={{this.className}}
+    @options={{this.options}}
+    @isSearchable={{this.isSearchable}}
+    @placeholder={{this.placeholder}}
+    @hideDefaultOption={{this.hideDefaultOption}}
+    @searchLabel={{this.searchLabel}}
+    @value={{this.value}}
+    @searchPlaceholder={{this.searchPlaceholder}}
+    @emptySearchMessage={{this.emptySearchMessage}}
+    @errorMessage={{this.errorMessage}}
+    @isDisabled={{this.isDisabled}}
+    @placement={{this.placement}}
+    @iconName={{this.iconName}}
+    @plainIcon={{this.plainIcon}}
+    @size={{this.size}}
+    @subLabel={{this.subLabel}}
+    @inlineLabel={{this.inlineLabel}}
+    @requiredLabel={{this.requiredLabel}}
+    @screenReaderOnly={{this.screenReaderOnly}}
+    @isFullWidth={{this.isFullWidth}}
+    @isComputeWidthDisabled={{this.isComputeWidthDisabled}}
+>
+    <:label>{{this.label}}</:label>
+</PixSelect>
+  </div>`,
     context: args,
   };
 };
@@ -467,4 +514,20 @@ WithOptionIcon.args = {
     { value: 'withSpeedIcon', label: 'Icone speed', icon: 'speed', iconTitle: 'speed title' },
   ],
   value: 'fr',
+};
+
+export const WithIsFullWidth = TemplateWithParent.bind({});
+WithIsFullWidth.args = {
+  options: [
+    { value: '1', label: 'Figues' },
+    { value: '3', label: 'Fraises' },
+    { value: '3', label: 'Noix' },
+    { value: '4', label: 'Papayes' },
+  ],
+  label: 'Mon label',
+  placeholder: 'Sélectionner un fruit',
+  isFullWidth: true,
+  inlineLabel: false,
+  isComputeWidthDisabled: true,
+  onChange: action('onChange'),
 };

--- a/tests/dummy/app/styles/app.scss
+++ b/tests/dummy/app/styles/app.scss
@@ -1,0 +1,10 @@
+.select-page__bordered-container {
+  width: 500px;
+  border: 1px solid;
+  padding-top: 2rem;
+  padding-bottom: 2rem;
+}
+
+.select-page__country-select {
+  width: 100%;
+}

--- a/tests/dummy/app/templates/select-page.hbs
+++ b/tests/dummy/app/templates/select-page.hbs
@@ -37,8 +37,9 @@
     <PixButton @triggerAction={{this.addNewMultiOption}}>Ajouter une option</PixButton>
   </div>
 
-  <div>
+  <div class="select-page__bordered-container">
     <PixSelect
+      class="select-page__country-select"
       @options={{this.countriesOptions}}
       @onChange={{this.onChangeCountry}}
       @value={{this.selectedCountry}}
@@ -46,6 +47,8 @@
       @placeholder="Select an option"
       @requiredLabel="Required"
       @errorMessage={{if this.countriesError "You must select a country"}}
+      {{!-- @isFullWidth={{true}} --}}
+      @inlineLabel={{true}}
     >
       <:label>Countries</:label>
     </PixSelect>

--- a/tests/integration/components/pix-input-test.js
+++ b/tests/integration/components/pix-input-test.js
@@ -25,9 +25,7 @@ module('Integration | Component | PixInput', function (hooks) {
 
     // then
     const selectorElement = this.element.querySelector(INPUT_SELECTOR);
-    // TODO: Fix this the next time the file is edited.
-    // eslint-disable-next-line qunit/no-assert-equal
-    assert.equal(selectorElement.id, '123');
+    assert.strictEqual(selectorElement.id, '123');
   });
 
   test('it should be possible to give a label to input', async function (assert) {
@@ -68,9 +66,7 @@ module('Integration | Component | PixInput', function (hooks) {
 
     // then
     const selectorElement = this.element.querySelector(INPUT_SELECTOR);
-    // TODO: Fix this the next time the file is edited.
-    // eslint-disable-next-line qunit/no-assert-equal
-    assert.equal(selectorElement.value, 'Jeanne');
+    assert.strictEqual(selectorElement.value, 'Jeanne');
   });
 
   test('it should be possible to give more params to input', async function (assert) {
@@ -81,9 +77,7 @@ module('Integration | Component | PixInput', function (hooks) {
 
     // then
     const selectorElement = this.element.querySelector(INPUT_SELECTOR);
-    // TODO: Fix this the next time the file is edited.
-    // eslint-disable-next-line qunit/no-assert-equal
-    assert.equal(selectorElement.autocomplete, 'on');
+    assert.strictEqual(selectorElement.autocomplete, 'on');
   });
 
   test('it should be possible to make pix input required', async function (assert) {
@@ -95,5 +89,47 @@ module('Integration | Component | PixInput', function (hooks) {
     // then
     const requiredInput = screen.getByLabelText('Prénom *');
     assert.dom(requiredInput).isRequired();
+  });
+
+  module('root class computation', function () {
+    const DIV_ROOT_SELECTOR = '.pix-input';
+
+    test('it should compute correct class for root when @isFullWidth param is true', async function (assert) {
+      // given & when
+      await render(
+        hbs`<PixInput @id='firstName' @isFullWidth={{true}}><:label>Prénom</:label></PixInput>`,
+      );
+
+      // then
+      const selectorElement = this.element.querySelector(DIV_ROOT_SELECTOR);
+      assert.strictEqual(selectorElement.classList.value, 'pix-input pix-input--full-width');
+    });
+
+    test('it should compute correct class for root when @inlineLabel param is true', async function (assert) {
+      // given & when
+      await render(
+        hbs`<PixInput @id='firstName' @inlineLabel={{true}}><:label>Prénom</:label></PixInput>`,
+      );
+
+      // then
+      const selectorElement = this.element.querySelector(DIV_ROOT_SELECTOR);
+      assert.strictEqual(selectorElement.classList.value, 'pix-input pix-input--inline');
+    });
+
+    test('it should compute correct class for root when @inlineLabel and @isFullWidth params are true', async function (assert) {
+      // given & when
+      await render(
+        hbs`<PixInput @id='firstName' @inlineLabel={{true}} @isFullWidth={{true}}>
+  <:label>Prénom</:label>
+</PixInput>`,
+      );
+
+      // then
+      const selectorElement = this.element.querySelector(DIV_ROOT_SELECTOR);
+      assert.strictEqual(
+        selectorElement.classList.value,
+        'pix-input pix-input--inline pix-input--full-width',
+      );
+    });
   });
 });

--- a/tests/integration/components/pix-select-test.js
+++ b/tests/integration/components/pix-select-test.js
@@ -765,4 +765,47 @@ module('Integration | Component | PixSelect', function (hooks) {
       });
     });
   });
+
+  module('root class computation', function () {
+    const DIV_ROOT_SELECTOR = '.pix-select';
+
+    test('it should compute correct class for root when @isFullWidth param is true', async function (assert) {
+      // given & when
+      await render(
+        hbs`<PixSelect @options={{this.options}} @isFullWidth={{true}}><:label
+  >{{this.label}}</:label></PixSelect>`,
+      );
+
+      // then
+      const selectorElement = this.element.querySelector(DIV_ROOT_SELECTOR);
+      assert.strictEqual(selectorElement.classList.value, 'pix-select pix-select--full-width');
+    });
+
+    test('it should compute correct class for root when @inlineLabel param is true', async function (assert) {
+      // given & when
+      await render(
+        hbs`<PixSelect @options={{this.options}} @inlineLabel={{true}}><:label
+  >{{this.label}}</:label></PixSelect>`,
+      );
+
+      // then
+      const selectorElement = this.element.querySelector(DIV_ROOT_SELECTOR);
+      assert.strictEqual(selectorElement.classList.value, 'pix-select pix-select--inline');
+    });
+
+    test('it should compute correct class for root when @inlineLabel and @isFullWidth params are true', async function (assert) {
+      // given & when
+      await render(
+        hbs`<PixSelect @options={{this.options}} @inlineLabel={{true}} @isFullWidth={{true}}><:label
+  >{{this.label}}</:label></PixSelect>`,
+      );
+
+      // then
+      const selectorElement = this.element.querySelector(DIV_ROOT_SELECTOR);
+      assert.strictEqual(
+        selectorElement.classList.value,
+        'pix-select pix-select--inline pix-select--full-width',
+      );
+    });
+  });
 });


### PR DESCRIPTION
## :christmas_tree: Problème
- Pour le **PixInput**: la façon dont le composant est actuellement fait ne permet pas de surcharger la classe de la div contenante de ce composant. Donc on ne peut pas facilement faire un `width: 100%` pour que le PixInput prenne la largeur de sont parent. 
- Pour le **PixSelect**: contrairement au PixInput, ce composant permet de surcharger la classe de la div contenante. 


## :gift: Proposition
- **PixInput**: pour ne pas introduire de breaking changes, on propose d'ajouter un attribut `isFullWidth` (boolean), permettant d'ajouter à la demande ce `width: 100%` sur la div contenante, sans changer le reste du comportement du composant
- **PixSelect**: soit on ne fait rien et on surcharge la classe manuellement lors de son utilisation avec un `width: 100%`, soit on implémente aussi un attribut `isFullWidth `pour être raccord avec la signature du PixInput
- Pour les deux composants, un `flex-grow: 1` a été ajouté sur le container de l'élement interactif (input pour le PixInput, button pour le PixSelect), afin de prendre toute la place restante dans le cas d'un label inline.

## :star2: Remarques
Rien n'a été fait pour le moment pour le PixMultiSelect car un autre chantier est en cours dessus.

## :santa: Pour tester
- Aller voir sur Storybook le comportement de `isFullWidth`: https://pix-ui-review-pr958.osc-fr1.scalingo.io/?path=/story/forms-input--with-is-full-width
- tester le comportement avec un label inline
- aller tester sur les différentes apps qui utilisent des PixInput et des PixSelect pour vérifier que leur style n'a pas été affecté
