### PR TITLE
[FEATURE] Ajoute un bouton de suppression à PixTag.

### DIFF
--- a/addon/components/pix-tag.gjs
+++ b/addon/components/pix-tag.gjs
@@ -1,6 +1,6 @@
 import Component from '@glimmer/component';
-import { formatMessage } from '../translations';
 
+import { formatMessage } from '../translations';
 import PixIconButton from './pix-icon-button';
 
 export default class PixTag extends Component {

--- a/addon/components/pix-tag.gjs
+++ b/addon/components/pix-tag.gjs
@@ -1,4 +1,5 @@
 import Component from '@glimmer/component';
+import { formatMessage } from '../translations';
 
 import PixIconButton from './pix-icon-button';
 
@@ -10,12 +11,16 @@ export default class PixTag extends Component {
     return classes.join(' ');
   }
 
+  get ariaLabel() {
+    return formatMessage(this.args.locale || 'fr', 'tag.removeButton');
+  }
+
   <template>
     <div class="pix-tag {{this.classes}}" ...attributes>
       {{yield}}
       {{#if @displayRemoveButton}}
         <PixIconButton
-          @ariaLabel="Supprimer"
+          @ariaLabel={{this.ariaLabel}}
           @iconName="close"
           @size="xsmall"
           @triggerAction={{@onRemove}}

--- a/addon/components/pix-tag.gjs
+++ b/addon/components/pix-tag.gjs
@@ -1,5 +1,7 @@
 import Component from '@glimmer/component';
 
+import PixIconButton from './pix-icon-button';
+
 export default class PixTag extends Component {
   get classes() {
     const { color } = this.args;
@@ -11,6 +13,14 @@ export default class PixTag extends Component {
   <template>
     <div class="pix-tag {{this.classes}}" ...attributes>
       {{yield}}
+      {{#if @displayRemoveButton}}
+        <PixIconButton
+          @ariaLabel="Supprimer"
+          @iconName="close"
+          @size="xsmall"
+          @triggerAction={{@onRemove}}
+        />
+      {{/if}}
     </div>
   </template>
 }

--- a/addon/styles/_pix-icon-button.scss
+++ b/addon/styles/_pix-icon-button.scss
@@ -54,4 +54,10 @@
     min-width: 2rem;
     height: 2rem;
   }
+
+  &--xsmall {
+    width: 1rem;
+    min-width: 1rem;
+    height: 1rem;
+  }
 }

--- a/addon/styles/_pix-tag.scss
+++ b/addon/styles/_pix-tag.scss
@@ -1,9 +1,11 @@
-@use "pix-design-tokens/typography";
+@use 'pix-design-tokens/typography';
 
 .pix-tag {
   @extend %pix-body-s;
 
-  display: inline-block;
+  display: inline-flex;
+  gap: 0.5rem;
+  align-items: center;
   padding: var(--pix-spacing-1x) var(--pix-spacing-4x);
   color: var(--pix-primary-900);
   font-weight: var(--pix-font-medium);
@@ -13,6 +15,12 @@
   background-color: var(--pix-primary-100);
   border: 1px solid transparent;
   border-radius: 0.95rem;
+
+  .pix-icon-button {
+    width: 1rem;
+    min-width: 1rem;
+    height: 1rem;
+  }
 
   &--grey-light,
   &--neutral,
@@ -28,15 +36,15 @@
     background-color: var(--pix-secondary-100);
   }
 
-  &--purple-light, 
-  &--tertiary, 
+  &--purple-light,
+  &--tertiary,
   &--blue {
     color: var(--pix-tertiary-900);
     background-color: var(--pix-tertiary-100);
   }
 
   &--green-light,
-  &--success, 
+  &--success,
   &--green {
     color: var(--pix-success-900);
     background-color: var(--pix-success-100);
@@ -55,7 +63,7 @@
   &--dark {
     color: var(--pix-neutral-0);
     background-color: var(--pix-neutral-800);
-  } 
+  }
 
   &--blue-light {
     color: var(--pix-primary-900);
@@ -68,7 +76,7 @@
   }
 
   &--orga {
-       /** Deprecated color **/
+    /** Deprecated color **/
     color: var(--pix-orga-50);
     background-color: var(--pix-orga-500);
   }

--- a/addon/styles/_pix-tag.scss
+++ b/addon/styles/_pix-tag.scss
@@ -25,6 +25,7 @@
   &--grey {
     color: var(--pix-neutral-900);
     background-color: var(--pix-neutral-100);
+
     .pix-icon-button {
       color: var(--pix-neutral-900);
     }
@@ -35,6 +36,7 @@
   &--yellow {
     color: var(--pix-secondary-900);
     background-color: var(--pix-secondary-100);
+
     .pix-icon-button {
       color: var(--pix-secondary-900);
     }
@@ -45,6 +47,7 @@
   &--blue {
     color: var(--pix-tertiary-900);
     background-color: var(--pix-tertiary-100);
+
     .pix-icon-button {
       color: var(--pix-tertiary-900);
     }
@@ -55,6 +58,7 @@
   &--green {
     color: var(--pix-success-900);
     background-color: var(--pix-success-100);
+
     .pix-icon-button {
       color: var(--pix-success-900);
     }
@@ -63,6 +67,7 @@
   &--error {
     color: var(--pix-error-900);
     background-color: var(--pix-error-100);
+
     .pix-icon-button {
       color: var(--pix-error-900);
     }
@@ -71,6 +76,7 @@
   &--purple {
     color: var(--pix-primary-900);
     background-color: var(--pix-primary-100);
+
     .pix-icon-button {
       color: var(--pix-primary-900);
     }
@@ -79,6 +85,7 @@
   &--dark {
     color: var(--pix-neutral-0);
     background-color: var(--pix-neutral-800);
+
     .pix-icon-button {
       color: var(--pix-neutral-0);
     }
@@ -87,6 +94,7 @@
   &--blue-light {
     color: var(--pix-primary-900);
     background-color: var(--pix-info-50);
+
     .pix-icon-button {
       color: var(--pix-primary-900);
     }
@@ -95,6 +103,7 @@
   &--white {
     color: var(--pix-neutral-900);
     background-color: var(--pix-neutral-0);
+
     .pix-icon-button {
       color: var(--pix-neutral-900);
     }

--- a/addon/styles/_pix-tag.scss
+++ b/addon/styles/_pix-tag.scss
@@ -16,11 +16,18 @@
   border: 1px solid transparent;
   border-radius: 0.95rem;
 
+  .pix-icon-button {
+    color: var(--pix-primary-900);
+  }
+
   &--grey-light,
   &--neutral,
   &--grey {
     color: var(--pix-neutral-900);
     background-color: var(--pix-neutral-100);
+    .pix-icon-button {
+      color: var(--pix-neutral-900);
+    }
   }
 
   &--yellow-light,
@@ -28,6 +35,9 @@
   &--yellow {
     color: var(--pix-secondary-900);
     background-color: var(--pix-secondary-100);
+    .pix-icon-button {
+      color: var(--pix-secondary-900);
+    }
   }
 
   &--purple-light,
@@ -35,6 +45,9 @@
   &--blue {
     color: var(--pix-tertiary-900);
     background-color: var(--pix-tertiary-100);
+    .pix-icon-button {
+      color: var(--pix-tertiary-900);
+    }
   }
 
   &--green-light,
@@ -42,31 +55,49 @@
   &--green {
     color: var(--pix-success-900);
     background-color: var(--pix-success-100);
+    .pix-icon-button {
+      color: var(--pix-success-900);
+    }
   }
 
   &--error {
     color: var(--pix-error-900);
     background-color: var(--pix-error-100);
+    .pix-icon-button {
+      color: var(--pix-error-900);
+    }
   }
 
   &--purple {
     color: var(--pix-primary-900);
     background-color: var(--pix-primary-100);
+    .pix-icon-button {
+      color: var(--pix-primary-900);
+    }
   }
 
   &--dark {
     color: var(--pix-neutral-0);
     background-color: var(--pix-neutral-800);
+    .pix-icon-button {
+      color: var(--pix-neutral-0);
+    }
   }
 
   &--blue-light {
     color: var(--pix-primary-900);
     background-color: var(--pix-info-50);
+    .pix-icon-button {
+      color: var(--pix-primary-900);
+    }
   }
 
   &--white {
     color: var(--pix-neutral-900);
     background-color: var(--pix-neutral-0);
+    .pix-icon-button {
+      color: var(--pix-neutral-900);
+    }
   }
 
   &--orga {

--- a/addon/styles/_pix-tag.scss
+++ b/addon/styles/_pix-tag.scss
@@ -16,12 +16,6 @@
   border: 1px solid transparent;
   border-radius: 0.95rem;
 
-  .pix-icon-button {
-    width: 1rem;
-    min-width: 1rem;
-    height: 1rem;
-  }
-
   &--grey-light,
   &--neutral,
   &--grey {

--- a/addon/translations/en.js
+++ b/addon/translations/en.js
@@ -9,4 +9,7 @@ export default {
     pageNumber: 'Page {current, number} / {total, number}',
     nextPageLabel: 'Go to next page',
   },
+  tag: {
+    removeButton: 'Remove',
+  },
 };

--- a/addon/translations/fr.js
+++ b/addon/translations/fr.js
@@ -15,4 +15,7 @@ export default {
     pageNumber: 'Page {current, number} / {total, number}',
     nextPageLabel: 'Aller à la page suivante',
   },
+  tag: {
+    removeButton: 'Supprimer',
+  },
 };

--- a/addon/translations/nl.js
+++ b/addon/translations/nl.js
@@ -9,4 +9,7 @@ export default {
     pageNumber: 'Pagina {current, number} / {total, number}',
     nextPageLabel: 'Ga naar volgende pagina',
   },
+  tag: {
+    removeButton: 'Verwijderen',
+  },
 };

--- a/app/stories/pix-icon-button.stories.js
+++ b/app/stories/pix-icon-button.stories.js
@@ -34,10 +34,10 @@ export default {
     },
     size: {
       name: 'size',
-      description: 'Size: `small`',
+      description: 'Size: `big`,`small` ou `xsmall`',
       type: { name: 'string', required: false },
       control: { type: 'select' },
-      options: ['small'],
+      options: ['big', 'small', 'xsmall'],
       table: {
         type: { summary: 'string' },
         defaultValue: { summary: 'big' },

--- a/app/stories/pix-tag.mdx
+++ b/app/stories/pix-tag.mdx
@@ -9,7 +9,7 @@ Un `Tag` est un type de `Chips` qui permet de mettre en avant une information ou
 
 > Il est possible de surcharger le style d'un `<PixTag>` via l'attribut `class` ainsi que de passer n'importe quel attribut sur sa `div` wrapper (par exemple, un `aria-label`)
 
-<Story of={ComponentStories.tag} height={60} />
+<Story of={ComponentStories.Default} height={60} />
 
 ## Usage
 

--- a/app/stories/pix-tag.mdx
+++ b/app/stories/pix-tag.mdx
@@ -11,6 +11,9 @@ Un `Tag` est un type de `Chips` qui permet de mettre en avant une information ou
 
 <Story of={ComponentStories.Default} height={60} />
 
+Il est également possible d'afficher un bouton de suppression.
+Il faut dans ce cas passer une locale en argument pour localiser l'aria label du bouton de suppression.
+
 ## Usage
 
 ```html
@@ -19,6 +22,10 @@ Par défaut:
 
 Customiser la couleur du tag:
 <PixTag @color="purple"> This is a purple tag </PixTag>
+
+<PixTag @displayRemoveButton="{{true}}" onRemove="{{this.removeTag}}" locale="fr"
+  >un tag supprimable</PixTag
+>
 ```
 
 ## Arguments

--- a/app/stories/pix-tag.stories.js
+++ b/app/stories/pix-tag.stories.js
@@ -6,7 +6,7 @@ export default {
     color: {
       name: 'color',
       description: 'Couleur du tag',
-      type: { name: 'number', required: false },
+      type: { name: 'string', required: false },
       table: { defaultValue: { summary: 'primary' } },
       control: {
         type: 'select',
@@ -39,6 +39,16 @@ export default {
       description: 'Fonction à appeler quand le bouton de suppression est cliqué',
       type: { required: false },
       control: { disable: true },
+    },
+    locale: {
+      name: 'locale',
+      description: "Locale permettant de localiser l'aria label du bouton de suppression",
+      type: { name: 'string', required: false },
+      table: { defaultValue: { summary: 'fr' } },
+      control: {
+        type: 'select',
+      },
+      options: ['fr', 'en', 'nl'],
     },
   },
 };

--- a/app/stories/pix-tag.stories.js
+++ b/app/stories/pix-tag.stories.js
@@ -2,12 +2,6 @@ import { hbs } from 'ember-cli-htmlbars';
 
 export default {
   title: 'Data display/Tag',
-  render: (args) => ({
-    template: hbs`<PixTag @color={{this.color}}>
-  Contenu du tag
-</PixTag>`,
-    context: args,
-  }),
   argTypes: {
     color: {
       name: 'color',
@@ -29,7 +23,36 @@ export default {
         'blue-light',
       ],
     },
+    displayRemoveButton: {
+      name: 'displayRemoveButton',
+      description: "Permet d'afficher un bouton pour retirer le tag",
+      type: { name: 'boolean', required: false },
+      table: {
+        type: { summary: 'boolean' },
+        defaultValue: { summary: false },
+        control: { type: 'radio' },
+        options: [true, false],
+      },
+    },
+    onRemove: {
+      name: 'onRemove',
+      description: 'Fonction à appeler quand le bouton de suppression est cliqué',
+      type: { required: false },
+      control: { disable: true },
+    },
   },
 };
 
-export const tag = {};
+const Template = (args) => ({
+  template: hbs`<PixTag @color={{this.color}} @displayRemoveButton={{this.displayRemoveButton}} @onRemove={{this.onRemove}}>
+Contenu du tag
+</PixTag>`,
+  context: args,
+});
+
+export const Default = Template.bind({});
+Default.args = {
+  color: 'primary',
+  displayRemoveButton: false,
+  onRemove: () => console.log('remove button clicked'),
+};

--- a/tests/integration/components/pix-tag-test.js
+++ b/tests/integration/components/pix-tag-test.js
@@ -1,7 +1,9 @@
 import { render } from '@1024pix/ember-testing-library';
+import { click } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { setupRenderingTest } from 'ember-qunit';
 import { module, test } from 'qunit';
+import sinon from 'sinon';
 
 module('Integration | Component | pix-tag', function (hooks) {
   setupRenderingTest(hooks);
@@ -23,5 +25,22 @@ module('Integration | Component | pix-tag', function (hooks) {
     const screen = await render(hbs`<PixTag @color='secondary' aria-label='world' />`);
 
     assert.dom(screen.getByLabelText('world')).exists();
+  });
+
+  test('it displays remove button when displayRemoveButton is true', async function (assert) {
+    const screen = await render(hbs`<PixTag @displayRemoveButton={{true}}>tag text</PixTag>`);
+
+    assert.dom(screen.getByRole('button', { name: 'Supprimer' })).exists();
+  });
+
+  test('it calls onRemove when button is clicked', async function (assert) {
+    this.onRemove = sinon.stub();
+    const screen = await render(
+      hbs`<PixTag @displayRemoveButton={{true}} @onRemove={{this.onRemove}}>tag text</PixTag>`,
+    );
+
+    await click(screen.getByRole('button', { name: 'Supprimer' }));
+
+    assert.ok(this.onRemove.calledOnce);
   });
 });


### PR DESCRIPTION
## :boom: BREAKING_CHANGES

Aucun

## :christmas_tree: Problème

Il n'est pas possible de supprimer un tag.

## :gift: Proposition

Ajout d'un bouton de suppression qui invoque une callback lors d'un clic dessus.

## :star2: Remarques

Pour la localisation du aria-label du bouton, il faut passer la locale en arguments du `PixTag`

## :santa: Pour tester

Dans la story de PixTag, choisir d'afficher le bouton de suppression puis cliquer dessus pour voir qu'un log est affiché dans la console.
