### PR TITLE
[TECH] Permettre à l'action de release d'écrire des commentaires sur les PR

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,7 @@ name: release
 permissions:
   id-token: write # necessary for publishing to npm
   contents: write # necessary for pushing to gh-pages branch
+  pull-requests: write # necessary for writing comment on PR
 
 on:
   push:


### PR DESCRIPTION
## :christmas_tree: Problème
L'action de release n'est plus capable d'écrire des commentaires sur les PR afin notamment de dire quelle PR est embarquée dans quelle release

## :gift: Proposition
Permettre à l'action de release d'écrire des commentaires sur les PR