### PR TITLE
[FEATURE] Add Variant Link for pix-table-column (PIX-16965)

### DIFF
--- a/addon/components/pix-table-column.js
+++ b/addon/components/pix-table-column.js
@@ -75,7 +75,7 @@ export default class PixTableColumn extends Component {
   }
 
   get typeClass() {
-    const correctTypes = ['number', 'text', 'checkbox', 'tag', 'tagDate'];
+    const correctTypes = ['number', 'text', 'checkbox', 'tag', 'tagDate', 'link'];
     warn('PixTableColumn: you need to provide a valid type', correctTypes.includes(this.type), {
       id: 'pix-ui.table-column.type.incorrect',
     });
@@ -90,6 +90,9 @@ export default class PixTableColumn extends Component {
     }
     if (this.args.type === 'tagDate') {
       return `pix-table-column--tag-date`;
+    }
+    if (this.args.type === 'link') {
+      return `pix-table-column--link`;
     }
     return '';
   }

--- a/addon/styles/_pix-table-column.scss
+++ b/addon/styles/_pix-table-column.scss
@@ -15,6 +15,12 @@ td.pix-table-column {
       text-align: left;
     }
 
+    &--link {
+      padding-top: 0.875rem;
+      padding-bottom: 0.875rem;
+      text-align: left;
+    }
+
   &--tag-date {
     padding-top: var(--pix-spacing-1x);
     padding-bottom: var(--pix-spacing-1x);
@@ -31,4 +37,4 @@ td.pix-table-column {
       text-align: center;
     }
   }
-  }
+}

--- a/addon/styles/_pix-table.scss
+++ b/addon/styles/_pix-table.scss
@@ -104,6 +104,11 @@
         padding-top: 0.375rem;
         padding-bottom: 0.375rem;
     }
+
+    td.pix-table-column--link {
+      padding-top: 0.375rem;
+      padding-bottom: 0.375rem;
+    }
   }
 }
 

--- a/app/stories/pix-table-column.mdx
+++ b/app/stories/pix-table-column.mdx
@@ -96,6 +96,9 @@ Une colonne d'un [PixTable](/docs/data-display-table--docs), gère l'affichage d
 ## Variant tag + date
 <Story of={ComponentStories.TagDate} height={400} />
 
+## Variant link
+<Story of={ComponentStories.Link} height={400} />
+
 ## Arguments
 
 <ArgTypes />

--- a/app/stories/pix-table-column.mdx
+++ b/app/stories/pix-table-column.mdx
@@ -36,6 +36,14 @@ Une colonne d'un [PixTable](/docs/data-display-table--docs), gère l'affichage d
         {{row.age}}
       </:cell>
     </PixTableColumn>
+    <PixTableColumn @context={{context}} @type="tag">
+      <:header>
+        Hobby
+      </:header>
+      <:cell>
+        <PixTag>{{row.hobby}}</PixTag
+      </:cell>
+    </PixTableColumn>
   </:columns>
 </PixTable>
 ```

--- a/app/stories/pix-table-column.stories.js
+++ b/app/stories/pix-table-column.stories.js
@@ -285,7 +285,7 @@ const templateLink = (args) => {
   return {
     template: hbs`<PixTable @data={{this.data}} @caption={{this.caption}}>
   <:columns as |row context|>
-    <PixTableColumn @context={{context}} @type='tag'>
+    <PixTableColumn @context={{context}} @type='link'>
       <:header>
         Link
       </:header>

--- a/app/stories/pix-table-column.stories.js
+++ b/app/stories/pix-table-column.stories.js
@@ -49,12 +49,12 @@ export default {
       defaultValue: {
         summary: 'text',
       },
-      options: ['text', 'number', 'checkbox', 'tag', 'tagDate'],
+      options: ['text', 'number', 'checkbox', 'tag', 'tagDate', 'link'],
       control: {
         type: 'select',
       },
       type: {
-        name: '"text" | "number" | "tag" | "tagDate"',
+        name: '"text" | "number" | "tag" | "tagDate" | "link"',
         description: 'Defini le style avec lequel nous afficherons la colonne',
       },
     },
@@ -276,6 +276,46 @@ TagDate.args = {
     {
       tag: 'tag2',
       date: '02/02/1980',
+    },
+  ],
+};
+
+// Link
+const templateLink = (args) => {
+  return {
+    template: hbs`<PixTable @data={{this.data}} @caption={{this.caption}}>
+  <:columns as |row context|>
+    <PixTableColumn @context={{context}} @type='tag'>
+      <:header>
+        Link
+      </:header>
+      <:cell>
+        <PixButtonLink href={{row.link.url}}
+                       target="_blank"
+                       @variant="tertiary"
+                       @iconBefore="openNew">{{row.link.label}}</PixButtonLink>
+      </:cell>
+    </PixTableColumn>
+  </:columns>
+</PixTable>`,
+    context: args,
+  };
+};
+export const Link = templateLink.bind({});
+Link.args = {
+  caption: 'Tableau avec une colonne de type link',
+  data: [
+    {
+      link: {
+        label: 'PixApp',
+        href: 'https://app.pix.fr',
+      },
+    },
+    {
+      link: {
+        label: 'RGAA',
+        href: 'https://accessibilite.numerique.gouv.fr/',
+      },
     },
   ],
 };

--- a/app/stories/pix-table.mdx
+++ b/app/stories/pix-table.mdx
@@ -38,6 +38,14 @@ Une table qui prend en argument des data et en `block content` des [PixTableColu
         {{row.age}}
       </:cell>
     </PixTableColumn>
+    <PixTableColumn @context={{context}} @type="tag">
+      <:header>
+        Tag
+      </:header>
+      <:cell>
+        <PixTag>{{row.tag}}</PixTag
+      </:cell>
+    </PixTableColumn>
   </:columns>
 </PixTable>
 <style>

--- a/app/stories/pix-table.stories.js
+++ b/app/stories/pix-table.stories.js
@@ -98,7 +98,7 @@ const Template = (args) => {
     </PixTableColumn>
     <PixTableColumn @context={{context}} @type='tag'>
       <:header>
-        tag
+        Tag
       </:header>
       <:cell>
         <PixTag>{{row.tag}}</PixTag>

--- a/tests/dummy/app/controllers/table-page.js
+++ b/tests/dummy/app/controllers/table-page.js
@@ -16,11 +16,19 @@ export default class TablePage extends Controller {
       name: 'jean',
       description: 'fort au jungle speed',
       age: 15,
+      link: {
+        label: 'PixApp',
+        url: 'https://app.pix.fr',
+      },
     },
     {
       name: 'brian',
       description: 'travail au peach pit',
       age: 25,
+      link: {
+        label: 'Ecosia',
+        url: 'https://www.ecosia.org',
+      },
     },
   ];
 

--- a/tests/dummy/app/templates/table-page.hbs
+++ b/tests/dummy/app/templates/table-page.hbs
@@ -91,6 +91,22 @@
       </:cell>
       <:subCell>01/01/1970</:subCell>
     </PixTableColumn>
+    <PixTableColumn @context={{context}} @type="link">
+      <:header>
+        Link
+      </:header>
+      <:cell>
+        <PixButtonLink
+          @href={{row.link.url}}
+          target="_blank"
+          @variant="tertiary"
+          @iconBefore="openNew"
+        >
+          {{row.link.label}}
+        </PixButtonLink>
+      </:cell>
+    </PixTableColumn>
+
   </:columns>
 </PixTable>
 {{! template-lint-disable no-forbidden-elements }}


### PR DESCRIPTION
## :gift: Proposition
Ajouter un variant `@type="link"` pour PixTableColumn. Les colonnes seront affichées comme décrit dans le ticket JIRA.

## :star2: Remarques
- Les utilisateurs doivent eux-mêmes spécifier dans `:cell` qu'ils utiliseront le composant `<PixButtonLink>`dans les colonnes de type `link`.
- J'ai complété la doc storybook pour mettre le code correspondant au variant `tag` qui est dans les exemples

## 🎄 Pour tester
- Ouvrir storybook et aller dans la doc de PixTableColumn > Link
- Constater que le variant Link permet un affichage conforme des cellules dans la colonne typée