### PR TITLE
[BREAKING] Permettre de réduire la navigation pour Pix Admin uniquement (PIX-16992).

### DIFF
--- a/addon/components/pix-app-layout.gjs
+++ b/addon/components/pix-app-layout.gjs
@@ -1,10 +1,13 @@
 import { VARIANTS } from '@1024pix/pix-ui/helpers/variants';
 import { warn } from '@ember/debug';
+import { inject as service } from '@ember/service';
 import Component from '@glimmer/component';
 
 import onWindowResize from '../modifiers/on-window-resize';
 
 export default class PixAppLayout extends Component {
+  @service shrinkNavigationService;
+
   #computeMarginTopElement(entries) {
     for (const entry of entries) {
       if (entry.target.id === 'pix-layout-banner-container') {
@@ -35,6 +38,10 @@ export default class PixAppLayout extends Component {
         id: 'pix-ui.pix-app-layout.variant.not-valid',
       },
     );
+
+    if (this.args.variant === 'admin') {
+      this.shrinkNavigationService.displayShrunkNavigationButton();
+    }
 
     return value;
   }

--- a/addon/components/pix-navigation-button.gjs
+++ b/addon/components/pix-navigation-button.gjs
@@ -4,11 +4,13 @@ import { service } from '@ember/service';
 import Component from '@glimmer/component';
 
 import PixIcon from './pix-icon';
+import PixNavigationShrunkButton from './pix-navigation-shrunk-button';
 
 export default class PixNavigationButton extends Component {
   defaultParams = {};
   defaultModel = [];
   @service router;
+  @service shrinkNavigationService;
 
   get isActiveRoute() {
     return this.args.route === this.router.currentRouteName;
@@ -19,56 +21,63 @@ export default class PixNavigationButton extends Component {
   }
 
   <template>
-    {{#if @route}}
-      <LinkTo
+    {{#if this.shrinkNavigationService.isShrunk}}
+      <PixNavigationShrunkButton
         @route={{@route}}
-        @models={{if @model (array @model) this.defaultModel}}
-        @query={{if @query @query this.defaultParams}}
-        class="pix-navigation-button"
-        target={{if this.isLinkOpenInANewWindow "_blank"}}
-        ...attributes
-      >
-        {{#if @icon}}
-          <PixIcon
-            class="pix-navigation-button__icon"
-            @ariaHidden={{true}}
-            @name={{@icon}}
-            @plainIcon={{if this.isActiveRoute true false}}
-          />
-        {{/if}}
-        {{yield}}
-        {{#if this.isLinkOpenInANewWindow}}
-          <PixIcon
-            class="pix-navigation-button__external-icon"
-            @ariaHidden={{true}}
-            @name="openNew"
-          />
-        {{/if}}
-      </LinkTo>
+        @icon={{@icon}}
+      >{{yield}}</PixNavigationShrunkButton>
     {{else}}
-      {{! template-lint-disable link-href-attributes }}
-      <a
-        class="pix-navigation-button"
-        target={{if this.isLinkOpenInANewWindow "_blank"}}
-        ...attributes
-      >
-        {{#if @icon}}
-          <PixIcon
-            class="pix-navigation-button__icon"
-            @ariaHidden={{true}}
-            @name={{@icon}}
-            @plainIcon={{@iconPlain}}
-          />
-        {{/if}}
-        {{yield}}
-        {{#if this.isLinkOpenInANewWindow}}
-          <PixIcon
-            class="pix-navigation-button__external-icon"
-            @ariaHidden={{true}}
-            @name="openNew"
-          />
-        {{/if}}
-      </a>
+      {{#if @route}}
+        <LinkTo
+          @route={{@route}}
+          @models={{if @model (array @model) this.defaultModel}}
+          @query={{if @query @query this.defaultParams}}
+          class="pix-navigation-button"
+          target={{if this.isLinkOpenInANewWindow "_blank"}}
+          ...attributes
+        >
+          {{#if @icon}}
+            <PixIcon
+              class="pix-navigation-button__icon"
+              @ariaHidden={{true}}
+              @name={{@icon}}
+              @plainIcon={{if this.isActiveRoute true false}}
+            />
+          {{/if}}
+          {{yield}}
+          {{#if this.isLinkOpenInANewWindow}}
+            <PixIcon
+              class="pix-navigation-button__external-icon"
+              @ariaHidden={{true}}
+              @name="openNew"
+            />
+          {{/if}}
+        </LinkTo>
+      {{else}}
+        {{! template-lint-disable link-href-attributes }}
+        <a
+          class="pix-navigation-button"
+          target={{if this.isLinkOpenInANewWindow "_blank"}}
+          ...attributes
+        >
+          {{#if @icon}}
+            <PixIcon
+              class="pix-navigation-button__icon"
+              @ariaHidden={{true}}
+              @name={{@icon}}
+              @plainIcon={{@iconPlain}}
+            />
+          {{/if}}
+          {{yield}}
+          {{#if this.isLinkOpenInANewWindow}}
+            <PixIcon
+              class="pix-navigation-button__external-icon"
+              @ariaHidden={{true}}
+              @name="openNew"
+            />
+          {{/if}}
+        </a>
+      {{/if}}
     {{/if}}
   </template>
 }

--- a/addon/components/pix-navigation-shrunk-button.gjs
+++ b/addon/components/pix-navigation-shrunk-button.gjs
@@ -1,0 +1,53 @@
+import { on } from '@ember/modifier';
+import { action } from '@ember/object';
+import { LinkTo } from '@ember/routing';
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+
+import PixIcon from './pix-icon';
+
+export default class PixNavigationShrunkButton extends Component {
+  @tracked isTooltipVisible = false;
+
+  @action
+  showTooltip() {
+    this.isTooltipVisible = true;
+  }
+
+  @action
+  hideTooltip() {
+    setTimeout(() => (this.isTooltipVisible = false));
+  }
+
+  @action
+  hideTooltipOnMouseOut(event) {
+    const isFocused = event.target.contains(document.activeElement);
+
+    if (isFocused) {
+      return;
+    }
+
+    this.hideTooltip(event);
+  }
+
+  <template>
+    <div
+      class="navigation-tooltip {{if this.isTooltipVisible 'navigation-tooltip--visible' ''}}"
+      {{on "mouseleave" this.hideTooltipOnMouseOut}}
+      {{on "mouseenter" this.showTooltip}}
+      {{on "focusin" this.showTooltip}}
+      {{on "focusout" this.hideTooltip}}
+    >
+      <LinkTo
+        @route={{@route}}
+        class="pix-navigation-button navigation-shrunk-button"
+        ...attributes
+      >
+        <PixIcon class="pix-navigation-button__icon" @ariaHidden={{true}} @name={{@icon}} />
+      </LinkTo>
+      <span role="tooltip" class="navigation-tooltip__content" aria-hidden="true">
+        {{yield}}
+      </span>
+    </div>
+  </template>
+}

--- a/addon/components/pix-navigation.hbs
+++ b/addon/components/pix-navigation.hbs
@@ -1,8 +1,20 @@
 <aside
   ...attributes
-  class="pix-navigation {{if this.navigationMenuOpened 'pix-navigation--opened'}}"
+  class="pix-navigation
+    {{if this.navigationMenuOpened 'pix-navigation--opened'}}
+    {{if this.shrinkNavigationService.isShrunk 'pix-navigation--shrunk'}}"
 >
   <header class="pix-navigation__brand">{{yield to="brand"}}
+    {{#if this.shrinkNavigationService.canNavigationBeShrunk}}
+      <div class="pix-navigation__shrunk-container">
+        <PixIconButton
+          class="pix-navigation-shrunk-button"
+          @iconName={{this.shrunkNavigationIcon}}
+          @triggerAction={{this.shrinkNavigation}}
+          @ariaLabel="{{this.shrunkNavigationAriaLabel}}"
+        />
+      </div>
+    {{/if}}
     <div class="pix-navigation__burger-menu"><PixButton
         aria-controls="{{this.navigationId}} {{this.footerId}}"
         aria-expanded={{this.navigationMenuOpened}}

--- a/addon/components/pix-navigation.js
+++ b/addon/components/pix-navigation.js
@@ -5,8 +5,11 @@ import { inject as service } from '@ember/service';
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 
-export default class PixMNavigation extends Component {
+import { formatMessage } from '../translations';
+
+export default class PixNavigation extends Component {
   @service router;
+  @service shrinkNavigationService;
 
   constructor(...args) {
     super(...args);
@@ -22,6 +25,10 @@ export default class PixMNavigation extends Component {
 
   @tracked
   navigationMenuOpened = false;
+
+  formatMessage(message, values) {
+    return formatMessage(this.args.locale ?? 'fr', `pixNavigation.${message}`, values);
+  }
 
   @action
   toggleNavigationMenu() {
@@ -42,6 +49,23 @@ export default class PixMNavigation extends Component {
       this.navigationMenuOpened = false;
       this.router.off('routeDidChange', this.closeNavigation);
     }
+  }
+
+  @action
+  shrinkNavigation() {
+    this.shrinkNavigationService.shrinkNavigation();
+  }
+
+  get shrunkNavigationIcon() {
+    return this.shrinkNavigationService.isShrunk ? 'arrowMenuOpen' : 'arrowMenuClose';
+  }
+
+  get shrunkNavigationAriaLabel() {
+    return this.formatMessage(
+      this.shrinkNavigationService.isShrunk
+        ? 'expandNavigationAriaLabel'
+        : 'shrinkNavigationAriaLabel',
+    );
   }
 
   get navigationId() {

--- a/addon/services/shrink-navigation-service.js
+++ b/addon/services/shrink-navigation-service.js
@@ -1,0 +1,23 @@
+import { action } from '@ember/object';
+import Service from '@ember/service';
+import { tracked } from '@glimmer/tracking';
+
+export default class ShrinkNavigationService extends Service {
+  @tracked canNavigationBeShrunk = false;
+  @tracked isShrunk = false;
+
+  @action displayShrunkNavigationButton() {
+    this.canNavigationBeShrunk = true;
+  }
+
+  @action shrinkNavigation() {
+    this.isShrunk = !this.isShrunk;
+
+    const root = document.documentElement;
+
+    if (this.isShrunk) {
+      return root.style.setProperty('--pix-navigation-width', '88px');
+    }
+    return root.style.setProperty('--pix-navigation-width', '15rem');
+  }
+}

--- a/addon/styles/_pix-navigation-shrunk-button.scss
+++ b/addon/styles/_pix-navigation-shrunk-button.scss
@@ -1,0 +1,43 @@
+@use "pix-design-tokens/typography";
+
+.navigation-tooltip {
+  position: relative;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+
+  &__content {
+    @extend %pix-title-xxs;
+
+    position: absolute;
+    left: calc(100% + 10px);
+    width: max-content;
+    padding: var(--pix-spacing-1x) var(--pix-spacing-4x);
+    color: var(--pix-neutral-800);
+    background-color: var(--pix-neutral-0);
+    border-radius: var(--pix-spacing-2x);
+    visibility: hidden;
+    opacity: 0;
+    transition: opacity 0.3s;
+    pointer-events: none;
+  }
+
+  &--visible {
+    &:hover, &:active {
+      .navigation-tooltip__content {
+        visibility: visible;
+        opacity: 1;
+      }
+    }
+
+    // Focus event is triggered by the button. That's why we are duplicating the style for this case.
+    .navigation-shrunk-button:focus-within + .navigation-tooltip__content {
+      visibility: visible;
+      opacity: 1;
+    }
+  }
+}
+
+.navigation-shrunk-button {
+  justify-content: center;
+}

--- a/addon/styles/_pix-navigation.scss
+++ b/addon/styles/_pix-navigation.scss
@@ -21,6 +21,7 @@
   color: var(--pix-navigation-text-color);
   background-color: var(--pix-navigation-color);
   border-radius: var(--pix-spacing-6x);
+  transition: all 0.3s ease;
 
   @include breakpoints.device-is('mobile') {
     flex-direction: column;
@@ -36,6 +37,16 @@
     }
   }
 
+  &--shrunk {
+    --pix-navigation-width: 88px;
+
+    transition: all 0.3s ease;
+  }
+
+  &__shrunk-container {
+    position: relative;
+    height: 20px;
+  }
 
   &__brand {
     margin-bottom: 0;
@@ -218,3 +229,14 @@
   }
 }
 
+.pix-navigation-shrunk-button {
+  position: absolute;
+  left: calc(100% - 4px);
+  background-color: var(--pix-neutral-0);
+  border: 1px solid var(--pix-primary-900);
+
+  @include breakpoints.device-is('mobile') {
+    visibility: hidden;
+    opacity: 0;
+  }
+}

--- a/addon/styles/addon.scss
+++ b/addon/styles/addon.scss
@@ -42,6 +42,7 @@
 @use 'toast-example';
 @use 'pix-navigation';
 @use 'pix-navigation-button';
+@use 'pix-navigation-shrunk-button';
 @use 'pix-navigation-separator';
 @use 'pix-app-layout';
 @use 'pix-structure-switcher';

--- a/addon/translations/en.js
+++ b/addon/translations/en.js
@@ -21,4 +21,8 @@ export default {
   tag: {
     removeButton: 'Remove',
   },
+  pixNavigation: {
+    shrinkNavigationAriaLabel: 'Reduce the width of the navigation menu',
+    expandNavigationAriaLabel: 'Return to the initial width of the navigation menu',
+  },
 };

--- a/addon/translations/es.js
+++ b/addon/translations/es.js
@@ -19,4 +19,8 @@ export default {
     pageNumber: 'Página {current, number} / {total, number}',
     nextPageLabel: 'Ir a la página siguiente',
   },
+  pixNavigation: {
+    shrinkNavigationAriaLabel: 'Reducir el ancho del menú de navegación',
+    expandNavigationAriaLabel: 'Volver al ancho inicial del menú de navegación',
+  },
 };

--- a/addon/translations/fr.js
+++ b/addon/translations/fr.js
@@ -21,4 +21,8 @@ export default {
   tag: {
     removeButton: 'Supprimer',
   },
+  pixNavigation: {
+    shrinkNavigationAriaLabel: 'Réduire la largeur du menu de navigation',
+    expandNavigationAriaLabel: 'Revenir à la largeur initiale du menu de navigation',
+  },
 };

--- a/addon/translations/nl.js
+++ b/addon/translations/nl.js
@@ -21,4 +21,8 @@ export default {
   tag: {
     removeButton: 'Verwijderen',
   },
+  pixNavigation: {
+    shrinkNavigationAriaLabel: 'De breedte van het navigatiemenu verkleinen',
+    expandNavigationAriaLabel: 'Terug naar de oorspronkelijke breedte van het navigatiemenu',
+  },
 };

--- a/app/components/pix-navigation-shrunk-button.js
+++ b/app/components/pix-navigation-shrunk-button.js
@@ -1,0 +1,1 @@
+export { default } from '@1024pix/pix-ui/components/pix-navigation-shrunk-button';

--- a/app/services/shrink-navigation-service.js
+++ b/app/services/shrink-navigation-service.js
@@ -1,0 +1,1 @@
+export { default } from '@1024pix/pix-ui/services/shrink-navigation-service';

--- a/tests/integration/components/pix-app-layout-test.js
+++ b/tests/integration/components/pix-app-layout-test.js
@@ -19,4 +19,20 @@ module('Integration | Component | pix-app-layout', function (hooks) {
       );
     });
   });
+
+  module('when variant is admin', function () {
+    test(`should canNavigationBeShrunk from shrinkNavigationService set to true`, async function (assert) {
+      // given
+      const shrinkNavigationService = this.owner.lookup('service:shrinkNavigationService');
+
+      // when
+      this.variant = 'admin';
+      await render(
+        hbs`<PixAppLayout @variant={{this.variant}}><:main>Hello</:main></PixAppLayout>`,
+      );
+
+      // then
+      assert.true(shrinkNavigationService.canNavigationBeShrunk);
+    });
+  });
 });

--- a/tests/integration/components/pix-navigation-button-test.js
+++ b/tests/integration/components/pix-navigation-button-test.js
@@ -98,4 +98,20 @@ module('Integration | Component | pix-navigation-button', function (hooks) {
 
     assert.ok(image.querySelector('use').getAttribute('href').endsWith('plain'));
   });
+
+  module('when navigation can be shrink', function () {
+    test(`should display the PixNavigationShrunkButton component`, async function (assert) {
+      // given
+      const shrinkNavigationService = this.owner.lookup('service:shrinkNavigationService');
+      shrinkNavigationService.isShrunk = true;
+
+      // when
+      const screen = await render(
+        hbs`<PixNavigationButton @route='hello' @icon='power'>content</PixNavigationButton>`,
+      );
+
+      // then
+      assert.dom(screen.getByRole('link')).hasClass('navigation-shrunk-button');
+    });
+  });
 });

--- a/tests/integration/components/pix-navigation-shrunk-button-test.js
+++ b/tests/integration/components/pix-navigation-shrunk-button-test.js
@@ -1,0 +1,30 @@
+import { render, within } from '@1024pix/ember-testing-library';
+import { hbs } from 'ember-cli-htmlbars';
+import { setupRenderingTest } from 'ember-qunit';
+import { module, test } from 'qunit';
+
+module('Integration | Component | pix-navigation-shrunk-button', function (hooks) {
+  setupRenderingTest(hooks);
+
+  test('it renders an EmberJS link', async function (assert) {
+    // when
+    const screen = await render(
+      hbs`<PixNavigationShrunkButton @route='hello'>Je suis dans un tooltip !</PixNavigationShrunkButton>`,
+    );
+
+    // then
+    const link = screen.getByRole('link');
+    assert.strictEqual(link.getAttribute('href'), '/hello-world');
+  });
+
+  test('it renders an icon', async function (assert) {
+    // when
+    const screen = await render(
+      hbs`<PixNavigationShrunkButton @route='hello' @icon='power'>Je suis dans un tooltip !</PixNavigationShrunkButton>`,
+    );
+
+    // then
+    const link = screen.getByRole('link');
+    assert.ok(within(link).getByRole('img', { hidden: true }));
+  });
+});

--- a/tests/integration/components/pix-navigation-test.js
+++ b/tests/integration/components/pix-navigation-test.js
@@ -56,12 +56,56 @@ module('Integration | Component | pix-navigation', function (hooks) {
       // then
       assert.ok(within(footer).getByRole('link', { name: 'mon lien' }));
     });
+
     test('it hides the burger menu', async function (assert) {
       // when
       const screen = await render(
         hbs`<PixNavigation @navigationAriaLabel='label' @openLabel='open' @closeLabel='close' />`,
       );
       assert.notOk(screen.queryByRole('button', { name: 'menu' }));
+    });
+
+    module('when navigation can be shrink', function () {
+      test(`should display the button`, async function (assert) {
+        // given
+        const shrinkNavigationService = this.owner.lookup('service:shrinkNavigationService');
+        shrinkNavigationService.canNavigationBeShrunk = true;
+
+        // when
+        const screen = await render(
+          hbs`<PixNavigation @navigationAriaLabel='label' @openLabel='open' @closeLabel='close' />`,
+        );
+
+        // then
+        assert
+          .dom(screen.getByRole('button', { name: 'Réduire la largeur du menu de navigation' }))
+          .exists();
+      });
+
+      module(`when the shrink button is clicked`, function () {
+        test(`should display an other aria label`, async function (assert) {
+          // given
+          const shrinkNavigationService = this.owner.lookup('service:shrinkNavigationService');
+          shrinkNavigationService.canNavigationBeShrunk = true;
+
+          // when
+          const screen = await render(
+            hbs`<PixNavigation @navigationAriaLabel='label' @openLabel='open' @closeLabel='close' />`,
+          );
+          await click(
+            screen.getByRole('button', { name: 'Réduire la largeur du menu de navigation' }),
+          );
+
+          // then
+          assert
+            .dom(
+              screen.getByRole('button', {
+                name: 'Revenir à la largeur initiale du menu de navigation',
+              }),
+            )
+            .exists();
+        });
+      });
     });
   });
 


### PR DESCRIPTION
## :boom: BREAKING_CHANGES
La navigation dans Pix Admin (uniquement) sera directement impactée par cette montée de version. Il faudra s'assurer du bon comportement de ce dernier.

## :christmas_tree: Problème
Pix Admin a la particularité de contenir bcp de tableaux, et selon les devices des membres internes de Pix, leur lecture peut parfois être difficile. 
La navigation actuelle prend une certaine place et il serait très pratique qu'on puisse la réduire afin de donner plus de place aux tableaux, et ainsi faciliter leurs consultation?

## :gift: Proposition
Permettre de réduire la navigation pour Pix Admin uniquement 

## :star2: Remarques

L'objectif du service est de pouvoir déclencher des actions/comportements entre différents composants, à savoir : 
- `PixAppLayout` => selon son variant (celui qui nous intéresse c'est admin) il va déclencher l'apparition du bouton pour réduire le menu (via un param @tracked dans le service: `canNavigationBeShrunk`).
- `PixNavigation` => selon la valeur d'un autre param @tracked dans le-dit service, il va adapter l'aria-label, l'icône et l'affichage du bouton: ìsShrunk`
- `PixNavigationButton` => selon le param tracked il va afficher le nouveau composant `PixNavigationShrunkButton` ou non.

Ainsi aucun ajout de paramètre dans les composants n'est nécessaire. A la montée de version de Pix UI sur Pix Admin, le bouton sera déjà là et les PixNavigationButton déjà présents dans la navigation n'auront pas a être changé (p-e celui de la déconnexion, mais à voir avec le design :) )

---

Une difficulté rencontrée dans cette PR est la largueur du `main` de `PixAppLayout` qui ne s'adaptait pas. 
En effet, lorsque je réduit la largeur de la nav au clic sur le bouton, je m'attend à ce que la largeur du `main` s'étende pour que le contenu prenne la nouvelle place que la nav réduite offre.

Le `max-width` présent dans le `main` de `PixAppLayout` est un `min()`  entre un `calc()` du (width du device) - (width du menu) - (3 x le spacing du padding), et d'une valeur max que peut avoir le `main` peut importe la taille du device (de 93rem.**, vu avec Xavier, cette valeur a été défini avec le design !)

`min(calc(100vw - var(--pix-navigation-width) - 3 * var(--pix-spacing-6x)), 93rem)`

On voulait au départ modifier ce 93rem et voir plus grand (de toute façon ça n'allait impacter que Pix Admin, puisque on modifiait via le nouveau service). Mais en discutant avec Xavier, on a fini par maintenir ce 93rem. Les grands écrans n'ont que faire de la nav réduite, l'intérêt c'est pour les petits écran. L'adaptation allait donc se faire sur la modification de la largeur de la nav uniquement.

> [!TIP]
> J'ai découvert un truc au moins, pour avoir le résultat de tout ce beau monde, je me suis servit de la console Google Chrome qui me donne ça.

<img width="621" height="305" alt="Capture d’écran 2026-01-15 à 19 07 55" src="https://github.com/user-attachments/assets/43040975-b3f5-4dd0-8838-9d91c0947df8" />


## :santa: Pour tester
https://github.com/1024pix/pix/pull/14728 La PR de test

https://admin-pr14728.review.pix.fr/
