### PR TITLE
[FEATURE] Ajout d'un nouveau token couleur pour neutral (PIX-21148)

### DIFF
--- a/addon/styles/pix-design-tokens/_colors.scss
+++ b/addon/styles/pix-design-tokens/_colors.scss
@@ -37,6 +37,8 @@
   --pix-neutral-20: rgb(var(--pix-neutral-20-inline));
   --pix-neutral-100-inline:205, 209, 217;
   --pix-neutral-100: rgb(var(--pix-neutral-100-inline));
+  --pix-neutral-300-inline:147, 157, 173;
+  --pix-neutral-300: rgb(var(--pix-neutral-300-inline));
   --pix-neutral-500-inline:94, 108, 132;
   --pix-neutral-500: rgb(var(--pix-neutral-500-inline));
   --pix-neutral-800-inline:37, 56, 88;

--- a/docs/colors-palette.mdx
+++ b/docs/colors-palette.mdx
@@ -58,6 +58,7 @@ import { Meta, ColorPalette, ColorItem } from '@storybook/blocks';
             0: '#ffffff',
             20: '#f4f5f7',
             100: '#cdd1d9',
+            300: '#939DAD',
             500: '#5e6c84',
             800: '#253858',
             900: '#122647'}}


### PR DESCRIPTION
## :christmas_tree: Problème
Un token intermédiaire dans neutral est manquant

## :gift: Proposition
Ajout d'un token couleur neutral-300

## :star2: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :santa: Pour tester
neutral-300 : #939DAD