### PR TITLE
[FEATURE] Masquer les éléments du footer quand la navigation est réduite.

### DIFF
--- a/addon/styles/_pix-navigation.scss
+++ b/addon/styles/_pix-navigation.scss
@@ -41,6 +41,11 @@
     --pix-navigation-width: 88px;
 
     transition: all 0.3s ease;
+
+    footer > :not(.navigation-tooltip){
+      display: none;
+      opacity: 0;
+    }
   }
 
   &__shrunk-container {

--- a/tests/integration/components/pix-navigation-test.js
+++ b/tests/integration/components/pix-navigation-test.js
@@ -105,6 +105,33 @@ module('Integration | Component | pix-navigation', function (hooks) {
             )
             .exists();
         });
+
+        test(`should hide footer elements except the navigation button`, async function (assert) {
+          // given
+          const shrinkNavigationService = this.owner.lookup('service:shrinkNavigationService');
+          shrinkNavigationService.canNavigationBeShrunk = true;
+          this.set('triggerAction', () => {});
+
+          // when
+          const screen = await render(
+            hbs`<PixNavigation @navigationAriaLabel='label' @openLabel='open' @closeLabel='close'>
+  <:footer>
+    <p>
+      Martin Dupond
+    </p>
+    <PixNavigationButton @icon='power' @triggerAction={{this.triggerAction}}>Se déconnecter</PixNavigationButton>
+  </:footer>
+</PixNavigation>`,
+          );
+
+          await click(
+            screen.getByRole('button', { name: 'Réduire la largeur du menu de navigation' }),
+          );
+
+          // then
+          assert.dom(screen.getByText('Martin Dupond')).isNotVisible();
+          assert.dom(screen.getByText('Se déconnecter')).isVisible();
+        });
       });
     });
   });


### PR DESCRIPTION
## :christmas_tree: Problème
Sur Pix Admin, quand on réduit la nav, le nom de l'utilisateur reste et c'est pas beau

<img width="146" height="248" alt="Capture d’écran 2026-01-22 à 16 22 33" src="https://github.com/user-attachments/assets/212dcbfb-d7f6-4cfc-8765-af593cb03dac" />

## :gift: Proposition
Masquer les éléments du footer sauf le bouton de navigation de déconnexion

## :star2: Remarques
J'avais eu d'autres retours concernant la nav que je n'ai pas pris en compte : 

- [css du bouton de déconnexion](https://github.com/1024pix/pix/pull/14822/changes#r2716334632) difficile à prendre en compte. Le bouton est un composant `PixNavigationButton` comme les autres, il est difficile de le traiter différemment via Pix UI, mais plus simple sur l'app qui l'utilise.

- [Que le tooltip ne disparaît pas quand on clic](https://github.com/1024pix/pix/pull/14822#issuecomment-3783691427) ne me semble pas un comportement indésirable. Si ça l'est je veut bien modifier.

## :santa: Pour tester
Veuillez tester ici : https://github.com/1024pix/pix/pull/14822
