### PR TITLE
[BUGFIX] Modifier le composant PixAppLayout pour réparer les tests flaky de pix App (PIX-21278)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -82,7 +82,7 @@ jobs:
 
   chromatic-deployment:
     executor: node-browsers-docker
-    resource_class: medium
+    resource_class: large
     working_directory: ~/pix-ui
     steps:
       - attach_workspace:

--- a/addon/components/pix-app-layout.gjs
+++ b/addon/components/pix-app-layout.gjs
@@ -18,7 +18,7 @@ export default class PixAppLayout extends Component {
         const top = bannerHeight / baseFontRemRatio;
 
         const layoutElement = document.querySelector('.pix-app-layout');
-        layoutElement.style.setProperty('--pix-app-layout-top', `${top}rem`);
+        layoutElement?.style.setProperty('--pix-app-layout-top', `${top}rem`);
       }
     }
   }


### PR DESCRIPTION
## :christmas_tree: Problème
Actuellement, le test du AppLayout est flaky sur le monorepo pix qui est assez réccurent : 
<img width="1448" height="353" alt="image" src="https://github.com/user-attachments/assets/5002567a-eb82-4ddd-bd0e-f7af5b40ec31" />

 Cela est du à la propriété style dans le composant PixAppLayout.

## :gift: Proposition
Utiliser un optional chaining pour ne pas avoir d'erreur si l'élément n'est pas présent dans le dom

## :star2: Remarques
C'est un fix rapide, il faudra voir pour refacto le composant et le rendre plus robuste

## :santa: Pour tester
Faire la montée de version et constater qu'il n'y a pas de flaky sur le long terme
