### PR TITLE
[TECH] Supprimer chromatic et arrêter de l'utiliser

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,10 +32,6 @@ workflows:
           context: PixUI
           requires:
             - checkout
-      - chromatic-deployment:
-          context: PixUI
-          requires:
-            - checkout
 
 jobs:
   checkout:
@@ -79,12 +75,3 @@ jobs:
       - attach_workspace:
           at: ~/pix-ui
       - run: npm run test
-
-  chromatic-deployment:
-    executor: node-browsers-docker
-    resource_class: large
-    working_directory: ~/pix-ui
-    steps:
-      - attach_workspace:
-          at: ~/pix-ui
-      - run: npm run chromatic -- --auto-accept-changes

--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -18,10 +18,6 @@ const preview = {
     previewTabs: {
       'storybook/docs/panel': { index: -1 },
     },
-    parameters: {
-      // Sets a delay for the component's stories
-      chromatic: { delay: 600 },
-    },
     options: {
       storySort: {
         order: [

--- a/package-lock.json
+++ b/package-lock.json
@@ -50,7 +50,6 @@
         "@storybook/theming": "^8.4.7",
         "@testing-library/dom": "^10.0.0",
         "@testing-library/user-event": "^14.4.3",
-        "chromatic": "^11.0.0",
         "core-js": "^3.26.1",
         "ember-cli": "^6.0.0",
         "ember-cli-dependency-checker": "^3.3.3",
@@ -695,6 +694,7 @@
       "version": "9.10.1",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "autoprefixer": "^9.0.0",
         "balanced-match": "^1.0.0",
@@ -851,6 +851,7 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.26.0.tgz",
       "integrity": "sha512-i1SLeK+DzNnQ3LL/CswPCa/E5u4lh1k6IAEphON8F+cXt0t9euTshDru0q7/IqMa1PMPz5RnHuHscF8/ZJsStg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.26.0",
@@ -2501,6 +2502,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -2524,6 +2526,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2656,6 +2659,7 @@
       "integrity": "sha512-Cclqeh0j6RnYvoaElAVC3Nd1fsSUkc3oUTwTsLlNiC3riyPq8lNYxh96VM59/yji2ntrd/cJQ7qhhSZWd6hsEw==",
       "devOptional": true,
       "license": "(MIT OR Apache-2.0)",
+      "peer": true,
       "dependencies": {
         "@ember/test-waiters": "^3.1.0 || ^4.0.0",
         "@embroider/addon-shim": "^1.8.7",
@@ -4455,6 +4459,7 @@
       "resolved": "https://registry.npmjs.org/@glimmer/component/-/component-2.0.0.tgz",
       "integrity": "sha512-eATSzBOUm0MZ9+YfJx7Y5p3gbwnaeMzLSSsCDn1ihDtUOIm5YYEV0ee0G7tXt/uKxowt8tXYn/EMbI9OlRF0CA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@embroider/addon-shim": "^1.8.9",
         "@glimmer/env": "^0.1.7"
@@ -6942,6 +6947,7 @@
       "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.10.4",
         "@babel/runtime": "^7.12.5",
@@ -7133,8 +7139,7 @@
     "node_modules/@types/prop-types": {
       "version": "15.7.12",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@types/qs": {
       "version": "6.9.15",
@@ -7414,6 +7419,7 @@
     "node_modules/acorn": {
       "version": "8.14.0",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -7434,6 +7440,7 @@
     "node_modules/ajv": {
       "version": "6.12.6",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -8057,6 +8064,7 @@
     "node_modules/babel-plugin-ember-modules-api-polyfill": {
       "version": "3.5.0",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ember-rfc176-data": "^0.3.17"
       },
@@ -8111,6 +8119,7 @@
     "node_modules/babel-plugin-htmlbars-inline-precompile": {
       "version": "5.3.1",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "babel-plugin-ember-modules-api-polyfill": "^3.5.0",
         "line-column": "^1.0.2",
@@ -9903,6 +9912,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "caniuse-lite": "^1.0.30001688",
         "electron-to-chromium": "^1.5.73",
@@ -10530,28 +10540,6 @@
       },
       "engines": {
         "node": ">= 6"
-      }
-    },
-    "node_modules/chromatic": {
-      "version": "11.7.1",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "chroma": "dist/bin.js",
-        "chromatic": "dist/bin.js",
-        "chromatic-cli": "dist/bin.js"
-      },
-      "peerDependencies": {
-        "@chromatic-com/cypress": "^0.*.* || ^1.0.0",
-        "@chromatic-com/playwright": "^0.*.* || ^1.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@chromatic-com/cypress": {
-          "optional": true
-        },
-        "@chromatic-com/playwright": {
-          "optional": true
-        }
       }
     },
     "node_modules/chrome-trace-event": {
@@ -11600,8 +11588,7 @@
     "node_modules/csstype": {
       "version": "3.1.3",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/ctype": {
       "version": "0.5.3",
@@ -14165,6 +14152,7 @@
     "node_modules/ember-modifier": {
       "version": "4.2.0",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@embroider/addon-shim": "^1.8.7",
         "decorator-transforms": "^2.0.0",
@@ -15284,6 +15272,7 @@
       "resolved": "https://registry.npmjs.org/ember-source/-/ember-source-5.12.0.tgz",
       "integrity": "sha512-2MWlJmQEeeiIk9p5CDMuvD470YPi7/4wXgU41ftbWc9svwF+0usoe4PLoLC0T/jV6YX+3SY5tumQfxLSLoFhmQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/core": "^7.24.4",
         "@ember/edition-utils": "^1.2.0",
@@ -16437,6 +16426,7 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "esbuild": "bin/esbuild"
       },
@@ -16513,6 +16503,7 @@
       "integrity": "sha512-KjeihdFqTPhOMXTt7StsDxriV4n66ueuF/jfPNC3j/lduHwr/ijDwJMsF+wyMJethgiKi5wniIE243vi07d3pg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -16598,6 +16589,7 @@
       "integrity": "sha512-1105/17ZIMjmCOJOPNfVdbXafLCLj3hPmkmB7dLgt7XsQ/zkxSuDerE/xgO3RxoHysR1N1whmquY0lSn2O0VLg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "eslint-config-prettier": "build/bin/cli.js"
       },
@@ -22528,6 +22520,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.8",
         "picocolors": "^1.1.1",
@@ -22972,6 +22965,7 @@
       "version": "0.36.2",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "postcss": ">=5.0.0"
       }
@@ -23002,6 +22996,7 @@
       "integrity": "sha512-QQtaxnoDJeAkDvDKWCLiwIXkTgRhwYDEQCghU9Z6q03iyek/rxRh/2lC3HB7P8sWT2xC/y5JDctPLBIGzHKbhw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -23269,6 +23264,7 @@
       "integrity": "sha512-CGrsGy7NhkQmfiyOixBpbexh2PT7ekIb35uWiBi/hBNdTJF1W98UonyACFJJs8UmcP96lH+YJlX99dYZi5rZkg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "commander": "7.2.0",
         "node-watch": "0.7.3",
@@ -23384,6 +23380,7 @@
       "version": "18.3.1",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -23395,6 +23392,7 @@
       "version": "18.3.1",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -24202,7 +24200,8 @@
       "version": "0.3.4",
       "resolved": "https://registry.npmjs.org/route-recognizer/-/route-recognizer-0.3.4.tgz",
       "integrity": "sha512-2+MhsfPhvauN1O8KaXpXAOfR/fwe8dnUXVM+xw7yt40lJRfPVQxV6yryZm0cgRvAj5fMF/mdRZbL2ptwbs5i2g==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/rsvp": {
       "version": "3.6.2",
@@ -24469,6 +24468,7 @@
     "node_modules/schema-utils/node_modules/ajv": {
       "version": "8.17.1",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -25317,6 +25317,7 @@
       "integrity": "sha512-RP/nMJxiWyFc8EVMH5gp20ID032Wvk+Yr3lmKidoegto5Iy+2dVQnUoElZb2zpbVXNHWakGuAkfI0dY1Hfp/vw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@storybook/core": "8.4.7"
       },
@@ -25562,6 +25563,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@csstools/css-parser-algorithms": "^3.0.4",
         "@csstools/css-tokenizer": "^3.0.3",
@@ -25924,6 +25926,7 @@
       "integrity": "sha512-8sLjZwK0R+JlxlYcTuVnyT2v+htpdrjDOKuMcOVdYjt52Lh8hWRYpxBPoKx/Zg+bcjc3wx6fmQevMmUztS/ccA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "cssesc": "^3.0.0",
         "util-deprecate": "^1.0.2"
@@ -27961,6 +27964,7 @@
       "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.97.1.tgz",
       "integrity": "sha512-EksG6gFY3L1eFMROS/7Wzgrii5mBAFe4rIr3r2BTfo7bcc+DWwFZ4OJ/miOuHJO/A85HwyI4eQ0F6IKXesO7Fg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/eslint-scope": "^3.7.7",
         "@types/estree": "^1.0.6",

--- a/package.json
+++ b/package.json
@@ -57,8 +57,7 @@
     "svg:generate-sprite": "npm run svg:compile && npm run svg:optimize && npm run svg:rename-id",
     "svg:compile": "svg-sprite -C 'svgs/svg-sprite.config.json' 'svgs/icons/*.svg'",
     "svg:optimize": "svgo --config='svgs/svgo.config.js' -i 'public/svg/' -o 'public/svg/'",
-    "svg:rename-id": "bash ./svgs/rename-icon-id-in-sprite.sh",
-    "chromatic": "npx chromatic --project-token=$CHROMATIC_PROJECT_TOKEN --only-changed"
+    "svg:rename-id": "bash ./svgs/rename-icon-id-in-sprite.sh"
   },
   "dependencies": {
     "@babel/core": "^7.25.2",

--- a/package.json
+++ b/package.json
@@ -100,7 +100,6 @@
     "@storybook/theming": "^8.4.7",
     "@testing-library/dom": "^10.0.0",
     "@testing-library/user-event": "^14.4.3",
-    "chromatic": "^11.0.0",
     "core-js": "^3.26.1",
     "ember-cli": "^6.0.0",
     "ember-cli-dependency-checker": "^3.3.3",


### PR DESCRIPTION
## :christmas_tree: Problème
Actuellement, Chromatic est installé sur le repo, mais on ne l'utilise pas. De plus on consomme des crédits circleCI pour rien.

## :gift: Proposition
On arrête de l'utiliser pour le moment.

## :star2: Remarques
- [x] Il faut enlever la variable d'env `CHROMATIC_PROJECT_TOKEN` du projet circle ci.

## :santa: Pour tester
La CI est green et on peut toujours utiliser notre DS
