### PR TITLE
[TECH] Corriger l'erreur d'arrondi sur le PixMultiSelect

### DIFF
--- a/addon/components/pix-multi-select.gjs
+++ b/addon/components/pix-multi-select.gjs
@@ -43,10 +43,10 @@ export default class PixMultiSelect extends Component {
           getComputedStyle(document.querySelector('html')).fontSize.match(/\d+(\.\d+)?/)[0],
         );
         const listWidth = elementList.getBoundingClientRect().width;
-        const selectWidth = listWidth / baseFontRemRatio;
+        const selectWidth = Number(listWidth / baseFontRemRatio + 0.5).toFixed(2); // Fix for FF
 
         const element = document.getElementById(`container-${this.multiSelectId}`);
-        element.style.setProperty('--pix-multi-select-width', `${selectWidth + 0.5}rem`); // Fix for FF
+        element.style.setProperty('--pix-multi-select-width', `${selectWidth}rem`);
       });
     }
 

--- a/addon/components/pix-select.gjs
+++ b/addon/components/pix-select.gjs
@@ -33,10 +33,10 @@ export default class PixSelect extends Component {
           getComputedStyle(document.querySelector('html')).fontSize.match(/\d+(\.\d+)?/)[0],
         );
         const listWidth = elementList.getBoundingClientRect().width;
-        const selectWidth = listWidth / baseFontRemRatio;
+        const selectWidth = Number(listWidth / baseFontRemRatio + 0.5).toFixed(2); // Fix for FF
 
         const element = document.getElementById(`container-${this.selectId}`);
-        element.style.setProperty('--pix-select-width', `${selectWidth + 0.5}rem`); // Fix for FF
+        element.style.setProperty('--pix-select-width', `${selectWidth}rem`);
       });
     }
   }

--- a/addon/styles/_pix-multi-select.scss
+++ b/addon/styles/_pix-multi-select.scss
@@ -106,7 +106,7 @@
   }
 
   &::-webkit-scrollbar {
-    width: 11px;
+    width: 0.5rem;
   }
 
   &::-webkit-scrollbar-track {


### PR DESCRIPTION
## :christmas_tree: Problème
la scrollbar du PixMultiSelect n'est pas ISO a celle du PixSelect ( 11px vs 6px ), pourquoi pas

## :gift: Proposition
Uniformiser la taille. et faire en sorte d'avoir un arrondi de rem plus cohérent que 50 chiffre après la virgule.

## :star2: Remarques
RAS

## :santa: Pour tester
CI au vert. et vérifier que sur PixOrga pour junior que la selection des classes soit OK