### PR TITLE
[BUGFIX] Rendre la largeur des jauges du composant PixGauge adaptative pour le bon affichage des chiffres (PIX-18702)

### DIFF
--- a/addon/components/pix-gauge.gjs
+++ b/addon/components/pix-gauge.gjs
@@ -36,7 +36,7 @@ export default class PixGauge extends Component {
     return this.args.hideValues ?? false;
   }
 
-  get maxLevelPourcentage() {
+  get maxLevelPercentage() {
     return this.maxLevel / 8;
   }
   get viewBox() {
@@ -70,6 +70,41 @@ export default class PixGauge extends Component {
   get statsFontHeight() {
     return this.args.isSmall ? 18 : 26;
   }
+
+  get gaugeWidths() {
+    let reachedLevelWidth = this.gaugeWidthCSS(this.reachedLevelPercentage);
+    let maxLevelWidth = this.gaugeWidthCSS(this.maxLevelPercentage);
+
+    const levelDifference = Math.round((this.maxLevel - this.reachedLevel) * 10) / 10;
+
+    const isMaxLevelInteger = this.maxLevel % 1 === 0;
+    const spacingRem = isMaxLevelInteger ? 1.75 : 2.625;
+
+    const isSpaceBetweenLevelsNarrow = this.args.isSmall
+      ? levelDifference < 1.5
+      : levelDifference < 0.5;
+
+    if (!this.hideValues && levelDifference !== 0 && isSpaceBetweenLevelsNarrow) {
+      if (this.maxLevel >= 7.5) {
+        reachedLevelWidth = this.gaugeWidthCSS(this.maxLevelPercentage, `- ${spacingRem}rem`);
+      } else {
+        maxLevelWidth = this.gaugeWidthCSS(this.reachedLevelPercentage, `+ ${spacingRem}rem`);
+      }
+    }
+
+    const reachedLevelMinWidth = `3rem`;
+    const maxLevelMinWidth = `${reachedLevelMinWidth} + ${spacingRem}rem`;
+
+    return {
+      reachedLevel: this.gaugeAdaptativeWidthCSS(reachedLevelMinWidth, reachedLevelWidth),
+      maxLevel: this.gaugeAdaptativeWidthCSS(maxLevelMinWidth, maxLevelWidth),
+    };
+  }
+
+  gaugeWidthCSS = (levelPercentage, spacing = '') =>
+    `calc(calc(100% - 8px) * ${levelPercentage} ${spacing})`;
+
+  gaugeAdaptativeWidthCSS = (width, minWidth) => `max(${minWidth}, ${width})`;
 
   isLevelActive = (index) => {
     if (this.reachedLevel === 0 && index === 0) return true;
@@ -127,13 +162,13 @@ export default class PixGauge extends Component {
         {{! gauge white max level}}
         <rect
           y={{26}}
-          width="calc(calc(100% - 8px) * {{this.maxLevelPourcentage}})"
+          width={{this.gaugeWidths.maxLevel}}
           height={{this.whiteAndPurpleGaugesHeight}}
           rx={{this.whiteAndPurpleGaugeRx}}
           class="result-level-gauge__max-bar"
         />
         {{#unless this.hideValues}}
-          <g style="transform: translate(calc(calc(100% - 8px) * {{this.maxLevelPourcentage}}))">
+          <g style="transform: translate({{this.gaugeWidths.maxLevel}})">
             <text
               y={{this.statsFontHeight}}
               x="0"
@@ -147,15 +182,13 @@ export default class PixGauge extends Component {
         {{! mean purple level }}
         <rect
           y={{26}}
-          width="max(calc(calc(100% - 8px) * {{this.reachedLevelPercentage}}), 44px)"
+          width={{this.gaugeWidths.reachedLevel}}
           height={{this.whiteAndPurpleGaugesHeight}}
           rx={{this.whiteAndPurpleGaugeRx}}
           class="result-level-gauge__mean-bar"
         />
         {{#unless this.hideValues}}
-          <g
-            style="transform: translate(max(calc(calc(100% - 8px) * {{this.reachedLevelPercentage}}), 44px))"
-          >
+          <g style="transform: translate({{this.gaugeWidths.reachedLevel}})">
             <text
               y={{this.statsFontHeight}}
               x="0"

--- a/tests/dummy/app/templates/gauge-page.hbs
+++ b/tests/dummy/app/templates/gauge-page.hbs
@@ -2,21 +2,21 @@
   @stepLabels={{array "Novice" "Intermédiaire" "Avancé" "Expert"}}
   @reachedLevel={{6.3}}
   @maxLevel={{8}}
-  @label="niveau atteind de 6.3 sur un maximum de 8"
+  @label="niveau atteint de 6.3 sur un maximum de 8"
 />
 
 <PixGauge
   @stepLabels={{array "Novice" "Intermédiaire" "Avancé" "Expert"}}
   @reachedLevel={{0.51}}
   @maxLevel={{8}}
-  @label="niveau atteind de 4 sur un maximum de 8"
+  @label="niveau atteint de 4 sur un maximum de 8"
 />
 
 <PixGauge
   @stepLabels={{array "Novice" "Intermédiaire" "Avancé" "Expert"}}
   @reachedLevel={{0}}
   @maxLevel={{8}}
-  @label="niveau atteind de 4 sur un maximum de 8"
+  @label="niveau atteint de 4 sur un maximum de 8"
 />
 
 <PixGauge
@@ -24,7 +24,7 @@
   @isSmall={{true}}
   @reachedLevel={{4}}
   @maxLevel={{8}}
-  @label="niveau atteind de 4 sur un maximum de 8"
+  @label="niveau atteint de 4 sur un maximum de 8"
 />
 
 <PixGauge
@@ -32,7 +32,7 @@
   @hideValues={{true}}
   @reachedLevel={{4}}
   @maxLevel={{8}}
-  @label="niveau atteind de 4 sur un maximum de 8"
+  @label="niveau atteint de 4 sur un maximum de 8"
 />
 
 <PixGauge
@@ -41,5 +41,69 @@
   @hideValues={{true}}
   @reachedLevel={{4}}
   @maxLevel={{8}}
-  @label="niveau atteind de 4 sur un maximum de 8"
+  @label="niveau atteint de 4 sur un maximum de 8"
+/>
+
+<br />
+<br />
+<h1>Affichage non superposé des chiffres (sauf si égal)</h1>
+<br />
+
+<PixGauge
+  @stepLabels={{array "Novice" "Intermédiaire" "Avancé" "Expert"}}
+  @reachedLevel={{0.9}}
+  @maxLevel={{1}}
+/>
+<PixGauge
+  @stepLabels={{array "Novice" "Intermédiaire" "Avancé" "Expert"}}
+  @reachedLevel={{2.1}}
+  @maxLevel={{2.2}}
+/>
+<PixGauge
+  @stepLabels={{array "Novice" "Intermédiaire" "Avancé" "Expert"}}
+  @reachedLevel={{7.7}}
+  @maxLevel={{7.9}}
+/>
+<PixGauge
+  @stepLabels={{array "Novice" "Intermédiaire" "Avancé" "Expert"}}
+  @reachedLevel={{7.9}}
+  @maxLevel={{8}}
+/>
+<PixGauge
+  @stepLabels={{array "Novice" "Intermédiaire" "Avancé" "Expert"}}
+  @reachedLevel={{8}}
+  @maxLevel={{8}}
+/>
+
+<br />
+
+<PixGauge
+  @stepLabels={{array "Novice" "Intermédiaire" "Avancé" "Expert"}}
+  @reachedLevel={{0.9}}
+  @maxLevel={{1}}
+  @isSmall={{true}}
+/>
+<PixGauge
+  @stepLabels={{array "Novice" "Intermédiaire" "Avancé" "Expert"}}
+  @reachedLevel={{2.1}}
+  @maxLevel={{2.2}}
+  @isSmall={{true}}
+/>
+<PixGauge
+  @stepLabels={{array "Novice" "Intermédiaire" "Avancé" "Expert"}}
+  @reachedLevel={{7.7}}
+  @maxLevel={{7.9}}
+  @isSmall={{true}}
+/>
+<PixGauge
+  @stepLabels={{array "Novice" "Intermédiaire" "Avancé" "Expert"}}
+  @reachedLevel={{7.9}}
+  @maxLevel={{8}}
+  @isSmall={{true}}
+/>
+<PixGauge
+  @stepLabels={{array "Novice" "Intermédiaire" "Avancé" "Expert"}}
+  @reachedLevel={{8}}
+  @maxLevel={{8}}
+  @isSmall={{true}}
 />


### PR DESCRIPTION
## :christmas_tree: Problème

Actuellement, lorsque le niveau atteint est très proche du niveau maximal, les jauges se superposent et le chiffre du dessous est partiellement, voire complètement masqué. 🤿 

<img width="1192" height="430" alt="Capture d’écran 2026-02-11 à 17 39 40" src="https://github.com/user-attachments/assets/a9d09ab2-b9ae-4eae-a807-7246fb0d7ad3" />

## :gift: Proposition

On calcule l'écart entre les deux jauges et on définit une largeur adaptée pour laisser plus d'espace au chiffre du dessous.
On fait également en fonction de si on est à la fin de jauge ou si on est en format réduit.

<img width="1205" height="446" alt="Capture d’écran 2026-02-11 à 17 40 20" src="https://github.com/user-attachments/assets/15eb5a8c-2c07-4a07-9acd-d5ca713852d7" />

## :santa: Pour tester

Faire une montée de version, et afficher plusieurs pages de statistiques (avec des valeurs de jauges proche notamment) pour constater le bon affichage des jauges.
