### PR TITLE
[BREAKING] Améliorer l'usage de la PixProgressBar (PIX-21593).

### DIFF
--- a/addon/components/pix-progress-bar.gjs
+++ b/addon/components/pix-progress-bar.gjs
@@ -1,30 +1,36 @@
+import { warn } from '@ember/debug';
 import { guidFor } from '@ember/object/internals';
 import Component from '@glimmer/component';
 
 export default class PixProgressBar extends Component {
-  get id() {
-    return guidFor(this);
-  }
+  constructor(...args) {
+    super(...args);
+    warn('PixProgressBar: you need to provide a locale', this.args.locale, {
+      id: 'pix-progress-bar.locale.required',
+    });
 
-  get value() {
-    if (Number(this.args.value) <= 0) return 0;
-    if (Number(this.args.value) > 100) return 100;
-    if (!this.args.value) {
-      throw new Error('ERROR in PixProgressBar component, @value param is not provided.');
-    }
-    return Number(this.args.value);
+    warn(
+      'PixProgressBar: you need to provide a number value between 0 and 1',
+      this.args.value >= 0 && this.args.value <= 1,
+      {
+        id: 'pix-progress-bar.value.type.incorrect',
+      },
+    );
+
+    this.id = guidFor(this);
   }
 
   get percentageValue() {
-    return Number(this.value / 100).toLocaleString(navigator.language, { style: 'percent' });
+    return Number(this.clampValue).toLocaleString(this.args.locale, { style: 'percent' });
   }
 
   get label() {
-    const thereIsNoLabel = !this.args.label || !this.args.label.trim();
+    const hasLabel = this.args.label && this.args.label.trim().length > 0;
 
-    if (thereIsNoLabel && !this.args.isDecorative) {
-      throw new Error('ERROR in PixProgressBar component, @label param is not provided.');
-    }
+    warn('PixProgressBar: you need to provide a valid label', hasLabel || this.args.isDecorative, {
+      id: 'pix-progress-bar.label.required',
+    });
+
     return this.args.label;
   }
 
@@ -56,6 +62,10 @@ export default class PixProgressBar extends Component {
     return `progress-bar--content-${color}`;
   }
 
+  get clampValue() {
+    return Math.max(Math.min(this.args.value, 1), 0);
+  }
+
   <template>
     <div
       class="progress-bar {{this.themeMode}} {{this.colorClass}}"
@@ -69,9 +79,10 @@ export default class PixProgressBar extends Component {
       <progress
         class="progress-bar__bar"
         id={{this.id}}
-        max="100"
-        value={{this.value}}
-      >{{this.value}}%</progress>
+        max="1"
+        min="0"
+        value={{this.clampValue}}
+      >{{this.percentageValue}}</progress>
       {{#if @subtitle}}
         <p class="progress-bar__sub-title">{{@subtitle}}</p>
       {{/if}}

--- a/app/stories/pix-progress-bar.mdx
+++ b/app/stories/pix-progress-bar.mdx
@@ -27,7 +27,7 @@ Démonstration d'une barre de progression blanche en dark mode avec un sous titr
 
 ```html
 <PixProgressBar
-  @value="50"
+  @value={{0.2}}
   @label="Chargement"
   @color="sucess"
   @themeMode="dark"

--- a/app/stories/pix-progress-bar.stories.js
+++ b/app/stories/pix-progress-bar.stories.js
@@ -16,6 +16,13 @@ export default {
       type: { name: 'string', required: true },
       table: { defaultValue: { summary: 'null' } },
     },
+    locale: {
+      name: 'locale',
+      description:
+        "Permet de traduire le pourcentage dans la langue de l'application utilisant le composant",
+      type: { name: 'string', required: true },
+      table: { defaultValue: { summary: 'null' } },
+    },
     themeMode: {
       name: 'themeMode',
       description:
@@ -61,6 +68,7 @@ export const Default = (args) => {
     template: hbs`<PixProgressBar
   @value={{this.value}}
   @color={{this.color}}
+  @locale={{this.locale}}
   @themeMode={{this.themeMode}}
   @subtitle={{this.subtitle}}
   @label={{this.label}}
@@ -69,7 +77,8 @@ export const Default = (args) => {
   };
 };
 Default.args = {
-  value: '50',
+  value: 0.5,
+  locale: 'fr',
 };
 
 export const Success = (args) => {
@@ -79,14 +88,16 @@ export const Success = (args) => {
   @color={{this.color}}
   @themeMode={{this.themeMode}}
   @subtitle={{this.subtitle}}
+  @locale={{this.locale}}
   @label={{this.label}}
 />`,
     context: args,
   };
 };
 Success.args = {
-  value: '50',
+  value: 0.5,
   color: 'success',
+  locale: 'fr',
 };
 
 export const Tertiary = (args) => {
@@ -94,6 +105,7 @@ export const Tertiary = (args) => {
     template: hbs`<PixProgressBar
   @value={{this.value}}
   @color={{this.color}}
+  @locale={{this.locale}}
   @themeMode={{this.themeMode}}
   @subtitle={{this.subtitle}}
   @label={{this.label}}
@@ -102,8 +114,9 @@ export const Tertiary = (args) => {
   };
 };
 Tertiary.args = {
-  value: '50',
+  value: 0.5,
   color: 'tertiary',
+  locale: 'en',
 };
 
 export const darkModeProgressBar = (args) => {
@@ -114,6 +127,7 @@ export const darkModeProgressBar = (args) => {
     @value={{this.value}}
     @color={{this.color}}
     @label={{this.label}}
+    @locale={{this.locale}}
     @themeMode={{this.themeMode}}
     @subtitle={{this.subtitle}}
   />
@@ -122,8 +136,9 @@ export const darkModeProgressBar = (args) => {
   };
 };
 darkModeProgressBar.args = {
-  value: '50',
+  value: 0.5,
   label: 'Chargement',
+  locale: 'es',
   color: 'primary',
   themeMode: 'dark',
   subtitle: 'Avancement',
@@ -135,6 +150,7 @@ export const WithoutPercentage = (args) => {
   @value={{this.value}}
   @color={{this.color}}
   @themeMode={{this.themeMode}}
+  @locale={{this.locale}}
   @subtitle={{this.subtitle}}
   @label={{this.label}}
   @hidePercentage={{this.hidePercentage}}
@@ -143,7 +159,8 @@ export const WithoutPercentage = (args) => {
   };
 };
 WithoutPercentage.args = {
-  value: '50',
+  value: 0.5,
   color: 'primary',
+  locale: 'fr',
   hidePercentage: true,
 };

--- a/tests/integration/components/pix-progress-bar-test.js
+++ b/tests/integration/components/pix-progress-bar-test.js
@@ -11,9 +11,9 @@ module('Integration | Component | PixProgressBar', function (hooks) {
   module('Attributes @value', function () {
     test('it renders the value with percentage', async function (assert) {
       // given & when
-      const screen = await render(hbs`<PixProgressBar @value='50' />`);
+      const screen = await render(hbs`<PixProgressBar @value={{0.5}} @locale='fr' />`);
 
-      const localizedPercentage = Number(50 / 100).toLocaleString(navigator.language, {
+      const localizedPercentage = Number(0.5).toLocaleString('fr', {
         style: 'percent',
       });
 
@@ -23,16 +23,16 @@ module('Integration | Component | PixProgressBar', function (hooks) {
 
     test('it renders the progress bar with correct width never exceed 100%', async function (assert) {
       // given & when
-      const screen = await render(hbs`<PixProgressBar @value='110' />`);
+      const screen = await render(hbs`<PixProgressBar @value={{1.1}} @locale='fr' />`);
 
       // then
       const progressbar = screen.getByRole('progressbar');
-      assert.strictEqual(progressbar.value, 100);
+      assert.strictEqual(progressbar.value, 1);
     });
 
     test('it renders the progress bar with correct width never under 0%', async function (assert) {
       // given & when
-      const screen = await render(hbs`<PixProgressBar @value='-20' />`);
+      const screen = await render(hbs`<PixProgressBar @value={{-0.2}} @locale='fr' />`);
 
       // then
       const progressbar = screen.getByRole('progressbar');
@@ -43,7 +43,7 @@ module('Integration | Component | PixProgressBar', function (hooks) {
   module('Attributes @color', function () {
     test('it renders the progress bar by default with primary class', async function (assert) {
       // given & when
-      await render(hbs`<PixProgressBar @value='50' />`);
+      await render(hbs`<PixProgressBar @value={{0.5}} @locale='fr' />`);
 
       // then
       const componentElement = this.element.querySelector(PROGRESS_BAR_SELECTOR);
@@ -52,7 +52,7 @@ module('Integration | Component | PixProgressBar', function (hooks) {
 
     test('it renders the progress bar with primary class when color not exists', async function (assert) {
       // given & when
-      await render(hbs`<PixProgressBar @value='50' @color='vert-lychen' />`);
+      await render(hbs`<PixProgressBar @value={{0.5}} @color='vert-lychen' @locale='fr' />`);
 
       // then
       const componentElement = this.element.querySelector(PROGRESS_BAR_SELECTOR);
@@ -61,7 +61,7 @@ module('Integration | Component | PixProgressBar', function (hooks) {
 
     test('it renders the progress bar with tertiary class', async function (assert) {
       // given & when
-      await render(hbs`<PixProgressBar @value='50' @color='tertiary' />`);
+      await render(hbs`<PixProgressBar @value={{0.5}} @color='tertiary' @locale='fr' />`);
 
       // then
       const componentElement = this.element.querySelector(PROGRESS_BAR_SELECTOR);
@@ -70,7 +70,7 @@ module('Integration | Component | PixProgressBar', function (hooks) {
 
     test('it renders the progress bar with success class', async function (assert) {
       // given & when
-      await render(hbs`<PixProgressBar @value='50' @color='success' />`);
+      await render(hbs`<PixProgressBar @value={{0.5}} @color='success' @locale='fr' />`);
 
       // then
       const componentElement = this.element.querySelector(PROGRESS_BAR_SELECTOR);
@@ -79,7 +79,7 @@ module('Integration | Component | PixProgressBar', function (hooks) {
 
     test('it renders the progress bar with primary class', async function (assert) {
       // given & when
-      await render(hbs`<PixProgressBar @value='50' @color='primary' />`);
+      await render(hbs`<PixProgressBar @value={{0.5}} @color='primary' @locale='fr' />`);
 
       // then
       const componentElement = this.element.querySelector(PROGRESS_BAR_SELECTOR);
@@ -90,7 +90,7 @@ module('Integration | Component | PixProgressBar', function (hooks) {
   module('Attributes @themeMode', function () {
     test('it renders the progress bar by default with light mode', async function (assert) {
       // given & when
-      await render(hbs`<PixProgressBar @value='50' />`);
+      await render(hbs`<PixProgressBar @value={{0.5}} @locale='fr' />`);
 
       // then
       const componentElement = this.element.querySelector(PROGRESS_BAR_SELECTOR);
@@ -99,7 +99,7 @@ module('Integration | Component | PixProgressBar', function (hooks) {
 
     test('it renders the progress bar with light mode when value not exists', async function (assert) {
       // given & when
-      await render(hbs`<PixProgressBar @value='50' @themeMode='darken-light' />`);
+      await render(hbs`<PixProgressBar @value={{0.5}} @themeMode='darken-light' @locale='fr' />`);
 
       // then
       const componentElement = this.element.querySelector(PROGRESS_BAR_SELECTOR);
@@ -108,7 +108,7 @@ module('Integration | Component | PixProgressBar', function (hooks) {
 
     test('it renders the progress bar with light mode', async function (assert) {
       // given & when
-      await render(hbs`<PixProgressBar @value='50' @themeMode='light' />`);
+      await render(hbs`<PixProgressBar @value={{0.5}} @themeMode='light' @locale='fr' />`);
 
       // then
       const componentElement = this.element.querySelector(PROGRESS_BAR_SELECTOR);
@@ -117,7 +117,7 @@ module('Integration | Component | PixProgressBar', function (hooks) {
 
     test('it renders the progress bar with dark mode', async function (assert) {
       // given & when
-      await render(hbs`<PixProgressBar @value='50' @themeMode='dark' />`);
+      await render(hbs`<PixProgressBar @value={{0.5}} @themeMode='dark' @locale='fr' />`);
 
       // then
       const componentElement = this.element.querySelector(PROGRESS_BAR_SELECTOR);
@@ -128,7 +128,7 @@ module('Integration | Component | PixProgressBar', function (hooks) {
   module('Attributes @subtitle', function () {
     test('it does not render the progress bar sub-title', async function (assert) {
       // given & when
-      await render(hbs`<PixProgressBar @value='50' />`);
+      await render(hbs`<PixProgressBar @value={{0.5}} @locale='fr' />`);
 
       // then
       const componentElement = this.element.querySelector('.progress-bar__sub-title');
@@ -137,7 +137,7 @@ module('Integration | Component | PixProgressBar', function (hooks) {
 
     test('it renders the progress bar sub-title', async function (assert) {
       // given & when
-      await render(hbs`<PixProgressBar @value='50' @subtitle='toto' />`);
+      await render(hbs`<PixProgressBar @value={{0.5}} @subtitle='toto' @locale='fr' />`);
 
       // then
       const componentElement = this.element.querySelector('.progress-bar__sub-title');
@@ -148,9 +148,9 @@ module('Integration | Component | PixProgressBar', function (hooks) {
   module('Attributes @hidePercentage', function () {
     test('it renders the progress bar percentage by default', async function (assert) {
       // when
-      const screen = await render(hbs`<PixProgressBar @value='50' />`);
+      const screen = await render(hbs`<PixProgressBar @value={{0.5}} @locale='fr' />`);
 
-      const localizedPercentage = Number(50 / 100).toLocaleString(navigator.language, {
+      const localizedPercentage = Number(50 / 100).toLocaleString('fr', {
         style: 'percent',
       });
 
@@ -160,8 +160,10 @@ module('Integration | Component | PixProgressBar', function (hooks) {
 
     test('it renders the progress bar percentage when attribute is false', async function (assert) {
       // when
-      const screen = await render(hbs`<PixProgressBar @value='50' @hidePercentage={{false}} />`);
-      const localizedPercentage = Number(50 / 100).toLocaleString(navigator.language, {
+      const screen = await render(
+        hbs`<PixProgressBar @value={{0.5}} @hidePercentage={{false}} @locale='fr' />`,
+      );
+      const localizedPercentage = Number(50 / 100).toLocaleString('fr', {
         style: 'percent',
       });
 
@@ -172,7 +174,7 @@ module('Integration | Component | PixProgressBar', function (hooks) {
 
     test('it does not render the progress bar percentage when attribute is true', async function (assert) {
       // when
-      await render(hbs`<PixProgressBar @value='50' @hidePercentage={{true}} />`);
+      await render(hbs`<PixProgressBar @value={{0.5}} @hidePercentage={{true}} @locale='fr' />`);
 
       // then
       assert.dom('.progress-bar__text').doesNotExist();
@@ -182,7 +184,7 @@ module('Integration | Component | PixProgressBar', function (hooks) {
   module('Attributes @isDecorative', () => {
     test('it sets progress bar aria-hidden to "true"', async function (assert) {
       // when
-      await render(hbs`<PixProgressBar @value='50' @isDecorative='true' />`);
+      await render(hbs`<PixProgressBar @value={{0.5}} @isDecorative='true' @locale='fr' />`);
 
       // then
       assert.dom('.progress-bar').hasAria('hidden', 'true');


### PR DESCRIPTION
## :boom: BREAKING_CHANGES
* Utilisation de locale de l'application plutôt que de celle du navigateur pour afficher le pourcentage
* Utilisation du ratio entre 0 et 1 plutôt que d'un nombre entre 0 et 100 ( pour être ISO avec l'utilisation de toLocaleString

## :christmas_tree: Problème
L'usage d'un nombre entre 0 et 100 impliquer des modification en interne du composant pour utiliser la fonction native tolocaleString.

## :gift: Proposition
Aligner les usages

## :star2: Remarques
RAS

## :santa: Pour tester
Vérifier que cela fonctionne bien sur PixUI.
l'implémenter sur PixApp et vérifier que tout fonctionne avec les modification