### PR TITLE
[BREAKING] Modification du PixButtonRadio tile pour Modulix (PIX-21644).

### DIFF
--- a/addon/components/pix-label-wrapped.gjs
+++ b/addon/components/pix-label-wrapped.gjs
@@ -8,9 +8,15 @@ export default class PixLabelWrapped extends Component {
 
     if (this.args.inlineLabel) classes.push('pix-label--inline-label');
     if (this.args.isDisabled) classes.push('pix-label-wrapped--disabled');
-    if (this.args.variant === 'modulix') classes.push('pix-label-wrapped--variant-modulix');
-    if (this.args.state === 'success') classes.push('pix-label-wrapped--state-success');
-    if (this.args.state === 'error') classes.push('pix-label-wrapped--state-error');
+    if (this.args.variant === 'modulix') {
+      classes.push('pix-label-wrapped--variant-modulix');
+      if (this.args.state === 'success') classes.push('pix-label-wrapped--state-modulix-success');
+      if (this.args.state === 'error') classes.push('pix-label-wrapped--state-modulix-error');
+      if (this.args.state === 'neutral') classes.push('pix-label-wrapped--state-modulix-neutral');
+    } else {
+      if (this.args.state === 'success') classes.push('pix-label-wrapped--state-success');
+      if (this.args.state === 'error') classes.push('pix-label-wrapped--state-error');
+    }
 
     const size = ['small', 'large'].includes(this.args.size) ? this.args.size : 'default';
 

--- a/addon/components/pix-label-wrapped.gjs
+++ b/addon/components/pix-label-wrapped.gjs
@@ -8,7 +8,7 @@ export default class PixLabelWrapped extends Component {
 
     if (this.args.inlineLabel) classes.push('pix-label--inline-label');
     if (this.args.isDisabled) classes.push('pix-label-wrapped--disabled');
-    if (this.args.variant === 'tile') classes.push('pix-label-wrapped--variant-tile');
+    if (this.args.variant === 'modulix') classes.push('pix-label-wrapped--variant-modulix');
     if (this.args.state === 'success') classes.push('pix-label-wrapped--state-success');
     if (this.args.state === 'error') classes.push('pix-label-wrapped--state-error');
 

--- a/addon/components/pix-radio-button.gjs
+++ b/addon/components/pix-radio-button.gjs
@@ -45,6 +45,10 @@ export default class PixRadioButton extends Component {
       classes.push(`${classes[0]}--state`);
     }
 
+    if (this.args.variant === 'modulix') {
+      classes.push('pix-radio-button__input--variant-modulix');
+    }
+
     return classes.join(' ');
   }
 

--- a/addon/components/pix-radio-button.gjs
+++ b/addon/components/pix-radio-button.gjs
@@ -10,10 +10,6 @@ import PixLabelWrapped from './pix-label-wrapped';
 export default class PixRadioButton extends Component {
   text = 'pix-radio-button';
 
-  get stateWarning() {
-    return Boolean(this.isDisabled) && (!this.hasErrorState || !this.hasSuccessState);
-  }
-
   get id() {
     return this.args.id || guidFor(this);
   }

--- a/addon/styles/_pix-label-wrapped.scss
+++ b/addon/styles/_pix-label-wrapped.scss
@@ -4,7 +4,7 @@
   align-items: center;
   cursor: pointer;
 
-  &--variant-tile {
+  &--variant-modulix {
     position: relative;
     z-index: -2;
     padding: var(--pix-spacing-3x) var(--pix-spacing-4x);

--- a/addon/styles/_pix-label-wrapped.scss
+++ b/addon/styles/_pix-label-wrapped.scss
@@ -41,6 +41,20 @@
           color: var(--pix-error-700);
         }
 
+        &.pix-label-wrapped--state-modulix-error {
+          --state-border-color: var(--pix-warning-700);
+          --state-background-color: var(--pix-warning-50);
+
+          color: var(--pix-warning-700);
+        }
+
+        &.pix-label-wrapped--state-modulix-success {
+          --state-border-color: var(--pix-success-700);
+          --state-background-color: var(--pix-success-50);
+
+          color: var(--pix-success-700);
+        }
+
         & .pix-label-wrapped__state-icon {
           z-index: 1;
           width: 1rem;

--- a/addon/styles/_pix-radio-button.scss
+++ b/addon/styles/_pix-radio-button.scss
@@ -92,4 +92,14 @@
       }
     }
   }
+
+  &__input--variant-modulix, svg:has(+ .pix-radio-button__input--variant-modulix) {
+    position: absolute;
+    clip-path: polygon(0 0);
+  }
+
+  .pix-label-wrapped--state-modulix-neutral:has(input:checked):not(.pix-label-wrapped--disabled) {
+    border: 1px solid var(--pix-primary-500);
+    outline: 2px solid var(--pix-primary-300);
+  }
 }

--- a/app/stories/pix-checkbox-variant-modulix.mdx
+++ b/app/stories/pix-checkbox-variant-modulix.mdx
@@ -1,16 +1,16 @@
 import { Meta, Story, ArgTypes } from '@storybook/blocks';
-import * as ComponentStories from './pix-checkbox-variant-tile.stories';
+import * as ComponentStories from './pix-checkbox-variant-modulix.stories';
 
 <Meta of={ComponentStories} />
 
-# PixCheckbox `@variant="title"`
+# PixCheckbox `@variant="modulix"`
 
 La PixCheckbox permet de créer des checkbox basiques ou des checkbox mixées (checkbox servant d'indicateur lors d'une sélection multiple).
 Un cursor `pointer` est défini sur la checkbox et son label par défaut.
 
 La checkbox et son label sont visuellement regroupés dans un ensemble intégralement cliquable.
 
-<Story of={ComponentStories.VariantTile} height={120} />
+<Story of={ComponentStories.VariantModulix} height={120} />
 
 ## États de la Checkbox
 
@@ -19,16 +19,16 @@ La checkbox et son label sont visuellement regroupés dans un ensemble intégral
 L'attribut `@isDisabled` permet de désactiver la checkbox en conservant la possibilité de naviguer avec le clavier ou le lecteur d'écran. Il est préféré à l'attribut natif `disabled` qui empêche ces usages.
 Un cursor `not-allowed` est défini sur la checkbox et son label lorsqu'elle est dans un état `disabled`.
 
-<Story of={ComponentStories.isDisabledVariantTile} height={120} />
-<Story of={ComponentStories.checkedIsDisabledVariantTile} height={120} />
-<Story of={ComponentStories.isIndeterminateIsDisabledVariantTile} height={120} />
+<Story of={ComponentStories.isDisabledVariantModulix} height={120} />
+<Story of={ComponentStories.checkedIsDisabledVariantModulix} height={120} />
+<Story of={ComponentStories.isIndeterminateIsDisabledVariantModulix} height={120} />
 
 #### Succès/Erreur
 
 Cumulée à la désactivation, une propriété de statut permet de préciser une coloration particulière en cas de "succès" ou d'"erreur".
 
-<Story of={ComponentStories.isDisabledIsSuccessVariantTile} height={120} />
-<Story of={ComponentStories.isDisabledIsErrorVariantTile} height={120} />
+<Story of={ComponentStories.isDisabledIsSuccessVariantModulix} height={120} />
+<Story of={ComponentStories.isDisabledIsErrorVariantModulix} height={120} />
 
 ## Usage
 
@@ -38,7 +38,7 @@ Cumulée à la désactivation, une propriété de statut permet de préciser une
   @isIndeterminate={{false}}
   @size="small"
   @isDisabled={{true}}
-  @variant="tile"
+  @variant="modulix"
 >
   <:label>Recevoir la newsletter</:label>
 </PixCheckbox>

--- a/app/stories/pix-checkbox-variant-modulix.stories.js
+++ b/app/stories/pix-checkbox-variant-modulix.stories.js
@@ -3,12 +3,12 @@ import { hbs } from 'ember-cli-htmlbars';
 import pixCheckboxStories from './pix-checkbox.stories.js';
 
 export default {
-  title: 'Forms/Checkbox/Variant Tile',
+  title: 'Forms/Checkbox/Variant modulix',
   argTypes: {
     variant: {
       name: 'variant',
       description: 'Utiliser une variante graphique du composant',
-      options: ['tile'],
+      options: ['modulix'],
       control: { type: 'select' },
       type: { required: true },
     },
@@ -26,7 +26,7 @@ export default {
   },
 };
 
-const VariantTileTemplate = (args) => {
+const VariantModulixTemplate = (args) => {
   return {
     template: hbs`{{! template-lint-disable no-inline-styles }}
 <div
@@ -45,58 +45,58 @@ const VariantTileTemplate = (args) => {
   };
 };
 
-export const VariantTile = VariantTileTemplate.bind({});
-VariantTile.args = {
+export const VariantModulix = VariantModulixTemplate.bind({});
+VariantModulix.args = {
   id: 'proposal',
   label: 'Une réponse',
-  variant: 'tile',
+  variant: 'modulix',
 };
 
-export const isDisabledVariantTile = VariantTileTemplate.bind({});
-isDisabledVariantTile.args = {
+export const isDisabledVariantModulix = VariantModulixTemplate.bind({});
+isDisabledVariantModulix.args = {
   id: 'accept-newsletter-2',
   label: 'Recevoir la newsletter',
-  variant: 'tile',
+  variant: 'modulix',
   state: 'neutral',
   isDisabled: true,
 };
 
-export const checkedIsDisabledVariantTile = VariantTileTemplate.bind({});
-checkedIsDisabledVariantTile.args = {
+export const checkedIsDisabledVariantModulix = VariantModulixTemplate.bind({});
+checkedIsDisabledVariantModulix.args = {
   id: 'accept-newsletter-2',
   label: 'Recevoir la newsletter',
-  variant: 'tile',
+  variant: 'modulix',
   state: 'neutral',
   isDisabled: true,
   checked: true,
 };
 
-export const isIndeterminateIsDisabledVariantTile = VariantTileTemplate.bind({});
-isIndeterminateIsDisabledVariantTile.args = {
+export const isIndeterminateIsDisabledVariantModulix = VariantModulixTemplate.bind({});
+isIndeterminateIsDisabledVariantModulix.args = {
   id: 'accept-newsletter-2',
   label: 'Recevoir la newsletter',
-  variant: 'tile',
+  variant: 'modulix',
   state: 'neutral',
   isDisabled: true,
   checked: true,
   isIndeterminate: true,
 };
 
-export const isDisabledIsSuccessVariantTile = VariantTileTemplate.bind({});
-isDisabledIsSuccessVariantTile.args = {
+export const isDisabledIsSuccessVariantModulix = VariantModulixTemplate.bind({});
+isDisabledIsSuccessVariantModulix.args = {
   id: 'accept-newsletter-2',
   label: 'Recevoir la newsletter',
-  variant: 'tile',
+  variant: 'modulix',
   isDisabled: true,
   checked: true,
   state: 'success',
 };
 
-export const isDisabledIsErrorVariantTile = VariantTileTemplate.bind({});
-isDisabledIsErrorVariantTile.args = {
+export const isDisabledIsErrorVariantModulix = VariantModulixTemplate.bind({});
+isDisabledIsErrorVariantModulix.args = {
   id: 'accept-newsletter-2',
   label: 'Recevoir la newsletter',
-  variant: 'tile',
+  variant: 'modulix',
   isDisabled: true,
   checked: true,
   state: 'error',

--- a/app/stories/pix-checkbox.mdx
+++ b/app/stories/pix-checkbox.mdx
@@ -1,6 +1,6 @@
 import { Meta, Story, ArgTypes } from '@storybook/blocks';
 import * as ComponentStories from './pix-checkbox.stories';
-import * as VariantTileStories from './pix-checkbox-variant-tile.stories';
+import * as VariantModulixStories from './pix-checkbox-variant-modulix.stories';
 
 <Meta of={ComponentStories} />
 
@@ -26,11 +26,11 @@ La PixCheckbox prend toute la largeur à sa disposition par défaut.
 
 <Story of={ComponentStories.FullWidth} height={100} />
 
-Si le paramètre `variant` est précisé avec la valeur `tile`, la checkbox et son label sont visuellement regroupés dans un ensemble intégralement cliquable.
+Si le paramètre `variant` est précisé avec la valeur `modulix`, la checkbox et son label sont visuellement regroupés dans un ensemble intégralement cliquable.
 
-<Story of={VariantTileStories.VariantTile} height={120} />
+<Story of={VariantModulixStories.VariantModulix} height={120} />
 
-Voir la [documentation de la variante `tile`](?path=/docs/form-inputs-checkbox-variant-tile--docs).
+Voir la [documentation de la variante `modulix`](?path=/docs/form-inputs-checkbox-variant-modulix--docs).
 
 ## États de la Checkbox
 

--- a/app/stories/pix-radio-button-variant-modulix.mdx
+++ b/app/stories/pix-radio-button-variant-modulix.mdx
@@ -14,6 +14,8 @@ Un cursor `pointer` est défini sur le RadioButton et son label par défaut.
 
 Le RadioButton et son label sont visuellement regroupés dans un ensemble intégralement cliquable.
 
+Le bouton radio (petit cercle à gauche du label), est ici volontairement masqué pour les besoins design des modules.
+
 <Story of={ComponentStories.VariantModulix} height={120} />
 
 ## États du RadioButton
@@ -29,6 +31,8 @@ Un cursor `not-allowed` est défini sur le RadioButton et son label lorsqu'il es
 #### Succès/Erreur
 
 Cumulée à la désactivation, une propriété de statut permet de préciser une coloration particulière en cas de "succès" ou d'"erreur".
+
+Comme dans ce variant, le bouton radio est masqué, on n'affiche pas de SVG de succès ou d'erreur. (comme on peut le voir dans le PixCheckbox variant modulix)
 
 <Story of={ComponentStories.isDisabledIsSuccessVariantModulix} height={120} />
 <Story of={ComponentStories.isDisabledIsErrorVariantModulix} height={120} />

--- a/app/stories/pix-radio-button-variant-modulix.mdx
+++ b/app/stories/pix-radio-button-variant-modulix.mdx
@@ -1,9 +1,9 @@
 import { Meta, Story, ArgTypes } from '@storybook/blocks';
-import * as ComponentStories from './pix-radio-button-variant-tile.stories.js';
+import * as ComponentStories from './pix-radio-button-variant-modulix.stories.js';
 
 <Meta of={ComponentStories} />
 
-# PixRadioButton `@variant="title"`
+# PixRadioButton `@variant="modulix"`
 
 Un bouton radio permettant de sélectionner une seule option dans une liste.
 
@@ -14,7 +14,7 @@ Un cursor `pointer` est défini sur le RadioButton et son label par défaut.
 
 Le RadioButton et son label sont visuellement regroupés dans un ensemble intégralement cliquable.
 
-<Story of={ComponentStories.VariantTile} height={120} />
+<Story of={ComponentStories.VariantModulix} height={120} />
 
 ## États du RadioButton
 
@@ -23,20 +23,20 @@ Le RadioButton et son label sont visuellement regroupés dans un ensemble intég
 L'attribut `@isDisabled` permet de désactiver le RadioButton en conservant la possibilité de naviguer avec le clavier ou le lecteur d'écran. Il est préféré à l'attribut natif `disabled` qui empêche ces usages.
 Un cursor `not-allowed` est défini sur le RadioButton et son label lorsqu'il est dans un état `disabled`.
 
-<Story of={ComponentStories.isDisabledVariantTile} height={120} />
-<Story of={ComponentStories.checkedIsDisabledVariantTile} height={120} />
+<Story of={ComponentStories.isDisabledVariantModulix} height={120} />
+<Story of={ComponentStories.checkedIsDisabledVariantModulix} height={120} />
 
 #### Succès/Erreur
 
 Cumulée à la désactivation, une propriété de statut permet de préciser une coloration particulière en cas de "succès" ou d'"erreur".
 
-<Story of={ComponentStories.isDisabledIsSuccessVariantTile} height={120} />
-<Story of={ComponentStories.isDisabledIsErrorVariantTile} height={120} />
+<Story of={ComponentStories.isDisabledIsSuccessVariantModulix} height={120} />
+<Story of={ComponentStories.isDisabledIsErrorVariantModulix} height={120} />
 
 ## Usage
 
 ```html
-<PixRadioButton name="input-name" @value="{{value}}" @variant="tile">
+<PixRadioButton name="input-name" @value="{{value}}" @variant="modulix">
   <:label>Exemple de label</:label>
 </PixRadioButton>
 ```

--- a/app/stories/pix-radio-button-variant-modulix.stories.js
+++ b/app/stories/pix-radio-button-variant-modulix.stories.js
@@ -3,12 +3,12 @@ import { hbs } from 'ember-cli-htmlbars';
 import pixRadioButtonStories from './pix-radio-button.stories.js';
 
 export default {
-  title: 'Forms/Radio Button/Variant Tile',
+  title: 'Forms/Radio Button/Variant Modulix',
   argTypes: {
     variant: {
       name: 'variant',
       description: 'Utiliser une variante graphique du composant',
-      options: ['tile'],
+      options: ['modulix'],
       control: { type: 'select' },
       type: { required: true },
     },
@@ -26,7 +26,7 @@ export default {
   },
 };
 
-const VariantTileTemplate = (args) => {
+const VariantModulixTemplate = (args) => {
   return {
     template: hbs`{{! template-lint-disable no-inline-styles }}
 <div
@@ -45,48 +45,48 @@ const VariantTileTemplate = (args) => {
   };
 };
 
-export const VariantTile = VariantTileTemplate.bind({});
-VariantTile.args = {
+export const VariantModulix = VariantModulixTemplate.bind({});
+VariantModulix.args = {
   id: 'proposal',
   label: 'Une réponse',
-  variant: 'tile',
+  variant: 'modulix',
   state: 'neutral',
 };
 
-export const isDisabledVariantTile = VariantTileTemplate.bind({});
-isDisabledVariantTile.args = {
+export const isDisabledVariantModulix = VariantModulixTemplate.bind({});
+isDisabledVariantModulix.args = {
   id: 'accept-newsletter-2',
   label: 'Recevoir la newsletter',
-  variant: 'tile',
+  variant: 'modulix',
   isDisabled: true,
   state: 'neutral',
 };
 
-export const checkedIsDisabledVariantTile = VariantTileTemplate.bind({});
-checkedIsDisabledVariantTile.args = {
+export const checkedIsDisabledVariantModulix = VariantModulixTemplate.bind({});
+checkedIsDisabledVariantModulix.args = {
   id: 'accept-newsletter-2',
   label: 'Recevoir la newsletter',
-  variant: 'tile',
+  variant: 'modulix',
   isDisabled: true,
   checked: true,
   state: 'neutral',
 };
 
-export const isDisabledIsSuccessVariantTile = VariantTileTemplate.bind({});
-isDisabledIsSuccessVariantTile.args = {
+export const isDisabledIsSuccessVariantModulix = VariantModulixTemplate.bind({});
+isDisabledIsSuccessVariantModulix.args = {
   id: 'accept-newsletter-2',
   label: 'La réponse est correcte',
-  variant: 'tile',
+  variant: 'modulix',
   isDisabled: true,
   checked: true,
   state: 'success',
 };
 
-export const isDisabledIsErrorVariantTile = VariantTileTemplate.bind({});
-isDisabledIsErrorVariantTile.args = {
+export const isDisabledIsErrorVariantModulix = VariantModulixTemplate.bind({});
+isDisabledIsErrorVariantModulix.args = {
   id: 'accept-newsletter-2',
   label: 'La réponse est fausse',
-  variant: 'tile',
+  variant: 'modulix',
   isDisabled: true,
   checked: true,
   state: 'error',

--- a/app/stories/pix-radio-button.mdx
+++ b/app/stories/pix-radio-button.mdx
@@ -56,4 +56,3 @@ L'attribut `@isDisabled` permet de désactiver la radio en conservant la possibi
 ## Arguments
 
 <ArgTypes of={ComponentStories} />
-./pix-radio-button-variant-modulix.stories.js

--- a/app/stories/pix-radio-button.mdx
+++ b/app/stories/pix-radio-button.mdx
@@ -1,7 +1,7 @@
 import { Meta, Story, ArgTypes } from '@storybook/blocks';
 
 import * as ComponentStories from './pix-radio-button.stories.js';
-import * as VariantTileStories from './pix-radio-button-variant-tile.stories.js';
+import * as VariantModulixStories from './pix-radio-button-variant-modulix.stories.js';
 
 <Meta of={ComponentStories} />
 
@@ -31,11 +31,11 @@ Le PixRadioButton prend toute la largeur à sa disposition par défaut.
 
 <Story of={ComponentStories.FullWidth} height={100} />
 
-Si le paramètre `variant` est précisé avec la valeur `tile`, le RadioButton et son label sont visuellement regroupés dans un ensemble intégralement cliquable.
+Si le paramètre `variant` est précisé avec la valeur `modulix`, le RadioButton et son label sont visuellement regroupés dans un ensemble intégralement cliquable.
 
-<Story of={VariantTileStories.VariantTile} height={100} />
+<Story of={VariantModulixStories.VariantModulix} height={100} />
 
-Voir la [documentation de la variante tile](http://localhost:9001/iframe.html?path=/docs/form-inputs-radiobutton-variant-tile--docs).
+Voir la [documentation de la variante modulix](http://localhost:9001/iframe.html?path=/docs/form-inputs-radiobutton-variant-modulix--docs).
 
 ## Disabled
 
@@ -56,4 +56,4 @@ L'attribut `@isDisabled` permet de désactiver la radio en conservant la possibi
 ## Arguments
 
 <ArgTypes of={ComponentStories} />
-./pix-radio-button-variant-tile.stories.js
+./pix-radio-button-variant-modulix.stories.js

--- a/tests/integration/components/pix-radio-button-test.js
+++ b/tests/integration/components/pix-radio-button-test.js
@@ -1,4 +1,5 @@
 import { clickByName, render } from '@1024pix/ember-testing-library';
+import { click } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { setupRenderingTest } from 'ember-qunit';
 import { module, test } from 'qunit';
@@ -177,6 +178,24 @@ module('Integration | Component | pix-radio-button', function (hooks) {
         // then
         assert.true(radiobutton.checked, 'Radiobutton should have changed state');
       });
+    });
+  });
+
+  module('@variant modulix', function () {
+    test(`it should be functional`, async function (assert) {
+      // given
+      const screen = await render(
+        hbs`<PixRadioButton @variant='modulix' @state='neutral'><:label>Abricot</:label></PixRadioButton>`,
+      );
+      const radiobutton = screen.getByRole('radio', {
+        name: 'Abricot',
+      });
+
+      // when
+      await click(radiobutton);
+
+      // then
+      assert.true(radiobutton.checked);
     });
   });
 });


### PR DESCRIPTION
## :boom: BREAKING_CHANGES

- Le variant tile est modifié pour modulix.
- Modifie le design du Pix Radio Button en variant modulix.

## :christmas_tree: Problème
On ne veut plus voir le radio button dans les QCU des modules.

Coté Pix UI, un radio button a été créé (variant `tile`) pour répondre aux besoin des modules. 

## :gift: Proposition
- renommer ce variant en modulix ( + clair )
- Faire en sorte que le radio button n'apparaisse plus 
- Plus d'icône success en cas de state success
- Plus d'icône error en cas de state error
- Tout en évitant la régression du PixCheckox variant `modulix` qui lui garder son check.

## :santa: Pour tester
- Aller voir la doc : https://pix-ui-review-pr987.osc-fr1.scalingo.io/?path=/docs/forms-radio-button-variant-modulix--docs
- https://pix-ui-review-pr987.osc-fr1.scalingo.io/?path=/docs/forms-checkbox-variant-modulix--docs
- https://app-pr15199.review.pix.fr/modules/6a68bf32/bac-a-sable/details voir le comportement du QCU ET du QCM (pour la non reg)
