### PR TITLE
[BUGFIX] Corriger l'affichage du PixProgressBar (PIX-21593).

### DIFF
--- a/addon/components/pix-progress-bar.gjs
+++ b/addon/components/pix-progress-bar.gjs
@@ -5,9 +5,6 @@ import Component from '@glimmer/component';
 export default class PixProgressBar extends Component {
   constructor(...args) {
     super(...args);
-    warn('PixProgressBar: you need to provide a locale', this.args.locale, {
-      id: 'pix-progress-bar.locale.required',
-    });
 
     warn(
       'PixProgressBar: you need to provide a number value between 0 and 1',
@@ -17,21 +14,11 @@ export default class PixProgressBar extends Component {
       },
     );
 
-    this.id = guidFor(this);
-  }
-
-  get percentageValue() {
-    return Number(this.clampValue).toLocaleString(this.args.locale, { style: 'percent' });
-  }
-
-  get label() {
-    const hasLabel = this.args.label && this.args.label.trim().length > 0;
-
-    warn('PixProgressBar: you need to provide a valid label', hasLabel || this.args.isDecorative, {
+    warn('PixProgressBar: you need to provide a valid label', this.args.label, {
       id: 'pix-progress-bar.label.required',
     });
 
-    return this.args.label;
+    this.id = guidFor(this);
   }
 
   get themeMode() {
@@ -42,7 +29,7 @@ export default class PixProgressBar extends Component {
         ? this.args.themeMode
         : 'light';
 
-    return `progress-bar--theme-${themeMode}`;
+    return `pix-progress-bar--theme-${themeMode}`;
   }
 
   get colorClass() {
@@ -59,32 +46,24 @@ export default class PixProgressBar extends Component {
     const color =
       this.args.color && availableColor.includes(this.args.color) ? this.args.color : 'primary';
 
-    return `progress-bar--content-${color}`;
-  }
-
-  get clampValue() {
-    return Math.max(Math.min(this.args.value, 1), 0);
+    return `pix-progress-bar--content-${color}`;
   }
 
   <template>
-    <div
-      class="progress-bar {{this.themeMode}} {{this.colorClass}}"
-      aria-hidden={{if @isDecorative "true"}}
-      ...attributes
-    >
+    <div class="pix-progress-bar {{this.themeMode}} {{this.colorClass}}" ...attributes>
       {{#unless @hidePercentage}}
-        <div class="progress-bar__text" role="presentation">{{this.percentageValue}}</div>
+        <div class="pix-progress-bar__text" role="presentation">{{@percentageValue}}</div>
       {{/unless}}
       <label for={{this.id}} class="screen-reader-only">{{@label}}</label>
       <progress
-        class="progress-bar__bar"
+        class="pix-progress-bar__bar"
         id={{this.id}}
         max="1"
         min="0"
-        value={{this.clampValue}}
-      >{{this.percentageValue}}</progress>
+        value={{@value}}
+      >{{@percentageValue}}</progress>
       {{#if @subtitle}}
-        <p class="progress-bar__sub-title">{{@subtitle}}</p>
+        <p class="pix-progress-bar__sub-title">{{@subtitle}}</p>
       {{/if}}
     </div>
   </template>

--- a/addon/styles/_pix-progress-bar.scss
+++ b/addon/styles/_pix-progress-bar.scss
@@ -1,6 +1,6 @@
 @use "pix-design-tokens/typography";
 
-.progress-bar {
+.pix-progress-bar {
   position: relative;
   display: grid;
   grid-template-areas:
@@ -62,68 +62,68 @@
 }
 
 // THEME DARK
-.progress-bar--theme-dark {
-  .progress-bar__bar {
+.pix-progress-bar--theme-dark {
+  .pix-progress-bar__bar {
     border: 2px solid var(--pix-neutral-0);
   }
 
-  .progress-bar__bar::-webkit-progress-bar {
+  .pix-progress-bar__bar::-webkit-progress-bar {
     background-color: var(--pix-neutral-0);
   }
 
-  .progress-bar__text,
-  .progress-bar__sub-title {
+  .pix-progress-bar__text,
+  .pix-progress-bar__sub-title {
     color: var(--pix-neutral-0);
   }
 }
 
 // SPECIFIC BAR COLORS
-.progress-bar--content-blue, .progress-bar--content-primary {
-  .progress-bar__bar::-webkit-progress-value {
+.pix-progress-bar--content-blue, .pix-progress-bar--content-primary {
+  .pix-progress-bar__bar::-webkit-progress-value {
     background-color: var(--pix-primary-500);
   }
 
-  .progress-bar__bar::-moz-progress-bar {
+  .pix-progress-bar__bar::-moz-progress-bar {
     background-color: var(--pix-primary-500);
   }
 
-  &:not(.progress-bar--theme-dark) {
-    .progress-bar__text,
-    .progress-bar__sub-title {
+  &:not(.pix-progress-bar--theme-dark) {
+    .pix-progress-bar__text,
+    .pix-progress-bar__sub-title {
       color: var(--pix-primary-500);
     }
   }
 }
 
-.progress-bar--content-green, .progress-bar--content-success {
-  .progress-bar__bar::-webkit-progress-value {
+.pix-progress-bar--content-green, .pix-progress-bar--content-success {
+  .pix-progress-bar__bar::-webkit-progress-value {
     background-color: var(--pix-success-700);
   }
 
-  .progress-bar__bar::-moz-progress-bar {
+  .pix-progress-bar__bar::-moz-progress-bar {
     background-color: var(--pix-success-700);
   }
 
-  &:not(.progress-bar--theme-dark) {
-    .progress-bar__text,
-    .progress-bar__sub-title {
+  &:not(.pix-progress-bar--theme-dark) {
+    .pix-progress-bar__text,
+    .pix-progress-bar__sub-title {
       color: var(--pix-success-700);
     }
   }
 }
 
-.progress-bar--content-purple, .progress-bar--content-tertiary {
-  .progress-bar__bar::-webkit-progress-value {
+.pix-progress-bar--content-purple, .pix-progress-bar--content-tertiary {
+  .pix-progress-bar__bar::-webkit-progress-value {
     background-color: var(--pix-tertiary-900);
   }
 
-  .progress-bar__bar::-moz-progress-bar {
+  .pix-progress-bar__bar::-moz-progress-bar {
     background-color: var(--pix-tertiary-900);
   }
 
-  &:not(.progress-bar--theme-dark) {
-    .progress-bar__text,
-    .progress-bar__sub-title {
+  &:not(.pix-progress-bar--theme-dark) {
+    .pix-progress-bar__text,
+    .pix-progress-bar__sub-title {
       color: var(--pix-tertiary-900);
     }
   }

--- a/app/stories/pix-progress-bar.stories.js
+++ b/app/stories/pix-progress-bar.stories.js
@@ -9,17 +9,16 @@ export default {
       type: { name: 'number', required: true },
       table: { defaultValue: { summary: null } },
     },
+    percentageValue: {
+      name: 'percentageValue',
+      description: "Valeur exprimé en pourcentage dans la langue de l'utilisateur",
+      type: { name: 'string', required: true },
+      table: { defaultValue: { summary: null } },
+    },
     label: {
       name: 'label',
       description:
         "Afficher un label caché permettant d'expliciter le contexte de la jauge de progression",
-      type: { name: 'string', required: true },
-      table: { defaultValue: { summary: 'null' } },
-    },
-    locale: {
-      name: 'locale',
-      description:
-        "Permet de traduire le pourcentage dans la langue de l'application utilisant le composant",
       type: { name: 'string', required: true },
       table: { defaultValue: { summary: 'null' } },
     },
@@ -53,13 +52,6 @@ export default {
       type: { name: 'boolean', required: false },
       table: { defaultValue: { summary: 'false' } },
     },
-    isDecorative: {
-      name: 'isDecorative',
-      description:
-        'Indiquer que la barre de progression est utilisée pour de la présentation et doit être ignorée par les lecteurs d’écran',
-      type: { name: 'boolean', required: false },
-      table: { defaultValue: { summary: 'false' } },
-    },
   },
 };
 
@@ -68,7 +60,6 @@ export const Default = (args) => {
     template: hbs`<PixProgressBar
   @value={{this.value}}
   @color={{this.color}}
-  @locale={{this.locale}}
   @themeMode={{this.themeMode}}
   @subtitle={{this.subtitle}}
   @label={{this.label}}
@@ -78,7 +69,6 @@ export const Default = (args) => {
 };
 Default.args = {
   value: 0.5,
-  locale: 'fr',
 };
 
 export const Success = (args) => {
@@ -88,7 +78,6 @@ export const Success = (args) => {
   @color={{this.color}}
   @themeMode={{this.themeMode}}
   @subtitle={{this.subtitle}}
-  @locale={{this.locale}}
   @label={{this.label}}
 />`,
     context: args,
@@ -97,7 +86,6 @@ export const Success = (args) => {
 Success.args = {
   value: 0.5,
   color: 'success',
-  locale: 'fr',
 };
 
 export const Tertiary = (args) => {
@@ -105,7 +93,6 @@ export const Tertiary = (args) => {
     template: hbs`<PixProgressBar
   @value={{this.value}}
   @color={{this.color}}
-  @locale={{this.locale}}
   @themeMode={{this.themeMode}}
   @subtitle={{this.subtitle}}
   @label={{this.label}}
@@ -116,7 +103,6 @@ export const Tertiary = (args) => {
 Tertiary.args = {
   value: 0.5,
   color: 'tertiary',
-  locale: 'en',
 };
 
 export const darkModeProgressBar = (args) => {
@@ -127,7 +113,6 @@ export const darkModeProgressBar = (args) => {
     @value={{this.value}}
     @color={{this.color}}
     @label={{this.label}}
-    @locale={{this.locale}}
     @themeMode={{this.themeMode}}
     @subtitle={{this.subtitle}}
   />
@@ -138,7 +123,6 @@ export const darkModeProgressBar = (args) => {
 darkModeProgressBar.args = {
   value: 0.5,
   label: 'Chargement',
-  locale: 'es',
   color: 'primary',
   themeMode: 'dark',
   subtitle: 'Avancement',
@@ -150,7 +134,6 @@ export const WithoutPercentage = (args) => {
   @value={{this.value}}
   @color={{this.color}}
   @themeMode={{this.themeMode}}
-  @locale={{this.locale}}
   @subtitle={{this.subtitle}}
   @label={{this.label}}
   @hidePercentage={{this.hidePercentage}}
@@ -161,6 +144,5 @@ export const WithoutPercentage = (args) => {
 WithoutPercentage.args = {
   value: 0.5,
   color: 'primary',
-  locale: 'fr',
   hidePercentage: true,
 };

--- a/tests/integration/components/pix-progress-bar-test.js
+++ b/tests/integration/components/pix-progress-bar-test.js
@@ -6,141 +6,119 @@ import { module, test } from 'qunit';
 module('Integration | Component | PixProgressBar', function (hooks) {
   setupRenderingTest(hooks);
 
-  const PROGRESS_BAR_SELECTOR = '.progress-bar';
+  const PROGRESS_BAR_SELECTOR = '.pix-progress-bar';
 
   module('Attributes @value', function () {
     test('it renders the value with percentage', async function (assert) {
       // given & when
-      const screen = await render(hbs`<PixProgressBar @value={{0.5}} @locale='fr' />`);
-
-      const localizedPercentage = Number(0.5).toLocaleString('fr', {
-        style: 'percent',
-      });
+      const screen = await render(hbs`<PixProgressBar @value={{0.5}} @percentageValue='50%' />`);
 
       // then
-      assert.strictEqual(screen.getByRole('presentation').innerText, localizedPercentage);
-    });
-
-    test('it renders the progress bar with correct width never exceed 100%', async function (assert) {
-      // given & when
-      const screen = await render(hbs`<PixProgressBar @value={{1.1}} @locale='fr' />`);
-
-      // then
-      const progressbar = screen.getByRole('progressbar');
-      assert.strictEqual(progressbar.value, 1);
-    });
-
-    test('it renders the progress bar with correct width never under 0%', async function (assert) {
-      // given & when
-      const screen = await render(hbs`<PixProgressBar @value={{-0.2}} @locale='fr' />`);
-
-      // then
-      const progressbar = screen.getByRole('progressbar');
-      assert.strictEqual(progressbar.value, 0);
+      assert.strictEqual(screen.getByRole('presentation').innerText, '50%');
     });
   });
 
   module('Attributes @color', function () {
     test('it renders the progress bar by default with primary class', async function (assert) {
       // given & when
-      await render(hbs`<PixProgressBar @value={{0.5}} @locale='fr' />`);
+      await render(hbs`<PixProgressBar @value={{0.5}} />`);
 
       // then
       const componentElement = this.element.querySelector(PROGRESS_BAR_SELECTOR);
-      assert.true(componentElement.classList.contains('progress-bar--content-primary'));
+      assert.true(componentElement.classList.contains('pix-progress-bar--content-primary'));
     });
 
     test('it renders the progress bar with primary class when color not exists', async function (assert) {
       // given & when
-      await render(hbs`<PixProgressBar @value={{0.5}} @color='vert-lychen' @locale='fr' />`);
+      await render(hbs`<PixProgressBar @value={{0.5}} @color='vert-lychen' />`);
 
       // then
       const componentElement = this.element.querySelector(PROGRESS_BAR_SELECTOR);
-      assert.true(componentElement.classList.contains('progress-bar--content-primary'));
+      assert.true(componentElement.classList.contains('pix-progress-bar--content-primary'));
     });
 
     test('it renders the progress bar with tertiary class', async function (assert) {
       // given & when
-      await render(hbs`<PixProgressBar @value={{0.5}} @color='tertiary' @locale='fr' />`);
+      await render(hbs`<PixProgressBar @value={{0.5}} @color='tertiary' />`);
 
       // then
       const componentElement = this.element.querySelector(PROGRESS_BAR_SELECTOR);
-      assert.true(componentElement.classList.contains('progress-bar--content-tertiary'));
+      assert.true(componentElement.classList.contains('pix-progress-bar--content-tertiary'));
     });
 
     test('it renders the progress bar with success class', async function (assert) {
       // given & when
-      await render(hbs`<PixProgressBar @value={{0.5}} @color='success' @locale='fr' />`);
+      await render(hbs`<PixProgressBar @value={{0.5}} @color='success' />`);
 
       // then
       const componentElement = this.element.querySelector(PROGRESS_BAR_SELECTOR);
-      assert.true(componentElement.classList.contains('progress-bar--content-success'));
+      assert.true(componentElement.classList.contains('pix-progress-bar--content-success'));
     });
 
     test('it renders the progress bar with primary class', async function (assert) {
       // given & when
-      await render(hbs`<PixProgressBar @value={{0.5}} @color='primary' @locale='fr' />`);
+      await render(hbs`<PixProgressBar @value={{0.5}} @color='primary' />`);
 
       // then
       const componentElement = this.element.querySelector(PROGRESS_BAR_SELECTOR);
-      assert.true(componentElement.classList.contains('progress-bar--content-primary'));
+      assert.true(componentElement.classList.contains('pix-progress-bar--content-primary'));
     });
   });
 
   module('Attributes @themeMode', function () {
     test('it renders the progress bar by default with light mode', async function (assert) {
       // given & when
-      await render(hbs`<PixProgressBar @value={{0.5}} @locale='fr' />`);
+      await render(hbs`<PixProgressBar @value={{0.5}} />`);
 
       // then
       const componentElement = this.element.querySelector(PROGRESS_BAR_SELECTOR);
-      assert.true(componentElement.classList.contains('progress-bar--theme-light'));
+      assert.true(componentElement.classList.contains('pix-progress-bar--theme-light'));
     });
 
     test('it renders the progress bar with light mode when value not exists', async function (assert) {
       // given & when
-      await render(hbs`<PixProgressBar @value={{0.5}} @themeMode='darken-light' @locale='fr' />`);
+      await render(hbs`<PixProgressBar @value={{0.5}} @themeMode='darken-light' />`);
 
       // then
       const componentElement = this.element.querySelector(PROGRESS_BAR_SELECTOR);
-      assert.true(componentElement.classList.contains('progress-bar--theme-light'));
+      assert.true(componentElement.classList.contains('pix-progress-bar--theme-light'));
     });
 
     test('it renders the progress bar with light mode', async function (assert) {
       // given & when
-      await render(hbs`<PixProgressBar @value={{0.5}} @themeMode='light' @locale='fr' />`);
+      await render(hbs`<PixProgressBar @value={{0.5}} @themeMode='light' />`);
 
       // then
       const componentElement = this.element.querySelector(PROGRESS_BAR_SELECTOR);
-      assert.true(componentElement.classList.contains('progress-bar--theme-light'));
+      assert.true(componentElement.classList.contains('pix-progress-bar--theme-light'));
     });
 
     test('it renders the progress bar with dark mode', async function (assert) {
       // given & when
-      await render(hbs`<PixProgressBar @value={{0.5}} @themeMode='dark' @locale='fr' />`);
+      await render(hbs`<PixProgressBar @value={{0.5}} @themeMode='dark' />`);
 
       // then
       const componentElement = this.element.querySelector(PROGRESS_BAR_SELECTOR);
-      assert.true(componentElement.classList.contains('progress-bar--theme-dark'));
+      assert.true(componentElement.classList.contains('pix-progress-bar--theme-dark'));
     });
   });
 
   module('Attributes @subtitle', function () {
     test('it does not render the progress bar sub-title', async function (assert) {
       // given & when
-      await render(hbs`<PixProgressBar @value={{0.5}} @locale='fr' />`);
+      await render(hbs`<PixProgressBar @value={{0.5}} />`);
 
       // then
-      const componentElement = this.element.querySelector('.progress-bar__sub-title');
+      const componentElement = this.element.querySelector('.pix-progress-bar__sub-title');
       assert.false(!!componentElement);
     });
 
     test('it renders the progress bar sub-title', async function (assert) {
       // given & when
-      await render(hbs`<PixProgressBar @value={{0.5}} @subtitle='toto' @locale='fr' />`);
+      await render(hbs`<PixProgressBar @value={{0.5}} @subtitle='toto' />`);
 
       // then
-      const componentElement = this.element.querySelector('.progress-bar__sub-title');
+      const componentElement = this.element.querySelector('.pix-progress-bar__sub-title');
       assert.strictEqual(componentElement.textContent.trim(), 'toto');
     });
   });
@@ -148,46 +126,29 @@ module('Integration | Component | PixProgressBar', function (hooks) {
   module('Attributes @hidePercentage', function () {
     test('it renders the progress bar percentage by default', async function (assert) {
       // when
-      const screen = await render(hbs`<PixProgressBar @value={{0.5}} @locale='fr' />`);
-
-      const localizedPercentage = Number(50 / 100).toLocaleString('fr', {
-        style: 'percent',
-      });
+      const screen = await render(hbs`<PixProgressBar @value={{0.5}} @percentageValue='50%' />`);
 
       // then
-      assert.dom(screen.getByRole('presentation', { hidden: true })).hasText(localizedPercentage);
+      assert.dom(screen.getByRole('presentation', { hidden: true })).hasText('50%');
     });
 
     test('it renders the progress bar percentage when attribute is false', async function (assert) {
       // when
       const screen = await render(
-        hbs`<PixProgressBar @value={{0.5}} @hidePercentage={{false}} @locale='fr' />`,
+        hbs`<PixProgressBar @value={{0.5}} @hidePercentage={{false}} @percentageValue='50%' />`,
       );
-      const localizedPercentage = Number(50 / 100).toLocaleString('fr', {
-        style: 'percent',
-      });
 
       // then
 
-      assert.dom(screen.getByRole('presentation', { hidden: true })).hasText(localizedPercentage);
+      assert.dom(screen.getByRole('presentation', { hidden: true })).hasText('50%');
     });
 
     test('it does not render the progress bar percentage when attribute is true', async function (assert) {
       // when
-      await render(hbs`<PixProgressBar @value={{0.5}} @hidePercentage={{true}} @locale='fr' />`);
+      await render(hbs`<PixProgressBar @value={{0.5}} @hidePercentage={{true}} />`);
 
       // then
-      assert.dom('.progress-bar__text').doesNotExist();
-    });
-  });
-
-  module('Attributes @isDecorative', () => {
-    test('it sets progress bar aria-hidden to "true"', async function (assert) {
-      // when
-      await render(hbs`<PixProgressBar @value={{0.5}} @isDecorative='true' @locale='fr' />`);
-
-      // then
-      assert.dom('.progress-bar').hasAria('hidden', 'true');
+      assert.dom('.pix-progress-bar__text').doesNotExist();
     });
   });
 });


### PR DESCRIPTION
## :christmas_tree: Problème
Un merge un peu trop rapide du composant est survenue

## :gift: Proposition
Effectuer les corrections adéquates

## :star2: Remarques
Tester sur l'app https://github.com/1024pix/pix/pull/15145 . qui implémente le progress bar dans PixApp

## :santa: Pour tester
Valider le bon fonctionnement sur l'app dans le monorepo
