### PR TITLE
[FEATURE] Ajouter les nouveaux design tokens d'ombres (PIX-21086)

### DIFF
--- a/addon/styles/pix-design-tokens/_shadows.scss
+++ b/addon/styles/pix-design-tokens/_shadows.scss
@@ -5,6 +5,14 @@
   box-shadow: 0 $verticalSize $blur rgba(7, 20, 46, 0.08);
 }
 
+@mixin coloredShadow($colorA, $colorB, $colorC) {
+  box-shadow:
+    0 2px 5px 0 $colorA,
+    0 -2px 5px 0 $colorB inset,
+    0 1px 1px 0 rgba(255, 255, 255, 0.1) inset,
+    0 3px 4px 0 $colorC inset;
+}
+
 %pix-shadow-xs,
 .pix-shadow-xs {
   @include shadow(4px, 8px);
@@ -28,4 +36,40 @@
 %pix-shadow-xl,
 .pix-shadow-xl {
   @include shadow(12px, 24px);
+}
+
+%pix-shadow-default,
+.pix-shadow-default {
+  @include coloredShadow(
+    rgba(74, 58, 255, 0.25),
+    rgba(74, 58, 255, 0.15),
+    rgba(223, 238, 255, 0.1)
+  );
+}
+
+%pix-shadow-neutral,
+.pix-shadow-neutral {
+  @include coloredShadow(
+    rgba(79, 99, 132, 0.25),
+    rgba(79, 99, 132, 0.15),
+    rgba(200, 207, 217, 0.1)
+  );
+}
+
+%pix-shadow-orga,
+.pix-shadow-orga {
+  @include coloredShadow(
+    rgba(54, 116, 191, 0.25),
+    rgba(54, 116, 191, 0.15),
+    rgba(235, 241, 249, 0.1)
+  );
+}
+
+%pix-shadow-certif,
+.pix-shadow-certif {
+  @include coloredShadow(
+    rgba(24, 127, 125, 0.25),
+    rgba(24, 127, 125, 0.15),
+    rgba(232, 242, 242, 0.1)
+  );
 }

--- a/docs/shadow.mdx
+++ b/docs/shadow.mdx
@@ -1,10 +1,62 @@
-import { Meta } from '@storybook/blocks';
+import { Meta, Unstyled } from '@storybook/blocks';
 
 <Meta title="Design Tokens/Ombres" />
 
 # Ombres
 
-Pour uniformiser les ombres dans nos applications, on dispose de plusieurs classes CSS :
+Pour uniformiser les ombres dans nos applications, on dispose de plusieurs tokens selon les applications.
+Ils sont disponibles sous forme de classe CSS :
+
+- `pix-shadow-default`
+- `pix-shadow-neutral`
+- `pix-shadow-orga`
+- `pix-shadow-certif`
+
+Et leur équivalent en placeholder SCSS :
+
+- `@extend %pix-shadow-default;`
+- `@extend %pix-shadow-neutral;`
+- `@extend %pix-shadow-orga;`
+- `@extend %pix-shadow-certif;`
+
+<Unstyled>
+  <div
+    className="pix-title-s pix-shadow-default"
+    style={{ padding: 'var(--pix-spacing-4x)', margin: 'var(--pix-spacing-8x)', width: '300px' }}
+  >
+    pix-shadow-default
+  </div>
+
+    <div
+    className="pix-title-s pix-shadow-neutral"
+    style={{ padding: 'var(--pix-spacing-4x)', margin: 'var(--pix-spacing-8x)', width: '300px' }}
+
+>
+
+    pix-shadow-neutral
+
+  </div>
+      <div
+    className="pix-title-s pix-shadow-orga"
+    style={{ padding: 'var(--pix-spacing-4x)', margin: 'var(--pix-spacing-8x)', width: '300px' }}
+
+>
+
+    pix-shadow-orga
+
+  </div>
+      <div
+    className="pix-title-s pix-shadow-certif"
+    style={{ padding: 'var(--pix-spacing-4x)', margin: 'var(--pix-spacing-8x)', width: '300px' }}
+
+>
+
+    pix-shadow-certif
+
+  </div>
+</Unstyled>
+
+On dispose aussi d'ombres neutres de plusieurs tailles. Les classes CSS correspondantes :
 
 - `pix-shadow-xs`
 - `pix-shadow-sm`
@@ -12,13 +64,57 @@ Pour uniformiser les ombres dans nos applications, on dispose de plusieurs class
 - `pix-shadow-lg`
 - `pix-shadow-xl`
 
-Et leur équivalent en placeholder SCSS :
+Ou de placeholder SCSS :
 
 - `@extend %pix-shadow-xs;`
 - `@extend %pix-shadow-sm;`
 - `@extend %pix-shadow-md;`
 - `@extend %pix-shadow-lg;`
 - `@extend %pix-shadow-xl;`
+
+<Unstyled>
+  <div
+    className="pix-title-s pix-shadow-xs"
+    style={{ padding: 'var(--pix-spacing-4x)', margin: 'var(--pix-spacing-8x)', width: '300px' }}
+  >
+    pix-shadow-xs
+  </div>
+
+<div
+  className="pix-title-s pix-shadow-sm"
+  style={{ padding: 'var(--pix-spacing-4x)', margin: 'var(--pix-spacing-8x)', width: '300px' }}
+>
+  pix-shadow-sm
+</div>
+
+    <div
+    className="pix-title-s pix-shadow-md"
+    style={{ padding: 'var(--pix-spacing-4x)', margin: 'var(--pix-spacing-8x)', width: '300px' }}
+
+>
+
+    pix-shadow-md
+
+  </div>
+      <div
+    className="pix-title-s pix-shadow-lg"
+    style={{ padding: 'var(--pix-spacing-4x)', margin: 'var(--pix-spacing-8x)', width: '300px' }}
+
+>
+
+    pix-shadow-lg
+
+  </div>
+      <div
+    className="pix-title-s pix-shadow-xl"
+    style={{ padding: 'var(--pix-spacing-4x)', margin: 'var(--pix-spacing-8x)', width: '300px' }}
+
+>
+
+    pix-shadow-xl
+
+  </div>
+</Unstyled>
 
 Code associé : [pix-ui/addon/styles/pix-design-tokens/\_shadows.scss](https://github.com/1024pix/pix-ui/blob/dev/addon/styles/pix-design-tokens/_shadows.scss)
 

--- a/docs/shadow.mdx
+++ b/docs/shadow.mdx
@@ -118,4 +118,4 @@ Ou de placeholder SCSS :
 
 Code associé : [pix-ui/addon/styles/pix-design-tokens/\_shadows.scss](https://github.com/1024pix/pix-ui/blob/dev/addon/styles/pix-design-tokens/_shadows.scss)
 
-[Lien Figma](https://www.figma.com/file/8RJ3aCSfdeQ8AZZVBBYKS8/Design-System-Pix?node-id=54%3A5141)
+[Lien Figma](https://www.figma.com/design/8RJ3aCSfdeQ8AZZVBBYKS8/Design-System-Nebulix?node-id=13446-21793&m=dev)


### PR DESCRIPTION
## :christmas_tree: Problème
De nouvelles ombres ont été maquettées.

## :gift: Proposition
Les ajouter sous forme de design tokens.

## :star2: Remarques
RAS

## :santa: Pour tester
Sur Storybook:
- aller sur Design Tokens -> Ombres
- constater les nouvelles ombres
- comparer le CSS avec la maquette https://www.figma.com/design/8RJ3aCSfdeQ8AZZVBBYKS8/Design-System-Nebulix?node-id=54-5134&p=f&t=ujWllgeRk8sSGwR3-0
