### PR TITLE
[FEATURE] Ajouter un token de couleur pix-primary-50 (PIX-21867)

### DIFF
--- a/addon/styles/pix-design-tokens/_colors.scss
+++ b/addon/styles/pix-design-tokens/_colors.scss
@@ -4,6 +4,8 @@
 // Primary
   --pix-primary-10-inline:247, 245, 255;
   --pix-primary-10: rgb(var(--pix-primary-10-inline));
+  --pix-primary-50-inline:239, 236, 252;
+  --pix-primary-50: rgb(var(--pix-primary-50-inline));
   --pix-primary-100-inline:206, 195, 244;
   --pix-primary-100: rgb(var(--pix-primary-100-inline));
   --pix-primary-300-inline:149, 126, 232;

--- a/docs/colors-palette.mdx
+++ b/docs/colors-palette.mdx
@@ -26,6 +26,7 @@ import { Meta, ColorPalette, ColorItem } from '@storybook/blocks';
     subtitle="--pix-primary-"
     colors={{
             10: '#f7f5ff',
+            50: '#efecfc',
             100: '#cec3f4',
             300: '#957ee8',
             500: '#613fdd',


### PR DESCRIPTION
## :christmas_tree: Problème
Il manque le token de couleur pix-primary-50 du design system.

## :gift: Proposition
On ajoute ce token.

## :star2: Remarques
RAS

## :santa: Pour tester
- vérifier que la couleur ajoutée est bien la même que sur Figma https://www.figma.com/design/8RJ3aCSfdeQ8AZZVBBYKS8/Design-System-Nebulix?node-id=16-2&p=f&m=dev
