### PR TITLE
[BUGFIX] Fixer la taille de l'icône dans les notifications

### DIFF
--- a/addon/styles/_pix-notification-alert.scss
+++ b/addon/styles/_pix-notification-alert.scss
@@ -1,4 +1,4 @@
-@use "pix-design-tokens/typography";
+@use 'pix-design-tokens/typography';
 
 .pix-notification-alert {
   @extend %pix-body-s;
@@ -11,6 +11,10 @@
   font-size: 0.875rem;
   border: 1px solid currentcolor;
   border-radius: var(--pix-spacing-1x);
+
+  &__icon {
+    flex-shrink: 0;
+  }
 
   &--info {
     color: var(--pix-info-700);


### PR DESCRIPTION
## :christmas_tree: Problème

La taille de l'icône fluctue en fonction du contenu
## :gift: Proposition

On empeche l'icône de rétrécir

## :star2: Remarques


## :santa: Pour tester
Afficher un pixNotificationAlert avec plein de contenu et reduire la taille de la fenêtre.

