### PR TITLE
[FEATURE] Ajouter des variantes pour le composant Pix-Modal (PIX-21085)

### DIFF
--- a/addon/components/pix-modal.gjs
+++ b/addon/components/pix-modal.gjs
@@ -1,3 +1,4 @@
+import { MODAL_VARIANTS } from '@1024pix/pix-ui/helpers/variants';
 import { guidFor } from '@ember/object/internals';
 import Component from '@glimmer/component';
 
@@ -17,6 +18,18 @@ export default class PixModal extends Component {
     return guidFor(this);
   }
 
+  get variant() {
+    if (this.args.variant && !MODAL_VARIANTS.includes(this.args.variant)) {
+      throw new Error(
+        `ERROR in PixModal component: @variant should be one of ${MODAL_VARIANTS.join(', ')}`,
+      );
+    }
+
+    const value = this.args.variant ?? 'default';
+
+    return value;
+  }
+
   <template>
     <PixOverlay
       @isVisible={{@showModal}}
@@ -25,14 +38,14 @@ export default class PixModal extends Component {
       @hasCenteredContent={{true}}
     >
       <div
-        class="pix-modal"
+        class="pix-modal pix-modal--{{this.variant}}"
         role="dialog"
         aria-labelledby="modal-title--{{this.id}}"
         aria-describedby="modal-content--{{this.id}}"
         aria-modal="true"
         ...attributes
       >
-        <div class="pix-modal__header">
+        <div class="pix-modal__header pix-modal__header--{{this.variant}}">
           <h1 id="modal-title--{{this.id}}" class="pix-modal__title">{{@title}}</h1>
           <PixIconButton
             @iconName="close"

--- a/addon/helpers/variants.js
+++ b/addon/helpers/variants.js
@@ -1,1 +1,3 @@
 export const VARIANTS = ['primary', 'orga', 'certif', 'admin', 'modulix'];
+
+export const MODAL_VARIANTS = ['default', 'orga', 'certif'];

--- a/addon/styles/_pix-modal.scss
+++ b/addon/styles/_pix-modal.scss
@@ -3,8 +3,6 @@
 @use "pix-design-tokens/shadows";
 
 .pix-modal {
-  @extend %pix-shadow-sm;
-
   position: relative;
   left: 50%;
   width: min(32rem, calc(100% - var(--pix-spacing-4x)));
@@ -13,15 +11,38 @@
   border-radius: var(--pix-spacing-4x);
   transform: translateX(-50%);
 
+  &--default {
+    @extend %pix-shadow-default;
+  }
+
+  &--orga {
+    @extend %pix-shadow-orga;
+  }
+
+  &--certif {
+    @extend %pix-shadow-certif;
+  }
+
   &__header {
     display: flex;
     align-items: flex-start;
     justify-content: space-between;
     padding: var(--pix-spacing-6x) var(--pix-spacing-4x) var(--pix-spacing-6x) var(--pix-spacing-6x);
     color: var(--pix-neutral-900);
-    background: var(--pix-gradient-default-light);
     border-top-left-radius: var(--pix-spacing-4x) var(--pix-spacing-4x);
     border-top-right-radius: var(--pix-spacing-4x) var(--pix-spacing-4x);
+
+    &--default {
+      background: var(--pix-gradient-default-light);
+    }
+
+    &--orga {
+      background: var(--pix-gradient-orga-light);
+    }
+
+    &--certif {
+      background: var(--pix-gradient-certif-light);
+    }
   }
 
   &__close-button {

--- a/app/stories/pix-modal.stories.js
+++ b/app/stories/pix-modal.stories.js
@@ -1,5 +1,7 @@
 import { hbs } from 'ember-cli-htmlbars';
 
+import { MODAL_VARIANTS } from '../../addon/helpers/variants';
+
 export default {
   title: 'Overlay/Modal',
   render: (args) => ({
@@ -7,6 +9,7 @@ export default {
   @showModal={{this.showModal}}
   @title={{this.title}}
   @onCloseButtonClick={{fn (mut this.showModal) (not this.showModal)}}
+  @variant={{this.variant}}
 >
   <:content>
     <p>
@@ -61,6 +64,16 @@ export default {
         defaultValue: { summary: false },
       },
     },
+    variant: {
+      name: 'variant',
+      description: "Variante du style de la modale selon l'app.",
+      options: MODAL_VARIANTS,
+      control: { type: 'select' },
+      table: {
+        defaultValue: { summary: 'default' },
+      },
+      type: { name: MODAL_VARIANTS.join(' | '), required: false },
+    },
   },
 };
 
@@ -69,5 +82,6 @@ export const Default = {
     showModal: true,
     title: "Qu'est-ce qu'une modale ?",
     onCloseButtonClick: () => {},
+    variant: 'default',
   },
 };

--- a/tests/dummy/app/templates/modal-page.hbs
+++ b/tests/dummy/app/templates/modal-page.hbs
@@ -2,6 +2,7 @@
   @showModal={{this.showModal}}
   @title={{this.title}}
   @onCloseButtonClick={{fn (mut this.showModal) (not this.showModal)}}
+  @variant="orga"
 >
   <:content>
     <LinkTo @route="hello" class="internal-link">My link</LinkTo>

--- a/tests/integration/components/pix-modal-test.js
+++ b/tests/integration/components/pix-modal-test.js
@@ -97,4 +97,116 @@ module('Integration | Component | modal', function (hooks) {
       assert.notOk(screen.queryByRole('heading', { name: this.title }));
     });
   });
+
+  module('variants', function () {
+    module('when variant is not provided', function () {
+      test('it should apply default style', async function (assert) {
+        // given
+        this.title = 'Modal with no variant';
+        this.showModal = true;
+
+        // when
+        const screen =
+          await render(hbs`<PixModal @title={{this.title}} @showModal={{this.showModal}}>
+  <:content>
+    content
+  </:content>
+  <:footer>
+    footer
+  </:footer>
+</PixModal>`);
+
+        // then
+        const modal = screen.getByRole('dialog', { name: 'Modal with no variant' });
+        const header = screen.getByRole('heading', { name: 'Modal with no variant' }).parentNode;
+
+        assert.dom(modal).hasClass('pix-modal--default');
+        assert.dom(header).hasClass('pix-modal__header--default');
+      });
+    });
+
+    module('when variant is "default"', function () {
+      test('it should apply default style', async function (assert) {
+        // given
+        this.title = 'Modal with "default" variant';
+        this.showModal = true;
+
+        // when
+        const screen =
+          await render(hbs`<PixModal @title={{this.title}} @showModal={{this.showModal}} @variant='default'>
+  <:content>
+    content
+  </:content>
+  <:footer>
+    footer
+  </:footer>
+</PixModal>`);
+
+        // then
+        const modal = screen.getByRole('dialog', { name: 'Modal with "default" variant' });
+        const header = screen.getByRole('heading', {
+          name: 'Modal with "default" variant',
+        }).parentNode;
+
+        assert.dom(modal).hasClass('pix-modal--default');
+        assert.dom(header).hasClass('pix-modal__header--default');
+      });
+    });
+
+    module('when variant is "orga"', function () {
+      test('it should apply orga style', async function (assert) {
+        // given
+        this.title = 'Modal with "orga" variant';
+        this.showModal = true;
+
+        // when
+        const screen =
+          await render(hbs`<PixModal @title={{this.title}} @showModal={{this.showModal}} @variant='orga'>
+  <:content>
+    content
+  </:content>
+  <:footer>
+    footer
+  </:footer>
+</PixModal>`);
+
+        // then
+        const modal = screen.getByRole('dialog', { name: 'Modal with "orga" variant' });
+        const header = screen.getByRole('heading', {
+          name: 'Modal with "orga" variant',
+        }).parentNode;
+
+        assert.dom(modal).hasClass('pix-modal--orga');
+        assert.dom(header).hasClass('pix-modal__header--orga');
+      });
+    });
+
+    module('when variant is "certif"', function () {
+      test('it should apply certif style', async function (assert) {
+        // given
+        this.title = 'Modal with "certif" variant';
+        this.showModal = true;
+
+        // when
+        const screen =
+          await render(hbs`<PixModal @title={{this.title}} @showModal={{this.showModal}} @variant='certif'>
+  <:content>
+    content
+  </:content>
+  <:footer>
+    footer
+  </:footer>
+</PixModal>`);
+
+        // then
+        const modal = screen.getByRole('dialog', { name: 'Modal with "certif" variant' });
+        const header = screen.getByRole('heading', {
+          name: 'Modal with "certif" variant',
+        }).parentNode;
+
+        assert.dom(modal).hasClass('pix-modal--certif');
+        assert.dom(header).hasClass('pix-modal__header--certif');
+      });
+    });
+  });
 });


### PR DESCRIPTION
## :christmas_tree: Problème
Le style composant Pix Modal doit pouvoir être configurable en fonction de l'application dans laquelle il est utilisé: couleur de l'arrière-plan de l'en-tête et couleur de l'ombre.

## :gift: Proposition
Ajouter un attribut `variant` au composant Pix Modal et 3 possibilités: `default`, `orga` et `certif`

## :star2: Remarques
- Cet attribut n'est pas obligatoire, et le style est par défaut `default`. **MAIS** le `default` utilise maintenant la nouvelle ombre `pix-shadow-default`. L'ombre de toutes les modales va donc changer. -> vu avec @pierrepougetpix c'est OK.
- La discussion sur la gestion d'erreur est ouverte: que faire si un développeur passe en args un variant non prévu ?
Actuellement, une erreur est jetée donc le composant ne se rend pas.
- On pourrait aussi imaginer ignorer le variant si elle n'est pas autorisée et appliquer le `default`, et lancer juste un warn, au risque d'avoir une valeur de variant non conforme dans le code.


## :santa: Pour tester
Sur Storybook:
- aller sur l'onglet Pix Modal
- constater le nouvel attribut `variant` et les changements de style
- vérifier que le style est conforme à la [maquette](https://www.figma.com/design/8RJ3aCSfdeQ8AZZVBBYKS8/Design-System-Nebulix?node-id=765-6526&m=dev) 
