### PR TITLE
[FEATURE] Modifier le style des étapes futures du Stepper (PIX-22338).

### DIFF
--- a/addon/styles/_pix-stepper.scss
+++ b/addon/styles/_pix-stepper.scss
@@ -12,8 +12,6 @@
   text-align: center;
 
   &__index {
-    @extend %pix-shadow-default;
-
     position: relative;
     display: flex;
     align-items: center;
@@ -32,6 +30,7 @@
       position: absolute;
       display: block;
       height: 3px;
+      margin-left: -1px;
       background-color: var(--pix-neutral-0);
       border-radius: 2px;
       content: '';
@@ -58,15 +57,16 @@
     @extend %pix-body-s;
 
     margin-top: var(--pix-spacing-1x);
-    color: var(--pix-primary-500);
+    color: var(--pix-primary-700);
     font-weight: 700;
     padding-inline: var(--pix-spacing-1x);
     text-wrap: pretty;
   }
 
   &__subtitle {
-    color: var(--pix-primary-500);
+    color: var(--pix-primary-700);
     font-size: 0.75rem;
+    line-height: 0.875rem;
     padding-inline: var(--pix-spacing-1x);
     text-wrap: pretty;
   }
@@ -92,6 +92,8 @@
     }
 
     .pix-step__index {
+      @extend %pix-shadow-default;
+
       color: var(--pix-neutral-0);
       background: linear-gradient(90deg, rgba(69, 45, 157, 0.8) 0%, rgba(69, 45, 157, 0) 60%), var(--pix-primary-300);
 
@@ -109,8 +111,9 @@
 
     .pix-step__index {
       color: var(--pix-neutral-500);
-      background: var(--pix-neutral-100);
-      box-shadow: none;
+      font-weight: normal;
+      background: transparent;
+      border: 1px solid currentcolor;
 
       &::before,
       &::after {


### PR DESCRIPTION
## :christmas_tree: Problème

Style actuel : 
<img width="408" height="151" alt="image" src="https://github.com/user-attachments/assets/0395b83d-4d9b-4faa-944e-8f01e1a383e8" />

## :gift: Proposition

Style souhaité : 
<img width="669" height="108" alt="image" src="https://github.com/user-attachments/assets/7a05ae7a-5196-44f0-b4f4-c5fa3c6e2fa5" />

## :santa: Pour tester

Regarder le [composant en RA](https://pix-ui-review-pr1000.osc-fr1.scalingo.io/?path=/docs/navigation-stepper--docs).
