### PR TITLE
[FEATURE] ajouter les design token de 3 dégradé des couleurs sombre (PIX-21257)

### DIFF
--- a/addon/styles/pix-design-tokens/_colors.scss
+++ b/addon/styles/pix-design-tokens/_colors.scss
@@ -1,282 +1,316 @@
 // See https://www.figma.com/file/8RJ3aCSfdeQ8AZZVBBYKS8/Design-System-Pix?node-id=16%3A2
 // stylelint-disable scss/double-slash-comment-empty-line-before
 :root {
-// Primary
-  --pix-primary-10-inline:247, 245, 255;
+  // Primary
+  --pix-primary-10-inline: 247, 245, 255;
   --pix-primary-10: rgb(var(--pix-primary-10-inline));
-  --pix-primary-50-inline:239, 236, 252;
+  --pix-primary-50-inline: 239, 236, 252;
   --pix-primary-50: rgb(var(--pix-primary-50-inline));
-  --pix-primary-100-inline:206, 195, 244;
+  --pix-primary-100-inline: 206, 195, 244;
   --pix-primary-100: rgb(var(--pix-primary-100-inline));
-  --pix-primary-300-inline:149, 126, 232;
+  --pix-primary-300-inline: 149, 126, 232;
   --pix-primary-300: rgb(var(--pix-primary-300-inline));
-  --pix-primary-500-inline:97, 63, 221;
+  --pix-primary-500-inline: 97, 63, 221;
   --pix-primary-500: rgb(var(--pix-primary-500-inline));
-  --pix-primary-700-inline:69, 45, 157;
+  --pix-primary-700-inline: 69, 45, 157;
   --pix-primary-700: rgb(var(--pix-primary-700-inline));
-  --pix-primary-900-inline:41, 26, 93;
+  --pix-primary-900-inline: 41, 26, 93;
   --pix-primary-900: rgb(var(--pix-primary-900-inline));
-// Secondary
-  --pix-secondary-50-inline:255, 250, 235;
+  // Secondary
+  --pix-secondary-50-inline: 255, 250, 235;
   --pix-secondary-50: rgb(var(--pix-secondary-50-inline));
-  --pix-secondary-100-inline:255, 239, 192;
+  --pix-secondary-100-inline: 255, 239, 192;
   --pix-secondary-100: rgb(var(--pix-secondary-100-inline));
-  --pix-secondary-300-inline:255, 220, 118;
+  --pix-secondary-300-inline: 255, 220, 118;
   --pix-secondary-300: rgb(var(--pix-secondary-300-inline));
-  --pix-secondary-500-inline:255, 203, 51;
+  --pix-secondary-500-inline: 255, 203, 51;
   --pix-secondary-500: rgb(var(--pix-secondary-500-inline));
-  --pix-secondary-700-inline:161, 98, 6;
+  --pix-secondary-700-inline: 161, 98, 6;
   --pix-secondary-700: rgb(var(--pix-secondary-700-inline));
-  --pix-secondary-900-inline:91, 56, 8;
+  --pix-secondary-900-inline: 91, 56, 8;
   --pix-secondary-900: rgb(var(--pix-secondary-900-inline));
-// Tertiary
-  --pix-tertiary-100-inline:195, 208, 255;
+  // Tertiary
+  --pix-tertiary-100-inline: 195, 208, 255;
   --pix-tertiary-100: rgb(var(--pix-tertiary-100-inline));
-  --pix-tertiary-500-inline:61, 104, 255;
+  --pix-tertiary-500-inline: 61, 104, 255;
   --pix-tertiary-500: rgb(var(--pix-tertiary-500-inline));
-  --pix-tertiary-900-inline:26, 44, 107;
+  --pix-tertiary-900-inline: 26, 44, 107;
   --pix-tertiary-900: rgb(var(--pix-tertiary-900-inline));
-// Neutral
-  --pix-neutral-0-inline:255, 255, 255;
+  // Neutral
+  --pix-neutral-0-inline: 255, 255, 255;
   --pix-neutral-0: rgb(var(--pix-neutral-0-inline));
-  --pix-neutral-20-inline:244, 245, 247;
+  --pix-neutral-20-inline: 244, 245, 247;
   --pix-neutral-20: rgb(var(--pix-neutral-20-inline));
-  --pix-neutral-100-inline:205, 209, 217;
+  --pix-neutral-100-inline: 205, 209, 217;
   --pix-neutral-100: rgb(var(--pix-neutral-100-inline));
-  --pix-neutral-300-inline:147, 157, 173;
+  --pix-neutral-300-inline: 147, 157, 173;
   --pix-neutral-300: rgb(var(--pix-neutral-300-inline));
-  --pix-neutral-500-inline:94, 108, 132;
+  --pix-neutral-500-inline: 94, 108, 132;
   --pix-neutral-500: rgb(var(--pix-neutral-500-inline));
-  --pix-neutral-800-inline:37, 56, 88;
+  --pix-neutral-800-inline: 37, 56, 88;
   --pix-neutral-800: rgb(var(--pix-neutral-800-inline));
-  --pix-neutral-900-inline:18, 38, 71;
+  --pix-neutral-900-inline: 18, 38, 71;
   --pix-neutral-900: rgb(var(--pix-neutral-900-inline));
-// Info
-  --pix-info-50-inline:234, 241, 255;
+  // Info
+  --pix-info-50-inline: 234, 241, 255;
   --pix-info-50: rgb(var(--pix-info-50-inline));
-  --pix-info-100-inline:190, 212, 255;
+  --pix-info-100-inline: 190, 212, 255;
   --pix-info-100: rgb(var(--pix-info-100-inline));
-  --pix-info-300-inline:114, 163, 255;
+  --pix-info-300-inline: 114, 163, 255;
   --pix-info-300: rgb(var(--pix-info-300-inline));
-  --pix-info-500-inline:44, 117, 255;
+  --pix-info-500-inline: 44, 117, 255;
   --pix-info-500: rgb(var(--pix-info-500-inline));
-  --pix-info-700-inline:31, 83, 181;
+  --pix-info-700-inline: 31, 83, 181;
   --pix-info-700: rgb(var(--pix-info-700-inline));
-  --pix-info-900-inline:18, 49, 107;
+  --pix-info-900-inline: 18, 49, 107;
   --pix-info-900: rgb(var(--pix-info-900-inline));
-// Success
-  --pix-success-50-inline:230, 246, 239;
+  // Success
+  --pix-success-50-inline: 230, 246, 239;
   --pix-success-50: rgb(var(--pix-success-50-inline));
-  --pix-success-100-inline:176, 228, 204;
+  --pix-success-100-inline: 176, 228, 204;
   --pix-success-100: rgb(var(--pix-success-100-inline));
-  --pix-success-300-inline:84, 197, 144;
+  --pix-success-300-inline: 84, 197, 144;
   --pix-success-300: rgb(var(--pix-success-300-inline));
-  --pix-success-500-inline:0, 168, 90;
+  --pix-success-500-inline: 0, 168, 90;
   --pix-success-500: rgb(var(--pix-success-500-inline));
-  --pix-success-700-inline:0, 119, 64;
+  --pix-success-700-inline: 0, 119, 64;
   --pix-success-700: rgb(var(--pix-success-700-inline));
-  --pix-success-900-inline:0, 71, 38;
+  --pix-success-900-inline: 0, 71, 38;
   --pix-success-900: rgb(var(--pix-success-900-inline));
-// Warning
-  --pix-warning-50-inline:253, 240, 231;
+  // Warning
+  --pix-warning-50-inline: 253, 240, 231;
   --pix-warning-50: rgb(var(--pix-warning-50-inline));
-  --pix-warning-100-inline:250, 209, 181;
+  --pix-warning-100-inline: 250, 209, 181;
   --pix-warning-100: rgb(var(--pix-warning-100-inline));
-  --pix-warning-300-inline:244, 155, 96;
+  --pix-warning-300-inline: 244, 155, 96;
   --pix-warning-300: rgb(var(--pix-warning-300-inline));
-  --pix-warning-500-inline:238, 105, 17;
+  --pix-warning-500-inline: 238, 105, 17;
   --pix-warning-500: rgb(var(--pix-warning-500-inline));
-  --pix-warning-700-inline:169, 75, 12;
+  --pix-warning-700-inline: 169, 75, 12;
   --pix-warning-700: rgb(var(--pix-warning-700-inline));
-  --pix-warning-900-inline:100, 44, 7;
+  --pix-warning-900-inline: 100, 44, 7;
   --pix-warning-900: rgb(var(--pix-warning-900-inline));
-// Error
-  --pix-error-50-inline:251, 235, 234;
+  // Error
+  --pix-error-50-inline: 251, 235, 234;
   --pix-error-50: rgb(var(--pix-error-50-inline));
-  --pix-error-100-inline:243, 192, 188;
+  --pix-error-100-inline: 243, 192, 188;
   --pix-error-100: rgb(var(--pix-error-100-inline));
-  --pix-error-300-inline:228, 118, 111;
+  --pix-error-300-inline: 228, 118, 111;
   --pix-error-300: rgb(var(--pix-error-300-inline));
-  --pix-error-500-inline:215, 51, 40;
+  --pix-error-500-inline: 215, 51, 40;
   --pix-error-500: rgb(var(--pix-error-500-inline));
-  --pix-error-700-inline:153, 36, 28;
+  --pix-error-700-inline: 153, 36, 28;
   --pix-error-700: rgb(var(--pix-error-700-inline));
-  --pix-error-900-inline:90, 21, 17;
+  --pix-error-900-inline: 90, 21, 17;
   --pix-error-900: rgb(var(--pix-error-900-inline));
-// Certif
-  --pix-certif-50-inline:232, 242, 242;
+  // Certif
+  --pix-certif-50-inline: 232, 242, 242;
   --pix-certif-50: rgb(var(--pix-certif-50-inline));
-  --pix-certif-300-inline:100, 169, 168;
+  --pix-certif-300-inline: 100, 169, 168;
   --pix-certif-300: rgb(var(--pix-certif-300-inline));
-  --pix-certif-500-inline:24, 127, 125;
+  --pix-certif-500-inline: 24, 127, 125;
   --pix-certif-500: rgb(var(--pix-certif-500-inline));
-  --pix-certif-700-inline:17, 90, 89;
+  --pix-certif-700-inline: 17, 90, 89;
   --pix-certif-700: rgb(var(--pix-certif-700-inline));
-// Orga
-  --pix-orga-50-inline:235, 241, 249;
+  // Orga
+  --pix-orga-50-inline: 235, 241, 249;
   --pix-orga-50: rgb(var(--pix-orga-50-inline));
-  --pix-orga-300-inline:120, 162, 212;
+  --pix-orga-300-inline: 120, 162, 212;
   --pix-orga-300: rgb(var(--pix-orga-300-inline));
-  --pix-orga-500-inline:54, 116, 191;
+  --pix-orga-500-inline: 54, 116, 191;
   --pix-orga-500: rgb(var(--pix-orga-500-inline));
-  --pix-orga-700-inline:38, 82, 136;
+  --pix-orga-700-inline: 38, 82, 136;
   --pix-orga-700: rgb(var(--pix-orga-700-inline));
-// Others
-  --pix-information-dark-inline:242, 70, 69;
+  // Others
+  --pix-information-dark-inline: 242, 70, 69;
   --pix-information-dark: rgb(var(--pix-information-dark-inline));
-  --pix-information-light-inline:241, 161, 65;
+  --pix-information-light-inline: 241, 161, 65;
   --pix-information-light: rgb(var(--pix-information-light-inline));
-  --pix-content-dark-inline:26, 140, 137;
+  --pix-content-dark-inline: 26, 140, 137;
   --pix-content-dark: rgb(var(--pix-content-dark-inline));
-  --pix-content-light-inline:82, 217, 135;
+  --pix-content-light-inline: 82, 217, 135;
   --pix-content-light: rgb(var(--pix-content-light-inline));
-  --pix-communication-dark-inline:61, 104, 255;
+  --pix-communication-dark-inline: 61, 104, 255;
   --pix-communication-dark: rgb(var(--pix-communication-dark-inline));
-  --pix-communication-light-inline:18, 163, 255;
+  --pix-communication-light-inline: 18, 163, 255;
   --pix-communication-light: rgb(var(--pix-communication-light-inline));
-  --pix-security-dark-inline:172, 0, 141;
+  --pix-security-dark-inline: 172, 0, 141;
   --pix-security-dark: rgb(var(--pix-security-dark-inline));
-  --pix-security-light-inline:255, 63, 148;
+  --pix-security-light-inline: 255, 63, 148;
   --pix-security-light: rgb(var(--pix-security-light-inline));
-  --pix-environment-dark-inline:94, 37, 99;
+  --pix-environment-dark-inline: 94, 37, 99;
   --pix-environment-dark: rgb(var(--pix-environment-dark-inline));
-  --pix-environment-light-inline:86, 77, 166;
+  --pix-environment-light-inline: 86, 77, 166;
   --pix-environment-light: rgb(var(--pix-environment-light-inline));
   --pix-shadow-inline: 7, 20, 46;
   --pix-shadow: rgb(var(--pix-shadow-inline));
-// Gradient
-  --pix-gradient-default-light: linear-gradient(180deg, rgb(var(--pix-primary-500-inline), 0.2) 0%, rgb(var(--pix-primary-500-inline), 0.1) 40%, rgb(var(--pix-neutral-0-inline), 0) 100%);
-  --pix-gradient-orga-light: linear-gradient(180deg, rgb(var(--pix-orga-500-inline), 0.2) 0%, rgb(var(--pix-orga-500-inline), 0.1) 40%, rgb(var(--pix-neutral-0-inline), 0) 100%);
-  --pix-gradient-certif-light: linear-gradient(180deg, rgb(var(--pix-certif-500-inline), 0.2) 0%, rgb(var(--pix-certif-500-inline), 0.1) 40%, rgb(var(--pix-neutral-0-inline), 0) 100%);
+
+  // Gradients
+  --pix-gradient-default-light: linear-gradient(
+    180deg,
+    rgb(var(--pix-primary-500-inline), 0.2) 0%,
+    rgb(var(--pix-primary-500-inline), 0.1) 40%,
+    rgb(var(--pix-neutral-0-inline), 0) 100%
+  );
+  --pix-gradient-default-dark:
+    linear-gradient(
+      90deg,
+      rgb(var(--pix-primary-700-inline), 0.8) 0%,
+      rgb(var(--pix-primary-700-inline), 0) 60%
+    ),
+    rgb(var(--pix-primary-300-inline));
+  --pix-gradient-orga-light: linear-gradient(
+    180deg,
+    rgb(var(--pix-orga-500-inline), 0.2) 0%,
+    rgb(var(--pix-orga-500-inline), 0.1) 40%,
+    rgb(var(--pix-neutral-0-inline), 0) 100%
+  );
+  --pix-gradient-orga-dark:
+    linear-gradient(90deg, rgb(0, 221, 255, 0) 19.71%, rgb(0, 170, 255, 0.8) 100%),
+    rgb(var(--pix-orga-700-inline));
+  --pix-gradient-certif-light: linear-gradient(
+    180deg,
+    rgb(var(--pix-certif-500-inline), 0.2) 0%,
+    rgb(var(--pix-certif-500-inline), 0.1) 40%,
+    rgb(var(--pix-neutral-0-inline), 0) 100%
+  );
+  --pix-gradient-certif-dark:
+    linear-gradient(
+      90deg,
+      rgb(var(--pix-certif-700-inline), 0.8) 0%,
+      rgb(var(--pix-certif-700-inline), 0) 60%
+    ),
+    rgb(56, 160, 159);
 }
+
 // stylelint-enable scss/double-slash-comment-empty-line-before
 
 // stylelint-disable color-no-hex
 // @deprecated - SCSS variables are replaced by CSS variables
 //// SOLID
 // Primary
-$pix-primary-5: #F2F9FF;
-$pix-primary-10: #DCF1FF;
-$pix-primary-20: #C4E6FF;
-$pix-primary-30: #88BEFF;
-$pix-primary-40: #5B94FF;
-$pix-primary: #3D68FF;
-$pix-primary-60: #2044DC;
-$pix-primary-70: #0D25B3;
-$pix-primary-80: #000E87;
+$pix-primary-5: #f2f9ff;
+$pix-primary-10: #dcf1ff;
+$pix-primary-20: #c4e6ff;
+$pix-primary-30: #88beff;
+$pix-primary-40: #5b94ff;
+$pix-primary: #3d68ff;
+$pix-primary-60: #2044dc;
+$pix-primary-70: #0d25b3;
+$pix-primary-80: #000e87;
 
 // Secondary
-$pix-secondary-5: #FFF9E6;
-$pix-secondary-10: #FFF1C5;
-$pix-secondary-20: #FFE381;
-$pix-secondary: #FFD235;
-$pix-secondary-40: #FFBE00;
-$pix-secondary-50: #EAA600;
-$pix-secondary-60: #D87016;
-$pix-secondary-70: #A95800;
-$pix-secondary-80: #874D00;
+$pix-secondary-5: #fff9e6;
+$pix-secondary-10: #fff1c5;
+$pix-secondary-20: #ffe381;
+$pix-secondary: #ffd235;
+$pix-secondary-40: #ffbe00;
+$pix-secondary-50: #eaa600;
+$pix-secondary-60: #d87016;
+$pix-secondary-70: #a95800;
+$pix-secondary-80: #874d00;
 
 // Secondary Pix Certif
-$pix-secondary-certif-5: #CCF6F5;
-$pix-secondary-certif-10: #9AEDEB;
-$pix-secondary-certif-20: #67E4E0;
-$pix-secondary-certif-30: #34DBD6;
-$pix-secondary-certif: #20B4AF;
-$pix-secondary-certif-50: #17817E;
+$pix-secondary-certif-5: #ccf6f5;
+$pix-secondary-certif-10: #9aedeb;
+$pix-secondary-certif-20: #67e4e0;
+$pix-secondary-certif-30: #34dbd6;
+$pix-secondary-certif: #20b4af;
+$pix-secondary-certif-50: #17817e;
 $pix-secondary-certif-60: #126765;
-$pix-secondary-certif-70: #0E4D4C;
+$pix-secondary-certif-70: #0e4d4c;
 $pix-secondary-certif-80: #093432;
 
 // Secondary Pix Orga
-$pix-secondary-orga-5: #D5F9FF;
-$pix-secondary-orga-10: #AAF4FF;
-$pix-secondary-orga-20: #80EEFF;
-$pix-secondary-orga-30: #55E8FF;
-$pix-secondary-orga: #00DDFF;
-$pix-secondary-orga-50: #00C1DF;
-$pix-secondary-orga-60: #00A6BF;
-$pix-secondary-orga-70: #008A9F;
-$pix-secondary-orga-80: #006E80;
+$pix-secondary-orga-5: #d5f9ff;
+$pix-secondary-orga-10: #aaf4ff;
+$pix-secondary-orga-20: #80eeff;
+$pix-secondary-orga-30: #55e8ff;
+$pix-secondary-orga: #00ddff;
+$pix-secondary-orga-50: #00c1df;
+$pix-secondary-orga-60: #00a6bf;
+$pix-secondary-orga-70: #008a9f;
+$pix-secondary-orga-80: #006e80;
 
 // Tertiary
-$pix-tertiary-5: #EBE1FF;
-$pix-tertiary-10: #D8C2FF;
-$pix-tertiary-20: #C4A4FF;
-$pix-tertiary-30: #B186FF;
-$pix-tertiary: #9D67FF;
-$pix-tertiary-50: #8A49FF;
-$pix-tertiary-60: #6712FF;
-$pix-tertiary-70: #4E00DB;
-$pix-tertiary-80: #3B00A4;
+$pix-tertiary-5: #ebe1ff;
+$pix-tertiary-10: #d8c2ff;
+$pix-tertiary-20: #c4a4ff;
+$pix-tertiary-30: #b186ff;
+$pix-tertiary: #9d67ff;
+$pix-tertiary-50: #8a49ff;
+$pix-tertiary-60: #6712ff;
+$pix-tertiary-70: #4e00db;
+$pix-tertiary-80: #3b00a4;
 
 // Success
-$pix-success-5: #ECFDF5;
-$pix-success-10: #D1FAE5;
-$pix-success-20: #A7F3D0;
-$pix-success-30: #6EE7B7;
-$pix-success: #34D399;
-$pix-success-50: #27B481;
-$pix-success-60: #14865D;
-$pix-success-70: #176C4D;
+$pix-success-5: #ecfdf5;
+$pix-success-10: #d1fae5;
+$pix-success-20: #a7f3d0;
+$pix-success-30: #6ee7b7;
+$pix-success: #34d399;
+$pix-success-50: #27b481;
+$pix-success-60: #14865d;
+$pix-success-70: #176c4d;
 $pix-success-80: #104834;
 
 // Warning
-$pix-warning-5: #FFF9E6;
-$pix-warning-10: #FFF1C5;
-$pix-warning-20: #FFE381;
-$pix-warning-30: #FFD235;
-$pix-warning-40: #FFBE00;
-$pix-warning-50: #EAA600;
-$pix-warning-60: #D87016;
-$pix-warning-70: #A95800;
-$pix-warning-80: #874D00;
+$pix-warning-5: #fff9e6;
+$pix-warning-10: #fff1c5;
+$pix-warning-20: #ffe381;
+$pix-warning-30: #ffd235;
+$pix-warning-40: #ffbe00;
+$pix-warning-50: #eaa600;
+$pix-warning-60: #d87016;
+$pix-warning-70: #a95800;
+$pix-warning-80: #874d00;
 
 // Error
-$pix-error-5: #FEF2F2;
-$pix-error-10: #FEE2E2;
-$pix-error-20: #FECACA;
-$pix-error-30: #FCA5A5;
-$pix-error-40: #F87171;
-$pix-error-50: #EF4444;
-$pix-error-60: #DC2626;
-$pix-error-70: #B91C1C;
-$pix-error-80: #991B1B;
+$pix-error-5: #fef2f2;
+$pix-error-10: #fee2e2;
+$pix-error-20: #fecaca;
+$pix-error-30: #fca5a5;
+$pix-error-40: #f87171;
+$pix-error-50: #ef4444;
+$pix-error-60: #dc2626;
+$pix-error-70: #b91c1c;
+$pix-error-80: #991b1b;
 $pix-error-90: #861212;
 
 // Neutral
-$pix-neutral-0: #FFFFFF;
-$pix-neutral-5: #FAFBFC;
-$pix-neutral-10: #F4F5F7;
-$pix-neutral-15: #EAECF0;
-$pix-neutral-20: #DFE1E6;
-$pix-neutral-22: #C1C7D0;
-$pix-neutral-25: #A5ADBA;
-$pix-neutral-30: #97A0AF;
-$pix-neutral-35: #8993A4;
-$pix-neutral-40: #7A869A;
-$pix-neutral-45: #6B778C;
-$pix-neutral-50: #5E6C84;
-$pix-neutral-60: #505F79;
+$pix-neutral-0: #ffffff;
+$pix-neutral-5: #fafbfc;
+$pix-neutral-10: #f4f5f7;
+$pix-neutral-15: #eaecf0;
+$pix-neutral-20: #dfe1e6;
+$pix-neutral-22: #c1c7d0;
+$pix-neutral-25: #a5adba;
+$pix-neutral-30: #97a0af;
+$pix-neutral-35: #8993a4;
+$pix-neutral-40: #7a869a;
+$pix-neutral-45: #6b778c;
+$pix-neutral-50: #5e6c84;
+$pix-neutral-60: #505f79;
 $pix-neutral-70: #344563;
 $pix-neutral-80: #253858;
-$pix-neutral-90: #172B4D;
-$pix-neutral-100: #091E42;
-$pix-neutral-110: #07142E;
+$pix-neutral-90: #172b4d;
+$pix-neutral-100: #091e42;
+$pix-neutral-110: #07142e;
 
 // Shades
 $pix-shades-100: #000000;
 
 // Domain
-$pix-information-dark: #F24645;
-$pix-information-light: #F1A141;
-$pix-content-dark: #1A8C89;
-$pix-content-light: #52D987;
-$pix-communication-dark: #3D68FF;
-$pix-communication-light: #12A3FF;
-$pix-security-dark: #AC008D;
-$pix-security-light: #FF3F94;
-$pix-environment-dark: #5E2563;
-$pix-environment-light: #564DA6;
+$pix-information-dark: #f24645;
+$pix-information-light: #f1a141;
+$pix-content-dark: #1a8c89;
+$pix-content-light: #52d987;
+$pix-communication-dark: #3d68ff;
+$pix-communication-light: #12a3ff;
+$pix-security-dark: #ac008d;
+$pix-security-light: #ff3f94;
+$pix-environment-dark: #5e2563;
+$pix-environment-light: #564da6;
 
 //// GRADIENT
 $pix-primary-app-gradient: linear-gradient(91.59deg, #3d68ff 0%, #8845ff 100%);

--- a/docs/colors-palette.mdx
+++ b/docs/colors-palette.mdx
@@ -194,18 +194,51 @@ import { Meta, ColorPalette, ColorItem } from '@storybook/blocks';
   />
   <ColorItem
     title="Default Light"
-    subtitle="$pix-gradient-default-light"
-    colors={{ DefaultLight: 'linear-gradient(180deg, rgb(var(--pix-primary-500-inline), 0.2) 0%, rgb(var(--pix-primary-500-inline), 0.1) 40%, rgb(var(--pix-neutral-0-inline), 0) 100%)' }}
+    subtitle="--pix-gradient-default-light"
+    colors={{
+      DefaultLight:
+        'linear-gradient(180deg, rgb(var(--pix-primary-500-inline), 0.2) 0%, rgb(var(--pix-primary-500-inline), 0.1) 40%, rgb(var(--pix-neutral-0-inline), 0) 100%)',
+    }}
+  />
+  <ColorItem
+    title="Default Dark"
+    subtitle="--pix-gradient-default-dark"
+    colors={{
+      DefaultDark:
+        'linear-gradient(90deg, rgb(var(--pix-primary-700-inline), 0.8) 0%, rgb(var(--pix-primary-700-inline), 0) 60% ), rgb(var(--pix-primary-300-inline))',
+    }}
   />
   <ColorItem
     title="Orga Light"
-    subtitle="$pix-gradient-orga-light"
-    colors={{ OrgaLight: 'linear-gradient(180deg, rgb(var(--pix-orga-500-inline), 0.2) 0%, rgb(var(--pix-orga-500-inline), 0.1) 40%, rgb(var(--pix-neutral-0-inline), 0) 100%)' }}
+    subtitle="--pix-gradient-orga-light"
+    colors={{
+      OrgaLight:
+        'linear-gradient(180deg, rgb(var(--pix-orga-500-inline), 0.2) 0%, rgb(var(--pix-orga-500-inline), 0.1) 40%, rgb(var(--pix-neutral-0-inline), 0) 100%)',
+    }}
+  />
+  <ColorItem
+    title="Orga Dark"
+    subtitle="--pix-gradient-orga-dark"
+    colors={{
+      OrgaDark:
+        'linear-gradient(90deg, rgb(0, 221, 255, 0) 19.71%, rgb(0, 170, 255, 0.8) 100% ), rgb(var(--pix-orga-700-inline))',
+    }}
   />
   <ColorItem
     title="Certif Light"
-    subtitle="$pix-gradient-certif-light"
-    colors={{ CertifLight: 'linear-gradient(180deg, rgb(var(--pix-certif-500-inline), 0.2) 0%, rgb(var(--pix-certif-500-inline), 0.1) 40%, rgb(var(--pix-neutral-0-inline), 0) 100%)' }}
+    subtitle="--pix-gradient-certif-light"
+    colors={{
+      CertifLight:
+        'linear-gradient(180deg, rgb(var(--pix-certif-500-inline), 0.2) 0%, rgb(var(--pix-certif-500-inline), 0.1) 40%, rgb(var(--pix-neutral-0-inline), 0) 100%)',
+    }}
+  />
+  <ColorItem
+    title="Certif Dark"
+    subtitle="--pix-gradient-certif-dark"
+    colors={{
+      CertifDark:
+        'linear-gradient(90deg, rgb(var(--pix-certif-700-inline), 0.8) 0%, rgb(var(--pix-certif-700-inline), 0) 60% ), rgb(56, 160, 159);',
+    }}
   />
   <ColorItem
     title="Domain Information"


### PR DESCRIPTION

## :christmas_tree: Problème
Le dessign system évolue, il manque des design token de degradés
## :gift: Proposition
On ajoute 3 nouveau design token sous forme de variable css 
- `--pix-gradient-default-dark`
- `--pix-gradient-orga-dark`
- `--pix-gradient-certif-dark`

## :star2: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :santa: Pour tester
Aller sur la page des design token de couleurs et voir les nouveaux degradés
> _Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc._
