### PR TITLE
[FEATURE] Ajouter un composant pix-card (PIX-22463)

### DIFF
--- a/addon/components/pix-card.gjs
+++ b/addon/components/pix-card.gjs
@@ -1,0 +1,53 @@
+import { warn } from '@ember/debug';
+import Component from '@glimmer/component';
+
+import PixBlock from './pix-block';
+
+export default class PixCard extends Component {
+  static get variants() {
+    return ['primary', 'admin', 'orga', 'certif'];
+  }
+
+  get variant() {
+    const value = this.args.variant ?? 'orga';
+    warn(
+      `PixCard: @variant "${value}" should be ${PixCard.variants.join(', ')}`,
+      PixCard.variants.includes(value),
+      {
+        id: 'pix-ui.pix-card.variant.not-valid',
+      },
+    );
+
+    return value;
+  }
+  <template>
+    <PixBlock @variant={{this.variant}} class="pix-card-wrapper">
+      <article class="pix-card">
+        {{#if @image}}
+          <div class="pix-card__image pix-card__image--{{this.variant}}">
+            <img src={{@image}} aria-hidden="true" alt="" />
+          </div>
+        {{/if}}
+        {{#if (has-block "tag")}}
+          {{yield to="tag"}}
+        {{/if}}
+        <div class="pix-card__content">
+          <header>
+            <h3 class="pix-card__title pix-title-xs" title={{@title}}>{{@title}}</h3>
+            {{#if @subtitle}}
+              <p title={{@subtitle}} class="pix-card__subtitle pix-subtitle-xs">
+                {{@subtitle}}
+              </p>
+            {{/if}}
+          </header>
+          {{#if (has-block "description")}}
+            <div class="pix-card__description pix-body-s">{{yield to="description"}}</div>
+          {{/if}}
+          {{#if (has-block "footer")}}
+            <footer class="pix-card__footer pix-body-xs">{{yield to="footer"}}</footer>
+          {{/if}}
+        </div>
+      </article>
+    </PixBlock>
+  </template>
+}

--- a/addon/styles/_pix-card.scss
+++ b/addon/styles/_pix-card.scss
@@ -1,0 +1,53 @@
+.pix-card-wrapper {
+  display: flex;
+}
+
+.pix-card {
+  display: flex;
+  flex-direction: column;
+  gap: var(--pix-spacing-3x);
+  align-items: flex-start;
+
+  &__image {
+    width: 76px;
+    height: 76px;
+    border-radius: var(--radius-3x, 12px);
+
+    img {
+      width: 100%;
+    }
+
+    &--orga {
+      background: var(--pix-orga-50);
+    }
+  }
+
+  &__content {
+    display: flex;
+    flex-direction: column;
+    flex-grow: 1;
+    gap: var(--pix-spacing-2x);
+    color: var(--pix-neutral-900);
+  }
+
+  &__title {
+    display: -webkit-box;
+    align-self: stretch;
+    overflow: hidden;
+    -webkit-box-orient: vertical;
+    -webkit-line-clamp: 2;
+    line-clamp: 2;
+  }
+
+  &__subtitle {
+    align-self: stretch;
+    overflow: hidden;
+    white-space: nowrap;
+    text-overflow: ellipsis;
+  }
+
+  &__footer {
+    margin-top: auto;
+    color: var(--pix-neutral-500);
+  }
+}

--- a/addon/styles/addon.scss
+++ b/addon/styles/addon.scss
@@ -51,6 +51,7 @@
 @use 'pix-tabs';
 @use 'pix-gauge';
 @use 'pix-stepper';
+@use 'pix-card';
 
 // at the end so it can override it's children scss
 @use 'pix-filterable-and-searchable-select';

--- a/app/components/pix-card.js
+++ b/app/components/pix-card.js
@@ -1,0 +1,1 @@
+export { default } from '@1024pix/pix-ui/components/pix-card';

--- a/app/stories/pix-card.mdx
+++ b/app/stories/pix-card.mdx
@@ -1,0 +1,37 @@
+import { Meta, Story, ArgTypes } from '@storybook/blocks';
+import * as ComponentStories from './pix-card.stories';
+
+<Meta of={ComponentStories} />
+
+# Pix Card
+
+Un \`Card\` est un bloc de fond blanc dont les bords sont arrondis.
+Elle doit contenir un titre, une illustration.
+Elle peut contenir un sous titre, un tag, un pied de carte
+
+<Story of={ComponentStories.Card} height={300} />
+
+## Usage
+
+```html
+<div style="max-width:280px">
+<PixCard
+  @variant="orga"
+  @title="Nom du parcours"
+  @subtitle="Catégorie"
+  @image="https://assets.pix.org/sites/orga/parcours-apprenant.png">
+  <:tag><PixTag @color="green">Parcours apprenants</PixTag></:tag>
+  <:description>
+    Lorem ipsum dolor sit amet, consectetur adipiscing elit. Fusce vestibulum nisl sapien, at
+    viverra lorem facilisis in.
+  </:description>
+  <:footer>
+    12 sujets • Accès sans compte
+  </:footer>
+</PixCard>
+</div>
+```
+
+## Arguments
+
+<ArgTypes of={ComponentStories} />

--- a/app/stories/pix-card.stories.js
+++ b/app/stories/pix-card.stories.js
@@ -1,0 +1,48 @@
+import { hbs } from 'ember-cli-htmlbars';
+
+export default {
+  title: 'Other/Card',
+  tags: ['new'],
+  argTypes: {
+    variant: {
+      name: 'variant',
+      description: 'Choisir une variante',
+      options: ['orga', 'certif', 'admin', 'primary'],
+      control: {
+        type: 'select',
+      },
+    },
+  },
+};
+
+const Template = (args) => {
+  return {
+    template: hbs`
+<PixCard
+  @variant={{this.variant}}
+  @title={{this.title}}
+  @subtitle={{this.subtitle}}
+  @image={{this.image}}
+>
+  <:tag><PixTag @color='green'>Parcours Apprenants</PixTag></:tag>
+  <:description>
+    {{this.description}}
+  </:description>
+  <:footer>
+    {{this.footer}}
+  </:footer>
+</PixCard>`,
+    context: args,
+  };
+};
+
+export const Card = Template.bind({});
+Card.args = {
+  variant: 'orga',
+  title: 'Parcours Combiné IA',
+  subtitle: 'Autres',
+  image: 'https://assets.pix.org/sites/orga/parcours-apprenant.png',
+  description:
+    'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Fusce vestibulum nisl sapien, at viverra lorem facilisis in.',
+  footer: '12 sujets • Accès sans compte',
+};

--- a/tests/dummy/app/router.js
+++ b/tests/dummy/app/router.js
@@ -7,6 +7,7 @@ export default class Router extends EmberRouter {
 }
 
 Router.map(function () {
+  this.route('index', { path: '/' });
   this.route('hello', { path: '/hello-world' });
   this.route('bye', { path: '/bye/:id' });
   this.route('modal-page', { path: '/modal' });

--- a/tests/dummy/app/styles/app.scss
+++ b/tests/dummy/app/styles/app.scss
@@ -8,3 +8,10 @@
 .select-page__country-select {
   width: 100%;
 }
+
+.grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(240px, 1fr));
+  gap: 12px;
+  width: 100%;
+}

--- a/tests/dummy/app/templates/index.hbs
+++ b/tests/dummy/app/templates/index.hbs
@@ -1,0 +1,28 @@
+<div class="grid">
+  <PixCard
+    @title="Nom du parcours"
+    @subtitle="Catégorie"
+    @image="https://assets.pix.org/sites/orga/profile-cible.png"
+  >
+    <:tag><PixTag @color="blue">Profil cible</PixTag></:tag>
+    <:description>
+      <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
+    </:description>
+    <:footer>
+      <p>12 sujets • Accès sans compte</p>
+    </:footer>
+  </PixCard>
+  <PixCard
+    @title="Nom du parcours IA super long"
+    @subtitle="Catégorie"
+    @image="https://assets.pix.org/sites/orga/parcours-apprenant.png"
+  >
+    <:tag><PixTag @color="green">Parcours apprenants</PixTag></:tag>
+    <:description>
+      <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
+    </:description>
+    <:footer>
+      <p>12 modules</p>
+    </:footer>
+  </PixCard>
+</div>

--- a/tests/integration/components/pix-card-test.gjs
+++ b/tests/integration/components/pix-card-test.gjs
@@ -1,0 +1,146 @@
+import { render } from '@1024pix/ember-testing-library';
+import PixCard from '@1024pix/pix-ui/components/pix-card';
+import { setupRenderingTest } from 'ember-qunit';
+import { module, test } from 'qunit';
+import sinon from 'sinon';
+
+module('Integration | Component | PixCard', function (hooks) {
+  setupRenderingTest(hooks);
+
+  test('it renders the title', async function (assert) {
+    // when
+    const screen = await render(<template><PixCard @title="Parcours Combiné IA" /></template>);
+
+    // then
+    assert.dom(screen.getByRole('heading', { level: 3 })).hasText('Parcours Combiné IA');
+  });
+
+  module('@variant', function (hooks) {
+    let warnStub;
+
+    hooks.beforeEach(function () {
+      warnStub = sinon.stub(console, 'warn');
+    });
+
+    hooks.afterEach(function () {
+      warnStub.restore();
+    });
+
+    test('it renders PixCard with primary variant', async function (assert) {
+      // when
+      await render(
+        <template>
+          <PixCard><:description>coucou</:description></PixCard>
+        </template>,
+      );
+      const blockElement = this.element.querySelector('.pix-card-wrapper');
+
+      // then
+      assert.contains('coucou');
+      assert.deepEqual(Array.from(blockElement.classList), [
+        'pix-block',
+        'pix-block--orga',
+        'pix-card-wrapper',
+      ]);
+    });
+
+    test('it should warn when variant is not supported', async function (assert) {
+      // when
+      await render(
+        <template>
+          <PixCard @variant="PIX APP"><:description>coucou</:description></PixCard>
+        </template>,
+      );
+
+      // then
+      assert.ok(
+        warnStub.firstCall.calledWithExactly(
+          'WARNING: PixCard: @variant "PIX APP" should be primary, admin, orga, certif',
+        ),
+      );
+    });
+  });
+
+  module('when @subtitle is provided', function () {
+    test('it renders the subtitle', async function (assert) {
+      // when
+      const screen = await render(
+        <template><PixCard @title="Mon titre" @subtitle="Autres" /></template>,
+      );
+
+      // then
+      assert.dom(screen.getByText('Autres')).exists();
+    });
+  });
+
+  module('when @image is provided', function () {
+    test('it renders the image', async function (assert) {
+      // when
+      const screen = await render(
+        <template><PixCard @title="Mon titre" @image="https://example.com/image.svg" /></template>,
+      );
+      // then
+      assert
+        .dom(screen.getByRole('presentation', { hidden: true }))
+        .hasAttribute('src', 'https://example.com/image.svg');
+    });
+  });
+
+  module('when @image is not provided', function () {
+    test('it does not render an image', async function (assert) {
+      // when
+      const screen = await render(<template><PixCard @title="Mon titre" /></template>);
+
+      // then
+      assert.dom(screen.queryByRole('img', { hidden: true })).doesNotExist();
+    });
+  });
+
+  module('when the :tag named block is provided', function () {
+    test('it renders the tag block', async function (assert) {
+      // when
+      const screen = await render(
+        <template>
+          <PixCard @title="Mon titre">
+            <:tag>Parcours</:tag>
+          </PixCard>
+        </template>,
+      );
+
+      // then
+      assert.dom(screen.getByText('Parcours')).exists();
+    });
+  });
+
+  module('when the :description named block is provided', function () {
+    test('it renders the description', async function (assert) {
+      // when
+      const screen = await render(
+        <template>
+          <PixCard @title="Mon titre">
+            <:description>Lorem ipsum dolor sit amet.</:description>
+          </PixCard>
+        </template>,
+      );
+
+      // then
+      assert.dom(screen.getByText('Lorem ipsum dolor sit amet.')).exists();
+    });
+  });
+
+  module('when the :footer named block is provided', function () {
+    test('it renders the footer', async function (assert) {
+      // when
+      const screen = await render(
+        <template>
+          <PixCard @title="Mon titre">
+            <:footer>Informations complémentaires</:footer>
+          </PixCard>
+        </template>,
+      );
+
+      // then
+      assert.dom(screen.getByText('Informations complémentaires')).exists();
+    });
+  });
+});


### PR DESCRIPTION

## :christmas_tree: Problème
On a besoin d'un composant card

## :gift: Proposition
On ajoute le composant card 
https://www.figma.com/design/jF3mrSPigJN6Sk80Kq6nsj/Cartes--formation-badge-profil_cible-module-?node-id=102-175&p=f&m=dev

## :star2: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :santa: Pour tester
- Afficher la  [story du composant pix-card](https://pix-ui-review-pr1003.osc-fr1.scalingo.io/?path=/docs/other-card--docs)
- Valider que le composant correspond à la maquette
