### PR TITLE
[BUGFIX] Éviter de recharger la page lors de l'appuie sur la touche Entée (PIX-18166).

### DIFF
--- a/addon/components/pix-filter-banner.gjs
+++ b/addon/components/pix-filter-banner.gjs
@@ -28,8 +28,8 @@ export default class PixFilterBanner extends Component {
 
   @action
   onSubmit(event) {
+    event.preventDefault();
     if (this.args.onLoadFilters) {
-      event.preventDefault();
       this.args.onLoadFilters(event);
     }
   }


### PR DESCRIPTION
## :christmas_tree: Problème
Quelque fois pas tout le temps, la page se recharge alors qu'elle ne devrait pas.

## :gift: Proposition
Sortir le preventDefault du IF afin qu'il soit toujours executé

## :star2: Remarques
RAS

## :santa: Pour tester
?