### PR TITLE
[FEATURE] Mettre à jour le variant purple du composant Pix Tag [PIX-22767] 

### DIFF
--- a/addon/styles/_pix-tag.scss
+++ b/addon/styles/_pix-tag.scss
@@ -74,8 +74,8 @@
   }
 
   &--purple {
-    color: var(--pix-primary-900);
-    background-color: var(--pix-primary-100);
+    color: var(--pix-neutral-0);
+    background-color: var(--pix-primary-500);
 
     .pix-icon-button {
       color: var(--pix-primary-900);

--- a/addon/styles/_pix-tag.scss
+++ b/addon/styles/_pix-tag.scss
@@ -42,7 +42,6 @@
     }
   }
 
-  &--purple-light,
   &--tertiary,
   &--blue {
     color: var(--pix-tertiary-900);
@@ -76,6 +75,15 @@
   &--purple {
     color: var(--pix-neutral-0);
     background-color: var(--pix-primary-500);
+
+    .pix-icon-button {
+      color: var(--pix-primary-900);
+    }
+  }
+
+  &--purple-light {
+    color: var(--pix-primary-900);
+    background-color: var(--pix-primary-100);
 
     .pix-icon-button {
       color: var(--pix-primary-900);

--- a/app/stories/pix-tag.stories.js
+++ b/app/stories/pix-tag.stories.js
@@ -15,6 +15,7 @@ export default {
         'grey',
         'yellow',
         'purple',
+        'purple-light',
         'blue',
         'green',
         'error',


### PR DESCRIPTION
## :christmas_tree: Problème
Le variant `purple` n'est pas à jour avec ce qui est indiqué sur le Design System côté Figma.

## :gift: Proposition
Le mettre à jour en alignant les couleurs

## :star2: Remarques
RAS

## :santa: Pour tester
- Aller sur la RA.
- Aller sur la story Tag -> Default
- Vérifier que le variant `purple` a bien la bonne couleur.
- Constater que le variant purple-light apparaît bien dans la liste sans aucune régression 😄 
