### PR TITLE
[FEATURE] Ajouter des tokens spacing (PIX-22833)

### DIFF
--- a/addon/styles/pix-design-tokens/_spacing.scss
+++ b/addon/styles/pix-design-tokens/_spacing.scss
@@ -14,9 +14,12 @@ $pix-spacing-xxl: 48px;
   --pix-spacing-2x: 8px;
   --pix-spacing-3x: 12px;
   --pix-spacing-4x: 16px;
+  --pix-spacing-5x: 20px;
   --pix-spacing-6x: 24px;
+  --pix-spacing-7x: 28px;
   --pix-spacing-8x: 32px;
   --pix-spacing-9x: 36px;
   --pix-spacing-10x: 40px;
+  --pix-spacing-11x: 44px;
   --pix-spacing-12x: 48px;
 }

--- a/docs/spacing.mdx
+++ b/docs/spacing.mdx
@@ -10,9 +10,13 @@ Pour uniformiser les espacements dans nos applications, on dispose de plusieurs 
 - `--pix-spacing-2x` 8px
 - `--pix-spacing-3x` 12px
 - `--pix-spacing-4x` 16px
+- `--pix-spacing-5x` 20px
 - `--pix-spacing-6x` 24px
+- `--pix-spacing-7x` 28px
 - `--pix-spacing-8x` 32px
+- `--pix-spacing-9x` 36px
 - `--pix-spacing-10x` 40px
+- `--pix-spacing-11x` 44px
 - `--pix-spacing-12x` 48px
 
 Code associé : [pix-ui/addon/styles/pix-design-tokens/\_spacing.scss](https://github.com/1024pix/pix-ui/blob/dev/addon/styles/pix-design-tokens/_spacing.scss)


### PR DESCRIPTION
## :christmas_tree: Problème
Il manque des tokens spacing (ex: `--pix-spacing-7x`) qui sont utilisés sur certaines maquettes.

## :gift: Proposition
Les ajouter. 

## :star2: Remarques
RAS

## :santa: Pour tester
- Aller sur la story [Espacements](https://pix-ui-review-pr1007.osc-fr1.scalingo.io/?path=/docs/design-tokens-espacements--docs) 
- Constater que les tokens spacing sont affichés de --pix-spacing-1x à --pix-spacing-12x
- Ouvrir la console navigateur sur une story (ex: [Input Code](https://pix-ui-review-pr1007.osc-fr1.scalingo.io/?path=/docs/forms-input-code--docs))
- Vérifier que les variables css `--pix-spacing-5x`, `--pix-spacing-7x` et `--pix-spacing-11x` existent bien dans la balise `<body class="sb-main-centered sb-show-main">` 🚀 
