### PR TITLE
[FEATURE] Créer un paramètre `isV2Version` pour PixAccordions (PIX-22881).

### DIFF
--- a/addon/components/pix-accordions.gjs
+++ b/addon/components/pix-accordions.gjs
@@ -28,11 +28,15 @@ export default class PixAccordions extends Component {
     this.hasUnCollapsedOnce = true;
   }
 
+  get isV2Version() {
+    return this.args.isV2Version ? '-v2' : '';
+  }
+
   <template>
-    <div class="pix-accordions">
+    <div class="pix-accordions{{this.isV2Version}}">
 
       <button
-        class="pix-accordions__title"
+        class="pix-accordions{{this.isV2Version}}__title"
         type="button"
         {{on "click" this.toggleAccordions}}
         aria-controls={{this.contentId}}
@@ -40,10 +44,10 @@ export default class PixAccordions extends Component {
         ...attributes
       >
 
-        <span class="pix-accordions-title__container">
+        <span class="pix-accordions{{this.isV2Version}}-title__container">
           {{#if @iconName}}
             <PixIcon
-              class="pix-accordions-title__icon"
+              class="pix-accordions{{this.isV2Version}}-title__icon"
               @name={{@iconName}}
               @plainIcon={{@plainIcon}}
               @ariaHidden={{true}}
@@ -53,14 +57,14 @@ export default class PixAccordions extends Component {
           {{yield to="title"}}
         </span>
 
-        <span class="pix-accordions-title__container">
+        <span class="pix-accordions{{this.isV2Version}}-title__container">
           {{#if @tagContent}}
             <PixTag @color={{@tagColor}}>
               {{@tagContent}}
             </PixTag>
           {{/if}}
           <PixIcon
-            class="pix-accordions-title-container__toggle-icon"
+            class="pix-accordions{{this.isV2Version}}-title-container__toggle-icon"
             @ariaHidden={{true}}
             @name="{{if this.isCollapsed 'chevronBottom' 'chevronTop'}}"
           />
@@ -69,7 +73,7 @@ export default class PixAccordions extends Component {
 
       <div
         id={{this.contentId}}
-        class="pix-accordions__content"
+        class="pix-accordions{{this.isV2Version}}__content"
         aria-hidden={{if this.isCollapsed "true" "false"}}
       >
         {{#if this.isContentRendered}}

--- a/addon/styles/_pix-accordions-v2.scss
+++ b/addon/styles/_pix-accordions-v2.scss
@@ -1,0 +1,98 @@
+@use "pix-design-tokens/typography";
+@use 'pix-design-tokens/shadows';
+@use 'pix-design-tokens/breakpoints';
+
+.pix-accordions-v2 {
+  background-color: var(--pix-neutral-0);
+  border-bottom: 1px solid var(--pix-neutral-100);
+
+  &:last-child {
+    border-bottom: none;
+  }
+
+  &:has(.pix-accordions-v2__title[aria-expanded='true']) {
+    @extend %pix-shadow-default;
+
+    margin: var(--pix-spacing-3x) 0;
+    border-bottom: none;
+    border-radius: 8px;
+  }
+
+  &:has(.pix-accordions-v2__title:hover) {
+    border-radius: 8px;
+  }
+
+  &:has(.pix-accordions-v2__title:not(:active)) {
+    &:focus-within {
+      background-color: var(--pix-primary-50);
+      border: 1px solid var(--pix-primary-500);
+      outline: 2px solid var(--pix-primary-300);
+    }
+  }
+
+  &__content {
+    @extend %pix-body-l;
+
+    padding: var(--pix-spacing-4x);
+    background-color: var(--pix-primary-10);
+    border-bottom-right-radius: 8px;
+    border-bottom-left-radius: 8px;
+
+    &[aria-hidden='true'] {
+      display: none;
+    }
+  }
+}
+
+.pix-accordions-v2__title {
+  @extend %pix-title-xs;
+
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  width: 100%;
+  padding: var(--pix-spacing-4x) var(--pix-spacing-2x);
+
+  @include breakpoints.device-is('mobile') {
+    padding: var(--pix-spacing-3x) var(--pix-spacing-2x);
+  }
+
+  &:hover:not([aria-expanded='true']) {
+    border-radius: 8px;
+  }
+
+  &:active:not([aria-expanded='true'])  {
+    @extend %pix-shadow-default;
+  }
+
+  &:hover,
+  &[aria-expanded='true'] {
+    background-color: var(--pix-primary-50);
+  }
+
+  &[aria-expanded='true'] {
+    background-color: var(--pix-primary-10);
+    border-bottom: 1px solid var(--pix-neutral-100);
+    border-top-left-radius: 8px;
+    border-top-right-radius: 8px;
+  }
+}
+
+.pix-accordions-v2-title {
+  &__container {
+    display: flex;
+    align-items: center;
+  }
+
+  &__icon {
+    margin-right: var(--pix-spacing-2x);
+    color: var(--pix-neutral-800);
+  }
+}
+
+.pix-accordions-v2-title-container {
+  &__toggle-icon {
+    margin-left: var(--pix-spacing-2x);
+    border-radius: 50%;
+  }
+}

--- a/addon/styles/addon.scss
+++ b/addon/styles/addon.scss
@@ -53,6 +53,7 @@
 @use 'pix-gauge';
 @use 'pix-stepper';
 @use 'pix-card';
+@use 'pix-accordions-v2';
 
 // at the end so it can override it's children scss
 @use 'pix-filterable-and-searchable-select';

--- a/app/stories/pix-accordions.mdx
+++ b/app/stories/pix-accordions.mdx
@@ -5,6 +5,8 @@ import * as ComponentStories from './pix-accordions.stories';
 
 # PixAccordions
 
+> **⚠️** **NEW : Veuillez utiliser le paramètre isV2Version=true pour ce composant. Il permet d'avoir le nouveau style du composant comme prévue dans le design system.**
+
 Un `PixAccordions` est un élément comprenant un libellé et un contenu.
 Par défaut le contenu est masqué et cliquer sur le libellé permet de montrer le contenu du `PixAccordions`.
 
@@ -30,7 +32,7 @@ Les paramètres `tagContent` et `tagColor` permettent d'afficher un `Pix Tag` pr
 ## Usage
 
 ```html
-<PixAccordions @iconName="users">`
+<PixAccordions @iconName="users" @isV2Version={{true}}>`
   <:title>Titre du contenu à dérouler en cliquant</:title>
   <:content>
     <div>Contenu du PixAccordions</div>

--- a/app/stories/pix-accordions.stories.js
+++ b/app/stories/pix-accordions.stories.js
@@ -5,6 +5,16 @@ import { ICONS } from '../../addon/helpers/icons';
 export default {
   title: 'Data display/Accordions',
   argTypes: {
+    isV2Version: {
+      name: 'isV2Version',
+      description: "Permet d'afficher le nouveau design de PixAccordions",
+      type: { name: 'boolean', required: false },
+      control: { type: 'boolean' },
+      table: {
+        type: { summary: 'boolean' },
+        defaultValue: { summary: false },
+      },
+    },
     iconName: {
       name: 'iconName',
       description: "Ajoute l'icône donnée en paramètre avant le titre du PixAccordions",
@@ -44,6 +54,7 @@ const Template = (args) => {
   @plainIcon={{this.plainIcon}}
   @tagContent={{this.tagContent}}
   @tagColor={{this.tagColor}}
+  @isV2Version={{this.isV2Version}}
 >
   <:title>
     {{this.title}}
@@ -60,12 +71,13 @@ export const accordions = Template.bind({});
 accordions.args = {
   title: 'Titre du contenu à dérouler en cliquant',
   iconName: 'users',
+  isV2Version: true,
 };
 
 export const multipleAccordions = (args) => {
   return {
     template: hbs`<div>
-  <PixAccordions @iconName={{this.iconName}} @plainIcon={{this.plainIcon}}>
+  <PixAccordions @iconName={{this.iconName}} @plainIcon={{this.plainIcon}} @isV2Version={{true}}>
     <:title>
       Titre A
     </:title>
@@ -74,7 +86,7 @@ export const multipleAccordions = (args) => {
     </:content>
   </PixAccordions>
 
-  <PixAccordions @iconName={{this.iconName}} @plainIcon={{this.plainIcon}}>
+  <PixAccordions @iconName={{this.iconName}} @plainIcon={{this.plainIcon}} @isV2Version={{true}}>
     <:title>
       Titre B
     </:title>
@@ -83,7 +95,7 @@ export const multipleAccordions = (args) => {
     </:content>
   </PixAccordions>
 
-  <PixAccordions @iconName={{this.iconName}} @plainIcon={{this.plainIcon}}>
+  <PixAccordions @iconName={{this.iconName}} @plainIcon={{this.plainIcon}} @isV2Version={{true}}>
     <:title>
       Titre C
     </:title>
@@ -106,6 +118,7 @@ export const accordionsWithTag = (args) => {
     @plainIcon={{this.plainIcon}}
     @tagColor='success'
     @tagContent='tag 1'
+    @isV2Version={{true}}
   >
     <:title>
       Titre A
@@ -120,6 +133,7 @@ export const accordionsWithTag = (args) => {
     @plainIcon={{this.plainIcon}}
     @tagColor='error'
     @tagContent='tag 2'
+    @isV2Version={{true}}
   >
     <:title>
       Titre B


### PR DESCRIPTION
## :christmas_tree: Problème

PixAccordions fait peau neuve. De nombreuses applis Pix utilisent ce dernier, souvent avec de la surchage CSS pour des besoins différents. La MAJ de Pix UI avec ce nouveau design va forcément casser l'existant et les équipes n'ont pas la dispo pour traiter cela.

## :gift: Proposition
Ajouter un paramètre `isV2Version` sur le PixAccordions pour avoir le nouveau design tout en maintenant l'ancien.

Le booléan est à false par défaut pour ne pas casser l'existant dans les applis Pix.

## :santa: Pour tester

https://pix-ui-review-pr1010.osc-fr1.scalingo.io/?path=/docs/data-display-accordions--docs

Le lien DS : https://www.figma.com/design/8RJ3aCSfdeQ8AZZVBBYKS8/Design-System-Nebulix?node-id=379-5247&p=f&m=dev


https://github.com/user-attachments/assets/d202f424-6c30-4307-9736-b2193a9f6a28

