### PR TITLE
[FEATURE] Ajout de l’argument @replace sur PixButtonLink

### DIFF
--- a/addon/components/pix-button-link.gjs
+++ b/addon/components/pix-button-link.gjs
@@ -19,6 +19,7 @@ export default class PixButtonLink extends PixButtonBase {
         @models={{if @model (array @model) this.defaultModel}}
         @disabled={{@isDisabled}}
         @query={{if @query @query this.defaultParams}}
+        @replace={{@replace}}
         class={{this.className}}
         aria-disabled="{{@isDisabled}}"
         ...attributes

--- a/app/stories/pix-button-link.stories.js
+++ b/app/stories/pix-button-link.stories.js
@@ -27,6 +27,11 @@ export default {
         "Paramètre facultatif du <LinkTo> Ember permettant d'ajouter des paires de clé/valeur dans les paramètres d'une URL",
       type: { required: false },
     },
+    replace: {
+      name: 'replace',
+      description: 'Écraser la dernière entrée de l’historique du navigateur',
+      type: { name: 'boolean', required: false },
+    },
     variant: {
       name: 'variant',
       description: 'Permet le choix de la déclinaison du bouton lien souhaité',


### PR DESCRIPTION
## :christmas_tree: Problème

`PixButtonLink` ne permet pas de valoriser l’argument `@replace` du `LinkTo`.

## :gift: Proposition

Ajouter l’argument `@replace` sur `PixButtonLink` et le mapper vers celui du `LinkTo`.

## :star2: Remarques

N/A

## :santa: Pour tester

À tester dans PixEditor.