### PR TITLE
[FEATURE] Mettre à jour le style de PixBlock (PIX-23025).

### DIFF
--- a/addon/components/pix-block.gjs
+++ b/addon/components/pix-block.gjs
@@ -5,6 +5,7 @@ import Component from '@glimmer/component';
 export default class PixBlockComponent extends Component {
   get variant() {
     const value = this.args.variant ?? 'primary';
+
     warn(
       `PixBlock: @variant "${value}" should be ${VARIANTS.join(', ')}`,
       VARIANTS.includes(value),
@@ -17,7 +18,7 @@ export default class PixBlockComponent extends Component {
   }
 
   get cssClass() {
-    const cssClass = ['pix-block', `pix-block--${this.variant}`];
+    const cssClass = ['pix-block', `pix-block--variant-${this.variant}`];
 
     if (this.args.condensed) {
       cssClass.push('pix-block--condensed');

--- a/addon/styles/_pix-block.scss
+++ b/addon/styles/_pix-block.scss
@@ -2,27 +2,26 @@
 
 .pix-block {
   position: relative;
+  padding: var(--pix-spacing-3x);
   background-color: var(--pix-neutral-0);
-  border-radius: var(--pix-spacing-2x);
+  border-radius: var(--pix-spacing-5x);
 
-  &--primary {
+  &--variant-primary {
+    @extend %pix-shadow-default;
+
     padding: var(--pix-spacing-6x);
-    border: solid 1px var(--pix-primary-100);
   }
 
-  &--orga {
-    padding: var(--pix-spacing-3x);
-    border: solid 1px rgb(var(--pix-orga-500-inline), 0.45);
+  &--variant-orga {
+    @extend %pix-shadow-orga;
   }
 
-  &--certif {
-    padding: var(--pix-spacing-3x);
-    border: solid 1px rgb(var(--pix-certif-500-inline), 0.45);
+  &--variant-certif {
+    @extend %pix-shadow-certif;
   }
 
-  &--admin {
-    padding: var(--pix-spacing-3x);
-    border: solid 1px var(--pix-primary-100);
+  &--variant-admin {
+    @extend %pix-shadow-default;
   }
 
   &--condensed {

--- a/app/stories/pix-block.mdx
+++ b/app/stories/pix-block.mdx
@@ -17,6 +17,7 @@ Un \`Block\` est un bloc de fond blanc dont les bords sont arrondis.
 <Story of={ComponentStories.orga} height={150} />
 <Story of={ComponentStories.certif} height={150} />
 <Story of={ComponentStories.admin} height={150} />
+<Story of={ComponentStories.condensed} height={150} />
 
 ## Usage
 

--- a/app/stories/pix-block.stories.js
+++ b/app/stories/pix-block.stories.js
@@ -68,5 +68,5 @@ export const condensed = Template.bind({});
 condensed.args = {
   variant: 'primary',
   condensed: true,
-  information: 'Primary Condensed',
+  information: 'Condensed',
 };

--- a/tests/integration/components/pix-background-header-test.js
+++ b/tests/integration/components/pix-background-header-test.js
@@ -36,9 +36,9 @@ module('Integration | Component | pix-background-header', function (hooks) {
       const lastBlockElement = this.element.querySelector(BACKGROUND_CONTENT_SELECTOR).children[1];
 
       // then
-      assert.strictEqual(firstBlockElement.className, 'pix-block pix-block--primary');
+      assert.strictEqual(firstBlockElement.className, 'pix-block pix-block--variant-primary');
       assert.contains('Je suis un bloc commun');
-      assert.strictEqual(lastBlockElement.className, 'pix-block pix-block--admin');
+      assert.strictEqual(lastBlockElement.className, 'pix-block pix-block--variant-admin');
       assert.contains('Je suis un bloc pour Pix Admin');
     });
   });

--- a/tests/integration/components/pix-block-test.js
+++ b/tests/integration/components/pix-block-test.js
@@ -18,7 +18,7 @@ module('Integration | Component | pix-block', function (hooks) {
 
     // then
     assert.contains('Je suis un beau bloc');
-    assert.strictEqual(blockElement.className, 'pix-block pix-block--certif');
+    assert.strictEqual(blockElement.className, 'pix-block pix-block--variant-certif');
   });
 
   module('when @variant parameter is not given', function (hooks) {
@@ -41,7 +41,7 @@ module('Integration | Component | pix-block', function (hooks) {
 
       // then
       assert.contains('Je suis un beau bloc');
-      assert.strictEqual(blockElement.className, 'pix-block pix-block--primary');
+      assert.strictEqual(blockElement.className, 'pix-block pix-block--variant-primary');
     });
 
     test('it should warn', async function (assert) {
@@ -79,7 +79,7 @@ module('Integration | Component | pix-block', function (hooks) {
       assert.contains('Je suis un beau bloc');
       assert.strictEqual(
         blockElement.className,
-        'pix-block pix-block--primary pix-block--condensed',
+        'pix-block pix-block--variant-primary pix-block--condensed',
       );
     });
   });

--- a/tests/integration/components/pix-card-test.gjs
+++ b/tests/integration/components/pix-card-test.gjs
@@ -39,7 +39,7 @@ module('Integration | Component | PixCard', function (hooks) {
       assert.contains('coucou');
       assert.deepEqual(Array.from(blockElement.classList), [
         'pix-block',
-        'pix-block--orga',
+        'pix-block--variant-orga',
         'pix-card-wrapper',
       ]);
     });


### PR DESCRIPTION
## :christmas_tree: Problème
Le style graphique du composant PixBlock évolue.

## :gift: Proposition
Intégrer ce nouveau style.

## :star2: Remarques
Petit changement au niveau des classes CSS liées aux variants

## :santa: Pour tester
Visualiser le [composant en RA](https://pix-ui-review-pr1012.osc-fr1.scalingo.io/?path=/docs/other-block--docs).
