### PR TITLE
[FEATURE] PixCheckbox - Faire évoluer le variant Modulix pour gérer declarative (PIX-23135)

### DIFF
--- a/addon/components/pix-checkbox.gjs
+++ b/addon/components/pix-checkbox.gjs
@@ -27,6 +27,10 @@ export default class PixCheckbox extends Component {
     return this.args.state === 'error';
   }
 
+  get hasDeclarativeState() {
+    return this.args.state === 'declarative' || this.args.state === 'declarative-selected';
+  }
+
   get inputClasses() {
     const classes = ['pix-checkbox__input'];
 
@@ -68,6 +72,10 @@ export default class PixCheckbox extends Component {
     return this.formatMessage('state.error');
   }
 
+  get stateDeclarativeMessage() {
+    return this.formatMessage('state.declarative');
+  }
+
   formatMessage(message) {
     return formatMessage(this.args.locale ?? 'fr', `input.${message}`);
   }
@@ -107,6 +115,8 @@ export default class PixCheckbox extends Component {
           {{this.stateSuccessMessage}}
         {{else if this.hasErrorState}}
           {{this.stateErrorMessage}}
+        {{else if this.hasDeclarativeState}}
+          {{this.stateDeclarativeMessage}}
         {{/if}}
       </span>
     </div>

--- a/addon/components/pix-label-wrapped.gjs
+++ b/addon/components/pix-label-wrapped.gjs
@@ -13,6 +13,10 @@ export default class PixLabelWrapped extends Component {
       if (this.args.state === 'success') classes.push('pix-label-wrapped--state-modulix-success');
       if (this.args.state === 'error') classes.push('pix-label-wrapped--state-modulix-error');
       if (this.args.state === 'neutral') classes.push('pix-label-wrapped--state-modulix-neutral');
+      if (this.args.state === 'declarative')
+        classes.push('pix-label-wrapped--state-modulix-declarative');
+      if (this.args.state === 'declarative-selected')
+        classes.push('pix-label-wrapped--state-modulix-declarative-selected');
     } else {
       if (this.args.state === 'success') classes.push('pix-label-wrapped--state-success');
       if (this.args.state === 'error') classes.push('pix-label-wrapped--state-error');

--- a/addon/styles/_pix-label-wrapped.scss
+++ b/addon/styles/_pix-label-wrapped.scss
@@ -23,6 +23,10 @@
     }
 
     &.pix-label-wrapped {
+      &.pix-label-wrapped--state-modulix-declarative {
+        border-color: var(--pix-neutral-500);
+      }
+
       &--disabled {
         --state-background-color: var(--pix-neutral-20);
         --state-border-color: var(--pix-neutral-100);
@@ -53,6 +57,20 @@
           --state-background-color: var(--pix-success-50);
 
           color: var(--pix-success-700);
+        }
+
+        &.pix-label-wrapped--state-modulix-declarative {
+          --state-border-color: transparent;
+          --state-background-color: var(--pix-primary-100);
+
+          color: var(--pix-neutral-900);
+        }
+
+        &.pix-label-wrapped--state-modulix-declarative-selected {
+          --state-border-color: var(--pix-neutral-500);
+          --state-background-color: var(--pix-neutral-0);
+
+          color: var(--pix-neutral-900);
         }
 
         & .pix-label-wrapped__state-icon {

--- a/addon/translations/fr.js
+++ b/addon/translations/fr.js
@@ -3,6 +3,7 @@ export default {
     state: {
       success: 'Sélection correcte',
       error: 'Sélection incorrecte',
+      declarative: 'Sélection sans bonne ou mauvaise réponse',
     },
   },
   select: {

--- a/app/stories/pix-checkbox-variant-modulix.mdx
+++ b/app/stories/pix-checkbox-variant-modulix.mdx
@@ -30,6 +30,17 @@ Cumulée à la désactivation, une propriété de statut permet de préciser une
 <Story of={ComponentStories.isDisabledIsSuccessVariantModulix} height={120} />
 <Story of={ComponentStories.isDisabledIsErrorVariantModulix} height={120} />
 
+### État déclaratif
+
+L'état `declarative` est utilisé pour les réponses d'un module qui ne sont pas évaluées (par exemple, des questions déclaratives). La checkbox reste active par défaut.
+
+<Story of={ComponentStories.declarativeVariantModulix} height={120} />
+
+Combiné à `@isDisabled`, il permet d'afficher l'état après soumission : non sélectionnée ou sélectionnée (`declarative-selected`).
+
+<Story of={ComponentStories.isDisabledDeclarativeVariantModulix} height={120} />
+<Story of={ComponentStories.isDisabledDeclarativeSelectedVariantModulix} height={120} />
+
 ## Usage
 
 ```html

--- a/app/stories/pix-checkbox-variant-modulix.stories.js
+++ b/app/stories/pix-checkbox-variant-modulix.stories.js
@@ -14,8 +14,9 @@ export default {
     },
     state: {
       name: 'state',
-      description: 'Si `isDisabled` permet de marquer la checkbox comme correcte ou incorrecte',
-      options: ['neutral', 'success', 'error'],
+      description:
+        'Si `isDisabled` permet de marquer la checkbox comme correcte ou incorrecte. `declarative` et `declarative-selected` permettent d’afficher un état déclaratif (réponse non évaluée après soumission).',
+      options: ['neutral', 'success', 'error', 'declarative', 'declarative-selected'],
       control: { type: 'select' },
       table: {
         type: { summary: 'string' },
@@ -100,4 +101,31 @@ isDisabledIsErrorVariantModulix.args = {
   isDisabled: true,
   checked: true,
   state: 'error',
+};
+
+export const declarativeVariantModulix = VariantModulixTemplate.bind({});
+declarativeVariantModulix.args = {
+  id: 'proposal-declarative',
+  label: 'Une réponse',
+  variant: 'modulix',
+  state: 'declarative',
+};
+
+export const isDisabledDeclarativeVariantModulix = VariantModulixTemplate.bind({});
+isDisabledDeclarativeVariantModulix.args = {
+  id: 'proposal-declarative-disabled',
+  label: 'Une réponse',
+  variant: 'modulix',
+  state: 'declarative',
+  isDisabled: true,
+};
+
+export const isDisabledDeclarativeSelectedVariantModulix = VariantModulixTemplate.bind({});
+isDisabledDeclarativeSelectedVariantModulix.args = {
+  id: 'proposal-declarative-selected-disabled',
+  label: 'Une réponse',
+  variant: 'modulix',
+  state: 'declarative-selected',
+  isDisabled: true,
+  checked: true,
 };

--- a/app/stories/pix-checkbox.stories.js
+++ b/app/stories/pix-checkbox.stories.js
@@ -11,13 +11,13 @@ export default {
     },
     class: {
       name: 'class',
-      description: "Permet d'ajouter une classe au parent du composant.",
+      description: 'Permet d’ajouter une classe au parent du composant.',
       type: { name: 'string' },
     },
     isIndeterminate: {
       name: 'isIndeterminate',
       description:
-        "Rendre la checkbox indéterminée, état indiquant que la/les case(s) n'est/ne sont ni cochée(s) ni décochée(s) (exemple: une checkbox parente indiquant la sélection partielle de plusieurs checkbox enfants)",
+        'Rendre la checkbox indéterminée, état indiquant que la/les case(s) n’est/ne sont ni cochée(s) ni décochée(s) (exemple: une checkbox parente indiquant la sélection partielle de plusieurs checkbox enfants)',
       type: { name: 'boolean', required: true },
       table: {
         type: { summary: 'boolean' },

--- a/tests/dummy/app/controllers/checkbox-page.js
+++ b/tests/dummy/app/controllers/checkbox-page.js
@@ -1,0 +1,9 @@
+import Controller from '@ember/controller';
+import { action } from '@ember/object';
+
+export default class CheckboxPage extends Controller {
+  @action
+  onClick() {
+    console.log('CLICKED');
+  }
+}

--- a/tests/dummy/app/router.js
+++ b/tests/dummy/app/router.js
@@ -19,4 +19,5 @@ Router.map(function () {
   this.route('button-page', { path: '/button' });
   this.route('stepper-page', { path: '/stepper' });
   this.route('layout-page', { path: '/layout' });
+  this.route('checkbox-page', { path: '/checkbox' });
 });

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -33,6 +33,7 @@
         <PixNavigationButton @route="gauge-page" @icon="barsUp">gauge</PixNavigationButton>
         <PixNavigationButton @route="button-page" @icon="lightBulb">Button</PixNavigationButton>
         <PixNavigationButton @route="stepper-page" @icon="brick">Stepper</PixNavigationButton>
+        <PixNavigationButton @route="checkbox-page" @icon="check">Checkbox</PixNavigationButton>
         <PixNavigationButton href="https://pix.fr" @icon="book">Documentation</PixNavigationButton>
         <PixNavigationButton
           href="https://pix.fr"

--- a/tests/dummy/app/templates/checkbox-page.hbs
+++ b/tests/dummy/app/templates/checkbox-page.hbs
@@ -1,0 +1,31 @@
+<div>
+  <h2>Etat activé</h2>
+  <PixCheckbox @variant="modulix" @state="neutral">
+    <:label>Proposition variant Modulix, état neutral</:label>
+  </PixCheckbox>
+
+  <PixCheckbox @variant="modulix" @state="declarative">
+    <:label>Proposition variant Modulix, état déclaratif</:label>
+  </PixCheckbox>
+
+  <h2>Etat désactivé (après soumission)</h2>
+  <PixCheckbox @variant="modulix" @state="neutral" @isDisabled="true">
+    <:label>Proposition variant Modulix, état neutre</:label>
+  </PixCheckbox>
+
+  <PixCheckbox @variant="modulix" @state="success" @isDisabled="true">
+    <:label>Proposition variant Modulix, état success</:label>
+  </PixCheckbox>
+
+  <PixCheckbox @variant="modulix" @state="error" @isDisabled="true">
+    <:label>Proposition variant Modulix, état error</:label>
+  </PixCheckbox>
+
+  <PixCheckbox @variant="modulix" @state="declarative" @isDisabled="true">
+    <:label>Proposition variant Modulix, état déclaratif, non sélectionné</:label>
+  </PixCheckbox>
+
+  <PixCheckbox @variant="modulix" @state="declarative-selected" @isDisabled="true" @checked="true">
+    <:label>Proposition variant Modulix, état déclaratif, sélectionné</:label>
+  </PixCheckbox>
+</div>

--- a/tests/integration/components/pix-checkbox-test.js
+++ b/tests/integration/components/pix-checkbox-test.js
@@ -135,6 +135,27 @@ module('Integration | Component | checkbox', function (hooks) {
         .exists();
     });
 
+    test(`it should read declarative state info if given`, async function (assert) {
+      // given
+      this.set('isDisabled', true);
+
+      // when
+      const screen = await render(
+        hbs`<PixCheckbox checked @isDisabled={{this.isDisabled}} @state='declarative'><:label>La galette des
+    rois</:label></PixCheckbox>`,
+      );
+
+      // then
+      assert
+        .dom(
+          screen.getByRole('checkbox', {
+            description: 'Sélection sans bonne ou mauvaise réponse',
+            hidden: true,
+          }),
+        )
+        .exists();
+    });
+
     ['true', 'false', 'null', 'undefined'].forEach(function (testCase) {
       test(`it should not be possible to interact when @isDisabled="${testCase}"`, async function (assert) {
         // given


### PR DESCRIPTION
## :christmas_tree: Problème

Dans la maquette du QCM-declarative dans Modulix, la version de pix-checkbox utilisée n'existe pas actuellement dans Nebulix.

## :gift: Proposition

Pour le variant "modulix" uniquement, ajouter les états `declarative` et `declarative-selected` pour afficher la checkbox comme attendu.
Lien vers la maquette [ici](https://www.figma.com/design/eO4BQwUjOjesNFBZONwvCP/-MAIN--Modulix?node-id=2107-444&m=dev).

## :star2: Remarques

Ces deux états ne concernant que le variant "modulix".

## :santa: Pour tester

- Ouvrir[ storybook de la RA](https://pix-ui-review-pr1014.osc-fr1.scalingo.io/?path=/docs/changelog--docs)
- Vérifier les exemples de PixCheckbox, variant Modulix, pour les états "declarative" et "declarative-selected"