### PR TITLE
[FEATURE] Ajouter les tokens de Shadow hover et pressed (PIX-23289)

### DIFF
--- a/addon/styles/pix-design-tokens/_shadows.scss
+++ b/addon/styles/pix-design-tokens/_shadows.scss
@@ -1,75 +1,134 @@
 // See https://www.figma.com/file/8RJ3aCSfdeQ8AZZVBBYKS8/Design-System-Pix?node-id=54%3A5141
 
-// Mixin pour permettre l'utilisation dans une classe css si jamais le tag html a trop de classe
-@mixin shadow($verticalSize, $blur) {
-  box-shadow: 0 $verticalSize $blur rgba(7, 20, 46, 0.08);
+:root {
+  // Size-based
+  --pix-shadow-xs: 0 4px 8px rgba(7, 20, 46, 0.08);
+  --pix-shadow-sm: 0 6px 12px rgba(7, 20, 46, 0.08);
+  --pix-shadow-md: 0 8px 16px rgba(7, 20, 46, 0.08);
+  --pix-shadow-lg: 0 10px 20px rgba(7, 20, 46, 0.08);
+  --pix-shadow-xl: 0 12px 24px rgba(7, 20, 46, 0.08);
+
+  // Default
+  --pix-shadow-default: 0 2px 5px 0 rgba(74, 58, 255, 0.25), 0 -2px 5px 0 rgba(74, 58, 255, 0.15) inset,
+    0 1px 1px 0 rgba(255, 255, 255, 0.1) inset, 0 3px 4px 0 rgba(223, 238, 255, 0.1) inset;
+  --pix-shadow-default-hover: 4px 4px 5px 0 rgba(74, 58, 255, 0.25), -4px 4px 5px 0 rgba(74, 58, 255, 0.25),
+    0 -2px 5px 0 rgba(74, 58, 255, 0.3) inset, 0 1px 1px 0 rgba(255, 255, 255, 0.25) inset,
+    0 3px 4px 0 rgba(223, 238, 255, 0.25) inset;
+  --pix-shadow-default-pressed: 0 0 15px 0 rgba(74, 58, 255, 0.6) inset, 0 -2px 5px 0 rgba(74, 58, 255, 0.25) inset,
+    0 1px 1px 0 rgba(255, 255, 255, 0.1) inset, 0 3px 4px 0 rgba(223, 238, 255, 0.1) inset;
+
+  // Neutral
+  --pix-shadow-neutral: 0 2px 5px 0 rgba(79, 99, 132, 0.25), 0 -2px 5px 0 rgba(79, 99, 132, 0.15) inset,
+    0 1px 1px 0 rgba(255, 255, 255, 0.1) inset, 0 3px 4px 0 rgba(200, 207, 217, 0.1) inset;
+  --pix-shadow-neutral-hover: 4px 4px 5px 0 rgba(79, 99, 132, 0.25), -4px 4px 5px 0 rgba(79, 99, 132, 0.25),
+    0 -2px 5px 0 rgba(79, 99, 132, 0.3) inset, 0 1px 1px 0 rgba(255, 255, 255, 0.25) inset,
+    0 3px 4px 0 rgba(200, 207, 217, 0.25) inset;
+  --pix-shadow-neutral-pressed: 0 0 15px 0 rgba(79, 99, 132, 0.6) inset, 0 -2px 5px 0 rgba(79, 99, 132, 0.25) inset,
+    0 1px 1px 0 rgba(255, 255, 255, 0.1) inset, 0 3px 4px 0 rgba(200, 207, 217, 0.1) inset;
+
+  // Orga
+  --pix-shadow-orga: 0 2px 5px 0 rgba(54, 116, 191, 0.25), 0 -2px 5px 0 rgba(54, 116, 191, 0.15) inset,
+    0 1px 1px 0 rgba(255, 255, 255, 0.1) inset, 0 3px 4px 0 rgba(235, 241, 249, 0.1) inset;
+  --pix-shadow-orga-hover: 4px 4px 5px 0 rgba(54, 116, 191, 0.25), -4px 4px 5px 0 rgba(54, 116, 191, 0.25),
+    0 -2px 5px 0 rgba(54, 116, 191, 0.3) inset, 0 1px 1px 0 rgba(255, 255, 255, 0.25) inset,
+    0 3px 4px 0 rgba(235, 241, 249, 0.25) inset;
+  --pix-shadow-orga-pressed: 0 0 15px 0 rgba(54, 116, 191, 0.6) inset, 0 -2px 5px 0 rgba(54, 116, 191, 0.25) inset,
+    0 1px 1px 0 rgba(255, 255, 255, 0.1) inset, 0 3px 4px 0 rgba(235, 241, 249, 0.1) inset;
+
+  // Certif
+  --pix-shadow-certif: 0 2px 5px 0 rgba(24, 127, 125, 0.25), 0 -2px 5px 0 rgba(24, 127, 125, 0.15) inset,
+    0 1px 1px 0 rgba(255, 255, 255, 0.1) inset, 0 3px 4px 0 rgba(232, 242, 242, 0.1) inset;
+  --pix-shadow-certif-hover: 4px 4px 5px 0 rgba(24, 127, 125, 0.25), -4px 4px 5px 0 rgba(24, 127, 125, 0.25),
+    0 -2px 5px 0 rgba(24, 127, 125, 0.3) inset, 0 1px 1px 0 rgba(255, 255, 255, 0.25) inset,
+    0 3px 4px 0 rgba(232, 242, 242, 0.25) inset;
+  --pix-shadow-certif-pressed: 0 0 15px 0 rgba(24, 127, 125, 0.6) inset, 0 -2px 5px 0 rgba(24, 127, 125, 0.25) inset,
+    0 1px 1px 0 rgba(255, 255, 255, 0.1) inset, 0 3px 4px 0 rgba(232, 242, 242, 0.1) inset;
 }
 
-@mixin coloredShadow($colorA, $colorB, $colorC) {
-  box-shadow:
-    0 2px 5px 0 $colorA,
-    0 -2px 5px 0 $colorB inset,
-    0 1px 1px 0 rgba(255, 255, 255, 0.1) inset,
-    0 3px 4px 0 $colorC inset;
-}
+// SCSS placeholders et classes CSS pour la compatibilité ascendante
+// Mixin pour permettre l'utilisation dans une classe css si jamais le tag html a trop de classe
 
 %pix-shadow-xs,
 .pix-shadow-xs {
-  @include shadow(4px, 8px);
+  box-shadow: var(--pix-shadow-xs);
 }
 
 %pix-shadow-sm,
 .pix-shadow-sm {
-  @include shadow(6px, 12px);
+  box-shadow: var(--pix-shadow-sm);
 }
 
 %pix-shadow-md,
 .pix-shadow-md {
-  @include shadow(8px, 16px);
+  box-shadow: var(--pix-shadow-md);
 }
 
 %pix-shadow-lg,
 .pix-shadow-lg {
-  @include shadow(10px, 20px);
+  box-shadow: var(--pix-shadow-lg);
 }
 
 %pix-shadow-xl,
 .pix-shadow-xl {
-  @include shadow(12px, 24px);
+  box-shadow: var(--pix-shadow-xl);
 }
 
 %pix-shadow-default,
 .pix-shadow-default {
-  @include coloredShadow(
-    rgba(74, 58, 255, 0.25),
-    rgba(74, 58, 255, 0.15),
-    rgba(223, 238, 255, 0.1)
-  );
+  box-shadow: var(--pix-shadow-default);
+}
+
+%pix-shadow-default-hover,
+.pix-shadow-default-hover {
+  box-shadow: var(--pix-shadow-default-hover);
+}
+
+%pix-shadow-default-pressed,
+.pix-shadow-default-pressed {
+  box-shadow: var(--pix-shadow-default-pressed);
 }
 
 %pix-shadow-neutral,
 .pix-shadow-neutral {
-  @include coloredShadow(
-    rgba(79, 99, 132, 0.25),
-    rgba(79, 99, 132, 0.15),
-    rgba(200, 207, 217, 0.1)
-  );
+  box-shadow: var(--pix-shadow-neutral);
+}
+
+%pix-shadow-neutral-hover,
+.pix-shadow-neutral-hover {
+  box-shadow: var(--pix-shadow-neutral-hover);
+}
+
+%pix-shadow-neutral-pressed,
+.pix-shadow-neutral-pressed {
+  box-shadow: var(--pix-shadow-neutral-pressed);
 }
 
 %pix-shadow-orga,
 .pix-shadow-orga {
-  @include coloredShadow(
-    rgba(54, 116, 191, 0.25),
-    rgba(54, 116, 191, 0.15),
-    rgba(235, 241, 249, 0.1)
-  );
+  box-shadow: var(--pix-shadow-orga);
+}
+
+%pix-shadow-orga-hover,
+.pix-shadow-orga-hover {
+  box-shadow: var(--pix-shadow-orga-hover);
+}
+
+%pix-shadow-orga-pressed,
+.pix-shadow-orga-pressed {
+  box-shadow: var(--pix-shadow-orga-pressed);
 }
 
 %pix-shadow-certif,
 .pix-shadow-certif {
-  @include coloredShadow(
-    rgba(24, 127, 125, 0.25),
-    rgba(24, 127, 125, 0.15),
-    rgba(232, 242, 242, 0.1)
-  );
+  box-shadow: var(--pix-shadow-certif);
+}
+
+%pix-shadow-certif-hover,
+.pix-shadow-certif-hover {
+  box-shadow: var(--pix-shadow-certif-hover);
+}
+
+%pix-shadow-certif-pressed,
+.pix-shadow-certif-pressed {
+  box-shadow: var(--pix-shadow-certif-pressed);
 }

--- a/docs/shadow.mdx
+++ b/docs/shadow.mdx
@@ -2,120 +2,157 @@ import { Meta, Unstyled } from '@storybook/blocks';
 
 <Meta title="Design Tokens/Ombres" />
 
+export const tableStyle = { borderCollapse: 'collapse', width: '100%', marginBottom: '24px', fontSize: '0.75rem', lineHeight: '1.5', letterSpacing: '0.02em' };
+export const thStyle = { padding: '4px 8px', borderBottom: '1px solid #e0e0e0', textAlign: 'left', fontWeight: '600' };
+export const tdStyle = { padding: '4px 8px', borderBottom: '1px solid #f0f0f0' };
+export const tdLastStyle = { padding: '4px 8px' };
+
 # Ombres
 
-Pour uniformiser les ombres dans nos applications, on dispose de plusieurs tokens selon les applications.
-Ils sont disponibles sous forme de classe CSS :
+Pour uniformiser les ombres dans nos applications, le design system expose des **custom properties CSS** utilisables directement :
 
-- `pix-shadow-default`
-- `pix-shadow-neutral`
-- `pix-shadow-orga`
-- `pix-shadow-certif`
+```css
+box-shadow: var(--pix-shadow-default);
+```
 
-Et leur équivalent en placeholder SCSS :
-
-- `@extend %pix-shadow-default;`
-- `@extend %pix-shadow-neutral;`
-- `@extend %pix-shadow-orga;`
-- `@extend %pix-shadow-certif;`
-
-<Unstyled>
-  <div
-    className="pix-title-s pix-shadow-default"
-    style={{ padding: 'var(--pix-spacing-4x)', margin: 'var(--pix-spacing-8x)', width: '300px' }}
-  >
-    pix-shadow-default
-  </div>
-
-    <div
-    className="pix-title-s pix-shadow-neutral"
-    style={{ padding: 'var(--pix-spacing-4x)', margin: 'var(--pix-spacing-8x)', width: '300px' }}
-
->
-
-    pix-shadow-neutral
-
-  </div>
-      <div
-    className="pix-title-s pix-shadow-orga"
-    style={{ padding: 'var(--pix-spacing-4x)', margin: 'var(--pix-spacing-8x)', width: '300px' }}
-
->
-
-    pix-shadow-orga
-
-  </div>
-      <div
-    className="pix-title-s pix-shadow-certif"
-    style={{ padding: 'var(--pix-spacing-4x)', margin: 'var(--pix-spacing-8x)', width: '300px' }}
-
->
-
-    pix-shadow-certif
-
-  </div>
-</Unstyled>
-
-On dispose aussi d'ombres neutres de plusieurs tailles. Les classes CSS correspondantes :
-
-- `pix-shadow-xs`
-- `pix-shadow-sm`
-- `pix-shadow-md`
-- `pix-shadow-lg`
-- `pix-shadow-xl`
-
-Ou de placeholder SCSS :
-
-- `@extend %pix-shadow-xs;`
-- `@extend %pix-shadow-sm;`
-- `@extend %pix-shadow-md;`
-- `@extend %pix-shadow-lg;`
-- `@extend %pix-shadow-xl;`
-
-<Unstyled>
-  <div
-    className="pix-title-s pix-shadow-xs"
-    style={{ padding: 'var(--pix-spacing-4x)', margin: 'var(--pix-spacing-8x)', width: '300px' }}
-  >
-    pix-shadow-xs
-  </div>
-
-<div
-  className="pix-title-s pix-shadow-sm"
-  style={{ padding: 'var(--pix-spacing-4x)', margin: 'var(--pix-spacing-8x)', width: '300px' }}
->
-  pix-shadow-sm
-</div>
-
-    <div
-    className="pix-title-s pix-shadow-md"
-    style={{ padding: 'var(--pix-spacing-4x)', margin: 'var(--pix-spacing-8x)', width: '300px' }}
-
->
-
-    pix-shadow-md
-
-  </div>
-      <div
-    className="pix-title-s pix-shadow-lg"
-    style={{ padding: 'var(--pix-spacing-4x)', margin: 'var(--pix-spacing-8x)', width: '300px' }}
-
->
-
-    pix-shadow-lg
-
-  </div>
-      <div
-    className="pix-title-s pix-shadow-xl"
-    style={{ padding: 'var(--pix-spacing-4x)', margin: 'var(--pix-spacing-8x)', width: '300px' }}
-
->
-
-    pix-shadow-xl
-
-  </div>
-</Unstyled>
+Les classes CSS et placeholders SCSS restent disponibles pour la compatibilité avec le code existant.
 
 Code associé : [pix-ui/addon/styles/pix-design-tokens/\_shadows.scss](https://github.com/1024pix/pix-ui/blob/dev/addon/styles/pix-design-tokens/_shadows.scss)
 
 [Lien Figma](https://www.figma.com/design/8RJ3aCSfdeQ8AZZVBBYKS8/Design-System-Nebulix?node-id=13446-21793&m=dev)
+
+---
+
+## Ombres neutres (taille)
+
+<Unstyled>
+  <table style={tableStyle}>
+    <thead>
+      <tr>
+        <th style={thStyle}>Custom property CSS</th>
+        <th style={thStyle}>Valeur</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr><td style={tdStyle}><code>--pix-shadow-xs</code></td><td style={tdStyle}><code>0 4px 8px rgba(7, 20, 46, 0.08)</code></td></tr>
+      <tr><td style={tdStyle}><code>--pix-shadow-sm</code></td><td style={tdStyle}><code>0 6px 12px rgba(7, 20, 46, 0.08)</code></td></tr>
+      <tr><td style={tdStyle}><code>--pix-shadow-md</code></td><td style={tdStyle}><code>0 8px 16px rgba(7, 20, 46, 0.08)</code></td></tr>
+      <tr><td style={tdStyle}><code>--pix-shadow-lg</code></td><td style={tdStyle}><code>0 10px 20px rgba(7, 20, 46, 0.08)</code></td></tr>
+      <tr><td style={tdLastStyle}><code>--pix-shadow-xl</code></td><td style={tdLastStyle}><code>0 12px 24px rgba(7, 20, 46, 0.08)</code></td></tr>
+    </tbody>
+  </table>
+</Unstyled>
+
+Classe CSS / placeholder SCSS : `.pix-shadow-xs` / `@extend %pix-shadow-xs` (idem pour `sm`, `md`, `lg`, `xl`).
+
+<Unstyled>
+  <div style={{ display: 'flex', flexDirection: 'column', gap: '32px', padding: '32px' }}>
+    <div className="pix-title-s pix-shadow-xs" style={{ padding: 'var(--pix-spacing-4x)', width: '300px' }}>--pix-shadow-xs</div>
+    <div className="pix-title-s pix-shadow-sm" style={{ padding: 'var(--pix-spacing-4x)', width: '300px' }}>--pix-shadow-sm</div>
+    <div className="pix-title-s pix-shadow-md" style={{ padding: 'var(--pix-spacing-4x)', width: '300px' }}>--pix-shadow-md</div>
+    <div className="pix-title-s pix-shadow-lg" style={{ padding: 'var(--pix-spacing-4x)', width: '300px' }}>--pix-shadow-lg</div>
+    <div className="pix-title-s pix-shadow-xl" style={{ padding: 'var(--pix-spacing-4x)', width: '300px' }}>--pix-shadow-xl</div>
+  </div>
+</Unstyled>
+
+---
+
+## Ombres colorées
+
+Les ombres colorées existent en trois états : **default**, **hover** et **pressed**.
+
+### Default (Pix App)
+
+<Unstyled>
+  <div style={{ display: 'flex', gap: '32px', padding: '32px', flexWrap: 'wrap' }}>
+    <div className="pix-title-s pix-shadow-default" style={{ padding: 'var(--pix-spacing-4x)', width: '200px', borderRadius: 'var(--pix-spacing-4x)' }}>--pix-shadow-default</div>
+    <div className="pix-title-s pix-shadow-default-hover" style={{ padding: 'var(--pix-spacing-4x)', width: '200px', borderRadius: 'var(--pix-spacing-4x)' }}>--pix-shadow-default-hover</div>
+    <div className="pix-title-s pix-shadow-default-pressed" style={{ padding: 'var(--pix-spacing-4x)', width: '200px', borderRadius: 'var(--pix-spacing-4x)' }}>--pix-shadow-default-pressed</div>
+  </div>
+  <table style={tableStyle}>
+    <thead>
+      <tr>
+        <th style={thStyle}>Custom property CSS</th>
+        <th style={thStyle}>Classe CSS</th>
+        <th style={thStyle}>Placeholder SCSS</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr><td style={tdStyle}><code>--pix-shadow-default</code></td><td style={tdStyle}><code>.pix-shadow-default</code></td><td style={tdStyle}><code>@extend %pix-shadow-default</code></td></tr>
+      <tr><td style={tdStyle}><code>--pix-shadow-default-hover</code></td><td style={tdStyle}><code>.pix-shadow-default-hover</code></td><td style={tdStyle}><code>@extend %pix-shadow-default-hover</code></td></tr>
+      <tr><td style={tdLastStyle}><code>--pix-shadow-default-pressed</code></td><td style={tdLastStyle}><code>.pix-shadow-default-pressed</code></td><td style={tdLastStyle}><code>@extend %pix-shadow-default-pressed</code></td></tr>
+    </tbody>
+  </table>
+</Unstyled>
+
+### Neutral
+
+<Unstyled>
+  <div style={{ display: 'flex', gap: '32px', padding: '32px', flexWrap: 'wrap' }}>
+    <div className="pix-title-s pix-shadow-neutral" style={{ padding: 'var(--pix-spacing-4x)', width: '200px', borderRadius: 'var(--pix-spacing-4x)' }}>--pix-shadow-neutral</div>
+    <div className="pix-title-s pix-shadow-neutral-hover" style={{ padding: 'var(--pix-spacing-4x)', width: '200px', borderRadius: 'var(--pix-spacing-4x)' }}>--pix-shadow-neutral-hover</div>
+    <div className="pix-title-s pix-shadow-neutral-pressed" style={{ padding: 'var(--pix-spacing-4x)', width: '200px', borderRadius: 'var(--pix-spacing-4x)' }}>--pix-shadow-neutral-pressed</div>
+  </div>
+  <table style={tableStyle}>
+    <thead>
+      <tr>
+        <th style={thStyle}>Custom property CSS</th>
+        <th style={thStyle}>Classe CSS</th>
+        <th style={thStyle}>Placeholder SCSS</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr><td style={tdStyle}><code>--pix-shadow-neutral</code></td><td style={tdStyle}><code>.pix-shadow-neutral</code></td><td style={tdStyle}><code>@extend %pix-shadow-neutral</code></td></tr>
+      <tr><td style={tdStyle}><code>--pix-shadow-neutral-hover</code></td><td style={tdStyle}><code>.pix-shadow-neutral-hover</code></td><td style={tdStyle}><code>@extend %pix-shadow-neutral-hover</code></td></tr>
+      <tr><td style={tdLastStyle}><code>--pix-shadow-neutral-pressed</code></td><td style={tdLastStyle}><code>.pix-shadow-neutral-pressed</code></td><td style={tdLastStyle}><code>@extend %pix-shadow-neutral-pressed</code></td></tr>
+    </tbody>
+  </table>
+</Unstyled>
+
+### Orga (Pix Orga)
+
+<Unstyled>
+  <div style={{ display: 'flex', gap: '32px', padding: '32px', flexWrap: 'wrap' }}>
+    <div className="pix-title-s pix-shadow-orga" style={{ padding: 'var(--pix-spacing-4x)', width: '200px', borderRadius: 'var(--pix-spacing-4x)' }}>--pix-shadow-orga</div>
+    <div className="pix-title-s pix-shadow-orga-hover" style={{ padding: 'var(--pix-spacing-4x)', width: '200px', borderRadius: 'var(--pix-spacing-4x)' }}>--pix-shadow-orga-hover</div>
+    <div className="pix-title-s pix-shadow-orga-pressed" style={{ padding: 'var(--pix-spacing-4x)', width: '200px', borderRadius: 'var(--pix-spacing-4x)' }}>--pix-shadow-orga-pressed</div>
+  </div>
+  <table style={tableStyle}>
+    <thead>
+      <tr>
+        <th style={thStyle}>Custom property CSS</th>
+        <th style={thStyle}>Classe CSS</th>
+        <th style={thStyle}>Placeholder SCSS</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr><td style={tdStyle}><code>--pix-shadow-orga</code></td><td style={tdStyle}><code>.pix-shadow-orga</code></td><td style={tdStyle}><code>@extend %pix-shadow-orga</code></td></tr>
+      <tr><td style={tdStyle}><code>--pix-shadow-orga-hover</code></td><td style={tdStyle}><code>.pix-shadow-orga-hover</code></td><td style={tdStyle}><code>@extend %pix-shadow-orga-hover</code></td></tr>
+      <tr><td style={tdLastStyle}><code>--pix-shadow-orga-pressed</code></td><td style={tdLastStyle}><code>.pix-shadow-orga-pressed</code></td><td style={tdLastStyle}><code>@extend %pix-shadow-orga-pressed</code></td></tr>
+    </tbody>
+  </table>
+</Unstyled>
+
+### Certif (Pix Certif)
+
+<Unstyled>
+  <div style={{ display: 'flex', gap: '32px', padding: '32px', flexWrap: 'wrap' }}>
+    <div className="pix-title-s pix-shadow-certif" style={{ padding: 'var(--pix-spacing-4x)', width: '200px', borderRadius: 'var(--pix-spacing-4x)' }}>--pix-shadow-certif</div>
+    <div className="pix-title-s pix-shadow-certif-hover" style={{ padding: 'var(--pix-spacing-4x)', width: '200px', borderRadius: 'var(--pix-spacing-4x)' }}>--pix-shadow-certif-hover</div>
+    <div className="pix-title-s pix-shadow-certif-pressed" style={{ padding: 'var(--pix-spacing-4x)', width: '200px', borderRadius: 'var(--pix-spacing-4x)' }}>--pix-shadow-certif-pressed</div>
+  </div>
+  <table style={tableStyle}>
+    <thead>
+      <tr>
+        <th style={thStyle}>Custom property CSS</th>
+        <th style={thStyle}>Classe CSS</th>
+        <th style={thStyle}>Placeholder SCSS</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr><td style={tdStyle}><code>--pix-shadow-certif</code></td><td style={tdStyle}><code>.pix-shadow-certif</code></td><td style={tdStyle}><code>@extend %pix-shadow-certif</code></td></tr>
+      <tr><td style={tdStyle}><code>--pix-shadow-certif-hover</code></td><td style={tdStyle}><code>.pix-shadow-certif-hover</code></td><td style={tdStyle}><code>@extend %pix-shadow-certif-hover</code></td></tr>
+      <tr><td style={tdLastStyle}><code>--pix-shadow-certif-pressed</code></td><td style={tdLastStyle}><code>.pix-shadow-certif-pressed</code></td><td style={tdLastStyle}><code>@extend %pix-shadow-certif-pressed</code></td></tr>
+    </tbody>
+  </table>
+</Unstyled>


### PR DESCRIPTION
## :gift: Proposition

Ajouter les tokens pour les ombres manquantes dans pix-ui, mais présentes dans les [maquettes](https://www.figma.com/design/8RJ3aCSfdeQ8AZZVBBYKS8/Design-System-Nebulix?node-id=12221-508&m=dev) de Nébulix.

## :star2: Remarques
RAS

## :santa: Pour tester
- Ouvrir le storybook
- Constater la documentation concernant les nouveaux tokens hover et pressed, par appli
<img width="958" height="460" alt="image" src="https://github.com/user-attachments/assets/5fb2e401-0df5-4963-a8de-cd557d76043b" />
