### PR TITLE
[FEATURE] Ajustement sur le token color success (PIX-23426)

### DIFF
--- a/addon/styles/pix-design-tokens/_colors.scss
+++ b/addon/styles/pix-design-tokens/_colors.scss
@@ -65,17 +65,17 @@
   --pix-info-900-inline: 18, 49, 107;
   --pix-info-900: rgb(var(--pix-info-900-inline));
   // Success
-  --pix-success-50-inline: 230, 246, 239;
+  --pix-success-50-inline: 230, 243, 237;
   --pix-success-50: rgb(var(--pix-success-50-inline));
-  --pix-success-100-inline: 176, 228, 204;
+  --pix-success-100-inline: 176, 218, 198;
   --pix-success-100: rgb(var(--pix-success-100-inline));
-  --pix-success-300-inline: 84, 197, 144;
+  --pix-success-300-inline: 84, 175, 131;
   --pix-success-300: rgb(var(--pix-success-300-inline));
-  --pix-success-500-inline: 0, 168, 90;
+  --pix-success-500-inline: 0, 136, 70;
   --pix-success-500: rgb(var(--pix-success-500-inline));
-  --pix-success-700-inline: 0, 119, 64;
+  --pix-success-700-inline: 0, 97, 50;
   --pix-success-700: rgb(var(--pix-success-700-inline));
-  --pix-success-900-inline: 0, 71, 38;
+  --pix-success-900-inline: 0, 57, 29;
   --pix-success-900: rgb(var(--pix-success-900-inline));
   // Warning
   --pix-warning-50-inline: 253, 240, 231;

--- a/docs/colors-palette.mdx
+++ b/docs/colors-palette.mdx
@@ -79,12 +79,12 @@ import { Meta, ColorPalette, ColorItem } from '@storybook/blocks';
     title="Pix Success"
     subtitle="--pix-success-"
     colors={{
-            50: '#e6f6ef',
-            100: '#b0e4cc',
-            300: '#54c590',
-            500: '#00a85a',
+            50: '#e6f3ed',
+            100: '#b0dac6',
+            300: '#54af83',
+            500: '#008846',
             700: '#007740',
-            900: '#004726'}}
+            900: '#00391d'}}
   />
   <ColorItem
     title="Pix Warning"


### PR DESCRIPTION
## :christmas_tree: Problème
Le token color success pose souvent un problème d'accessibilité (en particulier quand on l'utilise dans les boutons avec le texte en blanc par dessus)

## :gift: Proposition
Ajustement des codes couleurs pour éviter les soucis d'a11y

## :santa: Pour tester
Vérifier les codes couleurs dans le fichier figma
https://www.figma.com/design/8RJ3aCSfdeQ8AZZVBBYKS8/Design-System-Nebulix?node-id=12220-1231&m=dev