### PR TITLE
[TECH] Rendre le tabindex de PixTooltip optionnel (PIX-23519).

### DIFF
--- a/addon/components/pix-tooltip.gjs
+++ b/addon/components/pix-tooltip.gjs
@@ -58,7 +58,10 @@ export default class PixTooltip extends Component {
       ...attributes
     >
       {{#if (has-block "triggerElement")}}
-        <span class="pix-tooltip__trigger-element" tabindex="0">
+        <span
+          class="pix-tooltip__trigger-element"
+          tabindex={{unless @isTriggerElementFocusable "0" null}}
+        >
           {{yield to="triggerElement"}}
         </span>
       {{/if}}

--- a/app/stories/pix-tooltip.mdx
+++ b/app/stories/pix-tooltip.mdx
@@ -31,6 +31,20 @@ Si vous utilisez un élément `<div>` ou `<span>`, il faut ajouter `tabindex="0"
 </PixTooltip>
 ```
 
+Par défaut, `PixTooltip` ajoute lui-même un `tabindex="0"` sur l'élément qui encadre le `:triggerElement`, afin que celui-ci soit toujours focusable. Si votre élément est déjà focusable nativement (comme un `<button>` ou un `<input>`), cela crée un double arrêt de tabulation au clavier. Utilisez `@isTriggerElementFocusable={{true}}` pour indiquer que l'élément est déjà focusable : aucun `tabindex` ne sera alors ajouté automatiquement.
+
+```html
+<PixTooltip @isTriggerElementFocusable={{true}}>
+  <:triggerElement>
+    <PixButton>Mon bouton</PixButton>
+  </:triggerElement>
+
+  <:tooltip>
+    My tooltip
+  </:tooltip>
+</PixTooltip>
+```
+
 Les tooltips doivent prendre un `@id` et être référencées par leur élément déclencheur
 
 - soit via `aria-describedby` si l'élément possèdent déjà un label, car le tooltip agit alors comme une description supplémentaire.

--- a/app/stories/pix-tooltip.stories.js
+++ b/app/stories/pix-tooltip.stories.js
@@ -54,6 +54,13 @@ export default {
       type: { name: 'boolean', required: false },
       table: { defaultValue: { summary: false } },
     },
+    isTriggerElementFocusable: {
+      name: 'isTriggerElementFocusable',
+      description:
+        "Indique que l'élément passé dans le bloc triggerElement est déjà focusable nativement, pour ne pas ajouter de tabindex supplémentaire",
+      type: { name: 'boolean', required: false },
+      table: { defaultValue: { summary: false } },
+    },
   },
 };
 
@@ -66,6 +73,7 @@ const Template = (args) => {
   @isInline={{this.isInline}}
   @isWide={{this.isWide}}
   @hide={{this.hide}}
+  @isTriggerElementFocusable={{this.isTriggerElementFocusable}}
 >
   <:triggerElement>
     <PixButton aria-describedby={{this.id}}>

--- a/tests/integration/components/pix-tooltip-test.js
+++ b/tests/integration/components/pix-tooltip-test.js
@@ -58,6 +58,49 @@ module('Integration | Component | pix-tooltip', function (hooks) {
     assert.notOk(tooltipContentElement);
   });
 
+  module('trigger element tabindex', function () {
+    const TRIGGER_ELEMENT_SELECTOR = '.pix-tooltip__trigger-element';
+
+    test('it adds a tabindex to the trigger element by default', async function (assert) {
+      // when
+      await render(hbs`<PixTooltip>
+  <:triggerElement>
+    template block text
+  </:triggerElement>
+  <:tooltip>Some tooltip</:tooltip>
+</PixTooltip>`);
+
+      // then
+      assert.dom(TRIGGER_ELEMENT_SELECTOR).hasAttribute('tabindex', '0');
+    });
+
+    test('it does not add a tabindex to the trigger element when it is already focusable', async function (assert) {
+      // when
+      await render(hbs`<PixTooltip @isTriggerElementFocusable={{true}}>
+  <:triggerElement>
+    template block text
+  </:triggerElement>
+  <:tooltip>Some tooltip</:tooltip>
+</PixTooltip>`);
+
+      // then
+      assert.dom(TRIGGER_ELEMENT_SELECTOR).doesNotHaveAttribute('tabindex');
+    });
+
+    test('it adds a tabindex to the trigger element when isTriggerElementFocusable is false', async function (assert) {
+      // when
+      await render(hbs`<PixTooltip @isTriggerElementFocusable={{false}}>
+  <:triggerElement>
+    template block text
+  </:triggerElement>
+  <:tooltip>Some tooltip</:tooltip>
+</PixTooltip>`);
+
+      // then
+      assert.dom(TRIGGER_ELEMENT_SELECTOR).hasAttribute('tabindex', '0');
+    });
+  });
+
   test('it dismissed tooltip on escape keyup', async function (assert) {
     // given
     const screen = await render(hbs`<PixTooltip @position='bottom'>


### PR DESCRIPTION
## :christmas_tree: Problème
Le triggerElement de PixTooltip possède un tabindex à 0, en dur dans le code.
Dans le cas où le PixTooltip englobe un élément non sélectionnable ça a du sens, mais si ce dernier englobe un bouton, alors il y a une double tabulation à faire au clavier pour accéder au bouton.

## :gift: Proposition
Rendre ce tabindex optionnel avec un nouveau paramètre

## :star2: Remarques
Si on ne reseigne pas ce paramètre, alors le tabindex reste à 0 comme l'existant aujourd'hui, donc pas de risque de casser les PixTooltip présents dans les différentes app.

## :santa: Pour tester

j'ai mis le paramètre dans un PixTooltip ici https://app-pr16757.review.pix.fr/
Vérifier que la tabulation sur les émojis du drawer fonctionne