### PR TITLE
[FEATURE] Ajouter une variante wide au composant PixCard

### DIFF
--- a/addon/components/pix-card.gjs
+++ b/addon/components/pix-card.gjs
@@ -20,32 +20,38 @@ export default class PixCard extends Component {
 
     return value;
   }
+
+  get isWide() {
+    return this.args.wide ?? false;
+  }
   <template>
     <PixBlock @variant={{this.variant}} class="pix-card-wrapper">
-      <article class="pix-card">
+      <article class="pix-card {{if this.isWide 'pix-card--wide'}}">
         {{#if @image}}
           <div class="pix-card__image pix-card__image--{{this.variant}}">
             <img src={{@image}} aria-hidden="true" alt="" />
           </div>
         {{/if}}
-        {{#if (has-block "tag")}}
-          {{yield to="tag"}}
-        {{/if}}
-        <div class="pix-card__content">
-          <header>
-            <h3 class="pix-card__title pix-title-xs" title={{@title}}>{{@title}}</h3>
-            {{#if @subtitle}}
-              <p title={{@subtitle}} class="pix-card__subtitle pix-subtitle-xs">
-                {{@subtitle}}
-              </p>
+        <div class="pix-card__body">
+          {{#if (has-block "tag")}}
+            {{yield to="tag"}}
+          {{/if}}
+          <div class="pix-card__content">
+            <header>
+              <h3 class="pix-card__title pix-title-xxs" title={{@title}}>{{@title}}</h3>
+              {{#if @subtitle}}
+                <p title={{@subtitle}} class="pix-card__subtitle pix-subtitle-xxs">
+                  {{@subtitle}}
+                </p>
+              {{/if}}
+            </header>
+            {{#if (has-block "description")}}
+              <div class="pix-card__description pix-body-s">{{yield to="description"}}</div>
             {{/if}}
-          </header>
-          {{#if (has-block "description")}}
-            <div class="pix-card__description pix-body-s">{{yield to="description"}}</div>
-          {{/if}}
-          {{#if (has-block "footer")}}
-            <footer class="pix-card__footer pix-body-xs">{{yield to="footer"}}</footer>
-          {{/if}}
+            {{#if (has-block "footer")}}
+              <footer class="pix-card__footer pix-body-xs">{{yield to="footer"}}</footer>
+            {{/if}}
+          </div>
         </div>
       </article>
     </PixBlock>

--- a/addon/styles/_pix-card.scss
+++ b/addon/styles/_pix-card.scss
@@ -8,7 +8,20 @@
   gap: var(--pix-spacing-3x);
   align-items: flex-start;
 
+  &--wide {
+    flex-direction: row;
+    align-items: stretch;
+
+    .pix-card__image {
+      display: flex;
+      align-items: center;
+      height: auto;
+      overflow: hidden;
+    }
+  }
+
   &__image {
+    flex-shrink: 0;
     width: 76px;
     height: 76px;
     border-radius: var(--radius-3x, 12px);
@@ -22,11 +35,21 @@
     }
   }
 
+  &__body {
+    display: flex;
+    flex-direction: column;
+    flex-grow: 1;
+    gap: var(--pix-spacing-3x);
+    align-items: flex-start;
+    align-self: stretch;
+  }
+
   &__content {
     display: flex;
     flex-direction: column;
     flex-grow: 1;
     gap: var(--pix-spacing-2x);
+    align-self: stretch;
     color: var(--pix-neutral-900);
   }
 
@@ -49,5 +72,9 @@
   &__footer {
     margin-top: auto;
     color: var(--pix-neutral-500);
+  }
+
+  .pix-tag {
+    font-size: 0.75rem;
   }
 }

--- a/addon/styles/pix-design-tokens/_typography.scss
+++ b/addon/styles/pix-design-tokens/_typography.scss
@@ -170,6 +170,24 @@
   }
 }
 
+%pix-subtitle-xxs,
+.pix-subtitle-xxs {
+  @extend %-pix-subtitle;
+
+  --font-size-subtitle: 0.875rem;
+
+  font-size: var(--font-size-subtitle);
+  line-height: 1.5;
+
+  @include breakpoints.device-is('tablet') {
+    --font-size-subtitle: 0.875rem;
+  }
+
+  @include breakpoints.device-is('desktop') {
+    --font-size-subtitle: 1rem;
+  }
+}
+
 %-pix-body {
   font-weight: var(--pix-font-normal);
 

--- a/app/stories/pix-card.mdx
+++ b/app/stories/pix-card.mdx
@@ -11,6 +11,12 @@ Elle peut contenir un sous titre, un tag, un pied de carte
 
 <Story of={ComponentStories.Card} height={300} />
 
+### Wide
+
+Le contenu peut être affiché à droite de l'image en passant `@wide={{true}}`.
+
+<Story of={ComponentStories.WideCard} height={200} />
+
 ## Usage
 
 ```html
@@ -33,5 +39,7 @@ Elle peut contenir un sous titre, un tag, un pied de carte
 ```
 
 ## Arguments
+
+`@wide` (Boolean, optionnel) : lorsqu'il vaut `true`, l'image est affichée à gauche et le tag, le titre, le sous-titre, la description et le footer sont empilés verticalement à droite.
 
 <ArgTypes of={ComponentStories} />

--- a/app/stories/pix-card.stories.js
+++ b/app/stories/pix-card.stories.js
@@ -23,6 +23,7 @@ const Template = (args) => {
   @title={{this.title}}
   @subtitle={{this.subtitle}}
   @image={{this.image}}
+  @wide={{this.wide}}
 >
   <:tag><PixTag @color='green'>Parcours Apprenants</PixTag></:tag>
   <:description>
@@ -45,4 +46,10 @@ Card.args = {
   description:
     'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Fusce vestibulum nisl sapien, at viverra lorem facilisis in.',
   footer: '12 sujets • Accès sans compte',
+};
+
+export const WideCard = Template.bind({});
+WideCard.args = {
+  ...Card.args,
+  wide: true,
 };

--- a/docs/typography.mdx
+++ b/docs/typography.mdx
@@ -82,6 +82,12 @@ Des **placeholder SCSS** équivalents aux tokens de Figma sont disponibles. C'es
   >
     @extend %pix-subtitle-xs;
   </div>
+   <div
+      className="pix-subtitle-xxs pix-shadow-sm"
+      style={{ padding: 'var(--pix-spacing-4x)', margin: 'var(--pix-spacing-6x)' }}
+    >
+      @extend %pix-subtitle-xxs;
+    </div>
 </Unstyled>
 
 ### Corps de texte

--- a/tests/dummy/app/templates/index.hbs
+++ b/tests/dummy/app/templates/index.hbs
@@ -26,3 +26,33 @@
     </:footer>
   </PixCard>
 </div>
+<div>
+  <PixCard
+    @title="Nom du parcours"
+    @subtitle="Catégorie"
+    @image="https://assets.pix.org/sites/orga/profile-cible.png"
+    @wide="true"
+  >
+    <:tag><PixTag @color="blue">Profil cible</PixTag></:tag>
+    <:description>
+      <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
+    </:description>
+    <:footer>
+      <p>12 sujets • Accès sans compte</p>
+    </:footer>
+  </PixCard>
+  <PixCard
+    @title="Nom du parcours IA super long"
+    @subtitle="Catégorie"
+    @image="https://assets.pix.org/sites/orga/parcours-apprenant.png"
+    @wide="true"
+  >
+    <:tag><PixTag @color="green">Parcours apprenants</PixTag></:tag>
+    <:description>
+      <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
+    </:description>
+    <:footer>
+      <p>12 modules</p>
+    </:footer>
+  </PixCard>
+</div>


### PR DESCRIPTION
## :christmas_tree: Problème
Actuellement, le composant PixCard affiche tous les éléments qui le composent les uns à la suite des autres verticalement. Cependant, on a parfois besoin d'afficher ce composant hors d'une grille, et nous souhaitons dans ce cas, avoir l'image à gauche et le reste des éléments les uns après les autres verticalement sur la droite.

## :gift: Proposition
Ajouter une variante wide au composant PixCard

## :star2: Remarques
Fait avec Claude
