### PR TITLE
[BREAKING] Utiliser la balise native HTML dialog pour les modales (PIX-16294).

### DIFF
--- a/addon/components/pix-modal.gjs
+++ b/addon/components/pix-modal.gjs
@@ -36,15 +36,9 @@ export default class PixModal extends Component {
       @onClose={{@onCloseButtonClick}}
       @focusOnClose={{@focusOnClose}}
       @hasCenteredContent={{true}}
+      @labelledBy="modal-title--{{this.id}}"
     >
-      <div
-        class="pix-modal pix-modal--{{this.variant}}"
-        role="dialog"
-        aria-labelledby="modal-title--{{this.id}}"
-        aria-describedby="modal-content--{{this.id}}"
-        aria-modal="true"
-        ...attributes
-      >
+      <div class="pix-modal pix-modal--{{this.variant}}" ...attributes>
         <PixModalHeader
           @id="modal-title--{{this.id}}"
           @title={{@title}}
@@ -55,7 +49,7 @@ export default class PixModal extends Component {
           @onCloseButtonClick={{@onCloseButtonClick}}
         />
 
-        <div id="modal-content--{{this.id}}" class="pix-modal__content">
+        <div class="pix-modal__content">
           {{yield to="content"}}
         </div>
         <div class="pix-modal__footer">

--- a/addon/components/pix-overlay.gjs
+++ b/addon/components/pix-overlay.gjs
@@ -2,8 +2,7 @@ import { on } from '@ember/modifier';
 import { action } from '@ember/object';
 import Component from '@glimmer/component';
 
-import onEscapeAction from '../modifiers/on-escape-action';
-import trapFocus from '../modifiers/trap-focus';
+import modalDialog from '../modifiers/modal-dialog';
 
 export default class PixOverlay extends Component {
   @action
@@ -15,17 +14,41 @@ export default class PixOverlay extends Component {
     }
   }
 
+  /**
+   * A `<dialog>` cancel does not bubble, unlike an `<input type="file">` one when its picker is
+   * dismissed. Without `onClose`, the default action is kept so the user is not trapped inside.
+   */
+  @action
+  onCancel(event) {
+    const isCloseRequestOnOverlay = event.target === event.currentTarget;
+
+    if (!isCloseRequestOnOverlay || !this.args.onClose) {
+      return;
+    }
+
+    event.preventDefault();
+    this.args.onClose(event);
+  }
+
+  @action
+  onDialogClose(event) {
+    if (this.args.isVisible && this.args.onClose) {
+      this.args.onClose(event);
+    }
+  }
+
   <template>
-    <div
-      class="pix-overlay
-        {{unless @isVisible ' pix-overlay--hidden'}}
-        {{if @hasCenteredContent ' pix-overlay--with-centered-content'}}"
+    <dialog
+      class="pix-overlay {{if @hasCenteredContent ' pix-overlay--with-centered-content'}}"
+      aria-labelledby={{@labelledBy}}
+      aria-describedby={{@describedBy}}
       {{on "click" this.onClick}}
-      {{trapFocus @isVisible @focusOnClose}}
-      {{onEscapeAction @onClose}}
+      {{on "cancel" this.onCancel}}
+      {{on "close" this.onDialogClose}}
+      {{modalDialog @isVisible @focusOnClose}}
       ...attributes
     >
       {{yield}}
-    </div>
+    </dialog>
   </template>
 }

--- a/addon/components/pix-side-panel.gjs
+++ b/addon/components/pix-side-panel.gjs
@@ -36,16 +36,9 @@ export default class PixSidePanel extends Component {
       @isVisible={{@showSidePanel}}
       @onClose={{@onClose}}
       @focusOnClose={{@focusOnClose}}
+      @labelledBy="side-panel-title--{{this.id}}"
     >
-      <div
-        class="pix-side-panel pix-side-panel--{{this.variant}}
-          {{unless @showSidePanel ' pix-side-panel--hidden'}}"
-        role="dialog"
-        aria-labelledby="side-panel-title--{{this.id}}"
-        aria-describedby="side-panel-content--{{this.id}}"
-        aria-modal="true"
-        ...attributes
-      >
+      <div class="pix-side-panel pix-side-panel--{{this.variant}}" ...attributes>
         <PixModalHeader
           class="pix-side-panel__header"
           @id="side-panel-title--{{this.id}}"
@@ -56,7 +49,7 @@ export default class PixSidePanel extends Component {
           @onCloseButtonClick={{@onClose}}
         />
 
-        <div id="side-panel-content--{{this.id}}" class="pix-side-panel__content">
+        <div class="pix-side-panel__content">
           {{yield to="content"}}
         </div>
         <div class="pix-side-panel__footer pix-side-panel__footer--{{this.variant}}">

--- a/addon/modifiers/modal-dialog.js
+++ b/addon/modifiers/modal-dialog.js
@@ -1,0 +1,44 @@
+import { modifier } from 'ember-modifier';
+
+const SCROLL_LOCK_CLASS = 'pix-overlay-scroll-lock';
+
+const scrollLockingDialogs = new Set();
+
+function lockPageScrolling(element) {
+  scrollLockingDialogs.add(element);
+  document.body.classList.add(SCROLL_LOCK_CLASS);
+}
+
+function unlockPageScrolling(element) {
+  scrollLockingDialogs.delete(element);
+
+  if (scrollLockingDialogs.size === 0) {
+    document.body.classList.remove(SCROLL_LOCK_CLASS);
+  }
+}
+
+/**
+ * @param {boolean} isOpen
+ * @param {boolean} [focusOnClose=true]
+ */
+export default modifier(function modalDialog(element, [isOpen, focusOnClose = true]) {
+  if (isOpen) {
+    if (!element.open) {
+      element.showModal();
+    }
+
+    lockPageScrolling(element);
+  } else if (element.open) {
+    const hadFocusInside = element.contains(document.activeElement);
+
+    element.close();
+
+    if (focusOnClose === false && hadFocusInside) {
+      document.activeElement?.blur();
+    }
+  }
+
+  return () => {
+    unlockPageScrolling(element);
+  };
+});

--- a/addon/modifiers/trap-focus.js
+++ b/addon/modifiers/trap-focus.js
@@ -1,8 +1,15 @@
+import { warn } from '@ember/debug';
 import { modifier } from 'ember-modifier';
 
 let sourceActiveElement = null;
 
 export default modifier(function trapFocus(element, [isOpen, focusOnClose = true]) {
+  warn(
+    'trap-focus is deprecated: it only intercepts Tab, so it cannot keep the virtual cursor of a screen reader inside the element. Use PixModal, PixSidePanel or PixOverlay, which rely on a native <dialog> placed in the top layer.',
+    false,
+    { id: 'pix-ui.trap-focus.deprecated' },
+  );
+
   const [firstFocusableElement] = findFocusableElements(element);
 
   if (isOpen) {

--- a/addon/styles/_pix-modal.scss
+++ b/addon/styles/_pix-modal.scss
@@ -10,6 +10,11 @@
   background-color: var(--pix-neutral-0);
   border-radius: var(--pix-spacing-4x);
   transform: translateX(-50%);
+  animation: fade-out-modal 0.3s ease-out forwards;
+
+  .pix-overlay[open] & {
+    animation: fade-in-modal 0.3s ease-out forwards;
+  }
 
   &--default {
     @extend %pix-shadow-default;
@@ -49,5 +54,25 @@
       gap: var(--pix-spacing-4x);
       justify-content: flex-end;
     }
+  }
+}
+
+@keyframes fade-in-modal {
+  from {
+    opacity: 0;
+  }
+
+  to {
+    opacity: 1;
+  }
+}
+
+@keyframes fade-out-modal {
+  from {
+    opacity: 1;
+  }
+
+  to {
+    opacity: 0;
   }
 }

--- a/addon/styles/_pix-overlay.scss
+++ b/addon/styles/_pix-overlay.scss
@@ -1,19 +1,45 @@
 .pix-overlay {
   position: fixed;
   z-index: 1000;
+  width: 100%;
+  max-width: 100%;
+  height: 100%;
+  max-height: 100%;
+  margin: 0;
+  padding: 0;
   overflow-y: auto;
-  background-color: rgba(var(--pix-neutral-800-inline), 0.4);
-  transition: all 0.3s ease-in-out;
+  background-color: rgba(var(--pix-neutral-800-inline), 0);
+  border: none;
+  transition:
+    background-color 0.3s ease-out,
+    display 0.3s allow-discrete,
+    overlay 0.3s allow-discrete;
   inset: 0;
 
-  &--with-centered-content {
-    display: grid;
-    align-items: center;
-    padding-block: var(--pix-spacing-4x);
+  &::backdrop {
+    background-color: transparent;
   }
 
-  &--hidden {
-    visibility: hidden;
-    opacity: 0;
+  &[open] {
+    background-color: rgba(var(--pix-neutral-800-inline), 0.4);
   }
+
+  &--with-centered-content {
+    align-items: center;
+    padding-block: var(--pix-spacing-4x);
+
+    &[open] {
+      display: grid;
+    }
+  }
+
+  @starting-style {
+    &[open] {
+      background-color: rgba(var(--pix-neutral-800-inline), 0);
+    }
+  }
+}
+
+.pix-overlay-scroll-lock {
+  overflow: hidden;
 }

--- a/addon/styles/_pix-side-panel.scss
+++ b/addon/styles/_pix-side-panel.scss
@@ -3,7 +3,8 @@
 @use 'pix-design-tokens/shadows';
 
 .pix-side-panel__overlay {
-  overflow-x: hidden;
+  overflow: hidden; // fallback for Safari < 16, which ignores the clip value below
+  overflow: clip; // not a scroll container, so focus cannot scroll the sliding panel into place
 }
 
 .pix-side-panel {
@@ -16,15 +17,14 @@
   margin-left: auto;
   background: var(--pix-neutral-0);
   border-radius: var(--pix-spacing-4x) 0 0 var(--pix-spacing-4x);
-  transform: translate(0);
-  transition: transform 0.3s ease-in-out;
+  animation: slide-out-side-panel 0.3s ease-in-out forwards;
 
   @include breakpoints.device-is('tablet') {
     width: 412px;
   }
 
-  &--hidden {
-    transform: translate(100%);
+  .pix-overlay[open] & {
+    animation: slide-in-side-panel 0.3s ease-in-out forwards;
   }
 
   &--default {
@@ -82,5 +82,25 @@
     > ul {
       display: contents;
     }
+  }
+}
+
+@keyframes slide-in-side-panel {
+  from {
+    transform: translate(100%);
+  }
+
+  to {
+    transform: translate(0);
+  }
+}
+
+@keyframes slide-out-side-panel {
+  from {
+    transform: translate(0);
+  }
+
+  to {
+    transform: translate(100%);
   }
 }

--- a/addon/styles/addon.scss
+++ b/addon/styles/addon.scss
@@ -1,6 +1,8 @@
 @use 'pix-design-tokens';
 @use 'normalize-reset';
 @use 'a11y';
+@use 'trap-focus';
+@use 'pix-overlay';
 @use 'pix-icon';
 @use 'pix-background-header';
 @use 'pix-banner-alert';
@@ -37,7 +39,6 @@
 @use 'pix-checkbox';
 @use 'pix-segmented-control';
 @use 'pix-indicator-card';
-@use 'trap-focus';
 @use 'pix-search-input';
 @use 'pix-toast';
 @use 'toast-example';
@@ -48,7 +49,6 @@
 @use 'pix-app-layout';
 @use 'pix-structure-switcher';
 @use 'pix-code';
-@use 'pix-overlay';
 @use 'pix-tabs';
 @use 'pix-gauge';
 @use 'pix-stepper';

--- a/app/modifiers/modal-dialog.js
+++ b/app/modifiers/modal-dialog.js
@@ -1,0 +1,1 @@
+export { default } from '@1024pix/pix-ui/modifiers/modal-dialog';

--- a/app/stories/pix-overlay.stories.js
+++ b/app/stories/pix-overlay.stories.js
@@ -19,6 +19,20 @@ export default {
       control: { type: 'radio' },
       options: [true, false],
     },
+    labelledBy: {
+      name: 'labelledBy',
+      description:
+        "Identifiant de l'élément qui nomme l'overlay, repris dans son attribut aria-labelledby. Sans lui, l'overlay est annoncé sans nom par les lecteurs d'écran",
+      type: { name: 'string', required: true },
+      table: { type: { summary: 'string' } },
+    },
+    describedBy: {
+      name: 'describedBy',
+      description:
+        "Identifiant de l'élément qui décrit l'overlay, repris dans son attribut aria-describedby. À réserver à une description courte : les lecteurs d'écran aplatissent l'élément référencé en une seule chaîne annoncée d'un bloc, ce qui rend illisible un contenu structuré ou interactif",
+      type: { name: 'string', required: false },
+      table: { type: { summary: 'string' } },
+    },
     onClose: {
       name: 'onClose',
       description: "Callback déclenché à la fermeture de l'overlay",
@@ -27,8 +41,19 @@ export default {
 };
 
 export const overlay = (args) => ({
-  template: hbs`<PixOverlay @isVisible={{this.isVisible}} @hasCenteredContent={{this.hasCenteredContent}}>
-  Du contenu en dessous de l'overlay.
+  template: hbs`<PixOverlay
+  @isVisible={{this.isVisible}}
+  @hasCenteredContent={{this.hasCenteredContent}}
+  @labelledBy={{this.labelledBy}}
+  @describedBy={{this.describedBy}}
+>
+  <h1 id='overlay-title'>Titre de l'overlay</h1>
+  <p id='overlay-content'>Du contenu dans l'overlay.</p>
 </PixOverlay>`,
   context: args,
 });
+
+overlay.args = {
+  labelledBy: 'overlay-title',
+  describedBy: 'overlay-content',
+};

--- a/tests/helpers/wait-for.js
+++ b/tests/helpers/wait-for.js
@@ -4,12 +4,11 @@ import { waitUntil } from '@ember/test-helpers';
 export async function waitForDialog() {
   const screen = await getScreen();
 
-  await waitUntil(() => {
-    try {
-      screen.getByRole('dialog');
-      return true;
-    } catch {
-      return false;
-    }
-  });
+  await waitUntil(() => screen.queryAllByRole('dialog').length > 0);
+}
+
+export async function waitForDialogClose() {
+  const screen = await getScreen();
+
+  await waitUntil(() => screen.queryAllByRole('dialog').length === 0);
 }

--- a/tests/integration/components/pix-modal-test.gjs
+++ b/tests/integration/components/pix-modal-test.gjs
@@ -1,6 +1,6 @@
 import { render } from '@1024pix/ember-testing-library';
 import PixModal from '@1024pix/pix-ui/components/pix-modal';
-import { click, triggerKeyEvent } from '@ember/test-helpers';
+import { click, triggerEvent } from '@ember/test-helpers';
 import { setupRenderingTest } from 'ember-qunit';
 import { module, test } from 'qunit';
 import sinon from 'sinon';
@@ -61,7 +61,7 @@ module('Integration | Component | modal', function (hooks) {
       });
     });
 
-    module('when escape button is clicked', function () {
+    module('when the cancel event is triggered (escape key)', function () {
       test('it should call onClose function passed in argument', async function (assert) {
         // given
         const title = 'Close me baby one more time';
@@ -69,7 +69,7 @@ module('Integration | Component | modal', function (hooks) {
         const onCloseButtonClick = sinon.stub();
 
         // when
-        await render(
+        const screen = await render(
           <template>
             <PixModal
               @title={{title}}
@@ -80,7 +80,7 @@ module('Integration | Component | modal', function (hooks) {
             </PixModal>
           </template>,
         );
-        await triggerKeyEvent('.pix-modal', 'keyup', 'Escape');
+        await triggerEvent(screen.getByRole('dialog'), 'cancel');
 
         // then
         assert.ok(onCloseButtonClick.calledOnce);
@@ -136,9 +136,9 @@ module('Integration | Component | modal', function (hooks) {
         );
 
         // then
-        const modal = screen.getByRole('dialog', { name: 'Modal with no variant' });
+        const dialog = screen.getByRole('dialog', { name: 'Modal with no variant' });
 
-        assert.dom(modal).hasClass('pix-modal--default');
+        assert.dom(dialog.querySelector('.pix-modal')).hasClass('pix-modal--default');
       });
     });
 
@@ -163,9 +163,9 @@ module('Integration | Component | modal', function (hooks) {
         );
 
         // then
-        const modal = screen.getByRole('dialog', { name: 'Modal with "default" variant' });
+        const dialog = screen.getByRole('dialog', { name: 'Modal with "default" variant' });
 
-        assert.dom(modal).hasClass('pix-modal--default');
+        assert.dom(dialog.querySelector('.pix-modal')).hasClass('pix-modal--default');
       });
     });
 
@@ -190,9 +190,9 @@ module('Integration | Component | modal', function (hooks) {
         );
 
         // then
-        const modal = screen.getByRole('dialog', { name: 'Modal with "orga" variant' });
+        const dialog = screen.getByRole('dialog', { name: 'Modal with "orga" variant' });
 
-        assert.dom(modal).hasClass('pix-modal--orga');
+        assert.dom(dialog.querySelector('.pix-modal')).hasClass('pix-modal--orga');
       });
     });
 
@@ -217,9 +217,9 @@ module('Integration | Component | modal', function (hooks) {
         );
 
         // then
-        const modal = screen.getByRole('dialog', { name: 'Modal with "certif" variant' });
+        const dialog = screen.getByRole('dialog', { name: 'Modal with "certif" variant' });
 
-        assert.dom(modal).hasClass('pix-modal--certif');
+        assert.dom(dialog.querySelector('.pix-modal')).hasClass('pix-modal--certif');
       });
     });
   });

--- a/tests/integration/components/pix-overlay-test.js
+++ b/tests/integration/components/pix-overlay-test.js
@@ -1,23 +1,39 @@
 import { render } from '@1024pix/ember-testing-library';
-import { triggerEvent, triggerKeyEvent } from '@ember/test-helpers';
+import { click, settled, triggerEvent, waitUntil } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { setupRenderingTest } from 'ember-qunit';
 import { module, test } from 'qunit';
 import sinon from 'sinon';
 
+import { waitForDialogClose } from '../../helpers/wait-for';
+
 module('Integration | Component | Overlay', function (hooks) {
   setupRenderingTest(hooks);
 
   module('when isVisible is equal true', function () {
-    test('it renders the overlay', async function (assert) {
+    test('it shows the content to the user', async function (assert) {
       // when
-      await render(hbs`<PixOverlay @isVisible={{true}}>
+      const screen = await render(hbs`<PixOverlay @isVisible={{true}}>
   Main content
 </PixOverlay>`);
 
       // then
+      assert.ok(screen.getByRole('dialog'));
       assert.contains('Main content');
-      assert.dom('.pix-overlay--hidden').doesNotExist();
+    });
+
+    test('it keeps the focus inside the overlay when trying to reach the content behind it', async function (assert) {
+      // given
+      const screen = await render(hbs`<button type='button'>Behind the overlay</button>
+<PixOverlay @isVisible={{true}}>
+  <button type='button'>Inside the overlay</button>
+</PixOverlay>`);
+
+      // when
+      screen.getByRole('button', { name: 'Behind the overlay' }).focus();
+
+      // then
+      assert.true(screen.getByRole('dialog').contains(document.activeElement));
     });
 
     module('when overlay is clicked', function () {
@@ -26,26 +42,79 @@ module('Integration | Component | Overlay', function (hooks) {
         this.onCloseCallback = sinon.stub();
 
         // when
-        await render(hbs`<PixOverlay @isVisible={{true}} @onClose={{this.onCloseCallback}}>
+        const screen =
+          await render(hbs`<PixOverlay @isVisible={{true}} @onClose={{this.onCloseCallback}}>
   content
 </PixOverlay>`);
-        await triggerEvent('.pix-overlay', 'click');
+        await triggerEvent(screen.getByRole('dialog'), 'click');
 
         // then
         assert.ok(this.onCloseCallback.calledOnce);
       });
     });
 
-    module('when escape button is clicked', function () {
+    module('when the cancel event is triggered (escape key)', function () {
       test('it should call onClose function passed in argument', async function (assert) {
         // given
         this.onCloseCallback = sinon.stub();
 
         // when
-        await render(hbs`<PixOverlay @isVisible={{true}} @onClose={{this.onCloseCallback}}>
+        const screen =
+          await render(hbs`<PixOverlay @isVisible={{true}} @onClose={{this.onCloseCallback}}>
   content
 </PixOverlay>`);
-        await triggerKeyEvent('.pix-overlay', 'keyup', 'Escape');
+        await triggerEvent(screen.getByRole('dialog'), 'cancel');
+
+        // then
+        assert.ok(this.onCloseCallback.calledOnce);
+      });
+    });
+
+    module('when the user asks to close an overlay without an onClose function', function () {
+      test('it should not keep the user trapped inside the overlay', async function (assert) {
+        // given
+        const screen = await render(hbs`<PixOverlay @isVisible={{true}}>
+  Main content
+</PixOverlay>`);
+
+        // when
+        screen.getByRole('dialog').requestClose();
+        await waitForDialogClose();
+
+        // then
+        assert.notOk(screen.queryByRole('dialog'));
+      });
+    });
+
+    module('when the user dismisses the file picker of an upload field', function () {
+      test('it should not call onClose function passed in argument', async function (assert) {
+        // given
+        this.onCloseCallback = sinon.stub();
+        const screen =
+          await render(hbs`<PixOverlay @isVisible={{true}} @onClose={{this.onCloseCallback}}>
+  <input type='file' aria-label='Upload a file' />
+</PixOverlay>`);
+
+        // when
+        await triggerEvent(screen.getByLabelText('Upload a file'), 'cancel');
+
+        // then
+        assert.ok(this.onCloseCallback.notCalled);
+      });
+    });
+
+    module('when the browser closes the overlay on its own', function () {
+      test('it should call onClose function passed in argument', async function (assert) {
+        // given
+        this.onCloseCallback = sinon.stub();
+
+        // when
+        const screen =
+          await render(hbs`<PixOverlay @isVisible={{true}} @onClose={{this.onCloseCallback}}>
+  <form method='dialog'><button type='submit'>Submit</button></form>
+</PixOverlay>`);
+        await click(screen.getByRole('button', { name: 'Submit' }));
+        await waitUntil(() => this.onCloseCallback.called);
 
         // then
         assert.ok(this.onCloseCallback.calledOnce);
@@ -54,15 +123,85 @@ module('Integration | Component | Overlay', function (hooks) {
   });
 
   module('when isVisible is false', function () {
-    test('it does not display the overlay', async function (assert) {
+    test('it does not show the content to the user', async function (assert) {
       // when
-      await render(hbs`<PixOverlay @isVisible={{false}}>
+      const screen = await render(hbs`<PixOverlay @isVisible={{false}}>
   Main content
 </PixOverlay>`);
 
       // then
-      assert.contains('Main content');
-      assert.dom('.pix-overlay--hidden').exists();
+      assert.notOk(screen.queryByRole('dialog'));
+    });
+  });
+
+  module('when isVisible becomes false', function () {
+    test('it stops showing the content to the user', async function (assert) {
+      // given
+      this.isVisible = true;
+      const screen = await render(hbs`<PixOverlay @isVisible={{this.isVisible}}>
+  Main content
+</PixOverlay>`);
+
+      // when
+      this.set('isVisible', false);
+      await waitForDialogClose();
+
+      // then
+      assert.notOk(screen.queryByRole('dialog'));
+    });
+
+    test('it should not call onClose function passed in argument', async function (assert) {
+      // given
+      this.isVisible = true;
+      this.onCloseCallback = sinon.stub();
+      await render(hbs`<PixOverlay @isVisible={{this.isVisible}} @onClose={{this.onCloseCallback}}>
+  Main content
+</PixOverlay>`);
+
+      // when
+      this.set('isVisible', false);
+      await waitForDialogClose();
+
+      // then
+      assert.ok(this.onCloseCallback.notCalled);
+    });
+  });
+
+  module('when several overlays are stacked', function () {
+    test('it should keep the page behind locked while one of them is still open', async function (assert) {
+      // given
+      this.isFirstVisible = true;
+      await render(hbs`<PixOverlay @isVisible={{this.isFirstVisible}}>
+  First
+</PixOverlay>
+<PixOverlay @isVisible={{true}}>
+  Second
+</PixOverlay>`);
+
+      // when
+      this.set('isFirstVisible', false);
+      await settled();
+
+      // then
+      assert.strictEqual(getComputedStyle(document.body).overflowY, 'hidden');
+    });
+
+    test('it should let the user scroll the page again once all of them are closed', async function (assert) {
+      // given
+      this.areVisible = true;
+      await render(hbs`<PixOverlay @isVisible={{this.areVisible}}>
+  First
+</PixOverlay>
+<PixOverlay @isVisible={{this.areVisible}}>
+  Second
+</PixOverlay>`);
+
+      // when
+      this.set('areVisible', false);
+      await settled();
+
+      // then
+      assert.notStrictEqual(getComputedStyle(document.body).overflowY, 'hidden');
     });
   });
 });

--- a/tests/integration/components/pix-side-panel-test.gjs
+++ b/tests/integration/components/pix-side-panel-test.gjs
@@ -1,6 +1,6 @@
 import { render } from '@1024pix/ember-testing-library';
 import PixSidePanel from '@1024pix/pix-ui/components/pix-side-panel';
-import { click, triggerKeyEvent } from '@ember/test-helpers';
+import { click, triggerEvent } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { setupRenderingTest } from 'ember-qunit';
 import { module, test } from 'qunit';
@@ -33,6 +33,32 @@ module('Integration | Component | SidePanel', function (hooks) {
       assert.contains('footer');
     });
 
+    test('it should slide in from the right edge of the screen', async function (assert) {
+      // given
+      this.title = "It's a sidepanel!";
+
+      // when
+      const screen = await render(hbs`<PixSidePanel @title={{this.title}} @showSidePanel={{true}}>
+  <:content>
+    content
+  </:content>
+</PixSidePanel>`);
+      const title = screen.getByRole('heading', { name: this.title });
+      const leftOnOpening = title.getBoundingClientRect().left;
+      await Promise.all(
+        screen
+          .getByRole('dialog')
+          .getAnimations({ subtree: true })
+          .map((animation) => animation.finished),
+      );
+
+      // then
+      assert.true(
+        leftOnOpening > title.getBoundingClientRect().left,
+        'the side panel travels from the right edge instead of appearing in place',
+      );
+    });
+
     module('when close button is clicked', function () {
       test('it should call onClose function passed in argument', async function (assert) {
         // given
@@ -58,7 +84,7 @@ module('Integration | Component | SidePanel', function (hooks) {
       });
     });
 
-    module('when escape button is clicked', function () {
+    module('when the cancel event is triggered (escape key)', function () {
       test('it should call onClose function passed in argument', async function (assert) {
         // given
         const title = 'Close me baby one more time';
@@ -66,7 +92,7 @@ module('Integration | Component | SidePanel', function (hooks) {
         const onClose = sinon.stub();
 
         // when
-        await render(
+        const screen = await render(
           <template>
             <PixSidePanel @title={{title}} @onClose={{onClose}} @showSidePanel={{showSidePanel}}>
               <:content>
@@ -75,7 +101,7 @@ module('Integration | Component | SidePanel', function (hooks) {
             </PixSidePanel>
           </template>,
         );
-        await triggerKeyEvent('.pix-side-panel', 'keyup', 'Escape');
+        await triggerEvent(screen.getByRole('dialog'), 'cancel');
 
         // then
         assert.ok(onClose.calledOnce);
@@ -131,10 +157,10 @@ module('Integration | Component | SidePanel', function (hooks) {
         );
 
         // then
-        const sidePanel = screen.getByRole('dialog', { name: 'SidePanel with no variant' });
+        const dialog = screen.getByRole('dialog', { name: 'SidePanel with no variant' });
         const footer = this.element.querySelector('.pix-side-panel__footer');
 
-        assert.dom(sidePanel).hasClass('pix-side-panel--default');
+        assert.dom(dialog.querySelector('.pix-side-panel')).hasClass('pix-side-panel--default');
         assert.dom(footer).hasClass('pix-side-panel__footer--default');
       });
     });
@@ -160,10 +186,10 @@ module('Integration | Component | SidePanel', function (hooks) {
         );
 
         // then
-        const sidePanel = screen.getByRole('dialog', { name: 'SidePanel with default variant' });
+        const dialog = screen.getByRole('dialog', { name: 'SidePanel with default variant' });
         const footer = this.element.querySelector('.pix-side-panel__footer');
 
-        assert.dom(sidePanel).hasClass('pix-side-panel--default');
+        assert.dom(dialog.querySelector('.pix-side-panel')).hasClass('pix-side-panel--default');
         assert.dom(footer).hasClass('pix-side-panel__footer--default');
       });
     });
@@ -189,10 +215,10 @@ module('Integration | Component | SidePanel', function (hooks) {
         );
 
         // then
-        const sidePanel = screen.getByRole('dialog', { name: 'SidePanel with orga variant' });
+        const dialog = screen.getByRole('dialog', { name: 'SidePanel with orga variant' });
         const footer = this.element.querySelector('.pix-side-panel__footer');
 
-        assert.dom(sidePanel).hasClass('pix-side-panel--orga');
+        assert.dom(dialog.querySelector('.pix-side-panel')).hasClass('pix-side-panel--orga');
         assert.dom(footer).hasClass('pix-side-panel__footer--orga');
       });
     });
@@ -218,10 +244,10 @@ module('Integration | Component | SidePanel', function (hooks) {
         );
 
         // then
-        const sidePanel = screen.getByRole('dialog', { name: 'SidePanel with certif variant' });
+        const dialog = screen.getByRole('dialog', { name: 'SidePanel with certif variant' });
         const footer = this.element.querySelector('.pix-side-panel__footer');
 
-        assert.dom(sidePanel).hasClass('pix-side-panel--certif');
+        assert.dom(dialog.querySelector('.pix-side-panel')).hasClass('pix-side-panel--certif');
         assert.dom(footer).hasClass('pix-side-panel__footer--certif');
       });
     });

--- a/tests/integration/modifiers/on-escape-action-test.js
+++ b/tests/integration/modifiers/on-escape-action-test.js
@@ -13,8 +13,10 @@ module('Integration | Modifier | on-escape-action', function (hooks) {
     this.onCloseCallback = sinon.stub();
 
     // when
-    await render(hbs`<PixOverlay @onClose={{this.onCloseCallback}}>content</PixOverlay>`);
-    await triggerKeyEvent('.pix-overlay', 'keyup', 'Escape');
+    await render(
+      hbs`<div class='escapable' {{on-escape-action this.onCloseCallback}}>content</div>`,
+    );
+    await triggerKeyEvent('.escapable', 'keyup', 'Escape');
 
     // then
     assert.ok(this.onCloseCallback.calledOnce);


### PR DESCRIPTION
## :boom: BREAKING_CHANGES

- **PixOverlay** rend désormais une balise `<dialog>` native ouverte par `showModal()` ➕ le `role="dialog"`, `aria-modal` et le nom accessible changent d'élément HTML de référence en passant de la div interne au `<dialog>`.
- `aria-describedby` disparaît de **PixModal** et **PixSidePanel**.

## :christmas_tree: Problème

### Bug remonté sur la Sidebar (et même chose sur la Modal)

La **navigation aux flèches via lecteur d'écran** (VoiceOver) **sont capables de sortir** de la Sidebar/Modal contrairement au "tab".

Probablement que ce n'est pas géré par notre [focus trap](https://github.com/1024pix/pix-ui/blob/dev/app/modifiers/trap-focus.js).

## :gift: Proposition

Utiliser la balise HTML `dialog` qui gère l'**accessibilité** et les **interactions clavier** (flêches, tab, echap) des modales **de façon native**.

> Cela n'était pas fait avant car nous supportons les navigateurs datés de 3 ans max.
> Cette balise est [disponible depuis juillet 2022](https://developer.mozilla.org/fr/docs/Web/HTML/Reference/Elements/dialog#compatibilit%C3%A9_des_navigateurs), ce qui est maintenant largement suffisant.

Pour ce qui est des **animations** : les animations reposent sur `@starting-style`, qui est une fonctionnalité CSS plus récente.
Mais ce n'est pas critique si elles ne fonctionnent pas pour de vieux navigateurs.


## :star2: Remarques

Ce changement permet de passer le modifier `trap-focus` en **deprecated**.

## :santa: Pour tester

Tester le bon fonctionnement de :
- [PixModal](https://pix-ui-review-pr1021.osc-fr1.scalingo.io/?path=/docs/overlay-modal--docs)
- [PixSidePanel](https://pix-ui-review-pr1021.osc-fr1.scalingo.io/?path=/docs/navigation-sidepanel--docs)
