### PR TITLE
[BUGFIX] Afficher les arrondis du PixTable sur Firefox (PIX-16850).

### DIFF
--- a/addon/components/pix-table.gjs
+++ b/addon/components/pix-table.gjs
@@ -10,6 +10,7 @@ import PixBlock from './pix-block';
 export default class PixTable extends Component {
   get variant() {
     const value = this.args.variant ?? 'primary';
+
     warn(
       `PixTable: @variant "${value}" should be ${VARIANTS.join(', ')}`,
       VARIANTS.includes(value),
@@ -25,11 +26,11 @@ export default class PixTable extends Component {
     warn(`PixTable: @caption is required`, Boolean(this.args.caption), {
       id: 'pix-ui.pix-table.caption.required',
     });
+
     return this.args.caption;
   }
 
   get tableClass() {
-    const tableClass = ['pix-table'];
     warn(
       'PixTable: @condensed must be a boolean, default undefined',
       [true, false, undefined].includes(this.args.condensed),
@@ -37,15 +38,14 @@ export default class PixTable extends Component {
         id: 'pix-ui.pix-table.condensed.not-boolean',
       },
     );
-    if (this.args.condensed) {
-      tableClass.push('pix-table--condensed');
-    }
 
+    const tableClass = ['pix-table'];
+    if (this.args.condensed) tableClass.push('pix-table--condensed');
     return tableClass.join(' ');
   }
 
   get headerClass() {
-    return `pix-table-header--${this.variant}`;
+    return `pix-table-header pix-table-header--${this.variant}`;
   }
 
   get captionClass() {
@@ -59,6 +59,7 @@ export default class PixTable extends Component {
   @action
   onClick(row, event) {
     event.stopPropagation();
+
     if (this.hasOnRowClick) {
       this.args.onRowClick(row);
     }

--- a/addon/styles/_pix-table.scss
+++ b/addon/styles/_pix-table.scss
@@ -2,6 +2,8 @@
 @use "pix-design-tokens/typography";
 
 .pix-table {
+  @extend %pix-body-s;
+
   min-width: 100%;
   overflow: auto;
 
@@ -9,106 +11,98 @@
     overflow: unset;
   }
 
-  @extend %pix-body-s;
-
-  &__caption {
-    margin-bottom: var(--pix-spacing-3x);
-    text-align: left;
-    caption-side: top;
-
-    @extend %pix-title-xxs;
-  }
-
-  &__clickable-row {
-    cursor: pointer;
-
-    &:hover, &:focus, &:active {
-      transition: 0.25s ease;
-    }
-
-    &:hover {
-      background-color: rgba(var(--pix-neutral-100-inline), 0.50);
-    }
-
-    &:focus {
-      background-color: rgba(var(--pix-neutral-100-inline), 0.40);
-    }
-
-    &:active {
-      background-color: rgba(var(--pix-neutral-100-inline), 0.75);
-    }
-  }
-
   table {
     width: 100%;
     border-collapse: collapse;
   }
 
-   tbody > tr:nth-of-type(even):not(.pix-table__clickable-row:hover, .pix-table__clickable-row:focus, .pix-table__clickable-row:active) {
-      background-color: rgba(var(--pix-neutral-20-inline), 0.80);
+  tbody > tr:nth-of-type(even):not(.pix-table__clickable-row:hover, .pix-table__clickable-row:focus, .pix-table__clickable-row:active) {
+    background-color: rgba(var(--pix-neutral-20-inline), 0.80);
+  }
+
+  th[scope='col'] {
+    font-weight: var(--pix-font-bold);
+    text-align: start;
+    vertical-align: middle;
+  }
+
+  th[scope='row'] {
+    font-weight: var(--pix-font-normal);
+  }
+
+  td, th {
+    padding: var(--pix-spacing-4x);
+
+    &:first-child {
+      border-radius: var(--pix-spacing-2x) 0 0 var(--pix-spacing-2x);
     }
 
-    thead.pix-table-header {
-      &--primary {
-        background: var(--pix-primary-10);
-      }
-
-      &--orga {
-        background: var(--pix-orga-50);
-      }
-
-      &--certif {
-        background: var(--pix-certif-50);
-      }
-
-      &--admin {
-        background: var(--pix-primary-100);
-      }
-    }
-
-    .pix-table-header-container {
-      display: flex;
-      gap: var(--pix-spacing-1x);
-      align-items: center;
-    }
-
-    th[scope='col'] {
-      font-weight: var(--pix-font-bold);
-      text-align: start;
-      vertical-align: middle;
-    }
-
-    th[scope='row'] {
-      font-weight: var(--pix-font-normal);
-    }
-
-
-    td, th {
-      padding: var(--pix-spacing-4x) var(--pix-spacing-4x);
-
-      &:first-child {
-        border-radius: var(--pix-spacing-2x) 0 0 var(--pix-spacing-2x);
-      }
-
-      &:last-child {
-        border-radius: 0 var(--pix-spacing-2x) var(--pix-spacing-2x) 0;
-      }
-    }
-
-  &--condensed {
-    th, td {
-      padding: .5rem var(--pix-spacing-4x);
-    }
-
-    td.pix-table-column--tag {
-        padding-top: 0.375rem;
-        padding-bottom: 0.375rem;
-    }
-
-    td.pix-table-column--link {
-      padding-top: 0.375rem;
-      padding-bottom: 0.375rem;
+    &:last-child {
+      border-radius: 0 var(--pix-spacing-2x) var(--pix-spacing-2x) 0;
     }
   }
 }
 
+.pix-table--condensed {
+  th, td {
+    padding: 0.5rem var(--pix-spacing-4x);
+  }
+
+  td.pix-table-column--tag,
+  td.pix-table-column--link {
+    padding-top: 0.375rem;
+    padding-bottom: 0.375rem;
+  }
+}
+
+.pix-table-header {
+  &--primary {
+    background: var(--pix-primary-10);
+  }
+
+  &--orga {
+    background: var(--pix-orga-50);
+  }
+
+  &--certif {
+    background: var(--pix-certif-50);
+  }
+
+  &--admin {
+    background: var(--pix-primary-100);
+  }
+}
+
+.pix-table-header-container {
+  display: flex;
+  gap: var(--pix-spacing-1x);
+  align-items: center;
+}
+
+.pix-table__caption {
+  margin-bottom: var(--pix-spacing-3x);
+  text-align: left;
+  caption-side: top;
+
+  @extend %pix-title-xxs;
+}
+
+.pix-table__clickable-row {
+  cursor: pointer;
+
+  &:hover, &:focus, &:active {
+    transition: 0.25s ease;
+  }
+
+  &:hover {
+    background-color: rgba(var(--pix-neutral-100-inline), 0.50);
+  }
+
+  &:focus {
+    background-color: rgba(var(--pix-neutral-100-inline), 0.40);
+  }
+
+  &:active {
+    background-color: rgba(var(--pix-neutral-100-inline), 0.75);
+  }
+}

--- a/addon/styles/_pix-table.scss
+++ b/addon/styles/_pix-table.scss
@@ -16,36 +16,48 @@
     border-collapse: collapse;
   }
 
-  tbody > tr:nth-of-type(even):not(.pix-table__clickable-row:hover, .pix-table__clickable-row:focus, .pix-table__clickable-row:active) {
+  tbody > tr:nth-of-type(even) > :is(td, th) {
     background-color: rgba(var(--pix-neutral-20-inline), 0.80);
   }
 
-  th[scope='col'] {
-    font-weight: var(--pix-font-bold);
-    text-align: start;
-    vertical-align: middle;
-  }
+  tbody > tr.pix-table__clickable-row {
+    cursor: pointer;
 
-  th[scope='row'] {
-    font-weight: var(--pix-font-normal);
+    & > :is(td, th) {
+      transition: background-color 0.25s ease;
+    }
+
+    &:hover > :is(td, th) {
+      background-color: rgba(var(--pix-neutral-100-inline), 0.50);
+    }
+
+    &:focus > :is(td, th) {
+      background-color: rgba(var(--pix-neutral-100-inline), 0.40);
+    }
+
+    &:active > :is(td, th) {
+      background-color: rgba(var(--pix-neutral-100-inline), 0.75);
+    }
   }
 
   td, th {
     padding: var(--pix-spacing-4x);
 
     &:first-child {
-      border-radius: var(--pix-spacing-2x) 0 0 var(--pix-spacing-2x);
+      border-top-left-radius: var(--pix-spacing-2x);
+      border-bottom-left-radius: var(--pix-spacing-2x);
     }
 
     &:last-child {
-      border-radius: 0 var(--pix-spacing-2x) var(--pix-spacing-2x) 0;
+      border-top-right-radius: var(--pix-spacing-2x);
+      border-bottom-right-radius: var(--pix-spacing-2x);
     }
   }
 }
 
 .pix-table--condensed {
   th, td {
-    padding: 0.5rem var(--pix-spacing-4x);
+    padding: var(--pix-spacing-2x) var(--pix-spacing-4x);
   }
 
   td.pix-table-column--tag,
@@ -56,20 +68,30 @@
 }
 
 .pix-table-header {
-  &--primary {
+  &--primary th {
     background: var(--pix-primary-10);
   }
 
-  &--orga {
+  &--orga th {
     background: var(--pix-orga-50);
   }
 
-  &--certif {
+  &--certif th {
     background: var(--pix-certif-50);
   }
 
-  &--admin {
+  &--admin th {
     background: var(--pix-primary-100);
+  }
+
+  th[scope='col'] {
+    font-weight: var(--pix-font-bold);
+    text-align: start;
+    vertical-align: middle;
+  }
+
+  th[scope='row'] {
+    font-weight: var(--pix-font-normal);
   }
 }
 
@@ -85,24 +107,4 @@
   caption-side: top;
 
   @extend %pix-title-xxs;
-}
-
-.pix-table__clickable-row {
-  cursor: pointer;
-
-  &:hover, &:focus, &:active {
-    transition: 0.25s ease;
-  }
-
-  &:hover {
-    background-color: rgba(var(--pix-neutral-100-inline), 0.50);
-  }
-
-  &:focus {
-    background-color: rgba(var(--pix-neutral-100-inline), 0.40);
-  }
-
-  &:active {
-    background-color: rgba(var(--pix-neutral-100-inline), 0.75);
-  }
 }

--- a/app/stories/pix-table.mdx
+++ b/app/stories/pix-table.mdx
@@ -9,6 +9,7 @@ import * as ComponentStories from './pix-table.stories';
 Une table qui prend en argument des data et en `block content` des [PixTableColumn](/docs/data-display-table-tablecolumn--docs).
 
 ## Exemple basique
+
 <Story of={ComponentStories.Default} height={400} />
 
 ```html
@@ -43,7 +44,7 @@ Une table qui prend en argument des data et en `block content` des [PixTableColu
         Tag
       </:header>
       <:cell>
-        <PixTag>{{row.tag}}</PixTag
+        <PixTag>{{row.tag}}</PixTag>
       </:cell>
     </PixTableColumn>
   </:columns>
@@ -51,6 +52,38 @@ Une table qui prend en argument des data et en `block content` des [PixTableColu
 <style>
   .table__column--wide { width: 300px; }
 </style>
+```
+
+## Mode condensé
+
+`@condensed={{true}}` réduit le padding vertical des cellules, pour les tables à forte densité de données.
+
+<Story of={ComponentStories.Condensed} height={400} />
+
+```html
+<PixTable @data={{this.data}} @caption={{this.caption}} @condensed={{true}}>
+  <:columns as |row context|>
+    {{! ... colonnes ... }}
+  </:columns>
+</PixTable>
+```
+
+## Ligne cliquable
+
+`@onRowClick` pose un gestionnaire de clic sur le `<tr>` de chaque ligne et reçoit en paramètre l'objet complet de la ligne. Les lignes prennent alors un curseur `pointer` et un fond au survol.
+
+> **⚠️ `@onRowClick` seul n'est pas accessible au clavier** : le `<tr>` n'est ni focusable ni activable au clavier.
+>
+> **Pour une action principale, place un vrai lien ou bouton dans une cellule (voir le variant `link` de [PixTableColumn](/docs/data-display-table-tablecolumn--docs)) et réserve `@onRowClick` au confort de la souris.**
+
+<Story of={ComponentStories.ClickableRow} height={400} />
+
+```html
+<PixTable @data={{this.data}} @caption={{this.caption}} @onRowClick={{this.goToDetail}}>
+  <:columns as |row context|>
+    {{! ... colonnes ... }}
+  </:columns>
+</PixTable>
 ```
 
 ## Arguments

--- a/app/stories/pix-table.stories.js
+++ b/app/stories/pix-table.stories.js
@@ -1,3 +1,4 @@
+import { action } from '@storybook/addon-actions';
 import { hbs } from 'ember-cli-htmlbars';
 
 import { VARIANTS } from '../../addon/helpers/variants.js';
@@ -69,6 +70,7 @@ const Template = (args) => {
   @caption={{this.caption}}
   @displayCaption={{this.displayCaption}}
   @condensed={{this.condensed}}
+  @onRowClick={{this.onRowClick}}
 >
   <:columns as |row context|>
     <PixTableColumn @context={{context}} @type='text'>
@@ -134,4 +136,16 @@ Default.args = {
   onNameSort: () => {
     alert('Fonctionnalité seulement disponible en local sur dummy');
   },
+};
+
+export const Condensed = Template.bind({});
+Condensed.args = {
+  ...Default.args,
+  condensed: true,
+};
+
+export const ClickableRow = Template.bind({});
+ClickableRow.args = {
+  ...Default.args,
+  onRowClick: action('onRowClick'),
 };

--- a/tests/integration/components/pix-table-test.js
+++ b/tests/integration/components/pix-table-test.js
@@ -119,7 +119,7 @@ module('Integration | Component | table', function (hooks) {
       // then
       assert.strictEqual(
         this.element.querySelector('thead').getAttribute('class'),
-        `pix-table-header--${variant}`,
+        `pix-table-header pix-table-header--${variant}`,
       );
     });
   });


### PR DESCRIPTION
## :christmas_tree: Problème

Les arrondis du PixTable ne s'affichent pas sur Firefox.

## :gift: Proposition

Gérer les arrondis au niveau des tag de cellules pour bien les voir sur Firefox.

## :star2: Remarques

On en profite pour nettoyer un peu le fichier de style et pour avoir plus de cas dans les stories.

## :santa: Pour tester

Avec les différents navigateurs, visualiser le composant [sur Storybook](https://pix-ui-review-pr1022.osc-fr1.scalingo.io/?path=/docs/data-display-table--docs).
