### PR TITLE
[FEATURE] Créer le composant PixToggle (PIX-15778).

### DIFF
--- a/addon/components/pix-toggle.gjs
+++ b/addon/components/pix-toggle.gjs
@@ -1,0 +1,82 @@
+import { warn } from '@ember/debug';
+import { on } from '@ember/modifier';
+import { action } from '@ember/object';
+import { guidFor } from '@ember/object/internals';
+import Component from '@glimmer/component';
+import { eq } from 'ember-truth-helpers';
+
+import PixIcon from './pix-icon';
+import PixLabel from './pix-label';
+
+export default class PixToggle extends Component {
+  get id() {
+    return this.args.id || guidFor(this);
+  }
+
+  get cssClasses() {
+    const classes = ['pix-toggle'];
+
+    if (this.args.size) {
+      classes.push(`${classes[0]}--${this.args.size}`);
+    }
+
+    if (this.args.class) {
+      classes.push(this.args.class);
+    }
+
+    return classes.join(' ');
+  }
+
+  get isDisabled() {
+    warn(
+      'PixToggle: @isDisabled attribute should be a boolean.',
+      [true, false, undefined, null].includes(this.args.isDisabled),
+      {
+        id: 'pix-ui.toggle.is-disabled.not-boolean',
+      },
+    );
+
+    return this.args.isDisabled ? 'true' : null;
+  }
+
+  @action
+  avoidCheckedStateChangeIfIsDisabled(event) {
+    if (this.isDisabled) {
+      event.preventDefault();
+    }
+  }
+
+  <template>
+    <PixLabel
+      class={{this.cssClasses}}
+      for={{this.id}}
+      @size={{if (eq @size "large") "large" "small"}}
+      @inlineLabel={{true}}
+      @isDisabled={{this.isDisabled}}
+    >
+      {{#if (has-block)}}
+        <span class="pix-toggle__label">
+          {{yield}}
+        </span>
+      {{/if}}
+      <span class="pix-toggle__input">
+        {{! template-lint-disable require-mandatory-role-attributes }}
+        {{! Native checkbox checkedness conveys the switch state; aria-checked would be redundant and unreliable }}
+        <input
+          class="pix-toggle-input__checkbox"
+          role="switch"
+          type="checkbox"
+          id={{this.id}}
+          checked={{@checked}}
+          aria-disabled={{this.isDisabled}}
+          {{on "click" this.avoidCheckedStateChangeIfIsDisabled}}
+          ...attributes
+        />
+        <span class="pix-toggle-input__thumb">
+          <PixIcon class="pix-toggle-input__icon--checked" @name="check" @ariaHidden={{true}} />
+          <PixIcon class="pix-toggle-input__icon--unchecked" @name="close" @ariaHidden={{true}} />
+        </span>
+      </span>
+    </PixLabel>
+  </template>
+}

--- a/addon/styles/_pix-toggle.scss
+++ b/addon/styles/_pix-toggle.scss
@@ -1,0 +1,107 @@
+.pix-toggle {
+  --thumb-width: 1rem;
+
+  display: inline-block;
+  cursor: pointer;
+
+  &--large {
+    --thumb-width: 1.375rem;
+  }
+
+  &:has(:disabled),
+  &:has([aria-disabled='true']) {
+    cursor: not-allowed;
+  }
+}
+
+.pix-toggle__label {
+  margin-right: var(--pix-spacing-4x);
+  font-weight: var(--pix-font-bold);
+  vertical-align: middle;
+}
+
+.pix-toggle__input {
+  position: relative;
+  display: inline-block;
+  width: calc(var(--thumb-width) * 2.375);
+  color: var(--pix-neutral-500);
+  vertical-align: middle;
+  background-color: currentcolor;
+  border: 2px solid currentcolor;
+  border-radius: 5rem;
+  outline: 1px solid transparent;
+  transition: outline-color 0.2s ease-in-out, background-color 0.2s ease-in-out;
+
+  &:has(:checked) {
+    color: var(--pix-primary-500);
+
+    .pix-toggle-input__thumb {
+      transform: translateX(calc(137.5% - 4px));
+    }
+
+    .pix-toggle-input__icon--checked {
+      display: block;
+    }
+
+    .pix-toggle-input__icon--unchecked {
+      display: none;
+    }
+  }
+
+  &:not(:has(:disabled), :has([aria-disabled='true'])) {
+    &:hover,
+    &:has(:focus) {
+      color: var(--pix-neutral-800);
+    }
+
+    &:has(:checked):hover,
+    &:has(:checked):has(:focus) {
+      color: var(--pix-primary-700);
+    }
+  }
+
+  &:has(:focus) {
+    outline-color: currentcolor;
+    outline-offset: 1px;
+  }
+
+  // Disabled state
+  &:has(:disabled),
+  &:has([aria-disabled='true']) {
+    color: var(--pix-neutral-100);
+
+    &:has(:checked) {
+      color: var(--pix-primary-300);
+    }
+
+    &:has(:focus) {
+      outline-color: var(--pix-neutral-800);
+    }
+  }
+}
+
+.pix-toggle-input__checkbox {
+  position: absolute;
+  cursor: pointer;
+  opacity: 0;
+  inset: 0;
+}
+
+.pix-toggle-input__thumb {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: var(--thumb-width);
+  height: var(--thumb-width);
+  background-color: var(--pix-neutral-0);
+  border-radius: 50%;
+  transition: transform 0.2s ease-in-out;
+
+  svg {
+    transform: scale(0.8);
+  }
+}
+
+.pix-toggle-input__icon--checked {
+  display: none;
+}

--- a/addon/styles/addon.scss
+++ b/addon/styles/addon.scss
@@ -54,6 +54,7 @@
 @use 'pix-stepper';
 @use 'pix-card';
 @use 'pix-accordions-v2';
+@use 'pix-toggle';
 
 // at the end so it can override it's children scss
 @use 'pix-filterable-and-searchable-select';

--- a/app/components/pix-toggle.js
+++ b/app/components/pix-toggle.js
@@ -1,0 +1,1 @@
+export { default } from '@1024pix/pix-ui/components/pix-toggle';

--- a/app/stories/pix-toggle.mdx
+++ b/app/stories/pix-toggle.mdx
@@ -1,0 +1,52 @@
+import { Meta, Story, ArgTypes } from '@storybook/blocks';
+
+import * as ComponentStories from './pix-toggle.stories';
+
+<Meta of={ComponentStories} />
+
+# PixToggle
+
+Le PixToggle est un interrupteur : il permet à l'utilisateur d'activer ou de désactiver un réglage, dont l'effet est immédiat et ne nécessite pas de validation.
+
+Si le réglage n'est appliqué qu'après la soumission d'un formulaire, utiliser une [PixCheckbox](?path=/docs/forms-checkbox--docs) à la place.
+
+Le composant repose sur une case à cocher native portant le rôle `switch`, son label est cliquable et il est activable au clavier avec la barre d'espace.
+
+<Story of={ComponentStories.Default} height={60} />
+
+## États du Toggle
+
+L'état d'activation est piloté par le consommateur via `@checked` : le composant ne le mémorise pas. Il faut donc écouter l'évènement `change` pour le mettre à jour.
+
+L'attribut `@isDisabled` désactive le toggle en conservant la possibilité de naviguer avec le clavier ou le lecteur d'écran. Il est préféré à l'attribut natif `disabled` qui empêche ces usages.
+
+## Tailles
+
+<Story of={ComponentStories.sizes} height={120} />
+
+## Accessibilité
+
+Le label est facultatif. Lorsqu'aucun label visible n'est passé en bloc, il est impératif de nommer le toggle avec un `aria-label`, sans quoi il est inutilisable au lecteur d'écran.
+
+```html
+<PixToggle aria-label="Recevoir la newsletter" />
+```
+
+## Usage
+
+Tout attribut passé au composant (`aria-label`, `data-*`, modifieur `{{on "change"}}`, ...) est appliqué à la case à cocher.
+
+```html
+<PixToggle
+  @checked={{this.isSubscribedToNewsletter}}
+  @size="large"
+  @isDisabled={{false}}
+  {{on "change" this.toggleNewsletterSubscription}}
+>
+  Recevoir la newsletter
+</PixToggle>
+```
+
+## Arguments
+
+<ArgTypes />

--- a/app/stories/pix-toggle.stories.js
+++ b/app/stories/pix-toggle.stories.js
@@ -1,0 +1,94 @@
+import { hbs } from 'ember-cli-htmlbars';
+
+export default {
+  title: 'Forms/Toggle',
+  tags: ['new'],
+  argTypes: {
+    label: {
+      name: 'label',
+      description:
+        'Le label du composant, passé en bloc. Si aucun label visible n’est passé, un `aria-label` doit être fourni au composant.',
+      type: { name: 'string', required: false },
+      table: {
+        type: { summary: 'string' },
+      },
+    },
+    checked: {
+      name: 'checked',
+      description: 'Permet d’activer le toggle',
+      type: { name: 'boolean', required: false },
+      table: {
+        type: { summary: 'boolean' },
+        defaultValue: { summary: false },
+      },
+    },
+    isDisabled: {
+      name: 'isDisabled',
+      description:
+        'Permet de désactiver le toggle tout en le laissant accessible au clavier et aux lecteurs d’écran',
+      type: { name: 'boolean', required: false },
+      table: {
+        type: { summary: 'boolean' },
+        defaultValue: { summary: false },
+      },
+    },
+    size: {
+      name: 'size',
+      description: 'Correspond à la taille du toggle et de la police de son label.',
+      type: { name: 'string', required: false },
+      table: {
+        type: { summary: 'string' },
+        defaultValue: { summary: 'null' },
+      },
+      control: { type: 'select' },
+      options: ['small', 'large'],
+    },
+    id: {
+      name: 'id',
+      description:
+        'Identifiant du champ permettant de lui attacher son label. Généré automatiquement si non renseigné.',
+      type: { name: 'string', required: false },
+      table: {
+        type: { summary: 'string' },
+      },
+    },
+    class: {
+      name: 'class',
+      description: 'Permet d’ajouter une classe au parent du composant.',
+      type: { name: 'string', required: false },
+      table: {
+        type: { summary: 'string' },
+      },
+    },
+  },
+};
+
+const Template = (args) => {
+  return {
+    template: hbs`<PixToggle
+  @id={{this.id}}
+  @class={{this.class}}
+  @checked={{this.checked}}
+  @isDisabled={{this.isDisabled}}
+  @size={{this.size}}
+>{{this.label}}</PixToggle>`,
+    context: args,
+  };
+};
+
+const SizesTemplate = (args) => {
+  return {
+    template: hbs`<PixToggle @id='toggle-small' @checked={{true}}>Taille par défaut</PixToggle>
+<br />
+<br />
+<PixToggle @id='toggle-large' @size='large' @checked={{true}}>@size="large"</PixToggle>`,
+    context: args,
+  };
+};
+
+export const Default = Template.bind({});
+Default.args = {
+  label: 'Recevoir la newsletter',
+};
+
+export const sizes = SizesTemplate.bind({});

--- a/tests/dummy/app/templates/checkbox-page.hbs
+++ b/tests/dummy/app/templates/checkbox-page.hbs
@@ -1,4 +1,20 @@
 <div>
+  <h2>Switch / Toggle</h2>
+
+  <PixToggle />
+  <PixToggle @checked={{true}} />
+
+  <PixToggle @size="large" />
+  <PixToggle @checked={{true}} @size="large" />
+
+  <PixToggle>Label</PixToggle>
+  <PixToggle @checked={{true}}>Label</PixToggle>
+
+  <PixToggle @size="large" @isDisabled={{true}}>Label</PixToggle>
+  <PixToggle @checked={{true}} @size="large" @isDisabled={{true}}>Label</PixToggle>
+
+  <hr />
+
   <h2>Etat activé</h2>
   <PixCheckbox @variant="modulix" @state="neutral">
     <:label>Proposition variant Modulix, état neutral</:label>
@@ -7,6 +23,8 @@
   <PixCheckbox @variant="modulix" @state="declarative">
     <:label>Proposition variant Modulix, état déclaratif</:label>
   </PixCheckbox>
+
+  <hr />
 
   <h2>Etat désactivé (après soumission)</h2>
   <PixCheckbox @variant="modulix" @state="neutral" @isDisabled="true">

--- a/tests/integration/components/pix-toggle-test.gjs
+++ b/tests/integration/components/pix-toggle-test.gjs
@@ -1,0 +1,336 @@
+import { render } from '@1024pix/ember-testing-library';
+import PixToggle from '@1024pix/pix-ui/components/pix-toggle';
+import { on } from '@ember/modifier';
+import { click, focus, settled } from '@ember/test-helpers';
+import { tracked } from '@glimmer/tracking';
+import userEvent from '@testing-library/user-event';
+import { setupRenderingTest } from 'ember-qunit';
+import { module, test } from 'qunit';
+import sinon from 'sinon';
+
+module('Integration | Component | toggle', function (hooks) {
+  setupRenderingTest(hooks);
+
+  test('it changes state when the user activates it', async function (assert) {
+    // given
+    const screen = await render(
+      <template>
+        <PixToggle>Recevoir la newsletter</PixToggle>
+      </template>,
+    );
+    const toggle = screen.getByRole('switch', { name: 'Recevoir la newsletter', checked: false });
+
+    // when
+    await click(toggle);
+
+    // then
+    assert.ok(screen.getByRole('switch', { name: 'Recevoir la newsletter', checked: true }));
+  });
+
+  test('it changes state when the user deactivates it', async function (assert) {
+    // given
+    const screen = await render(
+      <template>
+        <PixToggle @checked={{true}}>Recevoir la newsletter</PixToggle>
+      </template>,
+    );
+    const toggle = screen.getByRole('switch', { name: 'Recevoir la newsletter', checked: true });
+
+    // when
+    await click(toggle);
+
+    // then
+    assert.ok(screen.getByRole('switch', { name: 'Recevoir la newsletter', checked: false }));
+  });
+
+  module('when the user presses the space bar', function () {
+    test('it changes state', async function (assert) {
+      // given
+      const screen = await render(
+        <template>
+          <PixToggle>Recevoir la newsletter</PixToggle>
+        </template>,
+      );
+      const toggle = screen.getByRole('switch', { name: 'Recevoir la newsletter', checked: false });
+      await focus(toggle);
+
+      // when
+      await userEvent.keyboard('[Space]');
+
+      // then
+      assert.ok(screen.getByRole('switch', { name: 'Recevoir la newsletter', checked: true }));
+    });
+  });
+
+  test('it notifies the consumer when the user changes its state', async function (assert) {
+    // given
+    const onChange = sinon.stub();
+    const screen = await render(
+      <template>
+        <PixToggle {{on "change" onChange}}>Recevoir la newsletter</PixToggle>
+      </template>,
+    );
+
+    // when
+    await click(screen.getByRole('switch', { name: 'Recevoir la newsletter' }));
+
+    // then
+    assert.true(onChange.calledOnce);
+  });
+
+  module('label', function () {
+    module('when the user clicks on the label', function () {
+      test('it changes state', async function (assert) {
+        // given
+        const screen = await render(
+          <template>
+            <PixToggle>Recevoir la newsletter</PixToggle>
+          </template>,
+        );
+        screen.getByRole('switch', { name: 'Recevoir la newsletter', checked: false });
+
+        // when
+        await click(screen.getByText('Recevoir la newsletter'));
+
+        // then
+        assert.ok(screen.getByRole('switch', { name: 'Recevoir la newsletter', checked: true }));
+      });
+    });
+
+    module('when the consumer provides no visible label', function () {
+      test('it can be named and operated', async function (assert) {
+        // given
+        const screen = await render(
+          <template><PixToggle aria-label="Recevoir la newsletter" /></template>,
+        );
+        const toggle = screen.getByRole('switch', {
+          name: 'Recevoir la newsletter',
+          checked: false,
+        });
+
+        // when
+        await click(toggle);
+
+        // then
+        assert.ok(screen.getByRole('switch', { name: 'Recevoir la newsletter', checked: true }));
+      });
+    });
+  });
+
+  module('@checked', function () {
+    class Consumer {
+      @tracked isChecked;
+
+      constructor(isChecked) {
+        this.isChecked = isChecked;
+      }
+    }
+
+    test('it turns on when the consumer turns it on', async function (assert) {
+      // given
+      const consumer = new Consumer(false);
+      const screen = await render(
+        <template>
+          <PixToggle @checked={{consumer.isChecked}}>Recevoir la newsletter</PixToggle>
+        </template>,
+      );
+      screen.getByRole('switch', { name: 'Recevoir la newsletter', checked: false });
+
+      // when
+      consumer.isChecked = true;
+      await settled();
+
+      // then
+      assert.ok(screen.getByRole('switch', { name: 'Recevoir la newsletter', checked: true }));
+    });
+
+    test('it turns off when the consumer turns it off', async function (assert) {
+      // given
+      const consumer = new Consumer(true);
+      const screen = await render(
+        <template>
+          <PixToggle @checked={{consumer.isChecked}}>Recevoir la newsletter</PixToggle>
+        </template>,
+      );
+      screen.getByRole('switch', { name: 'Recevoir la newsletter', checked: true });
+
+      // when
+      consumer.isChecked = false;
+      await settled();
+
+      // then
+      assert.ok(screen.getByRole('switch', { name: 'Recevoir la newsletter', checked: false }));
+    });
+  });
+
+  module('@id', function () {
+    test('it gives the switch the id provided by the consumer', async function (assert) {
+      // given & when
+      const screen = await render(
+        <template>
+          <PixToggle @id="newsletter-toggle">Recevoir la newsletter</PixToggle>
+        </template>,
+      );
+
+      // then
+      assert
+        .dom(screen.getByRole('switch', { name: 'Recevoir la newsletter' }))
+        .hasAttribute('id', 'newsletter-toggle');
+    });
+
+    module('when no id is set by the consumer', function () {
+      test('it activates only the switch whose label the user clicks', async function (assert) {
+        // given
+        const screen = await render(
+          <template>
+            <PixToggle>Recevoir la newsletter</PixToggle>
+            <PixToggle>Recevoir les actualités</PixToggle>
+          </template>,
+        );
+
+        // when
+        await click(screen.getByText('Recevoir les actualités'));
+
+        // then
+        assert.ok(screen.getByRole('switch', { name: 'Recevoir les actualités', checked: true }));
+        assert.ok(screen.queryByRole('switch', { name: 'Recevoir la newsletter', checked: false }));
+      });
+    });
+  });
+
+  module('@class', function () {
+    test('it applies the given class to the whole component', async function (assert) {
+      // given & when
+      const screen = await render(
+        <template>
+          <PixToggle @class="newsletter-toggle">Recevoir la newsletter</PixToggle>
+        </template>,
+      );
+
+      // then
+      const toggle = screen.getByRole('switch', { name: 'Recevoir la newsletter' });
+      const styledElement = this.element.querySelector('.newsletter-toggle');
+
+      assert.true(styledElement.contains(toggle));
+      assert.dom(styledElement).hasText('Recevoir la newsletter');
+    });
+  });
+
+  module('@isDisabled', function () {
+    test('it does not change state when the user activates it', async function (assert) {
+      // given
+      const screen = await render(
+        <template>
+          <PixToggle @checked={{true}} @isDisabled={{true}}>Recevoir la newsletter</PixToggle>
+        </template>,
+      );
+      const toggle = screen.getByRole('switch', { name: 'Recevoir la newsletter' });
+
+      // when
+      await click(toggle);
+
+      // then
+      assert.true(toggle.checked);
+    });
+
+    test('it exposes the disabled state to assistive technologies', async function (assert) {
+      // given & when
+      const screen = await render(
+        <template>
+          <PixToggle @isDisabled={{true}}>Recevoir la newsletter</PixToggle>
+        </template>,
+      );
+
+      // then
+      assert.strictEqual(
+        screen.getByRole('switch', { name: 'Recevoir la newsletter' }).ariaDisabled,
+        'true',
+      );
+    });
+
+    test('it does not change state when the user activates the label', async function (assert) {
+      // given
+      const screen = await render(
+        <template>
+          <PixToggle @checked={{true}} @isDisabled={{true}}>Recevoir la newsletter</PixToggle>
+        </template>,
+      );
+      const toggle = screen.getByRole('switch', { name: 'Recevoir la newsletter' });
+
+      // when
+      await click(screen.getByText('Recevoir la newsletter'));
+
+      // then
+      assert.true(toggle.checked);
+    });
+
+    test('it stays reachable with the keyboard', async function (assert) {
+      // given
+      const screen = await render(
+        <template>
+          <PixToggle @isDisabled={{true}}>Recevoir la newsletter</PixToggle>
+        </template>,
+      );
+      const toggle = screen.getByRole('switch', { name: 'Recevoir la newsletter' });
+
+      // when
+      await focus(toggle);
+
+      // then
+      assert.dom(toggle).isFocused();
+    });
+
+    test('it does not change state when the user presses the space bar', async function (assert) {
+      // given
+      const screen = await render(
+        <template>
+          <PixToggle @checked={{true}} @isDisabled={{true}}>Recevoir la newsletter</PixToggle>
+        </template>,
+      );
+      const toggle = screen.getByRole('switch', { name: 'Recevoir la newsletter', checked: true });
+      await focus(toggle);
+
+      // when
+      await userEvent.keyboard('[Space]');
+
+      // then
+      assert.ok(screen.getByRole('switch', { name: 'Recevoir la newsletter', checked: true }));
+    });
+
+    test('it does not notify the consumer when the user tries to change its state', async function (assert) {
+      // given
+      const onChange = sinon.stub();
+      const screen = await render(
+        <template>
+          <PixToggle @checked={{true}} @isDisabled={{true}} {{on "change" onChange}}>
+            Recevoir la newsletter
+          </PixToggle>
+        </template>,
+      );
+
+      // when
+      await click(screen.getByRole('switch', { name: 'Recevoir la newsletter' }));
+
+      // then
+      assert.false(onChange.called);
+    });
+  });
+
+  module('@size', function () {
+    test('it renders a bigger switch when the size is large', async function (assert) {
+      // given & when
+      const screen = await render(
+        <template>
+          <PixToggle @size="large" aria-label="Recevoir la newsletter" />
+          <PixToggle aria-label="Recevoir les actualités" />
+        </template>,
+      );
+
+      // then
+      const large = screen.getByRole('switch', { name: 'Recevoir la newsletter' });
+      const regular = screen.getByRole('switch', { name: 'Recevoir les actualités' });
+
+      assert.true(large.getBoundingClientRect().width > regular.getBoundingClientRect().width);
+    });
+  });
+});


### PR DESCRIPTION
## :christmas_tree: Problème

Le composant `PixCheckbox` existe mais il préférable d'avoir un composant "toggle" pour les activations de fonctionnalités.

## :gift: Proposition

Créer le composant `PixToggle`.

## :santa: Pour tester

Visualiser [le composant en RA](https://pix-ui-review-pr1024.osc-fr1.scalingo.io/?path=/docs/forms-toggle--docs).
