### PR TITLE
[FEATURE] Ajouter un mode contrôlé au composant PixAccordions (PIX-23916)

### DIFF
--- a/addon/components/pix-accordions.gjs
+++ b/addon/components/pix-accordions.gjs
@@ -11,21 +11,37 @@ export default class PixAccordions extends Component {
   text = 'pix-accordions';
   contentId = 'pix-accordions-' + guidFor(this);
 
-  @tracked isCollapsed = true;
-  @tracked hasUnCollapsedOnce = false;
+  @tracked isCollapsedWhenUncontrolled = true;
+  hasBeenExpandedOnce = false;
 
-  get isUnCollapsed() {
-    return !this.isCollapsed;
+  get isControlled() {
+    return this.args.isExpanded !== undefined && this.args.isExpanded !== null;
+  }
+
+  get isExpanded() {
+    return this.isControlled ? Boolean(this.args.isExpanded) : !this.isCollapsedWhenUncontrolled;
   }
 
   get isContentRendered() {
-    return this.hasUnCollapsedOnce;
+    if (this.isExpanded) {
+      // eslint-disable-next-line ember/no-side-effects
+      this.hasBeenExpandedOnce = true;
+    }
+
+    return this.hasBeenExpandedOnce;
   }
 
   @action
   toggleAccordions() {
-    this.isCollapsed = !this.isCollapsed;
-    this.hasUnCollapsedOnce = true;
+    const nextIsExpanded = !this.isExpanded;
+
+    if (!this.isControlled) {
+      this.isCollapsedWhenUncontrolled = !nextIsExpanded;
+    }
+
+    if (this.args.onToggle) {
+      this.args.onToggle(nextIsExpanded);
+    }
   }
 
   get isV2Version() {
@@ -40,7 +56,7 @@ export default class PixAccordions extends Component {
         type="button"
         {{on "click" this.toggleAccordions}}
         aria-controls={{this.contentId}}
-        aria-expanded={{if this.isUnCollapsed "true" "false"}}
+        aria-expanded={{if this.isExpanded "true" "false"}}
         ...attributes
       >
 
@@ -66,7 +82,7 @@ export default class PixAccordions extends Component {
           <PixIcon
             class="pix-accordions{{this.isV2Version}}-title-container__toggle-icon"
             @ariaHidden={{true}}
-            @name="{{if this.isCollapsed 'chevronBottom' 'chevronTop'}}"
+            @name="{{if this.isExpanded 'chevronTop' 'chevronBottom'}}"
           />
         </span>
       </button>
@@ -74,7 +90,7 @@ export default class PixAccordions extends Component {
       <div
         id={{this.contentId}}
         class="pix-accordions{{this.isV2Version}}__content"
-        aria-hidden={{if this.isCollapsed "true" "false"}}
+        aria-hidden={{if this.isExpanded "false" "true"}}
       >
         {{#if this.isContentRendered}}
           {{yield to="content"}}

--- a/addon/components/pix-accordions.gjs
+++ b/addon/components/pix-accordions.gjs
@@ -1,3 +1,4 @@
+import { warn } from '@ember/debug';
 import { on } from '@ember/modifier';
 import { action } from '@ember/object';
 import { guidFor } from '@ember/object/internals';
@@ -13,6 +14,18 @@ export default class PixAccordions extends Component {
 
   @tracked isCollapsedWhenUncontrolled = true;
   hasBeenExpandedOnce = false;
+
+  constructor(...args) {
+    super(...args);
+
+    warn(
+      'PixAccordions: uncontrolled mode is deprecated, use @isExpanded and @onToggle instead',
+      Boolean(this.args.onToggle),
+      {
+        id: 'pix-ui.pix-accordions.uncontrolled.deprecated',
+      },
+    );
+  }
 
   get isControlled() {
     return this.args.isExpanded !== undefined && this.args.isExpanded !== null;

--- a/app/stories/pix-accordions.mdx
+++ b/app/stories/pix-accordions.mdx
@@ -28,6 +28,33 @@ Les paramètres `tagContent` et `tagColor` permettent d'afficher un `Pix Tag` pr
 
 <Story of={ComponentStories.accordionsWithTag} height={260} />
 
+### PixAccordions contrôlé
+
+Par défaut, chaque `PixAccordions` gère son état tout seul. Le paramètre `isExpanded` permet au parent d'en
+prendre la main, ce qui est nécessaire pour piloter plusieurs accordéons d'un coup — un bouton « tout déplier »
+ou « tout replier », par exemple.
+
+Dans ce mode, le composant n'ouvre ni ne ferme plus de lui-même : il se contente de signaler l'intention de
+l'utilisateur via `onToggle`, et c'est au parent de répercuter la nouvelle valeur sur `isExpanded`.
+
+> **⚠️** `@isExpanded={{false}}` n'équivaut pas à ne pas passer le paramètre : il active le mode contrôlé, et les
+> clics resteront sans effet tant que `onToggle` n'est pas branché. Pour rester en mode non contrôlé, ne passez
+> pas le paramètre du tout, ou passez `null`.
+
+Un accordéon contrôlé déplié affiche son contenu dès le premier rendu, sans clic préalable. C'est ce qui permet
+de déplier d'un seul coup des accordéons imbriqués, y compris ceux qui n'étaient pas encore rendus.
+
+<Story of={ComponentStories.controlledAccordions} height={260} />
+
+```html
+<PixAccordions @isExpanded={{this.isExpanded}} @onToggle={{this.onToggle}} @isV2Version={{true}}>
+  <:title>Titre du contenu à dérouler en cliquant</:title>
+  <:content>
+    <div>Contenu du PixAccordions</div>
+  </:content>
+</PixAccordions>
+```
+
 
 ## Usage
 

--- a/app/stories/pix-accordions.mdx
+++ b/app/stories/pix-accordions.mdx
@@ -30,16 +30,15 @@ Les paramètres `tagContent` et `tagColor` permettent d'afficher un `Pix Tag` pr
 
 ### PixAccordions contrôlé
 
-Par défaut, chaque `PixAccordions` gère son état tout seul. Le paramètre `isExpanded` permet au parent d'en
-prendre la main, ce qui est nécessaire pour piloter plusieurs accordéons d'un coup — un bouton « tout déplier »
-ou « tout replier », par exemple.
+> **⚠️** **Le mode non contrôlé est déprécié.** Utilisez `isExpanded` et `onToggle` : le composant avertit en
+> développement lorsque `onToggle` n'est pas fourni.
 
-Dans ce mode, le composant n'ouvre ni ne ferme plus de lui-même : il se contente de signaler l'intention de
-l'utilisateur via `onToggle`, et c'est au parent de répercuter la nouvelle valeur sur `isExpanded`.
+Historiquement, chaque `PixAccordions` gérait son état tout seul. Les paramètres `isExpanded` et `onToggle`
+donnent la main au parent, ce qui est nécessaire pour piloter plusieurs accordéons d'un coup — un bouton
+« tout déplier » ou « tout replier », par exemple — et uniformise les usages autour d'un composant sans état.
 
-> **⚠️** `@isExpanded={{false}}` n'équivaut pas à ne pas passer le paramètre : il active le mode contrôlé, et les
-> clics resteront sans effet tant que `onToggle` n'est pas branché. Pour rester en mode non contrôlé, ne passez
-> pas le paramètre du tout, ou passez `null`.
+Dans ce mode, le composant n'ouvre ni ne ferme plus de lui-même : il signale l'intention de l'utilisateur via
+`onToggle`, et c'est au parent de répercuter la nouvelle valeur sur `isExpanded`.
 
 Un accordéon contrôlé déplié affiche son contenu dès le premier rendu, sans clic préalable. C'est ce qui permet
 de déplier d'un seul coup des accordéons imbriqués, y compris ceux qui n'étaient pas encore rendus.
@@ -55,11 +54,27 @@ de déplier d'un seul coup des accordéons imbriqués, y compris ceux qui n'éta
 </PixAccordions>
 ```
 
+Le parent tient l'état et le met à jour depuis `onToggle` :
+
+```js
+@tracked isExpanded = false;
+
+@action
+onToggle(isExpanded) {
+  this.isExpanded = isExpanded;
+}
+```
+
 
 ## Usage
 
 ```html
-<PixAccordions @iconName="users" @isV2Version={{true}}>`
+<PixAccordions
+  @iconName="users"
+  @isV2Version={{true}}
+  @isExpanded={{this.isExpanded}}
+  @onToggle={{this.onToggle}}
+>
   <:title>Titre du contenu à dérouler en cliquant</:title>
   <:content>
     <div>Contenu du PixAccordions</div>

--- a/app/stories/pix-accordions.stories.js
+++ b/app/stories/pix-accordions.stories.js
@@ -47,7 +47,7 @@ export default {
     isExpanded: {
       name: 'isExpanded',
       description:
-        "Passe le composant en mode contrôlé : c'est le parent qui décide si l'accordéon est déplié, et le composant n'ouvre plus ni ne ferme de lui-même au clic. À utiliser avec onToggle. Laisser vide (ou null) pour conserver le mode non contrôlé, où l'accordéon gère son état seul.",
+        "Passe le composant en mode contrôlé : c'est le parent qui décide si l'accordéon est déplié, et le composant n'ouvre plus ni ne ferme de lui-même au clic. À utiliser avec onToggle. Le mode non contrôlé, obtenu en ne passant ni isExpanded ni onToggle, est déprécié.",
       type: { name: 'boolean', required: false },
       control: { type: 'boolean' },
       table: {
@@ -58,7 +58,7 @@ export default {
     onToggle: {
       name: 'onToggle',
       description:
-        "Appelé à chaque clic sur le titre, avec l'état attendu par l'utilisateur (true pour déplier, false pour replier). Fonctionne dans les deux modes. En mode contrôlé, c'est au parent de répercuter cette valeur sur isExpanded.",
+        "Appelé à chaque clic sur le titre, avec l'état attendu par l'utilisateur (true pour déplier, false pour replier). C'est au parent de répercuter cette valeur sur isExpanded. Son absence déclenche un avertissement en développement, le mode non contrôlé étant déprécié.",
       type: { name: 'function', required: false },
       control: { type: null },
       table: { type: { summary: '(isExpanded: boolean) => void' } },

--- a/app/stories/pix-accordions.stories.js
+++ b/app/stories/pix-accordions.stories.js
@@ -44,6 +44,25 @@ export default {
       type: { name: 'string', required: false },
       table: { defaultValue: { summary: 'primary' } },
     },
+    isExpanded: {
+      name: 'isExpanded',
+      description:
+        "Passe le composant en mode contrôlé : c'est le parent qui décide si l'accordéon est déplié, et le composant n'ouvre plus ni ne ferme de lui-même au clic. À utiliser avec onToggle. Laisser vide (ou null) pour conserver le mode non contrôlé, où l'accordéon gère son état seul.",
+      type: { name: 'boolean', required: false },
+      control: { type: 'boolean' },
+      table: {
+        type: { summary: 'boolean' },
+        defaultValue: { summary: undefined },
+      },
+    },
+    onToggle: {
+      name: 'onToggle',
+      description:
+        "Appelé à chaque clic sur le titre, avec l'état attendu par l'utilisateur (true pour déplier, false pour replier). Fonctionne dans les deux modes. En mode contrôlé, c'est au parent de répercuter cette valeur sur isExpanded.",
+      type: { name: 'function', required: false },
+      control: { type: null },
+      table: { type: { summary: '(isExpanded: boolean) => void' } },
+    },
   },
 };
 
@@ -106,6 +125,34 @@ export const multipleAccordions = (args) => {
 </div>`,
     context: args,
   };
+};
+
+export const controlledAccordions = (args) => {
+  return {
+    template: hbs`<div>
+  <PixAccordions @isExpanded={{this.isExpanded}} @isV2Version={{true}}>
+    <:title>
+      Titre A
+    </:title>
+    <:content>
+      <div>Contenu A</div>
+    </:content>
+  </PixAccordions>
+
+  <PixAccordions @isExpanded={{this.isExpanded}} @isV2Version={{true}}>
+    <:title>
+      Titre B
+    </:title>
+    <:content>
+      <div>Contenu B</div>
+    </:content>
+  </PixAccordions>
+</div>`,
+    context: args,
+  };
+};
+controlledAccordions.args = {
+  isExpanded: true,
 };
 
 export const accordionsWithTag = (args) => {

--- a/tests/integration/components/pix-accordions-test.js
+++ b/tests/integration/components/pix-accordions-test.js
@@ -1,7 +1,14 @@
 import { clickByText, render } from '@1024pix/ember-testing-library';
+import { settled } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { setupRenderingTest } from 'ember-qunit';
 import { module, test } from 'qunit';
+import sinon from 'sinon';
+
+function getToggleIconName() {
+  const useElement = document.querySelector('.pix-accordions-title-container__toggle-icon use');
+  return useElement.getAttribute('href').split('#')[1];
+}
 
 module('Integration | Component | PixAccordions', function (hooks) {
   setupRenderingTest(hooks);
@@ -56,5 +63,222 @@ module('Integration | Component | PixAccordions', function (hooks) {
     assert.dom(screen.queryByText('Titre de mon élément déroulable')).isVisible();
     assert.dom(screen.queryByText('Contenu de mon élément')).isNotVisible();
     assert.dom(screen.queryByText('Contenu de mon élément')).exists();
+  });
+
+  test('it should call onToggle with the new state when uncontrolled', async function (assert) {
+    // given
+    const onToggle = sinon.stub();
+    this.set('onToggle', onToggle);
+
+    // when
+    await render(hbs`<PixAccordions @onToggle={{this.onToggle}}>
+  <:title>
+    Titre de mon élément déroulable
+  </:title>
+  <:content>
+    <p>Contenu de mon élément</p>
+  </:content>
+</PixAccordions>`);
+    await clickByText('Titre de mon élément déroulable');
+    await clickByText('Titre de mon élément déroulable');
+
+    // then
+    assert.true(onToggle.firstCall.calledWithExactly(true));
+    assert.true(onToggle.secondCall.calledWithExactly(false));
+  });
+
+  module('when controlled with @isExpanded', function () {
+    test('it should render content already expanded without any click', async function (assert) {
+      // when
+      const screen = await render(hbs`<PixAccordions @isExpanded={{true}}>
+  <:title>
+    Titre de mon élément déroulable
+  </:title>
+  <:content>
+    <p>Contenu de mon élément</p>
+  </:content>
+</PixAccordions>`);
+
+      // then
+      assert.dom(screen.queryByRole('button')).hasAria('expanded', 'true');
+      assert.dom(screen.queryByText('Contenu de mon élément')).isVisible();
+    });
+
+    test('it should render collapsed and without content when false', async function (assert) {
+      // when
+      const screen = await render(hbs`<PixAccordions @isExpanded={{false}}>
+  <:title>
+    Titre de mon élément déroulable
+  </:title>
+  <:content>
+    <p>Contenu de mon élément</p>
+  </:content>
+</PixAccordions>`);
+
+      // then
+      assert.dom(screen.queryByRole('button')).hasAria('expanded', 'false');
+      assert.dom(screen.queryByText('Contenu de mon élément')).doesNotExist();
+    });
+
+    test('it should call onToggle with the requested state on click', async function (assert) {
+      // given
+      const onToggle = sinon.stub();
+      this.set('onToggle', onToggle);
+
+      // when
+      await render(hbs`<PixAccordions @isExpanded={{false}} @onToggle={{this.onToggle}}>
+  <:title>
+    Titre de mon élément déroulable
+  </:title>
+  <:content>
+    <p>Contenu de mon élément</p>
+  </:content>
+</PixAccordions>`);
+      await clickByText('Titre de mon élément déroulable');
+
+      // then
+      assert.true(onToggle.calledOnceWithExactly(true));
+    });
+
+    test('it should not change its own state on click while @isExpanded is unchanged', async function (assert) {
+      // when
+      const screen = await render(hbs`<PixAccordions @isExpanded={{false}}>
+  <:title>
+    Titre de mon élément déroulable
+  </:title>
+  <:content>
+    <p>Contenu de mon élément</p>
+  </:content>
+</PixAccordions>`);
+      await clickByText('Titre de mon élément déroulable');
+
+      // then
+      assert.dom(screen.queryByRole('button')).hasAria('expanded', 'false');
+      assert.dom(screen.queryByText('Contenu de mon élément')).doesNotExist();
+    });
+
+    test('it should expand when @isExpanded becomes true after render', async function (assert) {
+      // given
+      this.set('isExpanded', false);
+      const screen = await render(hbs`<PixAccordions @isExpanded={{this.isExpanded}}>
+  <:title>
+    Titre de mon élément déroulable
+  </:title>
+  <:content>
+    <p>Contenu de mon élément</p>
+  </:content>
+</PixAccordions>`);
+
+      // when
+      this.set('isExpanded', true);
+      await settled();
+
+      // then
+      assert.dom(screen.queryByRole('button')).hasAria('expanded', 'true');
+      assert.dom(screen.queryByText('Contenu de mon élément')).isVisible();
+    });
+
+    test('it should collapse without destroying content when @isExpanded becomes false', async function (assert) {
+      // given
+      this.set('isExpanded', true);
+      const screen = await render(hbs`<PixAccordions @isExpanded={{this.isExpanded}}>
+  <:title>
+    Titre de mon élément déroulable
+  </:title>
+  <:content>
+    <p>Contenu de mon élément</p>
+  </:content>
+</PixAccordions>`);
+
+      // when
+      this.set('isExpanded', false);
+      await settled();
+
+      // then
+      assert.dom(screen.queryByRole('button')).hasAria('expanded', 'false');
+      assert.dom(screen.queryByText('Contenu de mon élément')).exists();
+      assert.dom(screen.queryByText('Contenu de mon élément')).isNotVisible();
+    });
+
+    test('it should display the toggle icon according to the controlled state', async function (assert) {
+      // given
+      this.set('isExpanded', true);
+      await render(hbs`<PixAccordions @isExpanded={{this.isExpanded}}>
+  <:title>
+    Titre de mon élément déroulable
+  </:title>
+  <:content>
+    <p>Contenu de mon élément</p>
+  </:content>
+</PixAccordions>`);
+
+      // then
+      assert.strictEqual(getToggleIconName(), 'chevronUp');
+
+      // when
+      this.set('isExpanded', false);
+      await settled();
+
+      // then
+      assert.strictEqual(getToggleIconName(), 'chevronDown');
+    });
+
+    test('it should set aria-hidden on content according to the controlled state', async function (assert) {
+      // given
+      this.set('isExpanded', true);
+      await render(hbs`<PixAccordions @isExpanded={{this.isExpanded}}>
+  <:title>
+    Titre de mon élément déroulable
+  </:title>
+  <:content>
+    <p>Contenu de mon élément</p>
+  </:content>
+</PixAccordions>`);
+      await settled();
+
+      // then
+      assert.dom('.pix-accordions__content').hasAria('hidden', 'false');
+
+      // when
+      this.set('isExpanded', false);
+      await settled();
+
+      // then
+      assert.dom('.pix-accordions__content').hasAria('hidden', 'true');
+    });
+
+    test('it should support the v2 version', async function (assert) {
+      // when
+      const screen = await render(hbs`<PixAccordions @isExpanded={{true}} @isV2Version={{true}}>
+  <:title>
+    Titre de mon élément déroulable
+  </:title>
+  <:content>
+    <p>Contenu de mon élément</p>
+  </:content>
+</PixAccordions>`);
+
+      // then
+      assert.dom(screen.queryByRole('button')).hasClass('pix-accordions-v2__title');
+      assert.dom(screen.queryByRole('button')).hasAria('expanded', 'true');
+      assert.dom(screen.queryByText('Contenu de mon élément')).isVisible();
+    });
+
+    test('it should stay uncontrolled when @isExpanded is null', async function (assert) {
+      // when
+      const screen = await render(hbs`<PixAccordions @isExpanded={{null}}>
+  <:title>
+    Titre de mon élément déroulable
+  </:title>
+  <:content>
+    <p>Contenu de mon élément</p>
+  </:content>
+</PixAccordions>`);
+      await clickByText('Titre de mon élément déroulable');
+
+      // then
+      assert.dom(screen.queryByRole('button')).hasAria('expanded', 'true');
+      assert.dom(screen.queryByText('Contenu de mon élément')).isVisible();
+    });
   });
 });

--- a/tests/integration/components/pix-accordions-test.js
+++ b/tests/integration/components/pix-accordions-test.js
@@ -13,6 +13,16 @@ function getToggleIconName() {
 module('Integration | Component | PixAccordions', function (hooks) {
   setupRenderingTest(hooks);
 
+  let warnStub;
+
+  hooks.beforeEach(function () {
+    warnStub = sinon.stub(console, 'warn');
+  });
+
+  hooks.afterEach(function () {
+    warnStub.restore();
+  });
+
   test('it should only render PixAccordions title by default', async function (assert) {
     // when
     const screen = await render(hbs`<PixAccordions>
@@ -264,6 +274,28 @@ module('Integration | Component | PixAccordions', function (hooks) {
       assert.dom(screen.queryByText('Contenu de mon élément')).isVisible();
     });
 
+    test('it should not warn when @onToggle is provided', async function (assert) {
+      // given
+      this.set('onToggle', sinon.stub());
+
+      // when
+      await render(hbs`<PixAccordions @isExpanded={{true}} @onToggle={{this.onToggle}}>
+  <:title>
+    Titre de mon élément déroulable
+  </:title>
+  <:content>
+    <p>Contenu de mon élément</p>
+  </:content>
+</PixAccordions>`);
+
+      // then
+      assert.false(
+        warnStub.calledWithExactly(
+          'WARNING: PixAccordions: uncontrolled mode is deprecated, use @isExpanded and @onToggle instead',
+        ),
+      );
+    });
+
     test('it should stay uncontrolled when @isExpanded is null', async function (assert) {
       // when
       const screen = await render(hbs`<PixAccordions @isExpanded={{null}}>
@@ -280,5 +312,24 @@ module('Integration | Component | PixAccordions', function (hooks) {
       assert.dom(screen.queryByRole('button')).hasAria('expanded', 'true');
       assert.dom(screen.queryByText('Contenu de mon élément')).isVisible();
     });
+  });
+
+  test('it should warn that the uncontrolled mode is deprecated when @onToggle is missing', async function (assert) {
+    // when
+    await render(hbs`<PixAccordions>
+  <:title>
+    Titre de mon élément déroulable
+  </:title>
+  <:content>
+    <p>Contenu de mon élément</p>
+  </:content>
+</PixAccordions>`);
+
+    // then
+    assert.ok(
+      warnStub.calledWithExactly(
+        'WARNING: PixAccordions: uncontrolled mode is deprecated, use @isExpanded and @onToggle instead',
+      ),
+    );
   });
 });


### PR DESCRIPTION
## :christmas_tree: Problème
Par défaut, chaque PixAccordions gère son état tout seul. 
Il faudrait permettre au parent d'en prendre la main, ce qui est nécessaire pour piloter plusieurs accordéons d'un coup. 


## :gift: Proposition
Ajouter un paramètre isExpanded qui permet au parent d'en prendre la main, ce qui est nécessaire pour piloter plusieurs accordéons d'un coup. 

## :star2: Remarques
On va utiliser ça pour permettre aux utilisateur d'ouvrir et fermer tous les accordéons en un clic lors de la création ou modification d'un profil cible.

## :santa: Pour tester
> _Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc._