### PR TITLE
[FEATURE] Déprécier le composant PixBackgroundHeader (PIX-23932)

### DIFF
--- a/app/stories/pix-background-header.stories.js
+++ b/app/stories/pix-background-header.stories.js
@@ -2,6 +2,7 @@ import { hbs } from 'ember-cli-htmlbars';
 
 export default {
   title: 'Other/Background Header',
+  tags: ['deprecated'],
 };
 
 export const backgroundHeader = (args) => {


### PR DESCRIPTION
## :christmas_tree: Problème
Il ne faut plus utiliser le composant PixBackgroundHeader mais rien ne l'indique côté DS.

## :gift: Proposition
Utiliser le tag `deprecated` provenant de l'addon storybook

## :star2: Remarques
RAS

## :santa: Pour tester
- Aller sur la [RA](https://pix-ui-review-pr1026.osc-fr1.scalingo.io/?path=/docs/other-background-header--docs)
- Constater qu'un tag deprecated apparaît maintenant à côté de la story du composant 😄 

<img width="1914" height="944" alt="Capture d’écran 2026-08-20 à 09 47 59" src="https://github.com/user-attachments/assets/7283c327-e346-4286-80fa-04d348ba3416" />

