### PR TITLE
[BREAKING] Supprimer les locales dans le composant Pagination (Pix-23984).

### DIFF
--- a/addon/components/pix-pagination.gjs
+++ b/addon/components/pix-pagination.gjs
@@ -1,7 +1,6 @@
 import { action } from '@ember/object';
 import { inject as service } from '@ember/service';
 import Component from '@glimmer/component';
-import { eq } from 'ember-truth-helpers';
 
 import PixIconButton from './pix-icon-button';
 import PixSelect from './pix-select';
@@ -54,10 +53,6 @@ export default class PixPagination extends Component {
     return Math.max(this.currentPage - 1, 1);
   }
 
-  get resultsCount() {
-    return this.args.pagination ? this.args.pagination.rowCount : 0;
-  }
-
   get firstItemPosition() {
     if (!this.args.pagination) return 0;
     return (this.currentPage - 1) * this.pageSize + 1;
@@ -97,10 +92,7 @@ export default class PixPagination extends Component {
   <template>
     <footer class={{this.isCondensed}}>
       <section class="pix-pagination__size">
-        <span
-          class="pagination-size__label"
-          aria-hidden="true"
-        >{{@beforeResultsPerPageLabel}}</span>
+        <span class="pagination-size__label" aria-hidden="true">{{@texts.title}}</span>
         <PixSelect
           @placeholder={{this.pageSize}}
           @screenReaderOnly={{true}}
@@ -110,22 +102,18 @@ export default class PixPagination extends Component {
           @onChange={{this.changePageSize}}
           @options={{this.pageOptions}}
         >
-          <:label>{{@selectPageSizeLabel}}</:label>
+          <:label>{{@texts.pageSize}}</:label>
         </PixSelect>
       </section>
       <section class="pix-pagination__navigation">
         <span>
-          {{#if (eq this.pageCount 1)}}
-            {{@singlePageElementCountLabel}}
-          {{else}}
-            {{@multiplePageElementCountLabel}}
-          {{/if}}
+          {{@texts.pageElementCount}}
         </span>
         <div class="pix-pagination-navigation__action">
           <PixIconButton
             class="pix-pagination-navigation__action-button"
             @iconName="arrowLeft"
-            @ariaLabel={{@previousPageLabel}}
+            @ariaLabel={{@texts.previousPage}}
             @triggerAction={{this.goToPreviousPage}}
             @withBackground={{false}}
             @size="big"
@@ -134,12 +122,12 @@ export default class PixPagination extends Component {
             aria-disabled="{{this.isPreviousPageDisabled}}"
           />
           <span>
-            {{@pageNumberLabel}}
+            {{@texts.pageNumber}}
           </span>
           <PixIconButton
             class="pix-pagination-navigation__action-button"
             @iconName="arrowRight"
-            @ariaLabel={{@nextPageLabel}}
+            @ariaLabel={{@texts.nextPage}}
             @triggerAction={{this.goToNextPage}}
             @withBackground={{false}}
             @size="big"

--- a/addon/components/pix-pagination.gjs
+++ b/addon/components/pix-pagination.gjs
@@ -3,7 +3,6 @@ import { inject as service } from '@ember/service';
 import Component from '@glimmer/component';
 import { eq } from 'ember-truth-helpers';
 
-import { formatMessage } from '../translations';
 import PixIconButton from './pix-icon-button';
 import PixSelect from './pix-select';
 
@@ -21,46 +20,8 @@ export default class PixPagination extends Component {
     return this.args.isCondensed ? 'pix-pagination-condensed' : 'pix-pagination';
   }
 
-  get beforeResultsPerPage() {
-    return this.formatMessage('beforeResultsPerPage');
-  }
-
-  get previousPageLabel() {
-    return this.formatMessage('previousPageLabel');
-  }
-
-  get nextPageLabel() {
-    return this.formatMessage('nextPageLabel');
-  }
-
-  get pageNumber() {
-    return this.formatMessage('pageNumber', {
-      total: this.pageCount,
-      current: this.currentPage,
-    });
-  }
-  get pageInfo() {
-    return this.formatMessage('pageInfo', {
-      total: this.resultsCount,
-      start: this.firstItemPosition,
-      end: this.lastItemPosition,
-    });
-  }
-
   get pageOptions() {
     return this.args.pageOptions ? this.args.pageOptions : DEFAULT_PAGE_OPTIONS;
-  }
-
-  get selectPageSizeLabel() {
-    return this.formatMessage('selectPageSizeLabel');
-  }
-
-  get pageResults() {
-    return this.formatMessage('pageResults', { total: this.args.pagination.rowCount });
-  }
-
-  formatMessage(message, values) {
-    return formatMessage(this.args.locale ?? 'fr', `pagination.${message}`, values);
   }
 
   get currentPage() {
@@ -136,7 +97,10 @@ export default class PixPagination extends Component {
   <template>
     <footer class={{this.isCondensed}}>
       <section class="pix-pagination__size">
-        <span class="pagination-size__label">{{this.beforeResultsPerPage}}</span>
+        <span
+          class="pagination-size__label"
+          aria-hidden="true"
+        >{{@beforeResultsPerPageLabel}}</span>
         <PixSelect
           @placeholder={{this.pageSize}}
           @screenReaderOnly={{true}}
@@ -146,22 +110,22 @@ export default class PixPagination extends Component {
           @onChange={{this.changePageSize}}
           @options={{this.pageOptions}}
         >
-          <:label>{{this.selectPageSizeLabel}}</:label>
+          <:label>{{@selectPageSizeLabel}}</:label>
         </PixSelect>
       </section>
       <section class="pix-pagination__navigation">
         <span>
           {{#if (eq this.pageCount 1)}}
-            {{this.pageResults}}
+            {{@singlePageElementCountLabel}}
           {{else}}
-            {{this.pageInfo}}
+            {{@multiplePageElementCountLabel}}
           {{/if}}
         </span>
         <div class="pix-pagination-navigation__action">
           <PixIconButton
             class="pix-pagination-navigation__action-button"
             @iconName="arrowLeft"
-            @ariaLabel={{this.previousPageLabel}}
+            @ariaLabel={{@previousPageLabel}}
             @triggerAction={{this.goToPreviousPage}}
             @withBackground={{false}}
             @size="big"
@@ -170,12 +134,12 @@ export default class PixPagination extends Component {
             aria-disabled="{{this.isPreviousPageDisabled}}"
           />
           <span>
-            {{this.pageNumber}}
+            {{@pageNumberLabel}}
           </span>
           <PixIconButton
             class="pix-pagination-navigation__action-button"
             @iconName="arrowRight"
-            @ariaLabel={{this.nextPageLabel}}
+            @ariaLabel={{@nextPageLabel}}
             @triggerAction={{this.goToNextPage}}
             @withBackground={{false}}
             @size="big"

--- a/addon/translations/en.js
+++ b/addon/translations/en.js
@@ -8,16 +8,6 @@ export default {
   select: {
     search: 'Search',
   },
-  pagination: {
-    beforeResultsPerPage: 'See',
-    selectPageSizeLabel: 'Select the number of items by page',
-    pageResults: '{total, plural, =0 {0 items} =1 {1 item} other {{total, number} items}}',
-    pageInfo:
-      '{start, number}-{end, number} of {total, plural, =0 {0 items} =1 {1 item} other {{total, number} items}}',
-    previousPageLabel: 'Go to previous page',
-    pageNumber: 'Page {current, number} / {total, number}',
-    nextPageLabel: 'Go to next page',
-  },
   tag: {
     removeButton: 'Remove',
   },

--- a/addon/translations/es-419.js
+++ b/addon/translations/es-419.js
@@ -11,15 +11,4 @@ export default {
   stepper: {
     ariaLabel: 'Paso {current, number} de {total, number}',
   },
-  pagination: {
-    beforeResultsPerPage: 'Ver',
-    selectPageSizeLabel: 'Número de elementos que se mostrarán por página',
-    pageResults:
-      '{total, plural, =0 {0 elemento} =1 {1 elemento} otros {{total, número} elementos}}',
-    pageInfo:
-      '{start, número}-{end, número} de {total, plural, =0 {0 elemento} =1 {1 elemento} otros {{total, número} elementos}}',
-    previousPageLabel: 'Ir a la página anterior',
-    pageNumber: 'Página {current, number} / {total, number}',
-    nextPageLabel: 'Ir a la página siguiente',
-  },
 };

--- a/addon/translations/es.js
+++ b/addon/translations/es.js
@@ -8,17 +8,6 @@ export default {
   select: {
     search: 'Buscar',
   },
-  pagination: {
-    beforeResultsPerPage: 'Ver',
-    selectPageSizeLabel: 'Número de elementos que se mostrarán por página',
-    pageResults:
-      '{total, plural, =0 {0 elemento} =1 {1 elemento} otros {{total, número} elementos}}',
-    pageInfo:
-      '{start, número}-{end, número} de {total, plural, =0 {0 elemento} =1 {1 elemento} otros {{total, número} elementos}}',
-    previousPageLabel: 'Ir a la página anterior',
-    pageNumber: 'Página {current, number} / {total, number}',
-    nextPageLabel: 'Ir a la página siguiente',
-  },
   stepper: {
     ariaLabel: 'Paso {current, number} de {total, number}',
   },

--- a/addon/translations/fr.js
+++ b/addon/translations/fr.js
@@ -9,16 +9,6 @@ export default {
   select: {
     search: 'Rechercher',
   },
-  pagination: {
-    beforeResultsPerPage: 'Voir',
-    selectPageSizeLabel: "Nombre d'élément à afficher par page",
-    pageResults: '{total, plural, =0 {0 élément} =1 {1 élément} other {{total, number} éléments}}',
-    pageInfo:
-      '{start, number}-{end, number} sur {total, plural, =0 {0 élément} =1 {1 élément} other {{total, number} éléments}}',
-    previousPageLabel: 'Aller à la page précédente',
-    pageNumber: 'Page {current, number} / {total, number}',
-    nextPageLabel: 'Aller à la page suivante',
-  },
   tag: {
     removeButton: 'Supprimer',
   },

--- a/addon/translations/nl.js
+++ b/addon/translations/nl.js
@@ -8,16 +8,7 @@ export default {
   select: {
     search: 'Zoeken',
   },
-  pagination: {
-    beforeResultsPerPage: 'Zie',
-    selectPageSizeLabel: 'Selecteer het aantal items per pagina',
-    pageResults: '{total, plural, =0 {0 items} =1 {1 item} other {{total, number} items}}',
-    pageInfo:
-      '{start, number}-{end, number} van {total, plural, =0 {0 items} =1 {1 item} other {{total, number} items}}',
-    previousPageLabel: 'Ga naar vorige pagina',
-    pageNumber: 'Pagina {current, number} / {total, number}',
-    nextPageLabel: 'Ga naar volgende pagina',
-  },
+
   tag: {
     removeButton: 'Verwijderen',
   },

--- a/app/stories/pix-pagination.mdx
+++ b/app/stories/pix-pagination.mdx
@@ -24,13 +24,9 @@ Le paramètre `pageOptions` n'est pas requis et possède une valeur par défaut.
 
 Sur mobile, le select qui permet de choisir le nombre d'élément à afficher sur la page est retiré.
 
-## En français avec paramètres par défaut
+## Avec plusieurs page
 
-<Story of={ComponentStories.French} height={110} />
-
-## En anglais avec le paramètre `pageOptions` custom
-
-<Story of={ComponentStories.English} height={110} />
+<Story of={ComponentStories.MultiplePage} height={110} />
 
 ## Avec une seule page
 
@@ -44,10 +40,16 @@ Sur mobile, le select qui permet de choisir le nombre d'élément à afficher su
 
 ```html
 <PixPagination
-  @pagination="{{pagination}}"
-  @locale="{{locale}}"
-  @pageOptions="{{pageOptions}}"
-  @isCondensed="{{isCondensed}}"
+  @pagination={{pagination}}
+  @beforeResultsPerPageLabel={{beforeResultsPerPageLabel}}
+  @selectPageSizeLabel={{selectPageSizeLabel}}
+  @singlePageElementCountLabel={{singlePageElementCountLabel}}
+  @multiplePageElementCountLabel={{multiplePageElementCountLabel}}
+  @pageNumberLabel={{pageNumberLabel}}
+  @previousPageLabel={{previousPageLabel}}
+  @nextPageLabel={{nextPageLabel}}
+  @pageOptions={{pageOptions}}
+  @isCondensed={{isCondensed}}
 />
 ```
 

--- a/app/stories/pix-pagination.mdx
+++ b/app/stories/pix-pagination.mdx
@@ -41,13 +41,7 @@ Sur mobile, le select qui permet de choisir le nombre d'élément à afficher su
 ```html
 <PixPagination
   @pagination={{pagination}}
-  @beforeResultsPerPageLabel={{beforeResultsPerPageLabel}}
-  @selectPageSizeLabel={{selectPageSizeLabel}}
-  @singlePageElementCountLabel={{singlePageElementCountLabel}}
-  @multiplePageElementCountLabel={{multiplePageElementCountLabel}}
-  @pageNumberLabel={{pageNumberLabel}}
-  @previousPageLabel={{previousPageLabel}}
-  @nextPageLabel={{nextPageLabel}}
+  @texts={{texts}}
   @pageOptions={{pageOptions}}
   @isCondensed={{isCondensed}}
 />

--- a/app/stories/pix-pagination.stories.js
+++ b/app/stories/pix-pagination.stories.js
@@ -5,7 +5,7 @@ export default {
   render: (args) => ({
     template: hbs`<PixPagination
   @pagination={{this.pagination}}
-  @locale={{this.locale}}
+  @texts={{this.texts}}
   @pageOptions={{this.pageOptions}}
   @isCondensed={{this.isCondensed}}
 />`,
@@ -49,17 +49,6 @@ export default {
         },
       },
     },
-    locale: {
-      name: 'locale',
-      description: "La langue de l'utilisateur",
-      type: { name: 'string', required: false },
-      control: { type: 'select' },
-      options: ['fr', 'en'],
-      table: {
-        type: { summary: 'string' },
-        defaultValue: { summary: 'fr' },
-      },
-    },
     onChange: {
       name: 'onChange',
       description: 'fonction éxecutée lors du changement de page ou pagination',
@@ -76,10 +65,29 @@ export default {
         defaultValue: { summary: 'false' },
       },
     },
+    texts: {
+      name: 'texts',
+      description: 'object contenant les traductions du composants',
+      type: { name: 'object', required: true },
+      control: { type: 'object' },
+      table: {
+        type: { summary: 'object' },
+        defaultValue: {
+          summary: JSON.stringify({
+            title: 'Voir :',
+            pageSize: "Séléctionner le nombre d'élement à afficher par page",
+            pageElementCount: '5 elements',
+            pageNumber: 'Page 1/3',
+            previousPage: 'Aller à la page précedente',
+            nextPage: 'Aller à la page suivante',
+          }),
+        },
+      },
+    },
   },
 };
 
-export const French = {
+export const MultiplePage = {
   args: {
     pagination: {
       page: 1,
@@ -87,25 +95,14 @@ export const French = {
       rowCount: 12,
       pageCount: 3,
     },
-    locale: 'fr',
-  },
-};
-
-export const English = {
-  args: {
-    pagination: {
-      page: 2,
-      pageSize: 10,
-      rowCount: 12,
-      pageCount: 2,
+    texts: {
+      title: 'Voir :',
+      pageSize: "Séléctionner le nombre d'élement à afficher par page",
+      pageElementCount: '5 elements',
+      pageNumber: 'Page 1/3',
+      previousPage: 'Aller à la page précedente',
+      nextPage: 'Aller à la page suivante',
     },
-    pageOptions: [
-      { label: '10', value: 10 },
-      { label: '20', value: 20 },
-      { label: '50', value: 50 },
-      { label: '100', value: 100 },
-    ],
-    locale: 'en',
   },
 };
 
@@ -117,7 +114,14 @@ export const OnePage = {
       rowCount: 2,
       pageCount: 1,
     },
-    locale: 'fr',
+    texts: {
+      title: 'Voir :',
+      pageSize: "Séléctionner le nombre d'élement à afficher par page",
+      pageElementCount: '5 elements',
+      pageNumber: 'Page 1/3',
+      previousPage: 'Aller à la page précedente',
+      nextPage: 'Aller à la page suivante',
+    },
   },
 };
 
@@ -129,7 +133,14 @@ export const Condensed = {
       rowCount: 2,
       pageCount: 1,
     },
-    locale: 'fr',
+    texts: {
+      title: 'Voir :',
+      pageSize: "Séléctionner le nombre d'élement à afficher par page",
+      pageElementCount: '5 elements',
+      pageNumber: 'Page 1/3',
+      previousPage: 'Aller à la page précedente',
+      nextPage: 'Aller à la page suivante',
+    },
     isCondensed: true,
   },
 };

--- a/tests/integration/components/pix-pagination-test.js
+++ b/tests/integration/components/pix-pagination-test.js
@@ -8,48 +8,6 @@ import sinon from 'sinon';
 module('Integration | Component | pagination', function (hooks) {
   setupRenderingTest(hooks);
 
-  test('Use PixPagination without locale params', async function (assert) {
-    // given
-    const paginationData = {
-      page: 1,
-      pageSize: 10,
-      rowCount: 2,
-      pageCount: 1,
-    };
-    this.set('pagination', paginationData);
-    // when
-    await render(hbs`<PixPagination @pagination={{this.pagination}} />`);
-
-    const PixPaginationElement = this.element.querySelector('.pix-pagination');
-    //then
-    assert.ok(PixPaginationElement);
-    assert.contains('Voir');
-    assert.contains('2 éléments');
-    assert.contains('Page 1 / 1');
-  });
-
-  test('Use locale params to translate component', async function (assert) {
-    // given
-    const paginationData = {
-      page: 1,
-      pageSize: 10,
-      rowCount: 2,
-      pageCount: 1,
-    };
-    this.set('locale', 'en');
-    this.set('pagination', paginationData);
-
-    // when
-    await render(hbs`<PixPagination @pagination={{this.pagination}} @locale={{this.locale}} />`);
-
-    const PixPaginationElement = this.element.querySelector('.pix-pagination');
-    //then
-    assert.ok(PixPaginationElement);
-    assert.contains('See');
-    assert.contains('2 items');
-    assert.contains('Page 1 / 1');
-  });
-
   module('PixPagination controls', function (hooks) {
     let onChangeStub, router;
 
@@ -67,17 +25,16 @@ module('Integration | Component | pagination', function (hooks) {
         rowCount: 12,
         pageCount: 2,
       };
+      const texts = { pageSize: "Nombre d'élément à afficher par page" };
 
       this.set('pagination', paginationData);
       this.set('onChange', onChangeStub);
-
+      this.set('texts', texts);
       // when
       const screen = await render(
-        hbs`<PixPagination @pagination={{this.pagination}} @onChange={{this.onChange}} />`,
+        hbs`<PixPagination @pagination={{this.pagination}} @onChange={{this.onChange}} @texts={{this.texts}} />`,
       );
-
-      await click(screen.getByLabelText("Nombre d'élément à afficher par page"));
-
+      await click(screen.getByLabelText(texts.pageSize));
       const optionLine = await screen.findByRole('option', { name: '50' });
 
       await click(optionLine);
@@ -97,17 +54,16 @@ module('Integration | Component | pagination', function (hooks) {
         rowCount: 12,
         pageCount: 2,
       };
-
+      const texts = { nextPage: 'Page Suivante' };
+      this.set('texts', texts);
       this.set('pagination', paginationData);
       this.set('onChange', onChangeStub);
 
       // when
       const screen = await render(
-        hbs`<PixPagination @pagination={{this.pagination}} @onChange={{this.onChange}} />`,
+        hbs`<PixPagination @pagination={{this.pagination}} @onChange={{this.onChange}} @texts={{this.texts}} />`,
       );
-
-      await click(screen.getByRole('button', { name: 'Aller à la page suivante', exact: false }));
-
+      await click(screen.getByRole('button', { name: texts.nextPage, exact: false }));
       // then
       assert.ok(router.replaceWith.calledWithExactly({ queryParams: { pageNumber: 2 } }));
       assert.ok(onChangeStub.called);
@@ -122,16 +78,17 @@ module('Integration | Component | pagination', function (hooks) {
         pageCount: 2,
       };
 
+      const texts = { previousPage: 'Page Précédente' };
+      this.set('texts', texts);
+
       this.set('pagination', paginationData);
       this.set('onChange', onChangeStub);
 
       // when
       const screen = await render(
-        hbs`<PixPagination @pagination={{this.pagination}} @onChange={{this.onChange}} />`,
+        hbs`<PixPagination @pagination={{this.pagination}} @onChange={{this.onChange}} @texts={{this.texts}} />`,
       );
-
-      await click(screen.getByRole('button', { name: 'Aller à la page précédente', exact: false }));
-
+      await click(screen.getByRole('button', { name: texts.previousPage, exact: false }));
       // then
       assert.ok(router.replaceWith.calledWithExactly({ queryParams: { pageNumber: 1 } }));
       assert.ok(onChangeStub.called);
@@ -146,17 +103,25 @@ module('Integration | Component | pagination', function (hooks) {
       rowCount: 12,
       pageCount: 2,
     };
+    const texts = {
+      title: 'Voir',
+      pageElementCount: '11-12 sur 12 éléments',
+      pageNumber: 'Page 2 / 2',
+    };
+    const onChangeStub = sinon.stub();
+
+    this.set('texts', texts);
     this.set('pagination', paginationData);
-
+    this.set('onChange', onChangeStub);
     // when
-    await render(hbs`<PixPagination @pagination={{this.pagination}} />`);
+    const screen = await render(
+      hbs`<PixPagination @pagination={{this.pagination}} @texts={{this.texts}} @onChange={{this.onChange}} />`,
+    );
 
-    const PixPaginationElement = this.element.querySelector('.pix-pagination');
     //then
-    assert.ok(PixPaginationElement);
-    assert.contains('Voir');
-    assert.contains('11-12 sur 12 éléments');
-    assert.contains('Page 2 / 2');
+    assert.notOk(screen.queryByRole('text', { name: texts.title }));
+    assert.ok(screen.getByText(texts.pageElementCount));
+    assert.ok(screen.getByText(texts.pageNumber));
   });
 
   test('When params isCondensed is true', async function (assert) {


### PR DESCRIPTION
## :boom: BREAKING_CHANGES
Suppression de l'argument locale
Ajout de 7 libellé :

```
beforeResultsPerPageLabel
selectPageSizeLabel
multiplePageElementCountLabel
singlePageElementCountLabel
pageNumberLabel
previousPageLabel
nextPageLabel
```


## :christmas_tree: Problème
Une librairie de composant ne devrait pas avoir à porter les traductions des label mis à disposition

## :gift: Proposition
On nettoie tout ça dans le but de supprimer la traduction

## :star2: Remarques
ce point est util dans le cadre de la migration vers les addons vé pix-ui-libs afin de garantir des packages le plus petit . 

## :santa: Pour tester
Brancher ça sur une RA faire l'implem. vérifier que tout est ok  .

Test d'implémentation sur [PixOrga](https://github.com/1024pix/pix/pull/17213)