### PR TITLE
[BREAKING] supprimer l'i18n du PixTag (PIX-23992) 

### DIFF
--- a/addon/components/pix-tag.gjs
+++ b/addon/components/pix-tag.gjs
@@ -1,9 +1,22 @@
+import { warn } from '@ember/debug';
 import Component from '@glimmer/component';
 
-import { formatMessage } from '../translations';
 import PixIconButton from './pix-icon-button';
 
 export default class PixTag extends Component {
+  constructor(...args) {
+    super(...args);
+    if (this.args.onRemove) {
+      warn(
+        'PixTag: texts.removeButtonLabel is mandatory when onRemove is provided  ',
+        Boolean(this.args.texts?.removeButtonLabel),
+        {
+          id: 'pix-ui.pix-tag.texts.mandatory',
+        },
+      );
+    }
+  }
+
   get classes() {
     const { color } = this.args;
     const classes = [];
@@ -11,16 +24,12 @@ export default class PixTag extends Component {
     return classes.join(' ');
   }
 
-  get ariaLabel() {
-    return formatMessage(this.args.locale || 'fr', 'tag.removeButton');
-  }
-
   <template>
     <div class="pix-tag {{this.classes}}" ...attributes>
       {{yield}}
-      {{#if @displayRemoveButton}}
+      {{#if @onRemove}}
         <PixIconButton
-          @ariaLabel={{this.ariaLabel}}
+          @ariaLabel={{@texts.removeButtonLabel}}
           @iconName="close"
           @size="xsmall"
           @triggerAction={{@onRemove}}

--- a/addon/translations/en.js
+++ b/addon/translations/en.js
@@ -8,9 +8,6 @@ export default {
   select: {
     search: 'Search',
   },
-  tag: {
-    removeButton: 'Remove',
-  },
   stepper: {
     ariaLabel: 'Step {current, number} of {total, number}',
   },

--- a/addon/translations/fr.js
+++ b/addon/translations/fr.js
@@ -9,9 +9,6 @@ export default {
   select: {
     search: 'Rechercher',
   },
-  tag: {
-    removeButton: 'Supprimer',
-  },
   pixNavigation: {
     shrinkNavigationAriaLabel: 'Réduire la largeur du menu de navigation',
     expandNavigationAriaLabel: 'Revenir à la largeur initiale du menu de navigation',

--- a/addon/translations/nl.js
+++ b/addon/translations/nl.js
@@ -8,10 +8,6 @@ export default {
   select: {
     search: 'Zoeken',
   },
-
-  tag: {
-    removeButton: 'Verwijderen',
-  },
   stepper: {
     ariaLabel: 'Stap {current, number} van {total, number}',
   },

--- a/app/stories/pix-tag.mdx
+++ b/app/stories/pix-tag.mdx
@@ -11,7 +11,8 @@ Un `Tag` est un type de `Chips` qui permet de mettre en avant une information ou
 
 <Story of={ComponentStories.Default} height={60} />
 
-Il est également possible d'afficher un bouton de suppression.
+Il est également possible d'afficher un bouton de suppression en passant la propriété `onRemove`.
+Dans ce cas il devient obligatoire de passer également la propriété `texts` contenant la clé `removeButtonLabel` avec le texte de l'aria label du bouton de suppression.
 Il faut dans ce cas passer une propriété `texts` contenant la clé `removeButtonLabel` avec le texte de l'aria label du bouton de suppression.
 Cette propriété est obligatoire si l'on passe la propriété `@onRemove`
 

--- a/app/stories/pix-tag.mdx
+++ b/app/stories/pix-tag.mdx
@@ -12,7 +12,8 @@ Un `Tag` est un type de `Chips` qui permet de mettre en avant une information ou
 <Story of={ComponentStories.Default} height={60} />
 
 Il est également possible d'afficher un bouton de suppression.
-Il faut dans ce cas passer une locale en argument pour localiser l'aria label du bouton de suppression.
+Il faut dans ce cas passer une propriété `texts` contenant la clé `removeButtonLabel` avec le texte de l'aria label du bouton de suppression.
+Cette propriété est obligatoire si l'on passe la propriété `@onRemove`
 
 ## Usage
 
@@ -23,9 +24,7 @@ Par défaut:
 Customiser la couleur du tag:
 <PixTag @color="purple"> This is a purple tag </PixTag>
 
-<PixTag @displayRemoveButton="{{true}}" onRemove="{{this.removeTag}}" locale="fr"
-  >un tag supprimable</PixTag
->
+<PixTag @texts="{{this.texts}}" @onRemove="{{this.removeTag}}"> un tag supprimable </PixTag>
 ```
 
 ## Arguments

--- a/app/stories/pix-tag.stories.js
+++ b/app/stories/pix-tag.stories.js
@@ -24,15 +24,18 @@ export default {
         'blue-light',
       ],
     },
-    displayRemoveButton: {
-      name: 'displayRemoveButton',
-      description: "Permet d'afficher un bouton pour retirer le tag",
-      type: { name: 'boolean', required: false },
+    texts: {
+      name: 'texts',
+      description: 'object contenant les traductions du composants',
+      type: { name: 'object', required: true },
+      control: { type: 'object' },
       table: {
-        type: { summary: 'boolean' },
-        defaultValue: { summary: false },
-        control: { type: 'radio' },
-        options: [true, false],
+        type: { summary: 'object' },
+        defaultValue: {
+          summary: JSON.stringify({
+            title: 'Supprimer le tag',
+          }),
+        },
       },
     },
     onRemove: {
@@ -41,21 +44,11 @@ export default {
       type: { required: false },
       control: { disable: true },
     },
-    locale: {
-      name: 'locale',
-      description: "Locale permettant de localiser l'aria label du bouton de suppression",
-      type: { name: 'string', required: false },
-      table: { defaultValue: { summary: 'fr' } },
-      control: {
-        type: 'select',
-      },
-      options: ['fr', 'en', 'nl'],
-    },
   },
 };
 
 const Template = (args) => ({
-  template: hbs`<PixTag @color={{this.color}} @displayRemoveButton={{this.displayRemoveButton}} @onRemove={{this.onRemove}}>
+  template: hbs`<PixTag @color={{this.color}} @texts={{this.texts}} @onRemove={{this.onRemove}}>
 Contenu du tag
 </PixTag>`,
   context: args,
@@ -64,6 +57,6 @@ Contenu du tag
 export const Default = Template.bind({});
 Default.args = {
   color: 'primary',
-  displayRemoveButton: false,
+  texts: { removeButtonLabel: 'Supprimer le bouton' },
   onRemove: () => console.log('remove button clicked'),
 };

--- a/tests/integration/components/pix-tag-test.js
+++ b/tests/integration/components/pix-tag-test.js
@@ -28,18 +28,25 @@ module('Integration | Component | pix-tag', function (hooks) {
   });
 
   test('it displays remove button when displayRemoveButton is true', async function (assert) {
-    const screen = await render(hbs`<PixTag @displayRemoveButton={{true}}>tag text</PixTag>`);
+    this.texts = { removeButtonLabel: 'Supprimer le tag' };
+    this.onRemove = sinon.stub();
 
-    assert.dom(screen.getByRole('button', { name: 'Supprimer' })).exists();
+    const screen = await render(
+      hbs`<PixTag @texts={{this.texts}} @onRemove={{this.onRemove}}>tag text</PixTag>`,
+    );
+
+    assert.dom(screen.getByRole('button', { name: this.texts.removeButtonLabel })).exists();
   });
 
   test('it calls onRemove when button is clicked', async function (assert) {
+    this.texts = { removeButtonLabel: 'Supprimer le tag' };
     this.onRemove = sinon.stub();
+
     const screen = await render(
-      hbs`<PixTag @displayRemoveButton={{true}} @onRemove={{this.onRemove}}>tag text</PixTag>`,
+      hbs`<PixTag @texts={{this.texts}} @onRemove={{this.onRemove}}>text</PixTag>`,
     );
 
-    await click(screen.getByRole('button', { name: 'Supprimer' }));
+    await click(screen.getByRole('button', { name: this.texts.removeButtonLabel }));
 
     assert.ok(this.onRemove.calledOnce);
   });


### PR DESCRIPTION
## :boom: BREAKING_CHANGES
Modification de l'API de PixTag.
`@locale` et `@displayRemoveButton` sont remplacés par `@removeButtonLabel` qui devient obligatoire si l'on passe `@onRemove`


## :christmas_tree: Problème
Le composant `PixTag` embarque des données traduite, cela peut poser des problèmes de desynchronisation entre les langues des front et les langues  supportées par pix-ui

## :gift: Proposition
Supprimer l'utilisation de `formatMessage` 

## :star2: Remarques
- Il faudra faire la modification côté PixAdmin

## :santa: Pour tester
Voir la story de `PixTag`

