### PR TITLE
[BREAKING] Supprimer les traductions du PixStepper (PIX-23996)

### DIFF
--- a/addon/components/pix-stepper.gjs
+++ b/addon/components/pix-stepper.gjs
@@ -1,10 +1,21 @@
+import { warn } from '@ember/debug';
 import Component from '@glimmer/component';
 import { eq } from 'ember-truth-helpers';
 
-import { formatMessage } from '../translations';
 import PixStep from './pix-step';
 
 export default class PixStepperComponent extends Component {
+  constructor(...args) {
+    super(...args);
+    warn(
+      'PixStepper: @texts attribute is mandatory for accessibility.',
+      Boolean(this.args.texts?.ariaLabel),
+      {
+        id: 'pix-ui.stepper-component.texts.mandatory',
+      },
+    );
+  }
+
   get cssClass() {
     const classes = ['pix-stepper'];
 
@@ -19,15 +30,8 @@ export default class PixStepperComponent extends Component {
     return this.args.currentStep - 1;
   }
 
-  get ariaLabel() {
-    return formatMessage(this.args.locale ?? 'fr', 'stepper.ariaLabel', {
-      current: this.args.currentStep,
-      total: this.args.steps.length,
-    });
-  }
-
   <template>
-    <ol class={{this.cssClass}} role="list" aria-label={{this.ariaLabel}} ...attributes>
+    <ol class={{this.cssClass}} role="list" ...attributes aria-label={{@texts.ariaLabel}}>
       {{#each @steps as |step index|}}
         <PixStep
           @index={{index}}

--- a/addon/translations/en.js
+++ b/addon/translations/en.js
@@ -8,9 +8,6 @@ export default {
   select: {
     search: 'Search',
   },
-  stepper: {
-    ariaLabel: 'Step {current, number} of {total, number}',
-  },
   pixNavigation: {
     shrinkNavigationAriaLabel: 'Reduce the width of the navigation menu',
     expandNavigationAriaLabel: 'Return to the initial width of the navigation menu',

--- a/addon/translations/es-419.js
+++ b/addon/translations/es-419.js
@@ -8,7 +8,4 @@ export default {
   select: {
     search: 'Buscar',
   },
-  stepper: {
-    ariaLabel: 'Paso {current, number} de {total, number}',
-  },
 };

--- a/addon/translations/es.js
+++ b/addon/translations/es.js
@@ -8,9 +8,6 @@ export default {
   select: {
     search: 'Buscar',
   },
-  stepper: {
-    ariaLabel: 'Paso {current, number} de {total, number}',
-  },
   pixNavigation: {
     shrinkNavigationAriaLabel: 'Reducir el ancho del menú de navegación',
     expandNavigationAriaLabel: 'Volver al ancho inicial del menú de navegación',

--- a/addon/translations/fr.js
+++ b/addon/translations/fr.js
@@ -13,7 +13,4 @@ export default {
     shrinkNavigationAriaLabel: 'Réduire la largeur du menu de navigation',
     expandNavigationAriaLabel: 'Revenir à la largeur initiale du menu de navigation',
   },
-  stepper: {
-    ariaLabel: 'Étape {current, number} sur {total, number}',
-  },
 };

--- a/addon/translations/nl.js
+++ b/addon/translations/nl.js
@@ -8,9 +8,6 @@ export default {
   select: {
     search: 'Zoeken',
   },
-  stepper: {
-    ariaLabel: 'Stap {current, number} van {total, number}',
-  },
   pixNavigation: {
     shrinkNavigationAriaLabel: 'De breedte van het navigatiemenu verkleinen',
     expandNavigationAriaLabel: 'Terug naar de oorspronkelijke breedte van het navigatiemenu',

--- a/app/stories/pix-stepper.mdx
+++ b/app/stories/pix-stepper.mdx
@@ -28,7 +28,7 @@ Au-delà de 3 étapes, le stepper adapte automatiquement son affichage (mode lon
 ## Usage
 
 ```html
-<PixStepper @steps="{{this.steps}}" @currentStep="{{2}}" @ariaLabel="Étape 1/2" />
+<PixStepper @steps="{{this.steps}}" @currentStep="{{2}}" @texts={{{ariaLabel: "Étape 1/2" }}}/>
 ```
 
 Où `steps` est un tableau d'objets :

--- a/app/stories/pix-stepper.mdx
+++ b/app/stories/pix-stepper.mdx
@@ -6,7 +6,7 @@ import * as ComponentStories from './pix-stepper.stories';
 # PixStepper
 
 Un `PixStepper` permet d'afficher une progression par étapes. Chaque étape peut avoir un titre et un sous-titre optionnel.
-
+Le composant nécessite une propriété `texts` contenant une clé `ariaLabel` contenant la valeur traduite du `aria-label` du composant.
 Au-delà de 3 étapes, le stepper adapte automatiquement son affichage (mode long).
 
 ## Par défaut
@@ -28,7 +28,7 @@ Au-delà de 3 étapes, le stepper adapte automatiquement son affichage (mode lon
 ## Usage
 
 ```html
-<PixStepper @steps={{this.steps}} @currentStep={{2}} />
+<PixStepper @steps="{{this.steps}}" @currentStep="{{2}}" @ariaLabel="Étape 1/2" />
 ```
 
 Où `steps` est un tableau d'objets :

--- a/app/stories/pix-stepper.stories.js
+++ b/app/stories/pix-stepper.stories.js
@@ -22,12 +22,26 @@ export default {
         type: { summary: 'number' },
       },
     },
+    texts: {
+      name: 'texts',
+      description: 'object contenant les traductions du composant',
+      type: { name: 'object', required: true },
+      control: { type: 'object' },
+      table: {
+        type: { summary: 'object' },
+        defaultValue: {
+          summary: JSON.stringify({
+            ariaLabel: 'texte contenant la traduction pour la propriété ariaLabel',
+          }),
+        },
+      },
+    },
   },
 };
 
 const Template = (args) => {
   return {
-    template: hbs`<PixStepper @steps={{this.steps}} @currentStep={{this.currentStep}} />`,
+    template: hbs`<PixStepper @steps={{this.steps}} @currentStep={{this.currentStep}} @texts={{this.texts}} />`,
     context: args,
   };
 };
@@ -40,6 +54,9 @@ Default.args = {
     { title: 'Validation', subtitle: 'Finalisez votre inscription' },
   ],
   currentStep: 1,
+  texts: {
+    ariaLabel: 'étape 1 sur 3',
+  },
 };
 
 export const secondStep = Template.bind({});
@@ -50,6 +67,9 @@ secondStep.args = {
     { title: 'Validation', subtitle: 'Finalisez votre inscription' },
   ],
   currentStep: 2,
+  texts: {
+    ariaLabel: 'étape 2 sur 3',
+  },
 };
 
 export const longStepper = Template.bind({});
@@ -62,10 +82,16 @@ longStepper.args = {
     { title: 'Étape 5', subtitle: 'Description de la cinquième étape' },
   ],
   currentStep: 3,
+  texts: {
+    ariaLabel: 'étape 3 sur 5',
+  },
 };
 
 export const withoutSubtitle = Template.bind({});
 withoutSubtitle.args = {
   steps: [{ title: 'Étape 1' }, { title: 'Étape 2' }, { title: 'Étape 3' }],
   currentStep: 2,
+  texts: {
+    ariaLabel: 'étape 2 sur 3',
+  },
 };

--- a/tests/integration/components/pix-stepper-test.js
+++ b/tests/integration/components/pix-stepper-test.js
@@ -34,42 +34,15 @@ module('Integration | Component | PixStepper', function (hooks) {
       // given
       this.set('steps', [{ title: 'Étape 1' }, { title: 'Étape 2' }, { title: 'Étape 3' }]);
       this.set('currentStep', 2);
+      this.set('texts', { ariaLabel: 'Étape 2 sur 3' });
 
       // when
       const screen = await render(
-        hbs`<PixStepper @steps={{this.steps}} @currentStep={{this.currentStep}} />`,
+        hbs`<PixStepper @steps={{this.steps}} @texts={{this.texts}} @currentStep={{this.currentStep}} />`,
       );
 
       // then
-      assert.dom(screen.getByRole('list', { name: 'Étape 2 sur 3' })).exists();
-    });
-
-    test('it translates aria-label according to @locale', async function (assert) {
-      // given
-      this.set('steps', [{ title: 'Step 1' }, { title: 'Step 2' }]);
-      this.set('currentStep', 1);
-
-      // when
-      const screen = await render(
-        hbs`<PixStepper @steps={{this.steps}} @currentStep={{this.currentStep}} @locale='en' />`,
-      );
-
-      // then
-      assert.dom(screen.getByRole('list', { name: 'Step 1 of 2' })).exists();
-    });
-
-    test('it allows overriding aria-label via splattributes', async function (assert) {
-      // given
-      this.set('steps', [{ title: 'Étape 1' }]);
-      this.set('currentStep', 1);
-
-      // when
-      const screen = await render(
-        hbs`<PixStepper @steps={{this.steps}} @currentStep={{this.currentStep}} aria-label='Inscription' />`,
-      );
-
-      // then
-      assert.dom(screen.getByRole('list', { name: 'Inscription' })).exists();
+      assert.dom(screen.getByRole('list', { name: this.texts.ariaLabel })).exists();
     });
   });
 


### PR DESCRIPTION
## :boom: BREAKING_CHANGES
L'api evolue, la traduction du aria-label est passé en paramêtre

## :christmas_tree: Problème
Les composants utilise des traductions et ne supporte pas toujours les meme langue que les applications qui les utilise. cela resulte a des traduction manquant selon certaines langues

## :gift: Proposition
passer les valeurs internationnalisées des textes par l'appelant
## :star2: Remarques
On a préféré passer par un prop @ariaLabel plutot qu'un attribute pour s'assurer que la propriété est bien passé. Pour cela on utilise l'utilitaire de debug warn.


## :santa: Pour tester
Afficher la story du PixStepper et vérifier ses propriété
