### PR TITLE
[BREAKING] Supprimer les traductions sur PixCheckbox / PixRadiobutton (Pix-24018)

### DIFF
--- a/addon/components/pix-checkbox.gjs
+++ b/addon/components/pix-checkbox.gjs
@@ -4,7 +4,6 @@ import { action } from '@ember/object';
 import { guidFor } from '@ember/object/internals';
 import Component from '@glimmer/component';
 
-import { formatMessage } from '../translations';
 import PixLabelWrapped from './pix-label-wrapped';
 export default class PixCheckbox extends Component {
   constructor() {
@@ -65,27 +64,23 @@ export default class PixCheckbox extends Component {
   }
 
   get stateSuccessMessage() {
-    return this.formatMessage('state.success');
+    return this.args.texts?.stateSuccess;
   }
 
   get stateErrorMessage() {
-    return this.formatMessage('state.error');
+    return this.args.texts?.stateError;
   }
 
   get stateDeclarativeMessage() {
-    return this.formatMessage('state.declarative');
-  }
-
-  formatMessage(message) {
-    return formatMessage(this.args.locale ?? 'fr', `input.${message}`);
+    return this.args.texts?.stateDeclarative;
   }
 
   <template>
     <div class="pix-checkbox {{@class}}">
       <PixLabelWrapped
         @for={{this.id}}
-        @requiredLabel={{@requiredLabel}}
-        @subLabel={{@subLabel}}
+        @requiredLabel={{@text?.requiredLabel}}
+        @subLabel={{@text?.subLabel}}
         @size={{@size}}
         @inlineLabel={{true}}
         @screenReaderOnly={{@screenReaderOnly}}

--- a/addon/components/pix-radio-button.gjs
+++ b/addon/components/pix-radio-button.gjs
@@ -4,7 +4,6 @@ import { action } from '@ember/object';
 import { guidFor } from '@ember/object/internals';
 import Component from '@glimmer/component';
 
-import { formatMessage } from '../translations';
 import PixLabelWrapped from './pix-label-wrapped';
 
 export default class PixRadioButton extends Component {
@@ -53,15 +52,11 @@ export default class PixRadioButton extends Component {
   }
 
   get stateSuccessMessage() {
-    return this.formatMessage('state.success');
+    return this.args.texts?.stateSuccess;
   }
 
   get stateErrorMessage() {
-    return this.formatMessage('state.error');
-  }
-
-  formatMessage(message) {
-    return formatMessage('fr', `input.${message}`);
+    return this.args.texts?.stateError;
   }
 
   @action
@@ -75,8 +70,8 @@ export default class PixRadioButton extends Component {
     <div class="pix-radio-button {{@class}}">
       <PixLabelWrapped
         @for={{this.id}}
-        @requiredLabel={{@requiredLabel}}
-        @subLabel={{@subLabel}}
+        @requiredLabel={{@text?.requiredLabel}}
+        @subLabel={{@text?.subLabel}}
         @size={{@size}}
         @screenReaderOnly={{@screenReaderOnly}}
         @isDisabled={{this.isDisabled}}

--- a/addon/translations/en.js
+++ b/addon/translations/en.js
@@ -1,10 +1,4 @@
 export default {
-  input: {
-    state: {
-      success: 'Correct selection',
-      error: 'Incorrect selection',
-    },
-  },
   select: {
     search: 'Search',
   },

--- a/addon/translations/es-419.js
+++ b/addon/translations/es-419.js
@@ -1,10 +1,4 @@
 export default {
-  input: {
-    state: {
-      success: 'Selección correcta',
-      error: 'Selección incorrecta',
-    },
-  },
   select: {
     search: 'Buscar',
   },

--- a/addon/translations/es.js
+++ b/addon/translations/es.js
@@ -1,10 +1,4 @@
 export default {
-  input: {
-    state: {
-      success: 'Selección correcta',
-      error: 'Selección incorrecta',
-    },
-  },
   select: {
     search: 'Buscar',
   },

--- a/addon/translations/fr.js
+++ b/addon/translations/fr.js
@@ -1,11 +1,4 @@
 export default {
-  input: {
-    state: {
-      success: 'Sélection correcte',
-      error: 'Sélection incorrecte',
-      declarative: 'Sélection sans bonne ou mauvaise réponse',
-    },
-  },
   select: {
     search: 'Rechercher',
   },

--- a/addon/translations/nl.js
+++ b/addon/translations/nl.js
@@ -1,10 +1,4 @@
 export default {
-  input: {
-    state: {
-      success: 'Correcte selectie',
-      error: 'Onjuiste selectie',
-    },
-  },
   select: {
     search: 'Zoeken',
   },

--- a/app/stories/pix-checkbox.mdx
+++ b/app/stories/pix-checkbox.mdx
@@ -62,6 +62,7 @@ Un cursor `not-allowed` est défini sur la checkbox et son label lorsqu'elle est
 ```html
 <PixCheckbox
   @screenReaderOnly={{false}}
+  @texts={{texts}}
   @isIndeterminate={{false}}
   @size="small"
   @isDisabled={{true}}

--- a/app/stories/pix-checkbox.stories.js
+++ b/app/stories/pix-checkbox.stories.js
@@ -50,17 +50,21 @@ export default {
         type: { summary: 'string' },
       },
     },
-    subLabel: {
-      name: 'subLabel',
-      description: 'Un descriptif complétant le label',
-      type: { name: 'string', required: false },
-    },
-    requiredLabel: {
-      name: 'requiredLabel',
-      description: 'Label indiquant que le champ est requis.',
-      type: { name: 'string', required: false },
+    texts: {
+      name: 'texts',
+      description: 'Objet contenant les différentes traductions',
+      type: { name: 'object', required: false },
       table: {
-        type: { summary: 'string' },
+        type: { summary: 'object' },
+        defaultValue: {
+          summary: JSON.stringify({
+            subLabel: 'Mon sous label',
+            requiredLabel: 'Champs requis',
+            stateSuccess: 'Etat valide',
+            stateError: 'Etat invalide',
+            stateDeclarative: 'Etat déclaratif',
+          }),
+        },
       },
     },
     screenReaderOnly: {
@@ -105,8 +109,7 @@ const Template = (args) => {
   @locale={{this.locale}}
   disabled={{this.disabled}}
   @size={{this.size}}
-  @subLabel={{this.subLabel}}
-  @requiredLabel={{this.requiredLabel}}
+  @texts={{this.texts}}
   @inlineLabel={{this.inlineLabel}}
   @screenReaderOnly={{this.screenReaderOnly}}
 >

--- a/app/stories/pix-radio-button.mdx
+++ b/app/stories/pix-radio-button.mdx
@@ -48,7 +48,7 @@ L'attribut `@isDisabled` permet de désactiver la radio en conservant la possibi
 ## Usage
 
 ```html
-<PixRadioButton name="input-name" @value="{{value}}">
+<PixRadioButton name="input-name" @value="{{value}}" @texts={{texts}}>
   <:label>Exemple de label</:label>
 </PixRadioButton>
 ```

--- a/app/stories/pix-radio-button.stories.js
+++ b/app/stories/pix-radio-button.stories.js
@@ -45,17 +45,20 @@ export default {
         type: { summary: 'string' },
       },
     },
-    subLabel: {
-      name: 'subLabel',
-      description: 'Un descriptif complétant le label',
-      type: { name: 'string', required: false },
-    },
-    requiredLabel: {
-      name: 'requiredLabel',
-      description: 'Label indiquant que le champ est requis.',
-      type: { name: 'string', required: false },
+    texts: {
+      name: 'texts',
+      description: 'Objet contenant les différentes traductions',
+      type: { name: 'object', required: false },
       table: {
-        type: { summary: 'string' },
+        type: { summary: 'object' },
+        defaultValue: {
+          summary: JSON.stringify({
+            subLabel: 'Mon sous label',
+            requiredLabel: 'Champs requis',
+            stateSuccess: 'Etat valide',
+            stateError: 'Etat invalide',
+          }),
+        },
       },
     },
     screenReaderOnly: {
@@ -93,8 +96,7 @@ const Template = (args) => {
   @isDisabled={{this.isDisabled}}
   @size={{this.size}}
   @screenReaderOnly={{this.screenReaderOnly}}
-  @requiredLabel={{this.requiredLabel}}
-  @subLabel={{this.subLabel}}
+  @texts={{this.texts}}
 >
   <:label>{{this.label}}</:label>
 </PixRadioButton>`,

--- a/tests/integration/components/pix-checkbox-test.js
+++ b/tests/integration/components/pix-checkbox-test.js
@@ -98,10 +98,13 @@ module('Integration | Component | checkbox', function (hooks) {
     test(`it should read success state info if given`, async function (assert) {
       // given
       this.set('isDisabled', true);
-
+      this.texts = {
+        stateSuccess: 'Sélection correcte',
+      };
       // when
       const screen = await render(
-        hbs`<PixCheckbox checked @isDisabled={{this.isDisabled}} @state='success'><:label>Recevoir la newsletter</:label></PixCheckbox>`,
+        hbs`<PixCheckbox checked @isDisabled={{this.isDisabled}} @state='success' @texts={{this.texts}}><:label
+  >Recevoir la newsletter</:label></PixCheckbox>`,
       );
 
       // then
@@ -118,10 +121,13 @@ module('Integration | Component | checkbox', function (hooks) {
     test(`it should read error state info if given`, async function (assert) {
       // given
       this.set('isDisabled', true);
-
+      this.texts = {
+        stateError: 'Sélection incorrecte',
+      };
       // when
       const screen = await render(
-        hbs`<PixCheckbox checked @isDisabled={{this.isDisabled}} @state='error'><:label>Recevoir la newsletter</:label></PixCheckbox>`,
+        hbs`<PixCheckbox checked @isDisabled={{this.isDisabled}} @state='error' @texts={{this.texts}}><:label
+  >Recevoir la newsletter</:label></PixCheckbox>`,
       );
 
       // then
@@ -138,14 +144,18 @@ module('Integration | Component | checkbox', function (hooks) {
     test(`it should read declarative state info if given`, async function (assert) {
       // given
       this.set('isDisabled', true);
-
+      this.texts = {
+        stateDeclarative: 'Sélection sans bonne ou mauvaise réponse',
+      };
       // when
       const screen = await render(
-        hbs`<PixCheckbox checked @isDisabled={{this.isDisabled}} @state='declarative'><:label>La galette des
-    rois</:label></PixCheckbox>`,
-      );
-
-      // then
+        hbs`<PixCheckbox
+  checked
+  @isDisabled={{this.isDisabled}}
+  @state='declarative'
+  @texts={{this.texts}}
+><:label>La galette des rois</:label></PixCheckbox>`,
+      ); // then
       assert
         .dom(
           screen.getByRole('checkbox', {

--- a/tests/integration/components/pix-radio-button-test.js
+++ b/tests/integration/components/pix-radio-button-test.js
@@ -81,14 +81,18 @@ module('Integration | Component | pix-radio-button', function (hooks) {
     test(`it should read success state info if given`, async function (assert) {
       // given
       this.set('isDisabled', true);
-
+      this.texts = {
+        stateSuccess: 'Sélection correcte',
+      };
       // when
       const screen = await render(
-        hbs`<PixRadioButton checked @isDisabled={{this.isDisabled}} @state='success'><:label>Recevoir la
-    newsletter</:label></PixRadioButton>`,
-      );
-
-      // then
+        hbs`<PixRadioButton
+  checked
+  @isDisabled={{this.isDisabled}}
+  @state='success'
+  @texts={{this.texts}}
+><:label>Recevoir la newsletter</:label></PixRadioButton>`,
+      ); // then
       assert
         .dom(
           screen.getByRole('radio', {
@@ -102,11 +106,13 @@ module('Integration | Component | pix-radio-button', function (hooks) {
     test(`it should read error state info if given`, async function (assert) {
       // given
       this.set('isDisabled', true);
-
+      this.texts = {
+        stateError: 'Sélection incorrecte',
+      };
       // when
       const screen = await render(
-        hbs`<PixRadioButton checked @isDisabled={{this.isDisabled}} @state='error'><:label>Recevoir la
-    newsletter</:label></PixRadioButton>`,
+        hbs`<PixRadioButton checked @isDisabled={{this.isDisabled}} @state='error' @texts={{this.texts}}><:label
+  >Recevoir la newsletter</:label></PixRadioButton>`,
       );
 
       // then


### PR DESCRIPTION
## :boom: BREAKING_CHANGES
Utilisations d'un args `@texts` pour transmettre les trad ( à l'exception du label )

## :christmas_tree: Problème
On ne veut plus que PixUI gère des traductions c'est pas son job

## :gift: Proposition
on enlève ça.

## :star2: Remarques
Surtout utilisé dans PixApp avec les module

## :santa: Pour tester
> _Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc._
