### PR TITLE
[BREAKING] Suprimer les traductions de PixNavigation (PIX-24016)

### DIFF
--- a/addon/components/pix-navigation.gjs
+++ b/addon/components/pix-navigation.gjs
@@ -6,7 +6,6 @@ import { inject as service } from '@ember/service';
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 
-import { formatMessage } from '../translations';
 import PixButton from './pix-button';
 import PixIconButton from './pix-icon-button';
 
@@ -18,20 +17,30 @@ export default class PixNavigation extends Component {
     super(...args);
     this._navigationId = 'navigation-' + guidFor(this);
     warn(
-      'PixNavigation: @openLabel and @closeLabel are required',
-      this.args.openLabel && this.args.closeLabel,
+      'PixNavigation: @texts.openMenu and @texts.closeMenu are required',
+      this.args.texts?.openMenu && this.args.texts?.closeMenu,
       {
-        id: 'pix-navigation.open-close-labels',
+        id: 'pix-navigation.open-close-menu.required',
+      },
+    );
+    warn(
+      'PixNavigation: @texts.mainNavigation attribute is required for accessibility.',
+      this.args.texts?.mainNavigation,
+      {
+        id: 'pix-ui.stepper-component.texts.mainNavigation.required',
+      },
+    );
+    warn(
+      'PixNavigation: @texts.expandNavigation and @texts.shrinkNavigation attributes are required for accessibility.',
+      this.args.texts?.expandNavigation && this.args.texts?.shrinkNavigation,
+      {
+        id: 'pix-ui.stepper-component.texts.shrink-expand-navigation.required',
       },
     );
   }
 
   @tracked
   navigationMenuOpened = false;
-
-  formatMessage(message, values) {
-    return formatMessage(this.args.locale ?? 'fr', `pixNavigation.${message}`, values);
-  }
 
   @action
   toggleNavigationMenu() {
@@ -64,11 +73,13 @@ export default class PixNavigation extends Component {
   }
 
   get shrunkNavigationAriaLabel() {
-    return this.formatMessage(
-      this.shrinkNavigationService.isShrunk
-        ? 'expandNavigationAriaLabel'
-        : 'shrinkNavigationAriaLabel',
-    );
+    return this.shrinkNavigationService.isShrunk
+      ? this.args.texts.expandNavigation
+      : this.args.texts.shrinkNavigation;
+  }
+
+  get menuLabel() {
+    return this.navigationMenuOpened ? this.args.texts.closeMenu : this.args.texts.openMenu;
   }
 
   get navigationId() {
@@ -104,11 +115,7 @@ export default class PixNavigation extends Component {
             @triggerAction={{this.toggleNavigationMenu}}
           >
             <span class="screen-reader-only">
-              {{#if this.navigationMenuOpened}}
-                {{@closeLabel}}
-              {{else}}
-                {{@openLabel}}
-              {{/if}}
+              {{this.menuLabel}}
             </span>
           </PixButton>
         </div>
@@ -116,7 +123,7 @@ export default class PixNavigation extends Component {
       <nav
         class="pix-navigation__nav"
         {{on "click" this.closeNavigation}}
-        aria-label={{@navigationAriaLabel}}
+        aria-label={{@texts.mainNavigation}}
         id={{this.navigationId}}
       >
         {{yield to="navElements"}}

--- a/addon/translations/en.js
+++ b/addon/translations/en.js
@@ -2,8 +2,4 @@ export default {
   select: {
     search: 'Search',
   },
-  pixNavigation: {
-    shrinkNavigationAriaLabel: 'Reduce the width of the navigation menu',
-    expandNavigationAriaLabel: 'Return to the initial width of the navigation menu',
-  },
 };

--- a/addon/translations/es.js
+++ b/addon/translations/es.js
@@ -2,8 +2,4 @@ export default {
   select: {
     search: 'Buscar',
   },
-  pixNavigation: {
-    shrinkNavigationAriaLabel: 'Reducir el ancho del menú de navegación',
-    expandNavigationAriaLabel: 'Volver al ancho inicial del menú de navegación',
-  },
 };

--- a/addon/translations/fr.js
+++ b/addon/translations/fr.js
@@ -2,8 +2,4 @@ export default {
   select: {
     search: 'Rechercher',
   },
-  pixNavigation: {
-    shrinkNavigationAriaLabel: 'Réduire la largeur du menu de navigation',
-    expandNavigationAriaLabel: 'Revenir à la largeur initiale du menu de navigation',
-  },
 };

--- a/addon/translations/nl.js
+++ b/addon/translations/nl.js
@@ -2,8 +2,4 @@ export default {
   select: {
     search: 'Zoeken',
   },
-  pixNavigation: {
-    shrinkNavigationAriaLabel: 'De breedte van het navigatiemenu verkleinen',
-    expandNavigationAriaLabel: 'Terug naar de oorspronkelijke breedte van het navigatiemenu',
-  },
 };

--- a/app/stories/pix-navigation.mdx
+++ b/app/stories/pix-navigation.mdx
@@ -14,7 +14,7 @@ Le composant `<PixNavigation/>` comporte 3 placeholders
 Ce composant doit être utilisé avec le composant `<PixAppLayout>` afin de pouvoir occuper tout la hauteur de la page et être toujours visible.
 
 En complément, les composants `<PixNavigationButton/>` et `<PixNavigationSeparator/>` permettent de composer la navigation souhaitée.
-Il est possible de definir différent textes (label-aria, label de menu,...) avec l'attribut `@texts`
+Il est possible de définir différents textes (label-aria, label de menu,...) avec l'attribut `@texts`
 
 ## Usage
 

--- a/app/stories/pix-navigation.mdx
+++ b/app/stories/pix-navigation.mdx
@@ -14,14 +14,14 @@ Le composant `<PixNavigation/>` comporte 3 placeholders
 Ce composant doit être utilisé avec le composant `<PixAppLayout>` afin de pouvoir occuper tout la hauteur de la page et être toujours visible.
 
 En complément, les composants `<PixNavigationButton/>` et `<PixNavigationSeparator/>` permettent de composer la navigation souhaitée.
-Il est possible de definir le label ARIA de la navigation principale avec l'attribut `@navigationAriaLabel`, le label du Menu fermé avec `@closeLabel` et le label du menu ouvert avec `@openLabel`.
+Il est possible de definir différent textes (label-aria, label de menu,...) avec l'attribut `@texts`
 
 ## Usage
 
 ```html
 <PixAppLayout @variant="orga">
   <:navigation>
-    <PixNavigation @navigationAriaLabel="navigation principale" @openLabel="Ouvrir le menu" @closeLabel="Fermer le menu">
+    <PixNavigation @navigationAriaLabel="navigation principale" @texts={{texts}}>
       <:brand>
           <!-- Affichage du bloc identité -->
           <a href="/">

--- a/app/stories/pix-navigation.stories.js
+++ b/app/stories/pix-navigation.stories.js
@@ -22,23 +22,12 @@ export default {
       },
     },
   },
-  args: {
-    mainNavigation: 'Navigation Principale',
-    openMenu: 'Ouvrir le menu',
-    closeMenu: 'Fermer le menu',
-    shrinkNavigation: 'Réduire la largeur',
-    expandNavigation: 'Revenir à la largeur initiale du menu de navigation',
-  },
 };
 
 export const Navigation = (args) => {
   return {
     template: hbs`<PixAppLayout @variant='primary'>
-  <PixNavigation
-    @navigationAriaLabel={{this.navigationAriaLabel}}
-    @openLabel={{this.openLabel}}
-    @closeLabel={{this.closeLabel}}
-  >
+  <PixNavigation @texts={{this.texts}}>
     <:brand>
       <a href='/'>
         <img src='/pix-orga.svg' alt='pix orga' />

--- a/app/stories/pix-navigation.stories.js
+++ b/app/stories/pix-navigation.stories.js
@@ -3,23 +3,31 @@ import { hbs } from 'ember-cli-htmlbars';
 export default {
   title: 'Navigation/Navigation',
   argTypes: {
-    navigationAriaLabel: {
-      description: 'Variante de la navigation',
-      type: { name: 'string', required: true },
-    },
-    openLabel: {
-      description: 'Label à afficher lorsque la navbar est fermée.',
-      type: { name: 'string', required: true },
-    },
-    closeLabel: {
-      description: 'Label à afficher lorsque la navbar est ouverte.',
-      type: { name: 'string', required: true },
+    texts: {
+      name: 'texts',
+      description: 'object contenant les traductions du composants',
+      type: { name: 'object', required: true },
+      control: { type: 'object' },
+      table: {
+        type: { summary: 'object' },
+        defaultValue: {
+          summary: JSON.stringify({
+            mainNavigation: 'Navigation Principale',
+            openMenu: 'Ouvrir le menu',
+            closeMenu: 'Fermer le menu',
+            shrinkNavigation: 'Réduire la largeur',
+            expandNavigation: 'Revenir à la largeur initiale du menu de navigation',
+          }),
+        },
+      },
     },
   },
   args: {
-    navigationAriaLabel: 'Navigation Principale',
-    openLabel: 'Ouvrir le menu',
-    closeLabel: 'Fermer le menu',
+    mainNavigation: 'Navigation Principale',
+    openMenu: 'Ouvrir le menu',
+    closeMenu: 'Fermer le menu',
+    shrinkNavigation: 'Réduire la largeur',
+    expandNavigation: 'Revenir à la largeur initiale du menu de navigation',
   },
 };
 

--- a/tests/dummy/app/controllers/application.js
+++ b/tests/dummy/app/controllers/application.js
@@ -42,6 +42,15 @@ export default class ModalPage extends Controller {
     },
   ];
 
+  @tracked
+  texts = {
+    openLabel: "Ouvrir le menu",
+    closeLabel: "Fermer le menu",
+    mainNavigation: "navigation principale",
+    expandNavigation:  "Revenir à la taille initiale",
+    shrinkNavigation: "Réduire la taille",
+  }
+
   @action
   setStructure(option) {
     this.structure = option;

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -9,11 +9,7 @@
     </PixBannerAlert>
   </:banner>
   <:navigation>
-    <PixNavigation
-      @openLabel="Ouvrir le menu"
-      @closeLabel="Fermer le menu"
-      @navigationAriaLabel="navigation principale"
-    >
+    <PixNavigation @texts={{this.texts}}>
       <:brand>
         <a href="/">
           <img src="/pix-orga.svg" alt="pix orga" />

--- a/tests/integration/components/pix-navigation-test.js
+++ b/tests/integration/components/pix-navigation-test.js
@@ -6,20 +6,35 @@ import { module, test } from 'qunit';
 
 module('Integration | Component | pix-navigation', function (hooks) {
   setupRenderingTest(hooks);
+  const texts = {
+    mainNavigation: 'Navigation Principale',
+    openMenu: 'Ouvrir le menu',
+    closeMenu: 'Fermer le menu',
+    shrinkNavigation: 'Réduire la largeur',
+    expandNavigation: 'Revenir à la largeur initiale',
+  };
 
   module('Desktop', function () {
     test('it renders the navigation in a sidebar', async function (assert) {
+      //given
+      this.set('texts', texts);
+
       // when
-      const screen = await render(hbs`<PixNavigation @navigationAriaLabel='label' />`);
+      const screen = await render(
+        hbs`<PixNavigation @navigationAriaLabel='label' @texts={{this.texts}} />`,
+      );
       const aside = screen.getByRole('complementary');
 
       // then
-      assert.ok(within(aside).getByRole('navigation', { name: 'label' }));
+      assert.ok(within(aside).getByRole('navigation', { name: texts.mainNavigation }));
     });
 
     test('it renders content at the header of the aside', async function (assert) {
+      //given
+      this.set('texts', texts);
+
       // when
-      const screen = await render(hbs`<PixNavigation @navigationAriaLabel='label'>
+      const screen = await render(hbs`<PixNavigation @texts={{this.texts}}>
   <:brand>
     <svg role='img'><title>logo</title></svg>
   </:brand>
@@ -31,21 +46,27 @@ module('Integration | Component | pix-navigation', function (hooks) {
     });
 
     test('it renders content in the navigation', async function (assert) {
+      //given
+      this.set('texts', texts);
+
       // when
-      const screen = await render(hbs`<PixNavigation @navigationAriaLabel='label'>
+      const screen = await render(hbs`<PixNavigation @texts={{this.texts}}>
   <:navElements>
     <a href='toto'>mon lien</a>
   </:navElements>
 </PixNavigation>`);
-      const navBar = screen.getByRole('navigation', { name: 'label' });
+      const navBar = screen.getByRole('navigation', { name: 'Navigation Principale' });
 
       // then
       assert.ok(within(navBar).getByRole('link', { name: 'mon lien' }));
     });
 
     test('it renders content in the footer', async function (assert) {
+      //given
+      this.set('texts', texts);
+
       // when
-      const screen = await render(hbs`<PixNavigation @navigationAriaLabel='label'>
+      const screen = await render(hbs`<PixNavigation @texts={{this.texts}}>
   <:footer>
     <a href='toto'>mon lien</a>
   </:footer>
@@ -58,11 +79,12 @@ module('Integration | Component | pix-navigation', function (hooks) {
     });
 
     test('it hides the burger menu', async function (assert) {
+      //given
+      this.set('texts', texts);
+
       // when
-      const screen = await render(
-        hbs`<PixNavigation @navigationAriaLabel='label' @openLabel='open' @closeLabel='close' />`,
-      );
-      assert.notOk(screen.queryByRole('button', { name: 'menu' }));
+      const screen = await render(hbs`<PixNavigation @texts={{this.texts}} />`);
+      assert.notOk(screen.queryByRole('button', { name: 'Ouvrir le menu' }));
     });
 
     module('when navigation can be shrink', function () {
@@ -70,16 +92,13 @@ module('Integration | Component | pix-navigation', function (hooks) {
         // given
         const shrinkNavigationService = this.owner.lookup('service:shrinkNavigationService');
         shrinkNavigationService.canNavigationBeShrunk = true;
+        this.set('texts', texts);
 
         // when
-        const screen = await render(
-          hbs`<PixNavigation @navigationAriaLabel='label' @openLabel='open' @closeLabel='close' />`,
-        );
+        const screen = await render(hbs`<PixNavigation @texts={{this.texts}} />`);
 
         // then
-        assert
-          .dom(screen.getByRole('button', { name: 'Réduire la largeur du menu de navigation' }))
-          .exists();
+        assert.dom(screen.getByRole('button', { name: texts.shrinkNavigation })).exists();
       });
 
       module(`when the shrink button is clicked`, function () {
@@ -87,20 +106,17 @@ module('Integration | Component | pix-navigation', function (hooks) {
           // given
           const shrinkNavigationService = this.owner.lookup('service:shrinkNavigationService');
           shrinkNavigationService.canNavigationBeShrunk = true;
+          this.set('texts', texts);
 
           // when
-          const screen = await render(
-            hbs`<PixNavigation @navigationAriaLabel='label' @openLabel='open' @closeLabel='close' />`,
-          );
-          await click(
-            screen.getByRole('button', { name: 'Réduire la largeur du menu de navigation' }),
-          );
+          const screen = await render(hbs`<PixNavigation @texts={{this.texts}} />`);
+          await click(screen.getByRole('button', { name: texts.shrinkNavigation }));
 
           // then
           assert
             .dom(
               screen.getByRole('button', {
-                name: 'Revenir à la largeur initiale du menu de navigation',
+                name: texts.expandkNavigation,
               }),
             )
             .exists();
@@ -111,10 +127,11 @@ module('Integration | Component | pix-navigation', function (hooks) {
           const shrinkNavigationService = this.owner.lookup('service:shrinkNavigationService');
           shrinkNavigationService.canNavigationBeShrunk = true;
           this.set('triggerAction', () => {});
+          this.set('texts', texts);
 
           // when
           const screen = await render(
-            hbs`<PixNavigation @navigationAriaLabel='label' @openLabel='open' @closeLabel='close'>
+            hbs`<PixNavigation @texts={{this.texts}}>
   <:footer>
     <p>
       Martin Dupond
@@ -124,9 +141,7 @@ module('Integration | Component | pix-navigation', function (hooks) {
 </PixNavigation>`,
           );
 
-          await click(
-            screen.getByRole('button', { name: 'Réduire la largeur du menu de navigation' }),
-          );
+          await click(screen.getByRole('button', { name: texts.shrinkNavigation }));
 
           // then
           assert.dom(screen.getByText('Martin Dupond')).isNotVisible();
@@ -142,10 +157,10 @@ module('Integration | Component | pix-navigation', function (hooks) {
         // given
         const disabledButtonLabel = 'bouton désactivé';
         this.set('label', disabledButtonLabel);
-
+        this.set('texts', texts);
         // when
         const screen = await render(
-          hbs`<PixNavigation @navigationAriaLabel='label' @openLabel='open' @closeLabel='close'>
+          hbs`<PixNavigation @texts={{this.texts}}>
   <:navElements>
     <PixButton
       aria-disabled='true'
@@ -157,7 +172,7 @@ module('Integration | Component | pix-navigation', function (hooks) {
 </PixNavigation>`,
         );
 
-        const openMenuButton = screen.getByText('open').closest('button');
+        const openMenuButton = screen.getByText(texts.openMenu).closest('button');
 
         await click(openMenuButton);
 
@@ -165,28 +180,27 @@ module('Integration | Component | pix-navigation', function (hooks) {
         await click(spanElement);
 
         // then
-        assert.ok(screen.queryByText('close'));
+        assert.ok(screen.queryByText(texts.closeMenu));
       });
     });
 
     test('it should close the menu on route change', async function (assert) {
       // given
+      this.set('texts', texts);
       const router = this.owner.lookup('service:router');
 
-      const screen = await render(
-        hbs`<PixNavigation @navigationAriaLabel='label' @openLabel='open' @closeLabel='close' />`,
-      );
+      const screen = await render(hbs`<PixNavigation @texts={{this.texts}} />`);
 
       // when
-      const openMenuButton = screen.getByText('open').closest('button');
+      const openMenuButton = screen.getByText(texts.openMenu).closest('button');
       await click(openMenuButton);
 
       router.trigger('routeDidChange');
       await settled();
 
       // then
-      assert.ok(screen.getByText('open').closest('button'));
-      assert.notOk(screen.queryByText('close'));
+      assert.notOk(screen.queryByText(texts.closeMenu));
+      assert.ok(screen.getByText(texts.openMenu).closest('button'));
     });
   });
 });


### PR DESCRIPTION
## :boom: BREAKING_CHANGES
L'api evolue, la traduction des textes (aria-label & co)  est passée en paramètre.
les propriétés `@navigationAriaLabel`, `@closeMenu`  `@openMenu` sont remplacées par  
``` js
const texts = {
    mainNavigation: 'Navigation Principale',
    openMenu: 'Ouvrir le menu',
    closeMenu: 'Fermer le menu',
    shrinkNavigation: 'Réduire la largeur',
    expandNavigation: 'Revenir à la largeur initiale du menu de navigation',
}
```

## :christmas_tree: Problème
Les composants utilisent des traductions et ne supportent pas toujours les même langues que les applications qui les utilisent.  Des traductions manquent alors selon certaines langues.

## :gift: Proposition
On supprime l'i18n des composants et on passe directement une clé `texts` qui contient les valeurs traduites.

## :star2: Remarques


## :santa: Pour tester
voir la storie de PixNavigation