### PR TITLE
[TECH] Supprimer la librairie ember-lifeline (PIX-24046)

### DIFF
--- a/addon/components/pix-search-input.gjs
+++ b/addon/components/pix-search-input.gjs
@@ -1,6 +1,5 @@
 import { on } from '@ember/modifier';
 import { action } from '@ember/object';
-import { debounceTask } from 'ember-lifeline';
 
 import PixIcon from './pix-icon';
 import PixInputBase from './pix-input-base';
@@ -8,6 +7,7 @@ import PixLabel from './pix-label';
 
 export default class PixSearchInput extends PixInputBase {
   initialValue = this.args.value;
+  #timeoutId;
 
   constructor() {
     super(...arguments);
@@ -21,20 +21,28 @@ export default class PixSearchInput extends PixInputBase {
     if (!this.args.triggerFiltering) {
       throw new Error('ERROR in PixSearchInput component, @triggerFiltering param is not provided');
     }
-  }
 
-  debouncedTriggerFiltering(value) {
-    this.args.triggerFiltering(this.id, value);
+    this.debouncedTriggerFiltering = this.#debounce(
+      this.args.triggerFiltering,
+      this.debounceTimeBeforeSearch,
+    );
   }
 
   @action
   onSearch(event) {
-    debounceTask(
-      this,
-      'debouncedTriggerFiltering',
-      event.target.value,
-      this.debounceTimeBeforeSearch,
-    );
+    this.debouncedTriggerFiltering(this.id, event.target.value);
+  }
+
+  willDestroy() {
+    super.willDestroy(...arguments);
+    clearTimeout(this.#timeoutId);
+  }
+
+  #debounce(func, delay) {
+    return (...args) => {
+      clearTimeout(this.#timeoutId);
+      this.#timeoutId = setTimeout(() => func(...args), delay);
+    };
   }
 
   <template>

--- a/package-lock.json
+++ b/package-lock.json
@@ -15053,24 +15053,6 @@
         "url": "https://opencollective.com/eslint"
       }
     },
-    "node_modules/ember-lifeline": {
-      "version": "7.0.0",
-      "license": "MIT",
-      "dependencies": {
-        "@embroider/addon-shim": "^1.6.0"
-      },
-      "engines": {
-        "node": "16.* || >= 18"
-      },
-      "peerDependencies": {
-        "@ember/test-helpers": ">= 1.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@ember/test-helpers": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/ember-load-initializers": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/ember-load-initializers/-/ember-load-initializers-3.0.1.tgz",

--- a/package.json
+++ b/package.json
@@ -67,7 +67,6 @@
     "ember-cli-htmlbars": "^6.3.0",
     "ember-cli-sass": "^11.0.1",
     "ember-click-outside": "^6.1.1",
-    "ember-lifeline": "^7.0.0",
     "ember-modifier": "^4.2.0",
     "ember-popperjs": "^3.0.0",
     "ember-template-imports": "^4.3.0",

--- a/tests/dummy/app/controllers/select-page.js
+++ b/tests/dummy/app/controllers/select-page.js
@@ -34,10 +34,10 @@ export default class SelectPage extends Controller {
     },
   ];
   @tracked multiOptions = [
-    { value: 'a', label: 'Salade'},
-    { value: 'b', label: 'Tomate'},
-    { value: 'c', label: 'Oignons'},
-  ]
+    { value: 'a', label: 'Salade' },
+    { value: 'b', label: 'Tomate' },
+    { value: 'c', label: 'Oignons' },
+  ];
   @tracked searchValue;
   @tracked multiSearchValue;
 
@@ -70,14 +70,14 @@ export default class SelectPage extends Controller {
   addNewOption() {
     if (this.options.length > 6) return;
     const newOption = { value: '7', label: 'Citron', category: 'yellow' };
-    this.options = [...this.options, newOption]
+    this.options = [...this.options, newOption];
   }
 
   @action
   addNewMultiOption() {
     if (this.multiOptions.length > 3) return;
     const newOption = { value: 'd', label: 'Harissa (NEW)' };
-    this.multiOptions = [...this.multiOptions, newOption]
+    this.multiOptions = [...this.multiOptions, newOption];
   }
 
   @action
@@ -90,6 +90,11 @@ export default class SelectPage extends Controller {
     this.multiSearchValue = search;
   }
 
+  @action
+  triggerFiltering(_, value) {
+    console.log('SEARCH', value);
+  }
+
   countriesOptions = [
     { value: '1', label: 'England' },
     { value: '2', label: 'Cambodgia' },
@@ -97,13 +102,13 @@ export default class SelectPage extends Controller {
   ];
 
   get options() {
-    return
+    return;
   }
 
   get filteredOptions() {
     if (this.searchValue) {
       try {
-        const searchRegex = new RegExp(`${this.searchValue}`, 'i')
+        const searchRegex = new RegExp(`${this.searchValue}`, 'i');
         return this.options.filter((option) => option.label.match(searchRegex));
       } catch {}
     }
@@ -113,7 +118,7 @@ export default class SelectPage extends Controller {
   get filteredMultiOptions() {
     if (this.multiSearchValue) {
       try {
-        const searchRegex = new RegExp(`${this.multiSearchValue}`, 'i')
+        const searchRegex = new RegExp(`${this.multiSearchValue}`, 'i');
         return this.multiOptions.filter((option) => option.label.match(searchRegex));
       } catch {}
     }

--- a/tests/dummy/app/templates/select-page.hbs
+++ b/tests/dummy/app/templates/select-page.hbs
@@ -62,5 +62,14 @@
     </PixSelect>
   </div>
 
+  <PixSearchInput
+    @id="123"
+    @placeholder="Rechercher"
+    @debounceTimeInMs="500"
+    @triggerFiltering={{this.triggerFiltering}}
+  >
+    <:label>Rechercher ici</:label>
+  </PixSearchInput>
+
   <PixPagination @pagination={{this.pagination}} />
 </div>

--- a/tests/integration/components/pix-button-test.js
+++ b/tests/integration/components/pix-button-test.js
@@ -81,14 +81,8 @@ module('Integration | Component | PixButton', function (hooks) {
   });
 
   module('when the button has a trigger action with a promise', function (hooks) {
-    let clock;
-
     hooks.beforeEach(function () {
-      clock = sinon.useFakeTimers();
-    });
-
-    hooks.afterEach(function () {
-      clock.restore();
+      sinon.useFakeTimers();
     });
 
     test('should display a loading state', async function (assert) {

--- a/tests/integration/components/pix-search-input-test.js
+++ b/tests/integration/components/pix-search-input-test.js
@@ -12,10 +12,6 @@ module('Integration | Component | PixSearchInput', function (hooks) {
     clock = sinon.useFakeTimers({ toFake: ['setTimeout', 'clearTimeout'] });
   });
 
-  hooks.afterEach(function () {
-    clock.restore();
-  });
-
   test('it renders the default PixSearchInput with given id and label', async function (assert) {
     // given
     this.set('triggerFiltering', sinon.stub());

--- a/tests/integration/components/pix-search-input-test.js
+++ b/tests/integration/components/pix-search-input-test.js
@@ -6,6 +6,15 @@ import sinon from 'sinon';
 
 module('Integration | Component | PixSearchInput', function (hooks) {
   setupRenderingTest(hooks);
+  let clock;
+
+  hooks.beforeEach(function () {
+    clock = sinon.useFakeTimers({ toFake: ['setTimeout', 'clearTimeout'] });
+  });
+
+  hooks.afterEach(function () {
+    clock.restore();
+  });
 
   test('it renders the default PixSearchInput with given id and label', async function (assert) {
     // given
@@ -37,9 +46,39 @@ module('Integration | Component | PixSearchInput', function (hooks) {
 ><:label>Champ de recherche de fruits</:label></PixSearchInput>`);
 
     await fillByLabel('Champ de recherche de fruits', 'Mangue');
+    clock.tick(0);
 
     // then
     assert.ok(triggerFiltering.calledWith('pix-123', 'Mangue'));
+  });
+
+  test('it does not call triggerFiltering until debounce time is elapsed', async function (assert) {
+    // given
+    const triggerFiltering = sinon.stub().resolves();
+    this.set('triggerFiltering', triggerFiltering);
+
+    // when
+    await render(hbs`<PixSearchInput
+  @id='pix-123'
+  @debounceTimeInMs='200'
+  @triggerFiltering={{this.triggerFiltering}}
+><:label>Champ de recherche de fruits</:label></PixSearchInput>`);
+
+    await fillByLabel('Champ de recherche de fruits', 'Man');
+    clock.tick(150);
+    // then
+    assert.ok(triggerFiltering.notCalled);
+
+    // when
+    await fillByLabel('Champ de recherche de fruits', 'gue');
+    clock.tick(150);
+    // then
+    assert.ok(triggerFiltering.notCalled);
+
+    // when
+    clock.tick(50);
+    // then
+    assert.ok(triggerFiltering.calledOnce);
   });
 
   test("doesn't update value when input value is udpated", async function (assert) {

--- a/tests/test-helper.js
+++ b/tests/test-helper.js
@@ -5,8 +5,13 @@ import { start } from 'ember-qunit';
 import { loadTests } from 'ember-qunit/test-loader';
 import * as QUnit from 'qunit';
 import { setup } from 'qunit-dom';
+import sinon from 'sinon';
 
 import { contains } from './helpers/contains';
+// Restore all sinon stubs after each test to avoid side-effects
+QUnit.hooks.afterEach(function () {
+  sinon.restore();
+});
 
 setup(QUnit.assert);
 setApplication(Application.create(config.APP));


### PR DESCRIPTION
## :christmas_tree: Problème
Dans le composant PixSearchInput, on utilise un debounce issu de la librairie ember-lifeline. C'est embêtant d'avoir une dépendance à une librairie externe uniquement pour un debounce.

## :gift: Proposition
Implémenter un debounce maison.

## :star2: Remarques
On ajouté `sinon.restore()` dans un `afterEach` global, pour ne pas avoir à le faire manuellement dans les tests.

## :santa: Pour tester
Tests au vert.
En local, avec la Dummy app lancée
- naviguer vers la page du select (http://localhost:4204/select)
- ouvrir la console du navigateur
- se positionner sur le search inpu tout en bas et taper un texte
- constater qu'on a qu'un seul log `SEARCH <texte tapé>` dans la console (à condition qu'on ait tapé dans le laps de temps du debounce fixé à 500ms dans la dummy app)
