### PR TITLE
[TECH] Utiliser FloatingUI au lieu de ember-popperjs

### DIFF
--- a/addon/components/pix-floating.gjs
+++ b/addon/components/pix-floating.gjs
@@ -1,0 +1,62 @@
+import { hash } from '@ember/helper';
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+import { modifier as eModifier } from 'ember-modifier';
+
+import { anchorTo } from '../modifiers/floating-ui';
+
+const ref = eModifier((element, positional) => {
+  const fn = positional[0];
+  fn(element);
+});
+
+/**
+ * A component that provides no DOM and yields two modifiers for creating
+ * creating floating uis, such as menus, popovers, tooltips, etc.
+ * This component currently uses [Floating UI](https://floating-ui.com/)
+ *
+ * Example usage:
+ * ```gjs
+ * import { PixFloating } from '@1024pix/pix-ui';
+ *
+ * <template>
+ *   <PixFloating as |reference floating|>
+ *     <button {{reference}}> ... </button>
+ *     <menu {{floating}}> ... </menu>
+ *   </PixFloating>
+ * </template>
+ * ```
+ */
+export default class PixFloating extends Component {
+  @tracked reference = undefined;
+  @tracked data = undefined;
+
+  setData = (data) => (this.data = data);
+
+  setReference = (element) => (this.reference = element);
+
+  <template>
+    {{#let
+      (modifier
+        anchorTo
+        flipOptions=@flipOptions
+        hideOptions=@hideOptions
+        middleware=@middleware
+        offsetOptions=@offsetOptions
+        placement=@placement
+        shiftOptions=@shiftOptions
+        strategy=@strategy
+        setData=this.setData
+      )
+      as |prewiredAnchorTo|
+    }}
+      {{#let (if this.reference (modifier prewiredAnchorTo this.reference)) as |floating|}}
+        {{yield
+          (modifier ref this.setReference)
+          floating
+          (hash setReference=this.setReference data=this.data)
+        }}
+      {{/let}}
+    {{/let}}
+  </template>
+}

--- a/addon/components/pix-multi-select.gjs
+++ b/addon/components/pix-multi-select.gjs
@@ -7,13 +7,13 @@ import { service } from '@ember/service';
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 import onClickOutside from 'ember-click-outside/modifiers/on-click-outside';
-import { PopperJS } from 'ember-popperjs';
 import { gt, or } from 'ember-truth-helpers';
 
 import onArrowDownUpAction from '../modifiers/on-arrow-down-up-action';
 import onEnterAction from '../modifiers/on-enter-action';
 import onEscapeAction from '../modifiers/on-escape-action';
 import PixCheckbox from './pix-checkbox';
+import PixFloating from './pix-floating';
 import PixIcon from './pix-icon';
 import PixLabel from './pix-label';
 
@@ -47,7 +47,7 @@ import PixLabel from './pix-label';
  * @property {boolean} [screenReaderOnly] - Masque le libellé visuellement, tout en le laissant lisible par les lecteurs d'écran.
  * @property {boolean} [inlineLabel] - Place le libellé sur la même ligne que le champ.
  * @property {string} [className] - Classes CSS ajoutées au bouton d'ouverture.
- * @property {string} [placement] - Position de la liste par rapport au champ, au sens de Popper. Par défaut : `bottom-start`.
+ * @property {string} [placement] - Position de la liste par rapport au champ, au sens de Floating UI. Par défaut : `bottom-start`.
  * @property {boolean} [isComputeWidthDisabled] - Désactive l'alignement automatique de la largeur du champ sur celle de la liste.
  */
 
@@ -234,7 +234,12 @@ export default class PixMultiSelect extends Component {
       </PixLabel>
 
       <div>
-        <PopperJS @placement={{or @placement "bottom-start"}} as |reference popover|>
+        <PixFloating
+          @placement={{or @placement "bottom-start"}}
+          @strategy="absolute"
+          @offsetOptions={{4}}
+          as |reference popover|
+        >
           <button
             {{reference}}
             id={{this.multiSelectId}}
@@ -306,7 +311,7 @@ export default class PixMultiSelect extends Component {
               >{{this.emptySearchMessage}}</li>
             {{/if}}
           </ul>
-        </PopperJS>
+        </PixFloating>
       </div>
     </div>
   </template>

--- a/addon/components/pix-select.gjs
+++ b/addon/components/pix-select.gjs
@@ -6,11 +6,11 @@ import { service } from '@ember/service';
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 import onClickOutside from 'ember-click-outside/modifiers/on-click-outside';
-import { PopperJS } from 'ember-popperjs';
 import { or } from 'ember-truth-helpers';
 
 import onArrowDownUpAction from '../modifiers/on-arrow-down-up-action';
 import onEscapeAction from '../modifiers/on-escape-action';
+import PixFloating from './pix-floating';
 import PixIcon from './pix-icon';
 import PixLabel from './pix-label';
 import PixSelectList from './pix-select-list';
@@ -53,7 +53,7 @@ import PixSelectList from './pix-select-list';
  * @property {boolean} [isFullWidth] - Étend le champ à toute la largeur disponible.
  * @property {string} [errorMessage] - Message d'erreur affiché sous le champ. Sa présence applique le style d'erreur.
  * @property {string} [className] - Classes CSS ajoutées au bouton d'ouverture.
- * @property {string} [placement] - Position de la liste par rapport au champ, au sens de Popper. Par défaut : `bottom-start`.
+ * @property {string} [placement] - Position de la liste par rapport au champ, au sens de Floating UI. Par défaut : `bottom-start`.
  * @property {boolean} [isComputeWidthDisabled] - Désactive l'alignement automatique de la largeur du champ sur celle de la liste.
  */
 
@@ -233,7 +233,12 @@ export default class PixSelect extends Component {
       {{/if}}
 
       <div class="pix-select__button-container">
-        <PopperJS @placement={{or @placement "bottom-start"}} as |reference popover|>
+        <PixFloating
+          @placement={{or @placement "bottom-start"}}
+          @strategy="absolute"
+          @offsetOptions={{4}}
+          as |reference popover|
+        >
           <button
             {{reference}}
             type="button"
@@ -298,7 +303,7 @@ export default class PixSelect extends Component {
               @emptySearchMessage={{@texts.emptySearchMessage}}
             />
           </div>
-        </PopperJS>
+        </PixFloating>
         {{#if @errorMessage}}
           <p class="pix-select__error-message">{{@errorMessage}}</p>
         {{/if}}

--- a/addon/components/pix-structure-switcher.gjs
+++ b/addon/components/pix-structure-switcher.gjs
@@ -4,11 +4,11 @@ import { guidFor } from '@ember/object/internals';
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 import onClickOutside from 'ember-click-outside/modifiers/on-click-outside';
-import { PopperJS } from 'ember-popperjs';
 
 import onArrowDownUpAction from '../modifiers/on-arrow-down-up-action';
 import onEscapeAction from '../modifiers/on-escape-action';
 import PixButton from './pix-button';
+import PixFloating from './pix-floating';
 import PixSelectList from './pix-select-list';
 
 export default class PixStructureSwitcher extends Component {
@@ -71,7 +71,12 @@ export default class PixStructureSwitcher extends Component {
       {{on "keydown" this.lockTab}}
       ...attributes
     >
-      <PopperJS @placement="right-end" as |reference popover|>
+      <PixFloating
+        @placement="right-end"
+        @strategy="absolute"
+        @offsetOptions={{20}}
+        as |reference popover|
+      >
         <PixButton
           {{reference}}
           @size="small"
@@ -101,7 +106,7 @@ export default class PixStructureSwitcher extends Component {
             />
           </div>
         {{/if}}
-      </PopperJS>
+      </PixFloating>
     </div>
   </template>
 }

--- a/addon/modifiers/floating-ui.js
+++ b/addon/modifiers/floating-ui.js
@@ -1,0 +1,94 @@
+import { assert } from '@ember/debug';
+import { autoUpdate, computePosition, flip, hide, offset, shift } from '@floating-ui/dom';
+import { modifier as eModifier } from 'ember-modifier';
+
+export const anchorTo = eModifier(
+  (
+    floatingElement,
+    [_referenceElement],
+    {
+      strategy = 'fixed',
+      offsetOptions = 0,
+      placement = 'bottom',
+      flipOptions,
+      shiftOptions,
+      middleware = [],
+      setData,
+    },
+  ) => {
+    const referenceElement =
+      typeof _referenceElement === 'string'
+        ? document.querySelector(_referenceElement)
+        : _referenceElement;
+
+    assert(
+      'no reference element defined',
+      referenceElement instanceof HTMLElement || referenceElement instanceof SVGElement,
+    );
+
+    assert(
+      'no floating element defined',
+      floatingElement instanceof HTMLElement || _referenceElement instanceof SVGElement,
+    );
+
+    assert(
+      'reference and floating elements cannot be the same element',
+      floatingElement !== _referenceElement,
+    );
+
+    assert('@middleware must be an array of one or more objects', Array.isArray(middleware));
+
+    Object.assign(floatingElement.style, {
+      position: strategy,
+      top: '0',
+      left: '0',
+    });
+
+    const update = async () => {
+      const { middlewareData, x, y } = await computePosition(referenceElement, floatingElement, {
+        middleware: [
+          offset(offsetOptions),
+          flip(flipOptions),
+          shift(shiftOptions),
+          ...middleware,
+          hide({ strategy: 'referenceHidden' }),
+          hide({ strategy: 'escaped' }),
+          exposeMetadata(),
+        ],
+        placement,
+        strategy,
+      });
+
+      const referenceHidden = middlewareData.hide?.referenceHidden;
+
+      Object.assign(floatingElement.style, {
+        top: `${y}px`,
+        left: `${x}px`,
+        margin: 0,
+        visibility: referenceHidden ? 'hidden' : 'visible',
+      });
+
+      void setData?.(middlewareData['metadata']);
+    };
+
+    void update();
+
+    const cleanup = autoUpdate(referenceElement, floatingElement, update);
+
+    /**
+     * in the function-modifier manager, teardown of the previous modifier
+     * occurs before setup of the next
+     * https://github.com/ember-modifier/ember-modifier/blob/main/ember-modifier/src/-private/function-based/modifier-manager.ts#L58
+     */
+    return cleanup;
+  },
+);
+
+function exposeMetadata() {
+  return {
+    name: 'metadata',
+    fn: (data) => {
+      return { data };
+    },
+  };
+}

--- a/addon/styles/_pix-multi-select.scss
+++ b/addon/styles/_pix-multi-select.scss
@@ -1,6 +1,6 @@
-@use "pix-design-tokens/typography";
-@use "component-state/form";
-@use "pix-design-tokens/shadows";
+@use 'pix-design-tokens/typography';
+@use 'component-state/form';
+@use 'pix-design-tokens/shadows';
 
 .pix-multi-select {
   position: relative;
@@ -87,21 +87,22 @@
   min-width: 100%;
   max-height: 12.5rem;
   margin: 0;
-  margin-top: var(--pix-spacing-1x);
   padding: 0;
   overflow-y: auto;
   list-style-type: none;
   background-color: var(--pix-neutral-0);
   border-top: none;
   border-radius: 0 0 var(--pix-spacing-1x) var(--pix-spacing-1x);
-  transition: all 0.1s ease-in-out;
+  transition:
+    opacity 0.1s ease-in-out,
+    visibility 0.1s ease-in-out;
 
   &__item-label {
     padding: var(--pix-spacing-2x) var(--pix-spacing-6x);
   }
 
   &--hidden {
-    visibility: hidden;
+    visibility: hidden !important;
     opacity: 0;
   }
 

--- a/addon/styles/_pix-select.scss
+++ b/addon/styles/_pix-select.scss
@@ -1,6 +1,6 @@
-@use "pix-design-tokens/typography";
-@use "component-state/form";
-@use "pix-design-tokens/shadows";
+@use 'pix-design-tokens/typography';
+@use 'component-state/form';
+@use 'pix-design-tokens/shadows';
 
 .pix-select {
   position: relative;
@@ -28,7 +28,6 @@
     width: 100%;
     min-width: fit-content;
     max-height: 12rem;
-    margin-top: var(--pix-spacing-1x);
     padding: 0;
     overflow-y: auto;
     white-space: nowrap;
@@ -36,7 +35,9 @@
     background-color: var(--pix-neutral-0);
     border-top: none;
     border-radius: 0 0 var(--pix-spacing-1x) var(--pix-spacing-1x);
-    transition: all 0.1s ease-in-out;
+    transition:
+      opacity 0.1s ease-in-out,
+      visibility 0.1s ease-in-out;
 
     &::-webkit-scrollbar {
       width: 0.5rem;
@@ -59,12 +60,10 @@
     }
 
     &--closed {
-      visibility: hidden;
+      visibility: hidden !important;
       opacity: 0;
     }
   }
-
-
 
   &__search {
     display: flex;
@@ -146,6 +145,6 @@
 
   &__icon {
     margin: auto var(--pix-spacing-1x);
-    color: var(--pix-neutral-100)
+    color: var(--pix-neutral-100);
   }
 }

--- a/addon/styles/_pix-structure-switcher.scss
+++ b/addon/styles/_pix-structure-switcher.scss
@@ -1,5 +1,5 @@
-@use "pix-design-tokens/breakpoints";
-@use "pix-design-tokens/shadows";
+@use 'pix-design-tokens/breakpoints';
+@use 'pix-design-tokens/shadows';
 
 .pix-structure-switcher {
   --pix-structure-bg-hover: var(--pix-primary-100);
@@ -12,7 +12,7 @@
     --pix-structure-bg-hover: var(--pix-certif-50);
   }
 
-  @include breakpoints.device-is("mobile") {
+  @include breakpoints.device-is('mobile') {
     width: 100%;
   }
 
@@ -21,7 +21,7 @@
 
     .pix-navigation--opened & {
       width: auto;
-      margin:auto;
+      margin: auto;
     }
   }
 
@@ -45,9 +45,10 @@
       width: 0; // force dropdown to resize to its parent
       max-width: none;
       max-height: none;
-      margin-left:0 !important;
+      margin-left: 0 !important;
       overflow-y: visible;
       transform: none !important;
+      visibility: visible !important;
       transition: none;
 
       .pix-navigation--opened &:not(.pix-select__dropdown--closed) {
@@ -67,7 +68,6 @@
     border-top: none;
   }
 
-
   .pix-select-list-category__option {
     padding: var(--pix-spacing-2x) var(--pix-spacing-8x) var(--pix-spacing-2x) var(--pix-spacing-4x);
     // stylelint-disable-next-line custom-property-pattern
@@ -76,7 +76,7 @@
     text-align: left;
     word-break: break-word;
 
-    &:focus:not(.pix-select-list-category__option--selected )  {
+    &:focus:not(.pix-select-list-category__option--selected) {
       background-color: var(--pix-structure-bg-hover);
     }
 
@@ -99,7 +99,7 @@
     }
 
     &:focus {
-      color: var(--pix-neutral-800)
+      color: var(--pix-neutral-800);
     }
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,6 @@
         "ember-cli-sass": "^11.0.1",
         "ember-click-outside": "^6.1.1",
         "ember-modifier": "^4.2.0",
-        "ember-popperjs": "^3.0.0",
         "ember-template-imports": "^4.3.0",
         "ember-truth-helpers": "^5.0.0",
         "tracked-toolbox": "^2.2.0"
@@ -4525,6 +4524,7 @@
       "version": "0.92.4",
       "resolved": "https://registry.npmjs.org/@glimmer/compiler/-/compiler-0.92.4.tgz",
       "integrity": "sha512-xoR8F6fsgFqWbPbCfSgJuJ95vaLnXw0SgDCwyl/KMeeaSxpHwJbr8+BfiUl+7ko2A+HzrY5dPXXnGr4ZM+CUXw==",
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@glimmer/interfaces": "0.92.3",
@@ -4541,6 +4541,7 @@
       "version": "0.92.3",
       "resolved": "https://registry.npmjs.org/@glimmer/util/-/util-0.92.3.tgz",
       "integrity": "sha512-K1oH93gGU36slycxJ9CcFpUTsdOc4XQ6RuZFu5oRsxFYtEF5PSu7ik11h58fyeoaWOr1ebfkyAMawbeI2AJ5GA==",
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@glimmer/env": "0.1.7",
@@ -4551,6 +4552,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@glimmer/component/-/component-2.0.0.tgz",
       "integrity": "sha512-eATSzBOUm0MZ9+YfJx7Y5p3gbwnaeMzLSSsCDn1ihDtUOIm5YYEV0ee0G7tXt/uKxowt8tXYn/EMbI9OlRF0CA==",
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@embroider/addon-shim": "^1.8.9",
@@ -4564,6 +4566,7 @@
       "version": "0.92.4",
       "resolved": "https://registry.npmjs.org/@glimmer/debug/-/debug-0.92.4.tgz",
       "integrity": "sha512-waTBOdtp92MC3h/51mYbc4GRumO+Tsa5jbXLoewqALjE1S8bMu9qgkG7Cx635x3/XpjsD9xceMqagBvYhuI6tA==",
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@glimmer/interfaces": "0.92.3",
@@ -4575,6 +4578,7 @@
       "version": "0.92.3",
       "resolved": "https://registry.npmjs.org/@glimmer/util/-/util-0.92.3.tgz",
       "integrity": "sha512-K1oH93gGU36slycxJ9CcFpUTsdOc4XQ6RuZFu5oRsxFYtEF5PSu7ik11h58fyeoaWOr1ebfkyAMawbeI2AJ5GA==",
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@glimmer/env": "0.1.7",
@@ -4585,6 +4589,7 @@
       "version": "0.92.3",
       "resolved": "https://registry.npmjs.org/@glimmer/destroyable/-/destroyable-0.92.3.tgz",
       "integrity": "sha512-vQ+mzT9Vkf+JueY7L5XbZqK0WyEVTKv0HOLrw/zDw9F5Szn3F/8Ea/qbAClo3QK3oZeg+ulFTa/61rdjSFYHGA==",
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@glimmer/env": "0.1.7",
@@ -4597,12 +4602,14 @@
       "version": "0.92.3",
       "resolved": "https://registry.npmjs.org/@glimmer/global-context/-/global-context-0.92.3.tgz",
       "integrity": "sha512-tvlK5pt6oSe3furJ1KsO9vG/KmF9S98HLrcR48XbfwXlkuxvUeS94cdQId4GCN5naeX4OC4xm6eEjZWdc2s+jw==",
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@glimmer/destroyable/node_modules/@glimmer/util": {
       "version": "0.92.3",
       "resolved": "https://registry.npmjs.org/@glimmer/util/-/util-0.92.3.tgz",
       "integrity": "sha512-K1oH93gGU36slycxJ9CcFpUTsdOc4XQ6RuZFu5oRsxFYtEF5PSu7ik11h58fyeoaWOr1ebfkyAMawbeI2AJ5GA==",
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@glimmer/env": "0.1.7",
@@ -4613,6 +4620,7 @@
       "version": "0.92.3",
       "resolved": "https://registry.npmjs.org/@glimmer/encoder/-/encoder-0.92.3.tgz",
       "integrity": "sha512-DJ8DB33LxODjzCWRrxozHUaRqVyZj4p8jDLG42aCNmWo3smxrsjshcaVUwDmib24DW+dzR7kMc39ObMqT5zK0w==",
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@glimmer/interfaces": "0.92.3",
@@ -4635,6 +4643,7 @@
       "version": "0.92.3",
       "resolved": "https://registry.npmjs.org/@glimmer/interfaces/-/interfaces-0.92.3.tgz",
       "integrity": "sha512-QwQeA01N+0h+TAi/J7iUnZtRuJy+093hNyagxDQBA6b1wCBw+q+al9+O6gmbWlkWE7EifzmNE1nnrgcecJBlJQ==",
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@simple-dom/interface": "^1.4.0"
@@ -4644,6 +4653,7 @@
       "version": "0.92.4",
       "resolved": "https://registry.npmjs.org/@glimmer/manager/-/manager-0.92.4.tgz",
       "integrity": "sha512-YMoarZT/+Ft2YSd+Wuu5McVsdP9y6jeAdVQGYFpno3NlL3TXYbl7ELtK7OGxFLjzQE01BdiUZZRvcY+a/s9+CQ==",
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@glimmer/debug": "0.92.4",
@@ -4661,12 +4671,14 @@
       "version": "0.92.3",
       "resolved": "https://registry.npmjs.org/@glimmer/global-context/-/global-context-0.92.3.tgz",
       "integrity": "sha512-tvlK5pt6oSe3furJ1KsO9vG/KmF9S98HLrcR48XbfwXlkuxvUeS94cdQId4GCN5naeX4OC4xm6eEjZWdc2s+jw==",
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@glimmer/manager/node_modules/@glimmer/reference": {
       "version": "0.92.3",
       "resolved": "https://registry.npmjs.org/@glimmer/reference/-/reference-0.92.3.tgz",
       "integrity": "sha512-Ud4LE689mEXL6BJnJx0ZPt2dt/A540C+TAnBFXHpcAjROz5gT337RN+tgajwudEUqpufExhcPSMGzs1pvWYCJg==",
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@glimmer/env": "^0.1.7",
@@ -4680,6 +4692,7 @@
       "version": "0.92.3",
       "resolved": "https://registry.npmjs.org/@glimmer/util/-/util-0.92.3.tgz",
       "integrity": "sha512-K1oH93gGU36slycxJ9CcFpUTsdOc4XQ6RuZFu5oRsxFYtEF5PSu7ik11h58fyeoaWOr1ebfkyAMawbeI2AJ5GA==",
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@glimmer/env": "0.1.7",
@@ -4690,6 +4703,7 @@
       "version": "0.92.3",
       "resolved": "https://registry.npmjs.org/@glimmer/validator/-/validator-0.92.3.tgz",
       "integrity": "sha512-HKrMYeW0YhiksSeKYqX2chUR/rz82j12DcY7p2dORQlTV3qlAfiE5zRTJH1KRA1X3ZMf7DI2/GOzkXwYp0o+3Q==",
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@glimmer/env": "^0.1.7",
@@ -4702,6 +4716,7 @@
       "version": "0.92.4",
       "resolved": "https://registry.npmjs.org/@glimmer/node/-/node-0.92.4.tgz",
       "integrity": "sha512-a5GME7HQJZFJPQDdSetQI6jjKXXQi0Vdr3WuUrYwhienVTV5LG0uClbFE2yYWC7TX97YDHpRrNk1CC258rujkQ==",
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@glimmer/interfaces": "0.92.3",
@@ -4714,6 +4729,7 @@
       "version": "0.92.3",
       "resolved": "https://registry.npmjs.org/@glimmer/util/-/util-0.92.3.tgz",
       "integrity": "sha512-K1oH93gGU36slycxJ9CcFpUTsdOc4XQ6RuZFu5oRsxFYtEF5PSu7ik11h58fyeoaWOr1ebfkyAMawbeI2AJ5GA==",
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@glimmer/env": "0.1.7",
@@ -4724,6 +4740,7 @@
       "version": "0.92.4",
       "resolved": "https://registry.npmjs.org/@glimmer/opcode-compiler/-/opcode-compiler-0.92.4.tgz",
       "integrity": "sha512-WnZSBwxNqW/PPD/zfxEg6BVR5tHwTm8fp76piix8BNCQ6CuzVn6HUJ5SlvBsOwyoRCmzt/pkKmBJn+I675KG4w==",
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@glimmer/debug": "0.92.4",
@@ -4742,12 +4759,14 @@
       "version": "0.92.3",
       "resolved": "https://registry.npmjs.org/@glimmer/global-context/-/global-context-0.92.3.tgz",
       "integrity": "sha512-tvlK5pt6oSe3furJ1KsO9vG/KmF9S98HLrcR48XbfwXlkuxvUeS94cdQId4GCN5naeX4OC4xm6eEjZWdc2s+jw==",
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@glimmer/opcode-compiler/node_modules/@glimmer/reference": {
       "version": "0.92.3",
       "resolved": "https://registry.npmjs.org/@glimmer/reference/-/reference-0.92.3.tgz",
       "integrity": "sha512-Ud4LE689mEXL6BJnJx0ZPt2dt/A540C+TAnBFXHpcAjROz5gT337RN+tgajwudEUqpufExhcPSMGzs1pvWYCJg==",
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@glimmer/env": "^0.1.7",
@@ -4761,6 +4780,7 @@
       "version": "0.92.3",
       "resolved": "https://registry.npmjs.org/@glimmer/util/-/util-0.92.3.tgz",
       "integrity": "sha512-K1oH93gGU36slycxJ9CcFpUTsdOc4XQ6RuZFu5oRsxFYtEF5PSu7ik11h58fyeoaWOr1ebfkyAMawbeI2AJ5GA==",
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@glimmer/env": "0.1.7",
@@ -4771,6 +4791,7 @@
       "version": "0.92.3",
       "resolved": "https://registry.npmjs.org/@glimmer/validator/-/validator-0.92.3.tgz",
       "integrity": "sha512-HKrMYeW0YhiksSeKYqX2chUR/rz82j12DcY7p2dORQlTV3qlAfiE5zRTJH1KRA1X3ZMf7DI2/GOzkXwYp0o+3Q==",
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@glimmer/env": "^0.1.7",
@@ -4783,6 +4804,7 @@
       "version": "0.92.3",
       "resolved": "https://registry.npmjs.org/@glimmer/owner/-/owner-0.92.3.tgz",
       "integrity": "sha512-ZxmXIUCy6DOobhGDhA6kMpaXZS7HAucEgIl/qcjV9crlzGOO8H4j+n2x6nA/8zpuqvO0gYaBzqdNdu+7EgOEmw==",
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@glimmer/util": "0.92.3"
@@ -4792,6 +4814,7 @@
       "version": "0.92.3",
       "resolved": "https://registry.npmjs.org/@glimmer/util/-/util-0.92.3.tgz",
       "integrity": "sha512-K1oH93gGU36slycxJ9CcFpUTsdOc4XQ6RuZFu5oRsxFYtEF5PSu7ik11h58fyeoaWOr1ebfkyAMawbeI2AJ5GA==",
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@glimmer/env": "0.1.7",
@@ -4802,6 +4825,7 @@
       "version": "0.92.4",
       "resolved": "https://registry.npmjs.org/@glimmer/program/-/program-0.92.4.tgz",
       "integrity": "sha512-fkquujQ11lsGCWl/+XpZW2E7bjHj/g6/Ht292A7pSoANBD8Bz/gPYiPM+XuMwes9MApEsTEMjV4EXlyk2/Cirg==",
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@glimmer/encoder": "0.92.3",
@@ -4818,6 +4842,7 @@
       "version": "0.92.3",
       "resolved": "https://registry.npmjs.org/@glimmer/util/-/util-0.92.3.tgz",
       "integrity": "sha512-K1oH93gGU36slycxJ9CcFpUTsdOc4XQ6RuZFu5oRsxFYtEF5PSu7ik11h58fyeoaWOr1ebfkyAMawbeI2AJ5GA==",
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@glimmer/env": "0.1.7",
@@ -4867,6 +4892,7 @@
       "version": "0.92.4",
       "resolved": "https://registry.npmjs.org/@glimmer/runtime/-/runtime-0.92.4.tgz",
       "integrity": "sha512-ISqM/8hVh+fY/gnLAAPKfts4CvnJBOyCYAXgGccIlzzQrSVLaz0NoRiWTLGj5B/3xyPbqLwYPDvlTsOjYtvPoA==",
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@glimmer/destroyable": "0.92.3",
@@ -4887,12 +4913,14 @@
       "version": "0.92.3",
       "resolved": "https://registry.npmjs.org/@glimmer/global-context/-/global-context-0.92.3.tgz",
       "integrity": "sha512-tvlK5pt6oSe3furJ1KsO9vG/KmF9S98HLrcR48XbfwXlkuxvUeS94cdQId4GCN5naeX4OC4xm6eEjZWdc2s+jw==",
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@glimmer/runtime/node_modules/@glimmer/reference": {
       "version": "0.92.3",
       "resolved": "https://registry.npmjs.org/@glimmer/reference/-/reference-0.92.3.tgz",
       "integrity": "sha512-Ud4LE689mEXL6BJnJx0ZPt2dt/A540C+TAnBFXHpcAjROz5gT337RN+tgajwudEUqpufExhcPSMGzs1pvWYCJg==",
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@glimmer/env": "^0.1.7",
@@ -4906,6 +4934,7 @@
       "version": "0.92.3",
       "resolved": "https://registry.npmjs.org/@glimmer/util/-/util-0.92.3.tgz",
       "integrity": "sha512-K1oH93gGU36slycxJ9CcFpUTsdOc4XQ6RuZFu5oRsxFYtEF5PSu7ik11h58fyeoaWOr1ebfkyAMawbeI2AJ5GA==",
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@glimmer/env": "0.1.7",
@@ -4916,6 +4945,7 @@
       "version": "0.92.3",
       "resolved": "https://registry.npmjs.org/@glimmer/validator/-/validator-0.92.3.tgz",
       "integrity": "sha512-HKrMYeW0YhiksSeKYqX2chUR/rz82j12DcY7p2dORQlTV3qlAfiE5zRTJH1KRA1X3ZMf7DI2/GOzkXwYp0o+3Q==",
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@glimmer/env": "^0.1.7",
@@ -4928,6 +4958,7 @@
       "version": "0.92.3",
       "resolved": "https://registry.npmjs.org/@glimmer/syntax/-/syntax-0.92.3.tgz",
       "integrity": "sha512-7wPKQmULyXCYf0KvbPmfrs/skPISH2QGR9atCnmDWnHyLv5SSZVLm1P0Ctrpta6+Ci3uGQb7hGk0IjsLEavcYQ==",
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@glimmer/interfaces": "0.92.3",
@@ -4941,6 +4972,7 @@
       "version": "0.92.3",
       "resolved": "https://registry.npmjs.org/@glimmer/util/-/util-0.92.3.tgz",
       "integrity": "sha512-K1oH93gGU36slycxJ9CcFpUTsdOc4XQ6RuZFu5oRsxFYtEF5PSu7ik11h58fyeoaWOr1ebfkyAMawbeI2AJ5GA==",
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@glimmer/env": "0.1.7",
@@ -4965,6 +4997,7 @@
       "version": "0.92.3",
       "resolved": "https://registry.npmjs.org/@glimmer/vm/-/vm-0.92.3.tgz",
       "integrity": "sha512-DNMQz7nn2zRwKO1irVZ4alg1lH+VInwR3vkWVgobUs0yh7OoHVGXKMd5uxzIksqJEUw1XOX9Qgu/GYZB1PiH3w==",
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@glimmer/interfaces": "0.92.3",
@@ -4975,6 +5008,7 @@
       "version": "0.92.3",
       "resolved": "https://registry.npmjs.org/@glimmer/vm-babel-plugins/-/vm-babel-plugins-0.92.3.tgz",
       "integrity": "sha512-VpkKsHc3oiq9ruiwT7sN4RuOIc5n10PCeWX7tYSNZ85S1bETcAFn0XbyNjI+G3uFshQGEK0T8Fn3+/8VTNIQIg==",
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "babel-plugin-debug-macros": "^0.3.4"
@@ -4987,6 +5021,7 @@
       "version": "0.92.3",
       "resolved": "https://registry.npmjs.org/@glimmer/util/-/util-0.92.3.tgz",
       "integrity": "sha512-K1oH93gGU36slycxJ9CcFpUTsdOc4XQ6RuZFu5oRsxFYtEF5PSu7ik11h58fyeoaWOr1ebfkyAMawbeI2AJ5GA==",
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@glimmer/env": "0.1.7",
@@ -4997,6 +5032,7 @@
       "version": "0.92.3",
       "resolved": "https://registry.npmjs.org/@glimmer/wire-format/-/wire-format-0.92.3.tgz",
       "integrity": "sha512-gFz81Q9+V7Xs0X8mSq6y8qacHm0dPaGJo2/Bfcsdow1hLOKNgTCLr4XeDBhRML8f6I6Gk9ugH4QDxyIOXOpC4w==",
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@glimmer/interfaces": "0.92.3",
@@ -5007,6 +5043,7 @@
       "version": "0.92.3",
       "resolved": "https://registry.npmjs.org/@glimmer/util/-/util-0.92.3.tgz",
       "integrity": "sha512-K1oH93gGU36slycxJ9CcFpUTsdOc4XQ6RuZFu5oRsxFYtEF5PSu7ik11h58fyeoaWOr1ebfkyAMawbeI2AJ5GA==",
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@glimmer/env": "0.1.7",
@@ -6052,14 +6089,6 @@
         "url": "https://opencollective.com/pnpm"
       }
     },
-    "node_modules/@popperjs/core": {
-      "version": "2.11.8",
-      "license": "MIT",
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/popperjs"
-      }
-    },
     "node_modules/@prettier/sync": {
       "version": "0.2.1",
       "dev": true,
@@ -6299,6 +6328,7 @@
     },
     "node_modules/@simple-dom/document": {
       "version": "1.4.0",
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@simple-dom/interface": "^1.4.0"
@@ -8339,6 +8369,7 @@
     },
     "node_modules/ast-types": {
       "version": "0.13.3",
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=4"
@@ -8728,6 +8759,7 @@
       "version": "2.8.0",
       "resolved": "https://registry.npmjs.org/backburner.js/-/backburner.js-2.8.0.tgz",
       "integrity": "sha512-zYXY0KvpD7/CWeOLF576mV8S+bQsaIoj/GNLXXB+Eb8SJcQy5lqSjkRrZ0MZhdKUs9QoqmGNIEIe3NQfGiiscQ==",
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/bail": {
@@ -9517,6 +9549,7 @@
     },
     "node_modules/broccoli-file-creator": {
       "version": "2.1.1",
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "broccoli-plugin": "^1.1.0",
@@ -9528,6 +9561,7 @@
     },
     "node_modules/broccoli-file-creator/node_modules/broccoli-plugin": {
       "version": "1.3.1",
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "promise-map-series": "^0.2.1",
@@ -9538,6 +9572,7 @@
     },
     "node_modules/broccoli-file-creator/node_modules/promise-map-series": {
       "version": "0.2.3",
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "rsvp": "^3.0.14"
@@ -9545,6 +9580,7 @@
     },
     "node_modules/broccoli-file-creator/node_modules/rimraf": {
       "version": "2.7.1",
+      "devOptional": true,
       "license": "ISC",
       "dependencies": {
         "glob": "^7.1.3"
@@ -14228,6 +14264,7 @@
     },
     "node_modules/ember-cli-get-component-path-option": {
       "version": "1.0.0",
+      "devOptional": true,
       "license": "ISC"
     },
     "node_modules/ember-cli-htmlbars": {
@@ -14419,6 +14456,7 @@
     },
     "node_modules/ember-cli-is-package-missing": {
       "version": "1.0.0",
+      "devOptional": true,
       "license": "ISC"
     },
     "node_modules/ember-cli-lodash-subset": {
@@ -14438,6 +14476,7 @@
     },
     "node_modules/ember-cli-path-utils": {
       "version": "1.0.0",
+      "devOptional": true,
       "license": "ISC"
     },
     "node_modules/ember-cli-preprocess-registry": {
@@ -14575,6 +14614,7 @@
     },
     "node_modules/ember-cli-typescript-blueprint-polyfill": {
       "version": "0.1.0",
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "chalk": "^4.0.0",
@@ -14583,6 +14623,7 @@
     },
     "node_modules/ember-cli-typescript-blueprint-polyfill/node_modules/ansi-styles": {
       "version": "4.3.0",
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "color-convert": "^2.0.1"
@@ -14596,6 +14637,7 @@
     },
     "node_modules/ember-cli-typescript-blueprint-polyfill/node_modules/chalk": {
       "version": "4.1.2",
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.1.0",
@@ -14610,6 +14652,7 @@
     },
     "node_modules/ember-cli-typescript-blueprint-polyfill/node_modules/has-flag": {
       "version": "4.0.0",
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -14617,6 +14660,7 @@
     },
     "node_modules/ember-cli-typescript-blueprint-polyfill/node_modules/supports-color": {
       "version": "7.2.0",
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "has-flag": "^4.0.0"
@@ -15121,18 +15165,6 @@
       },
       "engines": {
         "node": "16.* || >= 18"
-      }
-    },
-    "node_modules/ember-popperjs": {
-      "version": "3.0.0",
-      "license": "MIT",
-      "dependencies": {
-        "@embroider/addon-shim": "^1.7.1",
-        "@popperjs/core": "^2.11.1"
-      },
-      "peerDependencies": {
-        "ember-modifier": ">= 3.2.7",
-        "ember-source": ">= 3.25.0"
       }
     },
     "node_modules/ember-qunit": {
@@ -15707,6 +15739,7 @@
     },
     "node_modules/ember-router-generator": {
       "version": "2.0.0",
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/parser": "^7.4.5",
@@ -15721,6 +15754,7 @@
       "version": "5.12.0",
       "resolved": "https://registry.npmjs.org/ember-source/-/ember-source-5.12.0.tgz",
       "integrity": "sha512-2MWlJmQEeeiIk9p5CDMuvD470YPi7/4wXgU41ftbWc9svwF+0usoe4PLoLC0T/jV6YX+3SY5tumQfxLSLoFhmQ==",
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/core": "^7.24.4",
@@ -15790,12 +15824,14 @@
       "version": "0.92.3",
       "resolved": "https://registry.npmjs.org/@glimmer/global-context/-/global-context-0.92.3.tgz",
       "integrity": "sha512-tvlK5pt6oSe3furJ1KsO9vG/KmF9S98HLrcR48XbfwXlkuxvUeS94cdQId4GCN5naeX4OC4xm6eEjZWdc2s+jw==",
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/ember-source/node_modules/@glimmer/reference": {
       "version": "0.92.3",
       "resolved": "https://registry.npmjs.org/@glimmer/reference/-/reference-0.92.3.tgz",
       "integrity": "sha512-Ud4LE689mEXL6BJnJx0ZPt2dt/A540C+TAnBFXHpcAjROz5gT337RN+tgajwudEUqpufExhcPSMGzs1pvWYCJg==",
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@glimmer/env": "^0.1.7",
@@ -15809,6 +15845,7 @@
       "version": "0.92.3",
       "resolved": "https://registry.npmjs.org/@glimmer/util/-/util-0.92.3.tgz",
       "integrity": "sha512-K1oH93gGU36slycxJ9CcFpUTsdOc4XQ6RuZFu5oRsxFYtEF5PSu7ik11h58fyeoaWOr1ebfkyAMawbeI2AJ5GA==",
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@glimmer/env": "0.1.7",
@@ -15819,6 +15856,7 @@
       "version": "0.92.3",
       "resolved": "https://registry.npmjs.org/@glimmer/validator/-/validator-0.92.3.tgz",
       "integrity": "sha512-HKrMYeW0YhiksSeKYqX2chUR/rz82j12DcY7p2dORQlTV3qlAfiE5zRTJH1KRA1X3ZMf7DI2/GOzkXwYp0o+3Q==",
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@glimmer/env": "^0.1.7",
@@ -15829,6 +15867,7 @@
     },
     "node_modules/ember-source/node_modules/ansi-styles": {
       "version": "4.3.0",
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "color-convert": "^2.0.1"
@@ -15842,6 +15881,7 @@
     },
     "node_modules/ember-source/node_modules/chalk": {
       "version": "4.1.2",
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.1.0",
@@ -15856,6 +15896,7 @@
     },
     "node_modules/ember-source/node_modules/has-flag": {
       "version": "4.0.0",
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -15865,6 +15906,7 @@
       "version": "8.0.6",
       "resolved": "https://registry.npmjs.org/router_js/-/router_js-8.0.6.tgz",
       "integrity": "sha512-AjGxRDIpTGoAG8admFmvP/cxn1AlwwuosCclMU4R5oGHGt7ER0XtB3l9O04ToBDdPe4ivM/YcLopgBEpJssJ/Q==",
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@glimmer/env": "^0.1.7"
@@ -15881,6 +15923,7 @@
       "version": "4.8.5",
       "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-4.8.5.tgz",
       "integrity": "sha512-nfMOlASu9OnRJo1mbEk2cz0D56a1MBNrJ7orjRZQG10XDyuvwksKbuXNp6qa+kbn839HwjwhBzhFmdsaEAfauA==",
+      "devOptional": true,
       "license": "MIT",
       "peer": true,
       "engines": {
@@ -15889,6 +15932,7 @@
     },
     "node_modules/ember-source/node_modules/semver": {
       "version": "7.6.3",
+      "devOptional": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -15899,6 +15943,7 @@
     },
     "node_modules/ember-source/node_modules/supports-color": {
       "version": "7.2.0",
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "has-flag": "^4.0.0"
@@ -17505,6 +17550,7 @@
     },
     "node_modules/esprima": {
       "version": "4.0.1",
+      "devOptional": true,
       "license": "BSD-2-Clause",
       "bin": {
         "esparse": "bin/esparse.js",
@@ -19694,6 +19740,7 @@
     },
     "node_modules/inflection": {
       "version": "2.0.1",
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=14.0.0"
@@ -23385,6 +23432,7 @@
     },
     "node_modules/private": {
       "version": "0.1.8",
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -23848,6 +23896,7 @@
     },
     "node_modules/recast": {
       "version": "0.18.10",
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "ast-types": "0.13.3",
@@ -23861,6 +23910,7 @@
     },
     "node_modules/recast/node_modules/source-map": {
       "version": "0.6.1",
+      "devOptional": true,
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
@@ -24099,6 +24149,7 @@
     },
     "node_modules/remove-types": {
       "version": "1.0.0",
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/core": "^7.16.10",
@@ -24109,6 +24160,7 @@
     },
     "node_modules/remove-types/node_modules/prettier": {
       "version": "2.8.8",
+      "devOptional": true,
       "license": "MIT",
       "bin": {
         "prettier": "bin-prettier.js"
@@ -24493,6 +24545,7 @@
       "version": "0.3.4",
       "resolved": "https://registry.npmjs.org/route-recognizer/-/route-recognizer-0.3.4.tgz",
       "integrity": "sha512-2+MhsfPhvauN1O8KaXpXAOfR/fwe8dnUXVM+xw7yt40lJRfPVQxV6yryZm0cgRvAj5fMF/mdRZbL2ptwbs5i2g==",
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/rsvp": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,13 +11,13 @@
       "license": "MIT",
       "dependencies": {
         "@babel/core": "^7.25.2",
+        "@floating-ui/dom": "^1.8.0",
         "check-engine": "^1.14.0",
         "ember-auto-import": "^2.7.4",
         "ember-cli-babel": "^8.2.0",
         "ember-cli-htmlbars": "^6.3.0",
         "ember-cli-sass": "^11.0.1",
         "ember-click-outside": "^6.1.1",
-        "ember-lifeline": "^7.0.0",
         "ember-modifier": "^4.2.0",
         "ember-popperjs": "^3.0.0",
         "ember-template-imports": "^4.3.0",
@@ -2861,7 +2861,7 @@
       "version": "5.2.2",
       "resolved": "https://registry.npmjs.org/@ember/test-helpers/-/test-helpers-5.2.2.tgz",
       "integrity": "sha512-Cclqeh0j6RnYvoaElAVC3Nd1fsSUkc3oUTwTsLlNiC3riyPq8lNYxh96VM59/yji2ntrd/cJQ7qhhSZWd6hsEw==",
-      "devOptional": true,
+      "dev": true,
       "license": "(MIT OR Apache-2.0)",
       "dependencies": {
         "@ember/test-waiters": "^3.1.0 || ^4.0.0",
@@ -2874,7 +2874,7 @@
     },
     "node_modules/@ember/test-waiters": {
       "version": "3.1.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "calculate-cache-key-for-tree": "^2.0.0",
@@ -2888,7 +2888,7 @@
     },
     "node_modules/@ember/test-waiters/node_modules/@babel/plugin-proposal-private-property-in-object": {
       "version": "7.21.11",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-annotate-as-pure": "^7.18.6",
@@ -2905,7 +2905,7 @@
     },
     "node_modules/@ember/test-waiters/node_modules/@babel/runtime": {
       "version": "7.12.18",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "regenerator-runtime": "^0.13.4"
@@ -2913,7 +2913,7 @@
     },
     "node_modules/@ember/test-waiters/node_modules/@types/fs-extra": {
       "version": "5.1.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/node": "*"
@@ -2921,7 +2921,7 @@
     },
     "node_modules/@ember/test-waiters/node_modules/babel-plugin-module-resolver": {
       "version": "3.2.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "find-babel-config": "^1.1.0",
@@ -2936,7 +2936,7 @@
     },
     "node_modules/@ember/test-waiters/node_modules/broccoli-babel-transpiler": {
       "version": "7.8.1",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/core": "^7.12.0",
@@ -2958,7 +2958,7 @@
     },
     "node_modules/@ember/test-waiters/node_modules/broccoli-funnel": {
       "version": "2.0.2",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "array-equal": "^1.0.0",
@@ -2981,7 +2981,7 @@
     },
     "node_modules/@ember/test-waiters/node_modules/broccoli-funnel/node_modules/rimraf": {
       "version": "2.7.1",
-      "devOptional": true,
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "glob": "^7.1.3"
@@ -2992,7 +2992,7 @@
     },
     "node_modules/@ember/test-waiters/node_modules/broccoli-merge-trees": {
       "version": "3.0.2",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "broccoli-plugin": "^1.3.0",
@@ -3004,7 +3004,7 @@
     },
     "node_modules/@ember/test-waiters/node_modules/broccoli-plugin": {
       "version": "1.3.1",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "promise-map-series": "^0.2.1",
@@ -3015,7 +3015,7 @@
     },
     "node_modules/@ember/test-waiters/node_modules/broccoli-plugin/node_modules/rimraf": {
       "version": "2.7.1",
-      "devOptional": true,
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "glob": "^7.1.3"
@@ -3026,7 +3026,7 @@
     },
     "node_modules/@ember/test-waiters/node_modules/broccoli-source": {
       "version": "2.1.2",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": "6.* || 8.* || >= 10.*"
@@ -3034,7 +3034,7 @@
     },
     "node_modules/@ember/test-waiters/node_modules/debug": {
       "version": "2.6.9",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "2.0.0"
@@ -3042,7 +3042,7 @@
     },
     "node_modules/@ember/test-waiters/node_modules/ember-cli-babel": {
       "version": "7.26.11",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/core": "^7.12.0",
@@ -3082,7 +3082,7 @@
     },
     "node_modules/@ember/test-waiters/node_modules/ember-cli-babel/node_modules/ember-cli-version-checker": {
       "version": "4.1.1",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "resolve-package-path": "^2.0.0",
@@ -3095,7 +3095,7 @@
     },
     "node_modules/@ember/test-waiters/node_modules/ember-cli-babel/node_modules/ember-cli-version-checker/node_modules/resolve-package-path": {
       "version": "2.0.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "path-root": "^0.1.1",
@@ -3107,7 +3107,7 @@
     },
     "node_modules/@ember/test-waiters/node_modules/ember-cli-babel/node_modules/ember-cli-version-checker/node_modules/semver": {
       "version": "6.3.1",
-      "devOptional": true,
+      "dev": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -3115,7 +3115,7 @@
     },
     "node_modules/@ember/test-waiters/node_modules/ember-cli-babel/node_modules/semver": {
       "version": "5.7.2",
-      "devOptional": true,
+      "dev": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver"
@@ -3123,7 +3123,7 @@
     },
     "node_modules/@ember/test-waiters/node_modules/find-babel-config": {
       "version": "1.2.2",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "json5": "^1.0.2",
@@ -3135,7 +3135,7 @@
     },
     "node_modules/@ember/test-waiters/node_modules/find-up": {
       "version": "2.1.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "locate-path": "^2.0.0"
@@ -3146,7 +3146,7 @@
     },
     "node_modules/@ember/test-waiters/node_modules/fixturify": {
       "version": "1.3.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/fs-extra": "^5.0.5",
@@ -3161,7 +3161,7 @@
     },
     "node_modules/@ember/test-waiters/node_modules/fixturify-project": {
       "version": "1.10.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "fixturify": "^1.2.0",
@@ -3170,7 +3170,7 @@
     },
     "node_modules/@ember/test-waiters/node_modules/fs-extra": {
       "version": "7.0.1",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "graceful-fs": "^4.1.2",
@@ -3183,7 +3183,7 @@
     },
     "node_modules/@ember/test-waiters/node_modules/json5": {
       "version": "1.0.2",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "minimist": "^1.2.0"
@@ -3194,7 +3194,7 @@
     },
     "node_modules/@ember/test-waiters/node_modules/jsonfile": {
       "version": "4.0.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "optionalDependencies": {
         "graceful-fs": "^4.1.6"
@@ -3202,7 +3202,7 @@
     },
     "node_modules/@ember/test-waiters/node_modules/locate-path": {
       "version": "2.0.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "p-locate": "^2.0.0",
@@ -3214,12 +3214,12 @@
     },
     "node_modules/@ember/test-waiters/node_modules/ms": {
       "version": "2.0.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@ember/test-waiters/node_modules/p-limit": {
       "version": "1.3.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "p-try": "^1.0.0"
@@ -3230,7 +3230,7 @@
     },
     "node_modules/@ember/test-waiters/node_modules/p-locate": {
       "version": "2.0.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "p-limit": "^1.1.0"
@@ -3241,7 +3241,7 @@
     },
     "node_modules/@ember/test-waiters/node_modules/p-try": {
       "version": "1.0.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=4"
@@ -3249,7 +3249,7 @@
     },
     "node_modules/@ember/test-waiters/node_modules/path-exists": {
       "version": "3.0.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=4"
@@ -3257,7 +3257,7 @@
     },
     "node_modules/@ember/test-waiters/node_modules/pkg-up": {
       "version": "2.0.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "find-up": "^2.1.0"
@@ -3268,7 +3268,7 @@
     },
     "node_modules/@ember/test-waiters/node_modules/promise-map-series": {
       "version": "0.2.3",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "rsvp": "^3.0.14"
@@ -3276,7 +3276,7 @@
     },
     "node_modules/@ember/test-waiters/node_modules/promise-map-series/node_modules/rsvp": {
       "version": "3.6.2",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": "0.12.* || 4.* || 6.* || >= 7.*"
@@ -3284,17 +3284,17 @@
     },
     "node_modules/@ember/test-waiters/node_modules/regenerator-runtime": {
       "version": "0.13.11",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@ember/test-waiters/node_modules/reselect": {
       "version": "3.0.1",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@ember/test-waiters/node_modules/resolve-package-path": {
       "version": "3.1.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "path-root": "^0.1.1",
@@ -3306,7 +3306,7 @@
     },
     "node_modules/@ember/test-waiters/node_modules/rsvp": {
       "version": "4.8.5",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": "6.* || >= 7.*"
@@ -3314,7 +3314,7 @@
     },
     "node_modules/@ember/test-waiters/node_modules/semver": {
       "version": "7.6.3",
-      "devOptional": true,
+      "dev": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -3325,7 +3325,7 @@
     },
     "node_modules/@ember/test-waiters/node_modules/universalify": {
       "version": "0.1.2",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 4.0.0"
@@ -3333,7 +3333,7 @@
     },
     "node_modules/@ember/test-waiters/node_modules/walk-sync": {
       "version": "0.3.4",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ensure-posix-path": "^1.0.0",
@@ -3342,7 +3342,7 @@
     },
     "node_modules/@ember/test-waiters/node_modules/walk-sync/node_modules/matcher-collection": {
       "version": "1.1.2",
-      "devOptional": true,
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "minimatch": "^3.0.2"
@@ -3350,7 +3350,7 @@
     },
     "node_modules/@ember/test-waiters/node_modules/workerpool": {
       "version": "3.1.2",
-      "devOptional": true,
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/core": "^7.3.4",
@@ -4495,6 +4495,31 @@
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
+    },
+    "node_modules/@floating-ui/core": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.8.0.tgz",
+      "integrity": "sha512-0CIZ5itps/8x7BG8dEIhs53BvCUH2PCoogtakwRTut+Arm58sJooJ0AuZhLw2HJYIR5cMLNPBSS728sPho2khQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/utils": "^0.2.12"
+      }
+    },
+    "node_modules/@floating-ui/dom": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.8.0.tgz",
+      "integrity": "sha512-yXSrzeHZBTZadLOlfyhCkJHNeLJnHRnRInwdZ40L7ZiaAtrBwoYlsDrX3v5zB1Utk7CLfzcOVnVVWoXEky7Ceg==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/core": "^1.8.0",
+        "@floating-ui/utils": "^0.2.12"
+      }
+    },
+    "node_modules/@floating-ui/utils": {
+      "version": "0.2.12",
+      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.12.tgz",
+      "integrity": "sha512-HpCo8tmWzLVad5s2d19EhAz5zqrrQ6s69qd6moPMQvkOuSwDT1YgRfWSVuc4ennqrgv3OHppiOGMQ7oC13yIww==",
+      "license": "MIT"
     },
     "node_modules/@glimmer/compiler": {
       "version": "0.92.4",
@@ -12400,7 +12425,7 @@
     },
     "node_modules/dom-element-descriptors": {
       "version": "0.5.1",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/dom-serializer": {

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
   },
   "dependencies": {
     "@babel/core": "^7.25.2",
+    "@floating-ui/dom": "^1.8.0",
     "check-engine": "^1.14.0",
     "ember-auto-import": "^2.7.4",
     "ember-cli-babel": "^8.2.0",

--- a/package.json
+++ b/package.json
@@ -69,7 +69,6 @@
     "ember-cli-sass": "^11.0.1",
     "ember-click-outside": "^6.1.1",
     "ember-modifier": "^4.2.0",
-    "ember-popperjs": "^3.0.0",
     "ember-template-imports": "^4.3.0",
     "ember-truth-helpers": "^5.0.0",
     "tracked-toolbox": "^2.2.0"

--- a/tests/integration/components/pix-select-test.js
+++ b/tests/integration/components/pix-select-test.js
@@ -65,6 +65,18 @@ module('Integration | Component | PixSelect', function (hooks) {
       assert.dom(screen.queryByRole('option', { name: 'Oignon' })).doesNotExist();
     });
 
+    test('it keeps the closed dropdown hidden despite floating ui inline styles', async function (assert) {
+      // given & when
+      await render(
+        hbs`<PixSelect @options={{this.options}} @texts={{this.texts}}><:label
+  >{{this.label}}</:label></PixSelect>`,
+      );
+
+      // then
+      const dropdown = document.querySelector('.pix-select__dropdown');
+      assert.strictEqual(getComputedStyle(dropdown).visibility, 'hidden');
+    });
+
     test('it opens the dropdown', async function (assert) {
       // given
       const screen = await render(


### PR DESCRIPTION
## :christmas_tree: Problème

La librairie `ember-popperjs` est [dépréciée](https://github.com/NullVoxPopuli/ember-popperjs).

## :gift: Proposition

Utiliser directement `floating-ui/dom` ([doc](https://floating-ui.com/)) par l'intermédiaire d'un composant `PixFloating` copié à partir de l'implémentation de disponible dans https://github.com/universal-ember/ember-primitives.

Modifier les composants dépendants de `ember-popperjs`:
- `PixSelect`
- `PixMultiSelect`
- `PixStructureSwitcher`

Supprimer la librairie `ember-popperjs`

## :star2: Remarques

Dans une autre PR, `PixTooltip` pourra être réécrit en utilisant `PixFloating` afin de corriger les comportements buggués de la tooltip actuelle. Mais nécessitera des breaking change.

## :santa: Pour tester

Tester :
- `PixSelect`
- `PixMultiSelect`
- `PixStructureSwitcher`

Implementé sur [PixApp](https://github.com/1024pix/pix/pull/17377) 
