### PR TITLE
[FEATURE] Adaptation des border radius du composant PixIndicatorCard (PIX-24099)

### DIFF
--- a/addon/styles/_pix-indicator-card.scss
+++ b/addon/styles/_pix-indicator-card.scss
@@ -12,7 +12,7 @@
     align-items: center;
     justify-content: center;
     min-width: 96px;
-    border-radius: 7px 0 0 7px;
+    border-radius: var(--pix-spacing-5x) 0 0 var(--pix-spacing-5x);
 
     &--grey,
     &--neutral {


### PR DESCRIPTION
## :christmas_tree: Problème
Les borders radius des angles gauches ne respectent pas les maquettes

## :gift: Proposition
ajustement des border-radius

## :star2: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :santa: Pour tester
> _Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc._
