### PR TITLE
[TECH] Ajouter l'attribut variant dans PixIconButton (PIX-24070).

### DIFF
--- a/addon/components/pix-icon-button.gjs
+++ b/addon/components/pix-icon-button.gjs
@@ -16,6 +16,20 @@ export default class PixIconButton extends Component {
     return this.args.color || 'light-grey';
   }
 
+  get variant() {
+    return this.args.variant;
+  }
+
+  get className() {
+    const classNames = ['pix-icon-button', `pix-icon-button--${this.size}`];
+
+    if (this.variant) {
+      classNames.push(`pix-icon-button--${this.variant}`);
+    }
+
+    return classNames.join(' ');
+  }
+
   get isDisabled() {
     warn(
       'PixIconButton: @isDisabled attribute should be a boolean.',
@@ -52,7 +66,7 @@ export default class PixIconButton extends Component {
   <template>
     <button
       type="button"
-      class="pix-icon-button pix-icon-button--{{this.size}}"
+      class={{this.className}}
       {{on "click" this.triggerAction}}
       aria-disabled="{{this.isDisabled}}"
       ...attributes

--- a/addon/styles/_pix-icon-button.scss
+++ b/addon/styles/_pix-icon-button.scss
@@ -60,4 +60,31 @@
     min-width: 1rem;
     height: 1rem;
   }
+
+  &--secondary {
+    color: var(--pix-primary-700);
+    background-color: transparent;
+    border: 2px solid var(--pix-primary-700);
+
+    &:not([aria-disabled='true']) {
+      &:hover:enabled {
+        color: var(--pix-primary-700);
+        background-color: var(--pix-primary-100);
+        outline: 0;
+      }
+
+      &:focus:enabled {
+        color: var(--pix-primary-900);
+        background-color: var(--pix-primary-100);
+        outline: 1px solid var(--pix-primary-700);
+        outline-offset: -5px;
+      }
+
+      &:active:enabled {
+        color: var(--pix-neutral-0);
+        background-color: var(--pix-primary-700);
+        outline: none;
+      }
+    }
+  }
 }

--- a/app/stories/pix-icon-button.mdx
+++ b/app/stories/pix-icon-button.mdx
@@ -25,6 +25,12 @@ Exemple avec le bouton désactivé
 
 <Story of={ComponentStories.disabled} height={60} />
 
+## Variant
+
+Le bouton, version "secondary". Pour avoir le design original, il suffit de ne pas ajouter cet attribut.
+
+<Story of={ComponentStories.secondary} height={60} />
+
 ## Accessibilité / aria-label
 
 L'attribut `aria-label` étant indispensable pour l'accessibilité de ce composant, la propriété `ariaLabel` a été ajouté.

--- a/app/stories/pix-icon-button.stories.js
+++ b/app/stories/pix-icon-button.stories.js
@@ -52,6 +52,17 @@ export default {
         defaultValue: { summary: 'false' },
       },
     },
+    variant: {
+      name: 'variant',
+      description: "Permet d'avoir une déclinaison du design du bouton",
+      options: ['secondary'],
+      type: { name: 'string', required: false },
+      control: { type: 'select' },
+      table: {
+        type: { summary: 'string' },
+        defaultValue: { summary: 'undefined' },
+      },
+    },
   },
 };
 
@@ -64,6 +75,7 @@ const Template = (args) => {
   @triggerAction={{this.triggerAction}}
   @size={{this.size}}
   @isDisabled={{this.isDisabled}}
+  @variant={{this.variant}}
 />`,
     context: args,
   };
@@ -89,5 +101,12 @@ export const disabled = Template.bind({});
 disabled.args = {
   ...Default.args,
   isDisabled: true,
+  triggerAction,
+};
+
+export const secondary = Template.bind({});
+secondary.args = {
+  ...Default.args,
+  variant: 'secondary',
   triggerAction,
 };

--- a/tests/integration/components/pix-icon-button-test.js
+++ b/tests/integration/components/pix-icon-button-test.js
@@ -71,4 +71,30 @@ module('Integration | Component | icon-button', function (hooks) {
       assert.strictEqual(this.count, 1);
     });
   });
+
+  module('when no variant is given', function () {
+    test('it renders PixIconButton with the default design', async function (assert) {
+      // when
+      const screen = await render(
+        hbs`<PixIconButton @iconName='add' @ariaLabel='action du bouton' />`,
+      );
+
+      // then
+      const pixIconButton = screen.getByRole('button', { name: 'action du bouton' });
+      assert.dom(pixIconButton).doesNotHaveClass('pix-icon-button--secondary');
+    });
+  });
+
+  module('when variant is secondary', function () {
+    test('it renders PixIconButton with the secondary variant class', async function (assert) {
+      // when
+      const screen = await render(
+        hbs`<PixIconButton @iconName='add' @ariaLabel='action du bouton' @variant='secondary' />`,
+      );
+
+      // then
+      const pixIconButton = screen.getByRole('button', { name: 'action du bouton' });
+      assert.dom(pixIconButton).hasClass('pix-icon-button--secondary');
+    });
+  });
 });


### PR DESCRIPTION

## :christmas_tree: Problème
Une nouvelle maquette met en évidence le besoin d'avoir des boutons sans label, juste avec l'icône => PixIconButton. Mais avec un design de variant secondary, comme on à dans le PixButton.

## :gift: Proposition
Ajouter l'attribut variant dans PixIconButton avec le secondary.


## :santa: Pour tester
Voir la page de PixIconButton