### PR TITLE
[FEATURE] Rendre le stepper cliquable

### DIFF
--- a/addon/components/pix-step.gjs
+++ b/addon/components/pix-step.gjs
@@ -1,3 +1,4 @@
+import { on } from '@ember/modifier';
 import Component from '@glimmer/component';
 
 export default class PixStepComponent extends Component {
@@ -21,18 +22,16 @@ export default class PixStepComponent extends Component {
 
   <template>
     <li class={{this.cssClass}} aria-current={{this.ariaCurrent}} ...attributes>
-      <div class="pix-step__index" aria-hidden="true">
-        {{this.displayIndex}}
-      </div>
-      {{#if @title}}
-        <div class="pix-step__title">
-          {{@title}}
-        </div>
-      {{/if}}
-      {{#if @subtitle}}
-        <div class="pix-step__subtitle">
-          {{@subtitle}}
-        </div>
+      {{#if @isClickable}}
+        <button type="button" class="pix-step__button" {{on "click" @onClick}}>
+          <div class="pix-step__index" aria-hidden="true">{{this.displayIndex}}</div>
+          {{#if @title}}<div class="pix-step__title">{{@title}}</div>{{/if}}
+          {{#if @subtitle}}<div class="pix-step__subtitle">{{@subtitle}}</div>{{/if}}
+        </button>
+      {{else}}
+        <div class="pix-step__index" aria-hidden="true">{{this.displayIndex}}</div>
+        {{#if @title}}<div class="pix-step__title">{{@title}}</div>{{/if}}
+        {{#if @subtitle}}<div class="pix-step__subtitle">{{@subtitle}}</div>{{/if}}
       {{/if}}
     </li>
   </template>

--- a/addon/components/pix-stepper.gjs
+++ b/addon/components/pix-stepper.gjs
@@ -1,6 +1,6 @@
 import { warn } from '@ember/debug';
+import { fn } from '@ember/helper';
 import Component from '@glimmer/component';
-import { eq } from 'ember-truth-helpers';
 
 import PixStep from './pix-step';
 
@@ -26,18 +26,28 @@ export default class PixStepperComponent extends Component {
     return classes.join(' ');
   }
 
-  get currentStepIndex() {
-    return this.args.currentStep - 1;
+  get stepsWithState() {
+    const { onStepClick, canNavigateTo, steps, currentStep } = this.args;
+    const currentStepIndex = currentStep - 1;
+
+    return steps.map((step, index) => {
+      const stepNumber = index + 1;
+      const isClickable = onStepClick ? (canNavigateTo ? canNavigateTo(stepNumber) : true) : false;
+
+      return { ...step, stepNumber, isCurrent: index === currentStepIndex, isClickable };
+    });
   }
 
   <template>
     <ol class={{this.cssClass}} role="list" ...attributes aria-label={{@texts.ariaLabel}}>
-      {{#each @steps as |step index|}}
+      {{#each this.stepsWithState as |step index|}}
         <PixStep
           @index={{index}}
           @title={{step.title}}
           @subtitle={{step.subtitle}}
-          @isCurrent={{eq index this.currentStepIndex}}
+          @isCurrent={{step.isCurrent}}
+          @isClickable={{step.isClickable}}
+          @onClick={{if step.isClickable (fn @onStepClick step.stepNumber)}}
         />
       {{/each}}
     </ol>

--- a/addon/styles/_pix-stepper.scss
+++ b/addon/styles/_pix-stepper.scss
@@ -10,6 +10,8 @@
   position: relative;
   flex: 1;
   text-align: center;
+  cursor: default;
+  user-select: none;
 
   &__index {
     position: relative;
@@ -51,6 +53,17 @@
       transform-origin: bottom left;
       rotate: -45deg;
     }
+  }
+
+  &__button {
+    width: 100%;
+    padding: 0;
+    color: inherit;
+    font: inherit;
+    text-align: inherit;
+    background: none;
+    border: none;
+    cursor: pointer;
   }
 
   &__title {

--- a/app/stories/pix-stepper.mdx
+++ b/app/stories/pix-stepper.mdx
@@ -1,4 +1,4 @@
-import { Meta, Story, ArgTypes } from '@storybook/blocks';
+import { Meta, Story, ArgTypes } from '@storybook/addon-docs/blocks';
 import * as ComponentStories from './pix-stepper.stories';
 
 <Meta of={ComponentStories} />
@@ -25,10 +25,28 @@ Au-delà de 3 étapes, le stepper adapte automatiquement son affichage (mode lon
 
 <Story of={ComponentStories.withoutSubtitle} height={150} />
 
+## Navigable
+
+Fournir `@onStepClick` active le mode navigation. Toutes les étapes deviennent cliquables et le callback est appelé avec le numéro de l'étape au clic. Cliquez sur les étapes pour voir le stepper se mettre à jour.
+
+<Story of={ComponentStories.navigable} height={150} />
+
+## Navigable avec restriction
+
+`@canNavigateTo` permet de restreindre les étapes accessibles. Ici, seule l'étape 2 est cliquable depuis l'étape 3 (navigation arrière uniquement, étape 1 bloquée).
+
+<Story of={ComponentStories.navigableWithRestriction} height={150} />
+
 ## Usage
 
+### Non-navigable (par défaut)
+
 ```html
-<PixStepper @steps="{{this.steps}}" @currentStep="{{2}}" @texts={{{ariaLabel: "Étape 1/2" }}}/>
+<PixStepper
+  @steps={{this.steps}}
+  @currentStep={{this.currentStep}}
+  @texts={{this.texts}}
+/>
 ```
 
 Où `steps` est un tableau d'objets :
@@ -40,6 +58,34 @@ steps = [
   { title: 'Validation', subtitle: 'Finalisez votre inscription' },
 ];
 ```
+
+### Navigable
+
+```html
+<PixStepper
+  @steps={{this.steps}}
+  @currentStep={{this.currentStep}}
+  @texts={{this.texts}}
+  @onStepClick={{this.goToStep}}
+  @canNavigateTo={{this.canNavigateTo}}
+/>
+```
+
+```js
+// Dans le composant consommateur
+get canNavigateTo() {
+  const current = this.currentStep;
+  return (stepNumber) => stepNumber > 1 && stepNumber < current;
+}
+
+@action
+goToStep(stepNumber) {
+  this.currentStep = stepNumber;
+  // ou : this.router.transitionTo(this.routeForStep[stepNumber - 1]);
+}
+```
+
+`canNavigateTo` doit être un getter (et non un champ de classe) pour que la réactivité Glimmer fonctionne correctement lorsque `currentStep` change.
 
 ## Arguments
 

--- a/app/stories/pix-stepper.stories.js
+++ b/app/stories/pix-stepper.stories.js
@@ -36,6 +36,26 @@ export default {
         },
       },
     },
+    onStepClick: {
+      name: 'onStepClick',
+      description:
+        "Callback appelé avec le numéro de l'étape au clic. Active le mode navigation. Sans cette prop, le composant est non-interactif.",
+      type: { name: 'function' },
+      table: {
+        type: { summary: '(stepNumber: number) => void' },
+        defaultValue: { summary: 'undefined' },
+      },
+    },
+    canNavigateTo: {
+      name: 'canNavigateTo',
+      description:
+        'Fonction optionnelle qui détermine si une étape est cliquable. Sans cette prop, toutes les étapes sont cliquables dès que `@onStepClick` est fourni.',
+      type: { name: 'function' },
+      table: {
+        type: { summary: '(stepNumber: number) => boolean' },
+        defaultValue: { summary: 'undefined' },
+      },
+    },
   },
 };
 
@@ -94,4 +114,58 @@ withoutSubtitle.args = {
   texts: {
     ariaLabel: 'étape 2 sur 3',
   },
+};
+
+const NavigableTemplate = (args) => {
+  return {
+    template: hbs`<PixStepper
+  @steps={{this.steps}}
+  @currentStep={{this.currentStep}}
+  @texts={{this.texts}}
+  @onStepClick={{fn (mut this.currentStep)}}
+/>`,
+    context: args,
+  };
+};
+
+export const navigable = NavigableTemplate.bind({});
+navigable.args = {
+  steps: [
+    { title: 'Informations', subtitle: 'Renseignez vos informations' },
+    { title: 'Confirmation', subtitle: 'Vérifiez vos données' },
+    { title: 'Validation', subtitle: 'Finalisez votre inscription' },
+    { title: 'Finalisation', subtitle: 'Complétez votre dossier' },
+  ],
+  currentStep: 3,
+  texts: {
+    ariaLabel: 'étape 3 sur 4',
+  },
+};
+
+const NavigableWithRestrictionTemplate = (args) => {
+  return {
+    template: hbs`<PixStepper
+  @steps={{this.steps}}
+  @currentStep={{this.currentStep}}
+  @texts={{this.texts}}
+  @onStepClick={{fn (mut this.currentStep)}}
+  @canNavigateTo={{this.canNavigateTo}}
+/>`,
+    context: args,
+  };
+};
+
+export const navigableWithRestriction = NavigableWithRestrictionTemplate.bind({});
+navigableWithRestriction.args = {
+  steps: [
+    { title: 'Informations', subtitle: 'Renseignez vos informations' },
+    { title: 'Confirmation', subtitle: 'Vérifiez vos données' },
+    { title: 'Validation', subtitle: 'Finalisez votre inscription' },
+    { title: 'Finalisation', subtitle: 'Complétez votre dossier' },
+  ],
+  currentStep: 3,
+  texts: {
+    ariaLabel: 'étape 3 sur 4',
+  },
+  canNavigateTo: (n) => n > 1 && n < 3,
 };

--- a/tests/dummy/app/controllers/stepper-page.js
+++ b/tests/dummy/app/controllers/stepper-page.js
@@ -1,11 +1,24 @@
 import Controller from '@ember/controller';
+import { tracked } from '@glimmer/tracking';
+import { action } from '@ember/object';
 
 export default class StepperPage extends Controller {
   steps = [
-    { title: 'Bonjour', subtitle: 'Ceci est une belle journée !' },
-    { title: 'Bonjour', subtitle: 'Ceci est une belle journée !' },
-    { title: 'Bonjour', subtitle: 'Ceci est une belle journée !' },
-    { title: 'Bonjour', subtitle: 'Ceci est une belle journée !' },
-    { title: 'Bonjour', subtitle: 'Ceci est une belle journée !' },
+    { title: 'Étape 1', subtitle: "Ceci est l'étape 1" },
+    { title: 'Étape 2', subtitle: "Ceci est l'étape 2" },
+    { title: 'Étape 3', subtitle: "Ceci est l'étape 3" },
+    { title: 'Étape 4', subtitle: "Ceci est l'étape 4" },
   ];
+
+  @tracked currentStep = 3;
+
+  get canNavigateTo() {
+    const current = this.currentStep;
+    return (stepNumber) => stepNumber < current;
+  }
+
+  @action
+  goToStep(stepNumber) {
+    this.currentStep = stepNumber;
+  }
 }

--- a/tests/dummy/app/templates/stepper-page.hbs
+++ b/tests/dummy/app/templates/stepper-page.hbs
@@ -1,1 +1,12 @@
-<PixStepper @steps={{this.steps}} @currentStep={{3}} />
+<p>Étape courante : {{this.currentStep}}</p>
+
+<h2>Non-navigable</h2>
+<PixStepper @steps={{this.steps}} @currentStep={{this.currentStep}} />
+
+<h2>Navigable</h2>
+<PixStepper
+  @steps={{this.steps}}
+  @currentStep={{this.currentStep}}
+  @onStepClick={{this.goToStep}}
+  @canNavigateTo={{this.canNavigateTo}}
+/>

--- a/tests/integration/components/pix-step-test.js
+++ b/tests/integration/components/pix-step-test.js
@@ -1,4 +1,5 @@
 import { render } from '@1024pix/ember-testing-library';
+import { click } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { setupRenderingTest } from 'ember-qunit';
 import { module, test } from 'qunit';
@@ -117,5 +118,64 @@ module('Integration | Component | PixStep', function (hooks) {
     // then
     const step = this.element.querySelector('.pix-step');
     assert.dom(step).hasAttribute('data-test', 'custom');
+  });
+
+  module('navigation', function () {
+    test('it renders a button when @isClickable is true', async function (assert) {
+      // given
+      this.set('index', 1);
+      this.set('title', 'Étape 2');
+      this.set('onClick', () => {});
+
+      // when
+      const screen = await render(
+        hbs`<PixStep
+  @index={{this.index}}
+  @title={{this.title}}
+  @isClickable={{true}}
+  @onClick={{this.onClick}}
+/>`,
+      );
+
+      // then
+      assert.dom(screen.getByRole('button')).exists();
+      assert.dom(screen.getByRole('button')).containsText('Étape 2');
+    });
+
+    test('it does not render a button when @isClickable is false', async function (assert) {
+      // given
+      this.set('index', 0);
+      this.set('title', 'Étape 1');
+
+      // when
+      const screen = await render(
+        hbs`<PixStep @index={{this.index}} @title={{this.title}} @isClickable={{false}} />`,
+      );
+
+      // then
+      assert.dom(screen.queryByRole('button')).doesNotExist();
+    });
+
+    test('it calls @onClick when the button is clicked', async function (assert) {
+      // given
+      let clicked = false;
+      this.set('index', 1);
+      this.set('title', 'Étape 2');
+      this.set('onClick', () => (clicked = true));
+
+      // when
+      const screen = await render(
+        hbs`<PixStep
+  @index={{this.index}}
+  @title={{this.title}}
+  @isClickable={{true}}
+  @onClick={{this.onClick}}
+/>`,
+      );
+      await click(screen.getByRole('button'));
+
+      // then
+      assert.true(clicked);
+    });
   });
 });

--- a/tests/integration/components/pix-stepper-test.js
+++ b/tests/integration/components/pix-stepper-test.js
@@ -1,4 +1,5 @@
 import { render } from '@1024pix/ember-testing-library';
+import { click } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { setupRenderingTest } from 'ember-qunit';
 import { module, test } from 'qunit';
@@ -122,6 +123,86 @@ module('Integration | Component | PixStepper', function (hooks) {
 
       // then
       assert.dom('.pix-stepper').hasClass('pix-stepper--long');
+    });
+  });
+
+  module('navigation', function () {
+    test('it renders all steps as non-interactive when @onStepClick is not provided', async function (assert) {
+      // given
+      this.set('steps', [{ title: 'Étape 1' }, { title: 'Étape 2' }, { title: 'Étape 3' }]);
+      this.set('currentStep', 2);
+
+      // when
+      const screen = await render(
+        hbs`<PixStepper @steps={{this.steps}} @currentStep={{this.currentStep}} />`,
+      );
+
+      // then
+      assert.strictEqual(screen.queryAllByRole('button').length, 0);
+    });
+
+    test('it renders all steps as buttons when @onStepClick is provided without @canNavigateTo', async function (assert) {
+      // given
+      this.set('steps', [{ title: 'Étape 1' }, { title: 'Étape 2' }, { title: 'Étape 3' }]);
+      this.set('currentStep', 2);
+      this.set('onStepClick', () => {});
+
+      // when
+      const screen = await render(
+        hbs`<PixStepper
+  @steps={{this.steps}}
+  @currentStep={{this.currentStep}}
+  @onStepClick={{this.onStepClick}}
+/>`,
+      );
+
+      // then
+      assert.strictEqual(screen.getAllByRole('button').length, 3);
+    });
+
+    test('it renders only navigable steps as buttons when @canNavigateTo is provided', async function (assert) {
+      // given
+      this.set('steps', [{ title: 'Étape 1' }, { title: 'Étape 2' }, { title: 'Étape 3' }]);
+      this.set('currentStep', 3);
+      this.set('onStepClick', () => {});
+      this.set('canNavigateTo', (n) => n > 1 && n < 3);
+
+      // when
+      const screen = await render(
+        hbs`<PixStepper
+  @steps={{this.steps}}
+  @currentStep={{this.currentStep}}
+  @onStepClick={{this.onStepClick}}
+  @canNavigateTo={{this.canNavigateTo}}
+/>`,
+      );
+
+      // then
+      assert.strictEqual(screen.getAllByRole('button').length, 1);
+      assert.dom(screen.getByRole('button')).containsText('Étape 2');
+    });
+
+    test('it calls @onStepClick with the step number when a navigable step is clicked', async function (assert) {
+      // given
+      let clickedStep = null;
+      this.set('steps', [{ title: 'Étape 1' }, { title: 'Étape 2' }, { title: 'Étape 3' }]);
+      this.set('currentStep', 3);
+      this.set('onStepClick', (stepNumber) => (clickedStep = stepNumber));
+      this.set('canNavigateTo', (n) => n === 2);
+
+      // when
+      const screen = await render(
+        hbs`<PixStepper
+  @steps={{this.steps}}
+  @currentStep={{this.currentStep}}
+  @onStepClick={{this.onStepClick}}
+  @canNavigateTo={{this.canNavigateTo}}
+/>`,
+      );
+      await click(screen.getByRole('button'));
+
+      // then
+      assert.strictEqual(clickedStep, 2);
     });
   });
 


### PR DESCRIPTION
## Problème
On a besoin de rendre le stepper cliquable pour pouvoir l'utiliser pour naviguer entre les étapes d'un formulaire

## Proposition

  Deux nouvelles props sur PixStepper :

  - @onStepClick (stepNumber: number) => active la navigation. Le callback est appelé avec le numéro de l'étape au clic. Sans cette prop, le composant se comporte exactement comme avant.
  - @canNavigateTo (stepNumber: number) =>  optionnelle, permet de contrôler quelles étapes sont cliquables. Sans elle, toutes les étapes le sont dès que @onStepClick est fourni.

Une étape navigable est rendue comme un <button>, une non-navigable comme un <div>. 
Le découplage entre "quoi faire au clic" et "peut-on cliquer" permet d'exprimer des règles de navigation via une fonction ordinaire, facilement testable unitairement en dehors du composant.

## : Remarques
On en profite pour que le numéro de l'étape ne soit plus du texte sélectionnable, car il était même sélectionnable sous le "check :white_check_mark: " quand l'étape était validée
<img width="155" height="131" alt="image" src="https://github.com/user-attachments/assets/6b31ca56-d5ba-4572-9212-7487eafbfb4d" />

##  Pour tester
Aller voir le [composant en RA](https://pix-ui-review-pr1061.osc-fr1.scalingo.io/?path=/docs/navigation-stepper--docs).
